### PR TITLE
Smoke-test: PULSAR_RUNTIME_VERSION + spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `src/runtime/version.ts` exporting `PULSAR_RUNTIME_VERSION` plus a
+  Vitest spec covering it. First runtime symbol the test runner exercises.
 - Toolchain scaffold per ADR-009: TypeScript (strict), ESM, pnpm 9.15,
   Vite 6, Vitest 3 (`@vitest/coverage-v8` for lcov), Biome 1.9, Node 22
   LTS pinned via `.nvmrc` and `package.json` `engines` /

--- a/src/runtime/version.ts
+++ b/src/runtime/version.ts
@@ -1,0 +1,4 @@
+// Runtime build constant. Mirrors package.json#version. Will be replaced
+// by a build-time injection (vite define) once the runtime entry needs to
+// surface its version to consumers and the workbench.
+export const PULSAR_RUNTIME_VERSION = '0.1.0';

--- a/tests/runtime/version.test.ts
+++ b/tests/runtime/version.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { PULSAR_RUNTIME_VERSION } from '../../src/runtime/version';
+
+describe('PULSAR_RUNTIME_VERSION', () => {
+  it('is a non-empty string', () => {
+    expect(typeof PULSAR_RUNTIME_VERSION).toBe('string');
+    expect(PULSAR_RUNTIME_VERSION.length).toBeGreaterThan(0);
+  });
+
+  it('matches semver major.minor.patch shape', () => {
+    expect(PULSAR_RUNTIME_VERSION).toMatch(/^\d+\.\d+\.\d+(-[A-Za-z0-9.-]+)?$/);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 4 of the bootstrap plan. Exercises the implementation loop end-to-end
against the comprehensive quality gates installed in PR #3, on a no-op
change with zero in-scope requirements.

- \`src/runtime/version.ts\` exporting \`PULSAR_RUNTIME_VERSION\`.
- \`tests/runtime/version.test.ts\` covering it (semver shape + non-empty).
- CHANGELOG entry under \`[Unreleased]\`.

Closes #4.

## Test plan

- [x] \`pnpm typecheck && pnpm lint && pnpm test\` clean locally
- [x] \`pre-commit run\` clean across all 12 hooks
- [ ] All six required CI status checks green: \`Pre-commit hooks\`,
      \`Typecheck\`, \`Test + coverage\`, \`Build\`, \`Dependency audit\`,
      \`SonarCloud\`
- [ ] SonarCloud quality gate stays GREEN (new code = the version constant
      and its test, 100% covered)