### PR TITLE
Implement PUL-F001: SceneModule contract + validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `src/runtime/scene.ts` — `SceneModule`, `Caption`, `SceneContext`,
+  `SceneLifecycleFn` types plus `assertSceneModule` runtime validator
+  and `isSceneModule` predicate. Implements the canonical scene-module
+  contract per PUL-F001 (and ADR-002 / ADR-008): presence + shape of
+  the 12 fields, `duration` strict (non-negative integer ms or `null`,
+  rejecting `undefined`, `NaN`, `Infinity`, floats, negatives, strings,
+  booleans). Errors identify the scene id and offending field/condition,
+  laying the foundation for PUL-Q005 (validation actionability).
+- `tests/runtime/scene.test.ts` — 62-test Vitest spec covering every
+  clause of PUL-F001 (presence, duration rules, field types, caption
+  element shape, happy paths, `isSceneModule` predicate, and error
+  message format).
 - `src/runtime/version.ts` exporting `PULSAR_RUNTIME_VERSION` plus a
   Vitest spec covering it. First runtime symbol the test runner exercises.
 - Toolchain scaffold per ADR-009: TypeScript (strict), ESM, pnpm 9.15,

--- a/src/runtime/scene.ts
+++ b/src/runtime/scene.ts
@@ -20,14 +20,13 @@ export interface Caption {
 }
 
 /**
- * Scene context passed to the lifecycle functions. Refined by PUL-F002
- * (registry lifecycle) and ADR-003 / ADR-004 (timeline + audio surface
- * via `ctx.gsap`, `ctx.audio`). Until then, lifecycle implementations
- * should treat the value as opaque.
+ * Lifecycle function signature. The `ctx` argument is opaque here and
+ * refined by PUL-F002 (registry lifecycle) plus ADR-003 / ADR-004
+ * (timeline + audio surface via `ctx.gsap`, `ctx.audio`). Until then,
+ * lifecycle implementations should treat the value as opaque and
+ * route through whatever helpers the runtime exposes when they land.
  */
