### PR TITLE
Ratify ADRs 001-008 as Accepted

### DIFF
--- a/docs/adrs/001-custom-experience-runtime.md
+++ b/docs/adrs/001-custom-experience-runtime.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Date
 

--- a/docs/adrs/002-scene-registry-and-compositions.md
+++ b/docs/adrs/002-scene-registry-and-compositions.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Date
 

--- a/docs/adrs/003-gsap-timeline-engine.md
+++ b/docs/adrs/003-gsap-timeline-engine.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Date
 

--- a/docs/adrs/004-howler-audio-engine.md
+++ b/docs/adrs/004-howler-audio-engine.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Date
 

--- a/docs/adrs/005-dom-css-default-rendering-surface.md
+++ b/docs/adrs/005-dom-css-default-rendering-surface.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Date
 

--- a/docs/adrs/006-remotion-export-path.md
+++ b/docs/adrs/006-remotion-export-path.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Date
 

--- a/docs/adrs/007-browser-workbench.md
+++ b/docs/adrs/007-browser-workbench.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Date
 

--- a/docs/adrs/008-agent-native-authoring.md
+++ b/docs/adrs/008-agent-native-authoring.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Date
 

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -26,11 +26,11 @@ Each ADR includes:
 | ADR | Title | Status |
 |-----|-------|--------|
 | [000](000-template.md) | ADR Template | — |
-| [001](001-custom-experience-runtime.md) | Custom Experience Runtime, Not a Slide Framework | Proposed |
-| [002](002-scene-registry-and-compositions.md) | Scene Registry and Composition Manifests as the Core Abstraction | Proposed |
-| [003](003-gsap-timeline-engine.md) | GSAP as the Timeline Engine | Proposed |
-| [004](004-howler-audio-engine.md) | Howler.js as the Audio Engine | Proposed |
-| [005](005-dom-css-default-rendering-surface.md) | DOM/CSS as the Default Rendering Surface | Proposed |
-| [006](006-remotion-export-path.md) | Remotion as a Parallel Export Path, Not the Live Runtime | Proposed |
-| [007](007-browser-workbench.md) | Browser as the Default Workbench and Agent Collaboration Surface | Proposed |
-| [008](008-agent-native-authoring.md) | Agent-Native Authoring as a First-Class Architectural Constraint | Proposed |
+| [001](001-custom-experience-runtime.md) | Custom Experience Runtime, Not a Slide Framework | Accepted |
+| [002](002-scene-registry-and-compositions.md) | Scene Registry and Composition Manifests as the Core Abstraction | Accepted |
+| [003](003-gsap-timeline-engine.md) | GSAP as the Timeline Engine | Accepted |
+| [004](004-howler-audio-engine.md) | Howler.js as the Audio Engine | Accepted |
+| [005](005-dom-css-default-rendering-surface.md) | DOM/CSS as the Default Rendering Surface | Accepted |
+| [006](006-remotion-export-path.md) | Remotion as a Parallel Export Path, Not the Live Runtime | Accepted |
+| [007](007-browser-workbench.md) | Browser as the Default Workbench and Agent Collaboration Surface | Accepted |
+| [008](008-agent-native-authoring.md) | Agent-Native Authoring as a First-Class Architectural Constraint | Accepted |


### PR DESCRIPTION
## Summary

Transition foundation ADRs from \`Proposed\` to \`Accepted\` so requirements
and the upcoming ADR-009 (repo layout and build tooling) can build on a
ratified foundation.

- ADR-001 — Custom Experience Runtime, Not a Slide Framework
- ADR-002 — Scene Registry and Composition Manifests as the Core Abstraction
- ADR-003 — GSAP as the Timeline Engine
- ADR-004 — Howler.js as the Audio Engine
- ADR-005 — DOM/CSS as the Default Rendering Surface
- ADR-006 — Remotion as a Parallel Export Path, Not the Live Runtime
- ADR-007 — Browser as the Default Workbench and Agent Collaboration Surface
- ADR-008 — Agent-Native Authoring as a First-Class Architectural Constraint

No content changes — only the \`## Status\` header in each ADR file and the
index column in \`docs/adrs/README.md\`. Ground Control mirror will be
transitioned in the same wave once this lands.

## Test plan

- [x] \`pre-commit run\` clean
- [x] No source changes; CHANGELOG not required (per AGENTS.md, doc/GC-only changes are exempt)
- [ ] CI green on PR (current CI is the stub from the template; passes trivially)
- [ ] After merge: \`gc_transition_adr_status\` for each of ADR-001..008 in Ground Control