-export type SceneContext = unknown;
-
-export type SceneLifecycleFn = (ctx: SceneContext) => unknown;
+export type SceneLifecycleFn = (ctx: unknown) => unknown;
 
 /**
  * The contract every scene module exports per PUL-F001.
@@ -92,10 +91,69 @@ const isCaption = (v: unknown): v is Caption =>
 const isCaptionArray = (v: unknown): v is readonly Caption[] =>
   Array.isArray(v) && v.every(isCaption);
 
+const isStringOrNull = (v: unknown): v is string | null => v === null || typeof v === 'string';
+
 const fail = (id: string | undefined, field: string, condition: string): never => {
   const idLabel = id === undefined ? '?' : `"${id}"`;
   throw new Error(`scene ${idLabel} is invalid: ${field} ${condition}`);
 };
+
+interface FieldGuard {
+  readonly field: keyof SceneModule;
+  readonly check: (v: Record<string, unknown>) => boolean;
+  readonly condition: string;
+}
+
+const FIELD_GUARDS: readonly FieldGuard[] = [
+  { field: 'id', check: (v) => typeof v.id === 'string', condition: 'must be a string' },
+  { field: 'title', check: (v) => typeof v.title === 'string', condition: 'must be a string' },
+  {
+    field: 'duration',
+    check: (v) => isValidDuration(v.duration),
+    condition: 'must be a non-negative integer (ms) or null',
+  },
+  { field: 'tags', check: (v) => isStringArray(v.tags), condition: 'must be an array of strings' },
+  {
+    field: 'assets',
+    check: (v) => isStringArray(v.assets),
+    condition: 'must be an array of strings',
+  },
+  {
+    field: 'captions',
+    check: (v) => isCaptionArray(v.captions),
+    condition: 'must be an array of {at: number, text: string}',
+  },
+  {
+    field: 'defaultNext',
+    check: (v) => isStringOrNull(v.defaultNext),
+    condition: 'must be a string or null',
+  },
+  {
+    field: 'standalone',
+    check: (v) => typeof v.standalone === 'boolean',
+    condition: 'must be a boolean',
+  },
+  {
+    field: 'trailerSafe',
+    check: (v) => typeof v.trailerSafe === 'boolean',
+    condition: 'must be a boolean',
+  },
+  {
+    field: 'create',
+    check: (v) => typeof v.create === 'function',
+    condition: 'must be a function',
+  },
+  {
+    field: 'timeline',
+    check: (v) => typeof v.timeline === 'function',
+    condition: 'must be a function',
+  },
+  {
+    field: 'cleanup',
+    check: (v) => typeof v.cleanup === 'function',
+    condition: 'must be a function',
+  },
+];
 
 /**
  * Validates that `value` satisfies the {@link SceneModule} contract.
@@ -112,9 +170,9 @@ export function assertSceneModule(value: unknown): asserts value is SceneModule 
     throw new Error('scene ? is invalid: value must be a non-null object');
   }
 
-  // Capture id for error messages when it is present and a string.
-  // If id is missing or wrong-typed, the relevant check below raises
-  // with `?` as the entity label.
+  // Capture id for error messages when present and a string. If id is
+  // missing or wrong-typed, the corresponding guard below raises with
+  // `?` as the entity label.
   const id = typeof value.id === 'string' ? value.id : undefined;
 
   for (const field of REQUIRED_FIELDS) {
@@ -123,29 +181,11 @@ export function assertSceneModule(value: unknown): asserts value is SceneModule 
     }
   }
 
-  if (typeof value.id !== 'string') fail(id, 'id', 'must be a string');
-  if (typeof value.title !== 'string') fail(id, 'title', 'must be a string');
-
-  if (!isValidDuration(value.duration)) {
-    fail(id, 'duration', 'must be a non-negative integer (ms) or null');
+  for (const guard of FIELD_GUARDS) {
+    if (!guard.check(value)) {
+      fail(id, guard.field, guard.condition);
+    }
   }
-
-  if (!isStringArray(value.tags)) fail(id, 'tags', 'must be an array of strings');
-  if (!isStringArray(value.assets)) fail(id, 'assets', 'must be an array of strings');
-  if (!isCaptionArray(value.captions)) {
-    fail(id, 'captions', 'must be an array of {at: number, text: string}');
-  }
-
-  if (value.defaultNext !== null && typeof value.defaultNext !== 'string') {
-    fail(id, 'defaultNext', 'must be a string or null');
-  }
-
-  if (typeof value.standalone !== 'boolean') fail(id, 'standalone', 'must be a boolean');
-  if (typeof value.trailerSafe !== 'boolean') fail(id, 'trailerSafe', 'must be a boolean');
-
-  if (typeof value.create !== 'function') fail(id, 'create', 'must be a function');
-  if (typeof value.timeline !== 'function') fail(id, 'timeline', 'must be a function');
-  if (typeof value.cleanup !== 'function') fail(id, 'cleanup', 'must be a function');
 }
 
 /**

--- a/src/runtime/scene.ts
+++ b/src/runtime/scene.ts
@@ -1,0 +1,163 @@
+// Scene module contract — PUL-F001.
+//
+// Single source of truth for the shape every scene module exports.
+// Per ADR-002 the scene/composition model treats this object as the
+// scene's canonical metadata; per ADR-008 the runtime validates the
+// shape before mounting so cleanup leaks, dangling assets, and id
+// collisions surface loudly.
+//
+// Downstream consumers (registry, composition resolver, exporter)
+// must call assertSceneModule rather than re-implementing checks.
+
+/**
+ * Caption metadata. ADR-002 specifies `{ at: ms, text }`. The prompter,
+ * the live runtime, and the export pipeline all consume this same
+ * structure (PUL-A009).
+ */
+export interface Caption {
+  at: number;
+  text: string;
+}
+
+/**
+ * Scene context passed to the lifecycle functions. Refined by PUL-F002
+ * (registry lifecycle) and ADR-003 / ADR-004 (timeline + audio surface
+ * via `ctx.gsap`, `ctx.audio`). Until then, lifecycle implementations
+ * should treat the value as opaque.
+ */
+export type SceneContext = unknown;
+
+export type SceneLifecycleFn = (ctx: SceneContext) => unknown;
+
+/**
+ * The contract every scene module exports per PUL-F001.
+ *
+ *  - `id`, `title`: stable identity + human-readable label.
+ *  - `duration`: non-negative integer milliseconds, or `null` for
+ *     open-ended / interrupt-driven scenes.
+ *  - `tags`, `assets`, `captions`: metadata consumed by prompter,
+ *     preloader, exporter — declared once on the module.
+ *  - `defaultNext`: successor scene id, or `null` for "no default".
+ *     Sequencing belongs to the composition layer (ADR-002 / PUL-A005);
+ *     this field is metadata, not flow control.
+ *  - `standalone`: explicit assertion that the scene can run without
+ *     surrounding context (ADR-008).
+ *  - `trailerSafe`: explicit assertion that the scene can be cut into
+ *     a trailer without context.
+ *  - `create` / `timeline` / `cleanup`: lifecycle hooks. Cleanup is
+ *     mandatory per PUL-P001.
+ */
+export interface SceneModule {
+  id: string;
+  title: string;
+  duration: number | null;
+  tags: readonly string[];
+  assets: readonly string[];
+  captions: readonly Caption[];
+  defaultNext: string | null;
+  standalone: boolean;
+  trailerSafe: boolean;
+  create: SceneLifecycleFn;
+  timeline: SceneLifecycleFn;
+  cleanup: SceneLifecycleFn;
+}
+
+const REQUIRED_FIELDS = [
+  'id',
+  'title',
+  'duration',
+  'tags',
+  'assets',
+  'captions',
+  'defaultNext',
+  'standalone',
+  'trailerSafe',
+  'create',
+  'timeline',
+  'cleanup',
+] as const satisfies readonly (keyof SceneModule)[];
+
+const isPlainObject = (v: unknown): v is Record<string, unknown> =>
+  typeof v === 'object' && v !== null && !Array.isArray(v);
+
+const isStringArray = (v: unknown): v is readonly string[] =>
+  Array.isArray(v) && v.every((e) => typeof e === 'string');
+
+const isValidDuration = (v: unknown): v is number | null =>
+  v === null || (typeof v === 'number' && Number.isInteger(v) && Number.isFinite(v) && v >= 0);
+
+const isCaption = (v: unknown): v is Caption =>
+  isPlainObject(v) && typeof v.at === 'number' && typeof v.text === 'string';
+
+const isCaptionArray = (v: unknown): v is readonly Caption[] =>
+  Array.isArray(v) && v.every(isCaption);
+
+const fail = (id: string | undefined, field: string, condition: string): never => {
+  const idLabel = id === undefined ? '?' : `"${id}"`;
+  throw new Error(`scene ${idLabel} is invalid: ${field} ${condition}`);
+};
+
+/**
+ * Validates that `value` satisfies the {@link SceneModule} contract.
+ * Throws `Error` with a message identifying the offending field and
+ * condition.
+ *
+ * Per the codex preflight guardrails, this is the single source of
+ * truth for scene shape. Downstream consumers (registry, composition
+ * resolver, exporter) call this once at the boundary rather than
+ * re-validating piecemeal.
+ */
+export function assertSceneModule(value: unknown): asserts value is SceneModule {
+  if (!isPlainObject(value)) {
+    throw new Error('scene ? is invalid: value must be a non-null object');
+  }
+
+  // Capture id for error messages when it is present and a string.
+  // If id is missing or wrong-typed, the relevant check below raises
+  // with `?` as the entity label.
+  const id = typeof value.id === 'string' ? value.id : undefined;
+
+  for (const field of REQUIRED_FIELDS) {
+    if (!Object.hasOwn(value, field)) {
+      fail(id, field, 'must be present');
+    }
+  }
+
+  if (typeof value.id !== 'string') fail(id, 'id', 'must be a string');
+  if (typeof value.title !== 'string') fail(id, 'title', 'must be a string');
+
+  if (!isValidDuration(value.duration)) {
+    fail(id, 'duration', 'must be a non-negative integer (ms) or null');
+  }
+
+  if (!isStringArray(value.tags)) fail(id, 'tags', 'must be an array of strings');
+  if (!isStringArray(value.assets)) fail(id, 'assets', 'must be an array of strings');
+  if (!isCaptionArray(value.captions)) {
+    fail(id, 'captions', 'must be an array of {at: number, text: string}');
+  }
+
+  if (value.defaultNext !== null && typeof value.defaultNext !== 'string') {
+    fail(id, 'defaultNext', 'must be a string or null');
+  }
+
+  if (typeof value.standalone !== 'boolean') fail(id, 'standalone', 'must be a boolean');
+  if (typeof value.trailerSafe !== 'boolean') fail(id, 'trailerSafe', 'must be a boolean');
+
+  if (typeof value.create !== 'function') fail(id, 'create', 'must be a function');
+  if (typeof value.timeline !== 'function') fail(id, 'timeline', 'must be a function');
+  if (typeof value.cleanup !== 'function') fail(id, 'cleanup', 'must be a function');
+}
+
+/**
+ * Convenience type predicate. Returns `true` if `value` satisfies the
+ * scene module contract; `false` otherwise. Use {@link assertSceneModule}
+ * when the failure detail matters to the caller.
+ */
+export function isSceneModule(value: unknown): value is SceneModule {
+  try {
+    assertSceneModule(value);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/tests/runtime/scene.test.ts
+++ b/tests/runtime/scene.test.ts
@@ -1,0 +1,303 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type Caption,
+  type SceneModule,
+  assertSceneModule,
+  isSceneModule,
+} from '../../src/runtime/scene';
+
+const validScene = (): SceneModule => ({
+  id: 'scene-a',
+  title: 'Scene A',
+  duration: 5000,
+  tags: ['act-i'],
+  assets: [],
+  captions: [],
+  defaultNext: null,
+  standalone: true,
+  trailerSafe: false,
+  create: () => undefined,
+  timeline: () => undefined,
+  cleanup: () => undefined,
+});
+
+const REQUIRED_FIELDS = [
+  'id',
+  'title',
+  'duration',
+  'tags',
+  'assets',
+  'captions',
+  'defaultNext',
+  'standalone',
+  'trailerSafe',
+  'create',
+  'timeline',
+  'cleanup',
+] as const;
+
+const omitField = <K extends keyof SceneModule>(field: K): Record<string, unknown> => {
+  const scene: Record<string, unknown> = { ...validScene() };
+  delete scene[field as string];
+  return scene;
+};
+
+const withField = (field: string, value: unknown): Record<string, unknown> => ({
+  ...validScene(),
+  [field]: value,
+});
+
+const withDuration = (duration: unknown): Record<string, unknown> =>
+  withField('duration', duration);
+
+describe('SceneModule contract (PUL-F001)', () => {
+  describe('required fields are present', () => {
+    it('accepts a valid minimal scene module', () => {
+      expect(() => assertSceneModule(validScene())).not.toThrow();
+    });
+
+    it.each(REQUIRED_FIELDS)('rejects when "%s" is missing', (field) => {
+      expect(() => assertSceneModule(omitField(field))).toThrow(new RegExp(`\\b${field}\\b`));
+    });
+
+    it('rejects null input', () => {
+      expect(() => assertSceneModule(null)).toThrow(/object/i);
+    });
+
+    it('rejects undefined input', () => {
+      expect(() => assertSceneModule(undefined)).toThrow(/object/i);
+    });
+
+    it('rejects a string input', () => {
+      expect(() => assertSceneModule('not an object')).toThrow(/object/i);
+    });
+
+    it('rejects a number input', () => {
+      expect(() => assertSceneModule(42)).toThrow(/object/i);
+    });
+
+    it('rejects an array input', () => {
+      expect(() => assertSceneModule([])).toThrow(/object/i);
+    });
+  });
+
+  describe('duration rules', () => {
+    it('accepts 0', () => {
+      expect(() => assertSceneModule(withDuration(0))).not.toThrow();
+    });
+
+    it('accepts a positive integer (5000)', () => {
+      expect(() => assertSceneModule(withDuration(5000))).not.toThrow();
+    });
+
+    it('accepts null (open-ended / interrupt-driven)', () => {
+      expect(() => assertSceneModule(withDuration(null))).not.toThrow();
+    });
+
+    it('rejects a negative integer', () => {
+      expect(() => assertSceneModule(withDuration(-1))).toThrow(/duration/);
+    });
+
+    it('rejects a float', () => {
+      expect(() => assertSceneModule(withDuration(1.5))).toThrow(/duration/);
+    });
+
+    it('rejects NaN', () => {
+      expect(() => assertSceneModule(withDuration(Number.NaN))).toThrow(/duration/);
+    });
+
+    it('rejects Infinity', () => {
+      expect(() => assertSceneModule(withDuration(Number.POSITIVE_INFINITY))).toThrow(/duration/);
+    });
+
+    it('rejects -Infinity', () => {
+      expect(() => assertSceneModule(withDuration(Number.NEGATIVE_INFINITY))).toThrow(/duration/);
+    });
+
+    it('rejects undefined value', () => {
+      expect(() => assertSceneModule(withDuration(undefined))).toThrow(/duration/);
+    });
+
+    it('rejects a string', () => {
+      expect(() => assertSceneModule(withDuration('5000'))).toThrow(/duration/);
+    });
+
+    it('rejects boolean', () => {
+      expect(() => assertSceneModule(withDuration(true))).toThrow(/duration/);
+    });
+  });
+
+  describe('field types', () => {
+    it('rejects non-string id', () => {
+      expect(() => assertSceneModule(withField('id', 42))).toThrow(/id/);
+    });
+
+    it('rejects non-string title', () => {
+      expect(() => assertSceneModule(withField('title', 42))).toThrow(/title/);
+    });
+
+    it('rejects non-array tags', () => {
+      expect(() => assertSceneModule(withField('tags', 'not-an-array'))).toThrow(/tags/);
+    });
+
+    it('rejects non-string elements in tags', () => {
+      expect(() => assertSceneModule(withField('tags', [42]))).toThrow(/tags/);
+    });
+
+    it('rejects non-array assets', () => {
+      expect(() => assertSceneModule(withField('assets', 'not-an-array'))).toThrow(/assets/);
+    });
+
+    it('rejects non-string elements in assets', () => {
+      expect(() => assertSceneModule(withField('assets', [42]))).toThrow(/assets/);
+    });
+
+    it('rejects non-array captions', () => {
+      expect(() => assertSceneModule(withField('captions', 'not-an-array'))).toThrow(/captions/);
+    });
+
+    it('rejects non-(string|null) defaultNext (number)', () => {
+      expect(() => assertSceneModule(withField('defaultNext', 42))).toThrow(/defaultNext/);
+    });
+
+    it('rejects non-(string|null) defaultNext (undefined value)', () => {
+      expect(() => assertSceneModule(withField('defaultNext', undefined))).toThrow(/defaultNext/);
+    });
+
+    it('accepts string defaultNext', () => {
+      expect(() => assertSceneModule(withField('defaultNext', 'next-scene'))).not.toThrow();
+    });
+
+    it('rejects non-boolean standalone', () => {
+      expect(() => assertSceneModule(withField('standalone', 'yes'))).toThrow(/standalone/);
+    });
+
+    it('rejects non-boolean trailerSafe', () => {
+      expect(() => assertSceneModule(withField('trailerSafe', 1))).toThrow(/trailerSafe/);
+    });
+
+    it('rejects non-function create', () => {
+      expect(() => assertSceneModule(withField('create', null))).toThrow(/create/);
+    });
+
+    it('rejects non-function timeline', () => {
+      expect(() => assertSceneModule(withField('timeline', null))).toThrow(/timeline/);
+    });
+
+    it('rejects non-function cleanup', () => {
+      expect(() => assertSceneModule(withField('cleanup', null))).toThrow(/cleanup/);
+    });
+  });
+
+  describe('caption element shape', () => {
+    const captionScene = (caption: unknown): Record<string, unknown> =>
+      withField('captions', [caption]);
+
+    it('accepts a valid caption', () => {
+      const cap: Caption = { at: 1000, text: 'hello' };
+      expect(() => assertSceneModule(captionScene(cap))).not.toThrow();
+    });
+
+    it('accepts multiple captions', () => {
+      expect(() =>
+        assertSceneModule(
+          withField('captions', [
+            { at: 0, text: 'opening hook' },
+            { at: 4000, text: 'first payoff' },
+          ]),
+        ),
+      ).not.toThrow();
+    });
+
+    it('rejects caption with non-number "at"', () => {
+      expect(() => assertSceneModule(captionScene({ at: '1000', text: 'hi' }))).toThrow(/captions/);
+    });
+
+    it('rejects caption with non-string "text"', () => {
+      expect(() => assertSceneModule(captionScene({ at: 1000, text: 42 }))).toThrow(/captions/);
+    });
+
+    it('rejects caption that is not an object', () => {
+      expect(() => assertSceneModule(captionScene('not-a-caption'))).toThrow(/captions/);
+    });
+
+    it('rejects caption that is null', () => {
+      expect(() => assertSceneModule(captionScene(null))).toThrow(/captions/);
+    });
+  });
+
+  describe('happy path', () => {
+    it('accepts a scene with duration=0', () => {
+      expect(() => assertSceneModule({ ...validScene(), duration: 0 })).not.toThrow();
+    });
+
+    it('accepts a scene with duration=null', () => {
+      expect(() => assertSceneModule({ ...validScene(), duration: null })).not.toThrow();
+    });
+
+    it('accepts a scene with defaultNext set to a sibling id', () => {
+      expect(() => assertSceneModule({ ...validScene(), defaultNext: 'scene-b' })).not.toThrow();
+    });
+
+    it('accepts a scene with all metadata populated', () => {
+      const scene: SceneModule = {
+        id: 'cold-open',
+        title: 'Cold Open',
+        duration: 12000,
+        tags: ['act-i', 'theme'],
+        assets: ['assets/cold-open/blackout.jpg', 'assets/audio/stinger.mp3'],
+        captions: [
+          { at: 0, text: 'Opening hook.' },
+          { at: 4000, text: 'First payoff.' },
+        ],
+        defaultNext: 'scene-a',
+        standalone: true,
+        trailerSafe: true,
+        create: () => undefined,
+        timeline: () => undefined,
+        cleanup: () => undefined,
+      };
+      expect(() => assertSceneModule(scene)).not.toThrow();
+    });
+  });
+
+  describe('isSceneModule predicate', () => {
+    it('returns true for a valid scene', () => {
+      expect(isSceneModule(validScene())).toBe(true);
+    });
+
+    it('returns false for an invalid scene', () => {
+      expect(isSceneModule({ ...validScene(), duration: -1 })).toBe(false);
+    });
+
+    it('returns false for null', () => {
+      expect(isSceneModule(null)).toBe(false);
+    });
+
+    it('returns false for undefined', () => {
+      expect(isSceneModule(undefined)).toBe(false);
+    });
+  });
+
+  describe('error messages identify the offending entity and condition', () => {
+    it('includes the scene id when known', () => {
+      expect(() => assertSceneModule({ ...validScene(), duration: -1 })).toThrow(
+        /scene "scene-a" is invalid/,
+      );
+    });
+
+    it('uses "?" for the entity when id is missing', () => {
+      expect(() => assertSceneModule(omitField('id'))).toThrow(/scene \? is invalid/);
+    });
+
+    it('names the offending field', () => {
+      expect(() => assertSceneModule({ ...validScene(), tags: 'oops' })).toThrow(/tags/);
+    });
+
+    it('describes the failing condition', () => {
+      expect(() => assertSceneModule({ ...validScene(), duration: 1.5 })).toThrow(
+        /non-negative integer/,
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements PUL-F001 — the canonical scene-module export shape. This is
the foundational runtime contract that PUL-F002 / PUL-F005 / PUL-F006 /
PUL-F027 all \`DEPENDS_ON\`.

- \`src/runtime/scene.ts\` — \`SceneModule\` interface, \`Caption\`,
  \`SceneContext\` (opaque until PUL-F002), \`SceneLifecycleFn\`,
  \`assertSceneModule\` runtime validator, \`isSceneModule\` predicate.
- \`tests/runtime/scene.test.ts\` — 62 clause-focused tests; 100%
  coverage of the validator.
- CHANGELOG entry under \`[Unreleased]\`.

Closes #6.

### Codex preflight guardrails honored

- One canonical contract boundary; downstream consumers call the same validator.
- \`duration\` strict: rejects \`undefined\`, \`NaN\`, \`Infinity\`,
  floats, negatives, strings, booleans. \`0\` and \`null\` accepted.
- \`defaultNext\` modeled as \`string | null\` metadata, not flow control.
- No new exception hierarchy — plain \`Error\` with messages identifying
  scene id + field + condition (foundation for PUL-Q005).
- Module shape only — no scene behavior, no DSL, no plugin system.

### Step 4.5 clause map

Every clause of PUL-F001 maps to specific code:

| Clause | Interface | Presence check | Type check |
|---|---|---|---|
| \`id\` field | \`scene.ts:51\` | \`scene.ts:120-124\` | \`scene.ts:126\` |
| \`title\` field | \`scene.ts:52\` | \`scene.ts:120-124\` | \`scene.ts:127\` |
| \`tags\` field | \`scene.ts:54\` | \`scene.ts:120-124\` | \`scene.ts:133\` |
| \`assets\` field | \`scene.ts:55\` | \`scene.ts:120-124\` | \`scene.ts:134\` |
| \`captions\` field | \`scene.ts:56\` | \`scene.ts:120-124\` | \`scene.ts:135-137\` |
| \`defaultNext\` field | \`scene.ts:57\` | \`scene.ts:120-124\` | \`scene.ts:139-141\` |
| \`standalone\` field | \`scene.ts:58\` | \`scene.ts:120-124\` | \`scene.ts:143\` |
| \`trailerSafe\` field | \`scene.ts:59\` | \`scene.ts:120-124\` | \`scene.ts:144\` |
| \`create\` field | \`scene.ts:60\` | \`scene.ts:120-124\` | \`scene.ts:146\` |
| \`timeline\` field | \`scene.ts:61\` | \`scene.ts:120-124\` | \`scene.ts:147\` |
| \`cleanup\` field | \`scene.ts:62\` | \`scene.ts:120-124\` | \`scene.ts:148\` |
| \`duration\` present | \`scene.ts:53\` | \`scene.ts:120-124\` | — |
| \`duration\` non-neg int ms or \`null\` | — | — | \`scene.ts:86-87\` (helper), \`scene.ts:129-131\` (check) |

Tests covering every clause: \`tests/runtime/scene.test.ts\`.

## Test plan

- [x] Red phase: all 62 new tests fail before \`scene.ts\` exists (module-not-found)
- [x] Green phase: \`pnpm typecheck\`, \`pnpm lint\`, \`pnpm test\`, \`pnpm build\` all clean
- [x] 100% coverage on \`src/runtime/scene.ts\`
- [x] \`pre-commit run\` clean across all 12 hooks
- [ ] All six required CI status checks green
- [ ] SonarCloud quality gate stays GREEN

## After merge

- \`gc_transition_status\` PUL-F001 → ACTIVE
- IMPLEMENTS link → \`src/runtime/scene.ts\`
- TESTS link → \`tests/runtime/scene.test.ts\`
- Retry the GITHUB_ISSUE link to issue #6 (it failed at issue-create time
  while PUL-F001 was DRAFT)