### PR TITLE
Implement PUL-F002: scene registry

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -11,8 +11,6 @@ This skill handles the ENTIRE lifecycle: plan, implement, verify, commit, push, 
 
 **Every run is driven by a GitHub issue.** The issue is the durable artifact that records why the change is being made, what requirements are in scope (if any), and how completion is reviewed. `$ARGUMENTS` may be either a GitHub issue number OR a Ground Control requirement UID; in the UID case the skill finds or creates the matching issue and runs against it. Bug fixes, refactors, dependency updates, and other requirement-free work enter the same workflow via an issue with zero requirements in scope.
 
-This skill omits the end-of-flow Codex cross-model review. Test-quality review still runs.
-
 ---
 
 ## Phase A: Plan & Implement
@@ -62,9 +60,9 @@ This skill omits the end-of-flow Codex cross-model review. Test-quality review s
    - If a UID in the section fails to resolve via `gc_get_requirement`, stop and report the broken reference.
    - If the input was a requirement UID (Step 7), ensure that UID is in `in_scope_requirements[]` — add it if missing, which also means updating the issue body to include a Requirements section.
 
-10. **For each UID in `in_scope_requirements[]`**, fetch the full requirement via `gc_get_requirement` and cache its UUID, title, statement, status, and wave. You will use these for clause verification (Step 4.5), status transitions (Step 14), and traceability reconciliation (Step 15).
+10. **For each UID in `in_scope_requirements[]`**, fetch the full requirement via `gc_get_requirement` and cache its UUID, title, statement, status, and wave. You will use these for clause verification (Step 4.5), status transitions (Step 15), and traceability reconciliation (Step 16).
 
-11. **Fetch the existing traceability links for the issue** via `gc_get_traceability_by_artifact` with `artifact_type: GITHUB_ISSUE` and `artifact_identifier: <issue-number>`. Cache the result — you will need it to reconcile the issue's relationship to requirements in Step 15.
+11. **Fetch the existing traceability links for the issue** via `gc_get_traceability_by_artifact` with `artifact_type: GITHUB_ISSUE` and `artifact_identifier: <issue-number>`. Cache the result — you will need it to reconcile the issue's relationship to requirements in Step 16.
 
 12. **Switch to the issue's feature branch**: run `gh issue develop <issue-number> --checkout --base dev`. If the branch already exists, `gh` reuses it.
 
@@ -93,8 +91,17 @@ Preflight MUST cover every in-scope requirement, not just the first one. The pre
 
 Explore the codebase to determine whether the work described in the issue is already covered by existing code:
 - Search for relevant modules, functions, tests, and configurations touching the subsystems the issue describes.
-- Consult the repository knowledge base (`docs/knowledge/`) during exploration. Grep the knowledge index for keywords matching the issue's subject area and read any pages that match.
+- Consult the repository's existing documentation during exploration. Pulsar keeps design context in `docs/` — ADRs (`docs/adrs/`), design notes (`docs/design/`), the knowledge base (`docs/knowledge/`), and requirements (`docs/requirements/`). Grep these for keywords matching the issue's subject area and read any pages that match before designing changes.
 - Check if the described behavior already exists.
+- **Before designing new code, inventory the existing cross-cutting concerns the change will need.** Do not skip this — it is the single biggest defense against re-implementing helpers that already exist. For each concern the new code will touch, find and read the project's existing implementation:
+  - Logger (`logger = ...` patterns; project's chosen logging library; structured-logging conventions)
+  - Validation / schemas (Zod schemas, JSON Schema files, ground-control schema definitions, runtime validators like `assertSceneModule`)
+  - Error types and error-response builders
+  - Authentication / authorization helpers
+  - Configuration loaders and environment-variable access
+  - HTTP client wrappers, database session helpers, retry / backoff utilities
+  - Test fixtures, factory helpers, and mock builders
+  Use the existing helper. If you genuinely need a new one, justify the new helper in the plan (Step 4) and note why the existing one didn't fit. Re-implementing what's already there is the failure mode Step 12.5 is designed to catch — catch it here first.
 - For each requirement in `in_scope_requirements[]`, review its existing traceability links (IMPLEMENTS, TESTS) via `gc_get_traceability` on the requirement UUID. Some or all clauses may already be satisfied.
 - Reuse the architecture-preflight guidance from Step 2.5 while assessing existing coverage and planning changes.
 
@@ -105,13 +112,13 @@ Explore the codebase to determine whether the work described in the issue is alr
 - Your plans must respect the coding standards.
 - You must add or update ADRs as appropriate.
 - Plans must include updating the changelog, readme, and docs as appropriate.
-- If designing code, build off existing cross-cutting concerns, code, and patterns.
+- If designing code, remember to build off existing cross-cutting concerns, code, and patterns.
 - Good code is readable, maintainable, and follows the coding standards.
 - Address the concerns a senior engineer would have around security, performance, reliability, and scalability.
 - Avoid reinventing the wheel — use existing libraries and frameworks where appropriate.
 - Code should be easy to understand, test, and maintain. Simple is better than complex.
-- If Step 1.3 returned non-null `rules.plan_rules_content`, treat every bullet in that content as a mandatory plan constraint for this implementation. Apply all of them in addition to the general principles above.
-- **If the work is ALREADY complete**: Report that the issue is satisfied and identify which code satisfies it. If `in_scope_requirements[]` is non-empty, verify each requirement is already linked and ACTIVE; if not, continue to Steps 14–15 (transition then reconciliation) to fix the Ground Control state without re-implementing the code.
+- If Step 1.3 returned non-null `rules.plan_rules_content`, treat every bullet in that content as a mandatory plan constraint for this implementation. These are repo-specific "plans MUST..." rules (e.g., framework-specific migration rules, ADR conformance checks). Apply all of them in addition to the general principles above.
+- **If the work is ALREADY complete**: Report that the issue is satisfied and identify which code satisfies it. If `in_scope_requirements[]` is non-empty, verify each requirement is already linked and ACTIVE; if not, continue to Steps 15–16 (transition then reconciliation) to fix the Ground Control state without re-implementing the code.
 
 ### Step 4.4: Test-Driven Development (mandatory)
 
@@ -122,7 +129,7 @@ After plan approval, implement using **TDD**. This is not optional:
 3. **Refactor with the test green.** Clean up duplication, extract helpers, rename for clarity — but only with the safety net of green tests. Re-run the test after each refactor.
 4. **Repeat per clause / acceptance criterion / edge case.** Do not write a batch of production code first and then "fill in tests" afterwards — that is not TDD, it is post-hoc test-shaped coverage and fails to drive the design.
 5. **Edge cases and failure modes get tests too.** Validation errors, boundary inputs, conflict states, not-found paths, status transitions. If a behavior matters enough to ship, it matters enough for a red-green cycle.
-6. **Integration layers**: same loop. Write the failing test before the production code that satisfies it. Repository-policy rules from `.ground-control.yaml` are TDD targets, not afterthoughts.
+6. **Integration layers and framework-specific tests**: same loop. Write the failing test before the production code that satisfies it. Repository-policy rules from `.gc/plan-rules.md` are TDD targets, not afterthoughts.
 7. **If you discover during TDD that the plan is wrong**, stop and revise the plan rather than bending tests to match a flawed design. The tests are telling you something — listen to them.
 
 Pre-existing tests around touched code must stay green at every step. If a refactor breaks an unrelated test, fix the root cause; do not silence the test.
@@ -143,15 +150,15 @@ Before declaring implementation complete, build a mapping from every clause of e
 Present the mapping as a checklist with the requirement UID (or `issue`) as the source label:
 
 ```
-- [ ] PUL-F004 clause: "..." → Satisfied by: file.js:line
-- [ ] PUL-F004 clause: "..." → Satisfied by: file.js:line
-- [ ] PUL-F005 clause: "..." → Satisfied by: file.js:line
-- [ ] issue acceptance: "..." → Satisfied by: file.js:line
+- [ ] PUL-F004 clause: "..." → Satisfied by: src/runtime/<file>.ts:line
+- [ ] PUL-F004 clause: "..." → Satisfied by: tests/runtime/<file>.test.ts:line
+- [ ] PUL-F005 clause: "..." → Satisfied by: src/compositions/<file>.ts:line
+- [ ] issue acceptance: "..." → Satisfied by: vite.config.ts:line
 ```
 
 Do not proceed until every clause and criterion is checked off.
 
-Traceability reconciliation (IMPLEMENTS / TESTS links) and the `DRAFT → ACTIVE` status transitions are intentionally NOT done here. They land in Steps 14–15 after CI has passed, so Ground Control state never runs ahead of the actual code that ships.
+Traceability reconciliation (IMPLEMENTS / TESTS links) and the `DRAFT → ACTIVE` status transitions are intentionally NOT done here. They land in Steps 15–17 after CI and all reviews have passed, so Ground Control state never runs ahead of the actual code that ships.
 
 ---
 
@@ -159,7 +166,7 @@ Traceability reconciliation (IMPLEMENTS / TESTS links) and the `DRAFT → ACTIVE
 
 ### Step 5: Quality Assurance
 
-- Run `pre-commit run --all-files` to ensure the codebase is in a healthy state.
+- run `pre-commit run --all-files` to ensure the codebase is in a healthy state.
 
 ### Step 6: Completion Gate
 
@@ -189,7 +196,7 @@ If any check fails, fix it before proceeding. Do NOT move to Phase C until every
 
 ### Step 8: Commit & Push
 
-1. Craft a concise commit message in imperative mood. Example: "Add scene registry validation pass"
+1. Craft a concise commit message in imperative mood (per coding standards). Example: "Add scene registry validation pass"
 2. NEVER include Co-Authored-By, "Generated with Claude Code", or any Claude/AI attribution in commit messages.
 3. `git commit -m "<message>"`
 4. `git push -u origin <branch>`
@@ -214,8 +221,8 @@ If any check fails, fix it before proceeding. Do NOT move to Phase C until every
 
 1. Find the latest workflow run: `gh run list --branch <branch> --limit 1 --json status,conclusion,databaseId,createdAt`. Cache the `databaseId` as `<id>` and the `createdAt` timestamp.
 2. **Poll** `gh run view <id> --json status,conclusion` every 15 seconds. Track wall-clock elapsed time since you started polling.
-3. **Queued-too-long guard.** If `status` is still `"queued"` after **5 minutes** of polling, STOP and report to the user that no runner accepted the job. Do NOT wait silently past this point.
-4. **In-progress cap.** If `status` is `"in_progress"`, keep polling. Total wall-clock cap including the queued window is **45 minutes**. If the run has not reached `"completed"` by then, STOP and surface the run URL to the user.
+3. **Queued-too-long guard.** If `status` is still `"queued"` after **5 minutes** of polling, STOP and report to the user that no runner accepted the job. Suggest they check the runner pool (`gh api /repos/<owner>/<repo>/actions/runners`) and confirm a runner is `online` and `idle` if the repo uses self-hosted runners, or check GitHub-hosted runner availability otherwise. Do NOT wait silently past this point.
+4. **In-progress cap.** If `status` is `"in_progress"`, keep polling. Total wall-clock cap including the queued window is **45 minutes**. If the run has not reached `"completed"` by then, STOP and surface the run URL to the user — something is wrong with the runner or the workflow.
 5. When `status` becomes `"completed"`:
    - If `conclusion` is `"success"`, proceed.
    - Otherwise, get failed logs: `gh run view <id> --log-failed`. Diagnose, fix, `git add`, `git commit`, `git push`, and go back to step 1 of this phase.
@@ -240,7 +247,7 @@ Otherwise:
    - Request every page until all issues are retrieved (`ps=500` plus `p=2,3,...` until `total` is covered). Do not truncate.
    - Repeat the same query with `types=SECURITY_HOTSPOT` via `api/hotspots/search?projectKey=...&pullRequest=...&status=TO_REVIEW` so security hotspots are not missed — they are a separate endpoint from plain issues.
 
-4. **Fix ALL open issues the query returns — code-smell, bug, vulnerability, and security hotspot, regardless of severity (INFO through BLOCKER).** No "low priority", "out of scope", "follow-up PR", or "style-only" deferrals. If you believe a specific finding should be left unfixed (false positive, intentional pattern, etc.), STOP and ask the user for explicit permission before marking it resolved in SonarCloud or skipping it.
+4. **Fix every open issue the query returns — code-smell, bug, vulnerability, and security hotspot, every severity from INFO to BLOCKER, pre-existing or not.** Same rule as the review loop below. If you think a finding is dangerous to fix, unwise in context, or a false positive, STOP and ask the user. Wait for their answer; do not push commits while the question is open.
 
 5. For each fix cycle:
    - Apply the fixes.
@@ -255,56 +262,126 @@ Otherwise:
 
 ## Review loop rules (apply to every review step in this phase)
 
-The test quality review step below follows this **loop**:
+Every review step below (Codex cross-model, refactor / cross-cutting concerns, test quality review) follows the **same loop**:
 
 1. **Invoke the review.**
 2. **Read the FULL output.** Do not stop after the first few findings.
-3. **Fix ALL issues the reviewer identifies — blocking or not, severity-rated or not, "nitpick" or not.** There is no triage bucket. "Low priority", "nice to have", "follow-up PR", "out of scope" are not valid reasons to skip a finding.
-4. **If you cannot or believe you should not fix a specific finding**, you MUST stop and ask the user for explicit permission to leave it unfixed. State the finding, why you think it should be skipped, and wait for the user's answer. Resume only after they explicitly confirm.
-5. **Re-run the SAME review after fixing.** Do not assume your fixes are complete — the re-run is the verification.
-6. **Repeat until the reviewer reports zero findings, OR the cycle cap is hit.**
-7. **Cycle cap: 5 iterations.** If the review still reports findings after 5 invoke→fix→re-run cycles, STOP and escalate to the user with the full history of findings, fixes, and remaining issues.
+3. **Fix every finding, pre-existing or not.** If you think a finding is dangerous to fix, unwise in context, or a false positive, STOP and ask the user. Wait for their answer; do not push commits while the question is open.
+4. **Re-run the SAME review after fixing.** Do not assume your fixes are complete — the re-run is the verification.
+5. **Repeat until the reviewer reports zero findings, OR the cycle cap is hit.**
+6. **Cycle cap: 5 iterations per review step.** If a review still reports findings after 5 invoke→fix→re-run cycles, STOP and escalate to the user with the full history of findings, fixes, and remaining issues. Do not loop indefinitely.
 
-For every cycle, after applying fixes, commit and push BEFORE re-running the review so the reviewer sees the updated tree. Format every fix commit as `Fix review findings (review-tests, cycle <N>)` so the loop history is visible in git log.
+For every cycle, after applying fixes, commit and push BEFORE re-running the review so the reviewer sees the updated tree. Format every fix commit as `Fix review findings (<reviewer>, cycle <N>)` so the loop history is visible in git log.
 
-### Step 12: Test Quality Review
+### Step 12: Cross-Model Review (Codex)
+
+`gc_codex_review` runs two focused codex reviewers — a core production-readiness reviewer and a dedicated application-security reviewer — against a single pre-computed diff. By default the reviewers run sequentially (set `GC_CODEX_REVIEW_PARALLEL=2` to opt back into parallel execution). Both post their findings as inline PR review comments with a reviewer-tagged title (`[core]` or `[security]`). The tool returns a single deduplicated list; you then drive a per-finding fix/verify loop via `gc_codex_verify_finding`, which handles the GitHub API bookkeeping for you.
+
+1. Run `pwd` to capture the absolute repository root.
+2. Determine the pull request number for the current branch: `gh pr view --json number`. Cache it.
+3. Call the `gc_codex_review` MCP tool with:
+   - `repo_path`: absolute path from `pwd`
+   - `base_branch`: `dev`
+   - `pr_number`: the PR number from step 2
+4. The tool returns `{pr_number, finding_count, comments: [{comment_id, thread_id, reviewer, path, line, title, html_url}, ...], reviewers, core_review_text, security_review_text}`. Each comment carries a `reviewer` field (`core` or `security`) so you can triage attention, but the fix/verify loop below is the same regardless. Codex has already posted each finding as an inline PR review comment — you do NOT need to post anything yourself.
+5. If `finding_count` is 0, skip to Step 13.
+6. Otherwise, for EACH entry in `comments`, run the following fix/verify loop:
+   1. Read the comment body if needed: `gh api /repos/<owner>/<repo>/pulls/comments/<comment_id>`.
+   2. Fix the finding locally. Apply the **Review loop rules** above: fix every finding, pre-existing or not; STOP and ask the user only if you think a specific finding is dangerous to fix, unwise in context, or a false positive.
+   3. Run the local completion gate to make sure nothing regressed locally.
+   4. Call `gc_codex_verify_finding` with `repo_path`, `pr_number`, and the `comment_id`. Codex will read your local changes and decide:
+      - **`status: "resolved"`** — the review thread has already been marked resolved on GitHub. Move on to the next comment.
+      - **`status: "unresolved"`** — codex posted a threaded reply with `reply_body` containing concrete new directions. Read `reply_body`, fix per those directions, and re-invoke `gc_codex_verify_finding`. **Per-finding cap: 2 verify calls.** If the third call would be needed, STOP and escalate to the user with the finding, your fix history, and the latest `reply_body`.
+7. After all findings in the returned `comments` list are marked `resolved`, commit and push the fixes (one commit per fix cycle, message `Fix review findings (codex, cycle <N>)`), then re-invoke `gc_codex_review` with the same arguments to confirm no new issues surfaced after your fixes.
+8. **Overall step cap: 3 iterations of `gc_codex_review`.** Tightened from 5 — if the third invocation still returns findings, the diff has structural issues that need a human conversation, not another auto-fix pass. STOP and escalate to the user with the full history of findings, fixes, and remaining issues.
+
+**Tool shape**: `gc_codex_verify_finding` accepts only `repo_path`, `pr_number`, and `comment_id`. It reads the comment directly from GitHub; do not try to paraphrase the finding or pass additional context through the tool.
+
+### Step 12.5: Refactor & Cross-Cutting Concerns Review
+
+This review is the corrective for two systemic failure modes that bloat the codebase if left unchecked: **god classes / god methods / god functions / oversized files**, and **rebuilding helpers locally** instead of using the cross-cutting concerns the codebase already has (project logger, validation schemas, error types, config loaders, HTTP/DB session wrappers, test fixtures). Both compound silently if every PR adds another instance.
+
+**Every finding gets fixed, pre-existing or not.** This applies to bloat in any file the PR touched: "it was already like that" is not a valid skip — the goal is to sort the codebase out as we go, not to ratchet quality down by deferring. If you think a specific finding is dangerous to fix, unwise in context, or a false positive, STOP and ask the user. Wait for their answer; do not push commits while the question is open.
+
+#### Run the review
+
+Run a refactor-focused codex review against the PR diff. Mechanism (in order of preference):
+
+1. **`gc_codex_review`** if it exposes a refactor reviewer set (`reviewer_set: "refactor"` or equivalent). Same fix/verify loop machinery as Step 12.
+2. **Direct codex invocation** via Bash (`codex exec`) using the prompt template below. Post findings as PR review comments yourself; track them through the same fix loop.
+3. **Subagent fallback** via the Agent tool (`subagent_type: general-purpose`) with the prompt template below. Have the subagent return findings as a structured markdown list; you walk the list applying fixes.
+
+Use the same prompt regardless of mechanism:
+
+```
+Review PR #<N> (diff: `gh pr diff <N>`, branch: <branch-name>) for refactor and cross-cutting-concerns issues. Anchor every finding to a specific file:line range.
+
+Scope: every PRODUCTION file the PR added or modified (skip pure test files, doc files, and configuration). Pre-existing bloat in those files IS in scope — if a file the PR touched contains a god unit or a duplicated helper, surface it regardless of whether the PR introduced it.
+
+For each file, check:
+
+1. **God units.** Flag any single file > 400 LOC, any function/method > 80 LOC or with cyclomatic complexity ≥ 10, any class with > 15 public methods, any unit carrying multiple unrelated responsibilities. For each, propose a concrete extraction: which lines move where, what the resulting unit's single responsibility is.
+
+2. **Cross-cutting concern reuse.** SEARCH THE REPO before flagging — if the existing helper exists, name it (file:line). Check that the PR's new code uses, not re-implements:
+   - The project's logger
+   - Validation schemas (Pydantic / Zod / JSON Schema)
+   - Error types and error-response builders
+   - Auth / authz helpers
+   - Configuration loaders and env-var access
+   - HTTP client / DB session wrappers, retry / backoff utilities
+   - Test fixtures, factory helpers, mock builders
+   For each duplication, show the offending new code AND the existing helper that should be used instead.
+
+3. **Modularity & testability.** Flag code that mixes I/O with pure logic (extract pure functions), code that requires heavy mocking to test, code with implicit shared mutable state. Suggest the explicit-interface refactor.
+
+Return findings as markdown, one per finding:
+- `file:line-range` — `category` — concrete fix (specific extraction targets, specific existing helper file:line to reuse).
+```
+
+#### Fix loop
+
+Apply the **Review loop rules** (above Step 12). Fix every finding the review surfaces. After fixes, commit with message `Refactor per review (cycle <N>)` and re-run the review. If you genuinely believe a specific finding should be left unfixed, STOP and ask the user — do not decide unilaterally — but the default answer is always fix.
+
+**Cycle cap: 2 iterations.** Tight by design — if a second pass still surfaces findings, the diff has structural issues that need a design conversation, not another auto-fix pass. STOP and escalate to the user with the full finding history.
+
+### Step 13: Test Quality Review
 
 **CRITICAL: You MUST use the Skill tool to invoke the review-tests skill.**
 
 1. Call the Skill tool with `skill="review-tests"` to invoke the test quality review.
-2. Apply the **Review loop rules** above: fix every finding, ask user permission for anything you will not fix (including "warning" level — there is no triage bucket), re-invoke `skill="review-tests"` after each fix cycle, cap at 5 cycles.
+2. Apply the **Review loop rules** above: fix every finding, pre-existing or not, including "warning" level. STOP and ask the user only if you think a specific finding is dangerous to fix, unwise in context, or a false positive. Re-invoke `skill="review-tests"` after each fix cycle, cap at 5 cycles.
 
-### Step 13: Final CI re-verification
+### Step 14: Final CI re-verification
 
-After the test quality review (Step 12) has reported zero findings (or you have documented user-approved exceptions):
+After both review steps (12-13) have reported zero findings (or you have documented user-approved exceptions):
 
 1. Verify the branch is pushed with the latest fix commits.
 2. Re-run Step 10 (CI Monitor) to confirm CI is still green after the review fixes.
 3. Re-run Step 11 (SonarCloud) — or skip again if `sonarcloud` was null.
-4. If either re-check fails, loop back through the test quality review — the cycle cap (5) applies per review step, not total.
+4. If either re-check fails, loop back through the appropriate review step — the cycle cap (5) applies per review step, not total.
 
-### Step 14: Transition In-Scope Requirements to ACTIVE
+### Step 15: Transition In-Scope Requirements to ACTIVE
 
-The status transition MUST happen BEFORE traceability reconciliation (Step 15). The Ground Control API enforces `IMPLEMENTS → ACTIVE`: any `gc_create_traceability_link` call with `link_type: IMPLEMENTS` against a `DRAFT` requirement returns `422 requirement_not_active`. Reconciling first therefore produces silent-looking failures; transitioning first is the only order that actually works.
+The status transition MUST happen BEFORE traceability reconciliation (Step 16). The Ground Control API enforces `IMPLEMENTS → ACTIVE`: any `gc_create_traceability_link` call with `link_type: IMPLEMENTS` against a `DRAFT` requirement returns `422 requirement_not_active`. Reconciling first therefore produces 10+ silent-looking failures; transitioning first is the only order that actually works.
 
-Semantically, moving a requirement from DRAFT to ACTIVE is the point at which the team commits to its statement. Once real code exists pointing at it, the requirement is no longer a proposal — it's a contract. The transition locks in the statement, and the subsequent reconciliation in Step 15 records the code that fulfills it.
+Semantically, moving a requirement from DRAFT to ACTIVE is the point at which the team commits to its statement. Once real code exists pointing at it, the requirement is no longer a proposal — it's a contract. The transition locks in the statement, and the subsequent reconciliation in Step 16 records the code that fulfills it.
 
 For each UID in `in_scope_requirements[]`:
 - Use the `gc_transition_status` MCP tool to transition the requirement from `DRAFT` to `ACTIVE`.
 - If the requirement was already `ACTIVE`, skip it.
 - If the requirement was in any other state (`DEPRECATED`, `ARCHIVED`), STOP and surface the anomaly to the user — transitioning out of those states is a user decision.
 
-If `in_scope_requirements[]` is empty, this step is a no-op (bug/refactor/maintenance run with no formal requirements). Proceed to Step 15 anyway — the reconciliation step still needs to run to catch drift on other requirements whose files this diff touched.
+If `in_scope_requirements[]` is empty, this step is a no-op (bug/refactor/maintenance run with no formal requirements). Proceed to Step 16 anyway — the reconciliation step still needs to run to catch drift on other requirements whose files this diff touched.
 
-### Step 15: Reconcile Traceability Links Against the Diff
+### Step 16: Reconcile Traceability Links Against the Diff
 
-Now that CI and the test quality review are green AND every in-scope requirement is ACTIVE, reconcile the Ground Control traceability graph against the actual diff. This MUST happen AFTER Step 14 (transition) and BEFORE Step 18 (Report). Doing the reconciliation earlier either fails outright (IMPLEMENTS against DRAFT) or records links against unproven code if the review cycle rejects the work.
+Now that CI and all reviews are green AND every in-scope requirement is ACTIVE, reconcile the Ground Control traceability graph against the actual diff. This MUST happen AFTER Step 15 (transition) and BEFORE Step 19 (Report). Doing the reconciliation earlier either fails outright (IMPLEMENTS against DRAFT) or records links against unproven code if the review cycle rejects the work.
 
 **Reconciliation is not the same as "create links for the in-scope requirements"**. Even runs with zero in-scope requirements (pure bug fixes, refactors, maintenance) must reconcile, because the diff may have touched files that were already linked to OTHER requirements and those links may now be stale.
 
 1. **Compute the touched file set.** Run `git diff --name-status <base-ref>...HEAD` to get every added (`A`), modified (`M`), deleted (`D`), renamed (`R`), and copied (`C`) file in this branch. Cache the full list.
 
-   Resolve `<base-ref>` in this order so reconciliation works in fully-hydrated GitHub clones, local-only checkouts, and disconnected workstations:
+   Resolve `<base-ref>` in the same order the codex review already uses so reconciliation works in fully-hydrated GitHub clones, local-only checkouts, and disconnected workstations:
    1. `origin/dev` — the canonical remote-tracking ref. Verify it exists with `git rev-parse --verify origin/dev` before using.
    2. `dev` — the local branch. Verify with `git rev-parse --verify dev`.
    3. `origin/main` — fallback for repos whose default base is not `dev`.
@@ -345,7 +422,7 @@ Now that CI and the test quality review are green AND every in-scope requirement
      - **Configuration requirements** (repo config, workflow config, policy files, ground-control.yaml sections) — IMPLEMENTS points at the config file or schema file that encodes the requirement.
      - **Workflow requirements** (CI steps, hooks, policy rules) — IMPLEMENTS points at the workflow file, hook script, or policy script.
      If the diff does not touch any file that implements a given in-scope requirement, either add the implementation (go back to Step 4) or the requirement is not actually in scope and should be removed from the issue body before reconciliation proceeds.
-   - **TESTS coverage is conditional.** Add a TESTS link when the diff introduces or touches an automated test that verifies the requirement — unit test, integration test, policy test, property test, or any other form of executable verification. TESTS is NOT required when the requirement is satisfied purely by documentation, configuration, or structural invariants that have no executable behavior to test. In that case the IMPLEMENTS link alone is the complete coverage record.
+   - **TESTS coverage is conditional.** Add a TESTS link when the diff introduces or touches an automated test that verifies the requirement — vitest unit/integration test, property test, or any other form of executable verification. TESTS is NOT required when the requirement is satisfied purely by documentation, configuration, or structural invariants that have no executable behavior to test (for example: "the repo shall declare its sonar config in `.ground-control.yaml`"). In that case the IMPLEMENTS link alone is the complete coverage record.
    - **Do not fabricate test links** just to satisfy this step. If a requirement has testable behavior and no test was added, go back to Step 4.4 (TDD) and add the missing test; do not paper over the gap with a link to an unrelated file.
    - **Never link the diff to a requirement it does not satisfy** just to satisfy this step. Ripping out real coverage and linking a plausible-looking neighbor is worse than leaving a gap — STOP and surface the mismatch to the user instead.
 
@@ -359,25 +436,25 @@ Now that CI and the test quality review are green AND every in-scope requirement
 6. **Reconcile the issue → requirement links (both directions).**
    The `## Requirements` section of the issue body is the source of truth for which requirements this issue covers. Reconciliation must make the Ground Control graph match that list exactly — which means both adding missing links AND deleting stale ones.
    - **Add missing links.** For each UID in `in_scope_requirements[]`, ensure there is a traceability link with `artifact_type: GITHUB_ISSUE` and `artifact_identifier: <issue-number>` on the requirement, pointing at this run's issue. Create it via `gc_create_traceability_link` if missing.
-   - **Delete stale links.** Call `gc_get_traceability_by_artifact` with `artifact_type: GITHUB_ISSUE` and `artifact_identifier: <issue-number>` to list every requirement currently linked to this issue. For each returned link, if the requirement UID is NOT in `in_scope_requirements[]`, delete the link via `gc_delete_traceability_link`. This catches the case where an issue was narrowed down and leaves no orphan pointers.
+   - **Delete stale links.** Call `gc_get_traceability_by_artifact` with `artifact_type: GITHUB_ISSUE` and `artifact_identifier: <issue-number>` to list every requirement currently linked to this issue. For each returned link, if the requirement UID is NOT in `in_scope_requirements[]`, delete the link via `gc_delete_traceability_link`. This catches the case where an issue was narrowed from `[PUL-A, PUL-B]` down to `[PUL-A]` and leaves no orphan pointers from PUL-B.
    - Stale links from the current issue to requirements in `in_scope_requirements[]` (a no-op) are fine; duplicate-create is intentionally rejected by `gc_create_traceability_link`, so re-adding is safe.
 
 Reconciliation is idempotent: running it on a branch where the GC graph is already correct is a no-op. Running it on a branch where the graph has drifted fixes the drift in both directions.
 
-### Step 16: Verify Ground Control State Landed
+### Step 17: Verify Ground Control State Landed
 
 1. For each UID in `in_scope_requirements[]`:
-   - Re-fetch with `gc_get_requirement` and confirm status is `ACTIVE` (Step 14 should have transitioned it).
-   - Re-fetch with `gc_get_traceability` and confirm the expected IMPLEMENTS, TESTS, and GITHUB_ISSUE links are present (Step 15 should have recorded them).
-2. Re-run the deleted/renamed/modified audit from Step 15 point-by-point: every file in the diff should either have up-to-date links or have been intentionally left un-linked.
-3. If anything is missing or still drifted, loop back to the responsible step and fix: Step 14 for status drift, Step 15 for link drift. Do not proceed to Step 17 (close issue) or Step 18 (report) until Ground Control state matches reality across every file in the diff and every in-scope requirement.
-4. **Never declare success on silent failures.** If any `gc_create_traceability_link` / `gc_delete_traceability_link` / `gc_transition_status` call returned a non-2xx response during Steps 14–15, treat that as a failure, surface the error to the user if it is not clearly fixable, and loop back to correct the root cause. A batch of 10 parallel calls where 7 succeeded and 3 failed is not "mostly done" — it's broken.
+   - Re-fetch with `gc_get_requirement` and confirm status is `ACTIVE` (Step 15 should have transitioned it).
+   - Re-fetch with `gc_get_traceability` and confirm the expected IMPLEMENTS, TESTS, and GITHUB_ISSUE links are present (Step 16 should have recorded them).
+2. Re-run the deleted/renamed/modified audit from Step 16 point-by-point: every file in the diff should either have up-to-date links or have been intentionally left un-linked.
+3. If anything is missing or still drifted, loop back to the responsible step and fix: Step 15 for status drift, Step 16 for link drift. Do not proceed to Step 18 (close issue) or Step 19 (report) until Ground Control state matches reality across every file in the diff and every in-scope requirement.
+4. **Never declare success on silent failures.** If any `gc_create_traceability_link` / `gc_delete_traceability_link` / `gc_transition_status` call returned a non-2xx response during Steps 15–16, treat that as a failure, surface the error to the user if it is not clearly fixable (e.g., a permission issue or an API constraint you cannot work around), and loop back to correct the root cause. A batch of 10 parallel calls where 7 succeeded and 3 failed is not "mostly done" — it's broken.
 
-### Step 17: Close the Issue
+### Step 18: Close the Issue
 
 Close the GitHub issue now via `gh issue close <issue-number>`. The work is done, the PR records it, and GitHub's auto-close on merge is unreliable — close it yourself.
 
-### Step 18: Report (DO NOT MERGE)
+### Step 19: Report (DO NOT MERGE)
 
 **You MUST NOT merge the PR. You MUST NOT run `gh pr merge`. The user reviews and merges.**
 
@@ -386,6 +463,7 @@ Provide a final summary:
 - `in_scope_requirements[]` — each UID + title, with its new status
 - Files created, modified, renamed, or deleted
 - Traceability reconciliation summary — how many links were added, deleted, updated, and which requirements gained coverage
+- Review findings and fixes (if any)
 - Test quality review findings and fixes (if any)
 - Confirmation: CI green, SonarCloud passed (or skipped if not configured), PR ready for user review
 - PR URL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   registry / §Navigation, ADR-008 #2 "manifests over flow control"):
   scene id is the source of truth for addressability and the registry
   is the only navigation lookup path.
-- `tests/runtime/registry.test.ts` — 32-test Vitest spec covering both
+- `tests/runtime/registry.test.ts` — 35-test Vitest spec covering both
   clauses of PUL-F002: registry construction (happy paths over arrays,
   generators, sets), validation delegation to PUL-F001, duplicate-id
   rejection, lookup hits and misses, `has` semantics, insertion-order

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `src/runtime/registry.ts` — `SceneRegistry` interface and
+  `createSceneRegistry` factory. Builds a single in-memory registry
+  keyed by `scene.id`, delegating per-scene shape validation to
+  `assertSceneModule` (PUL-F001) and rejecting duplicate ids on
+  construction. The returned registry is frozen and exposes only
+  id-based lookup (`get`, `has`, `ids`, `size`) — no positional or
+  mutation API by design. Implements PUL-F002 (and ADR-002 §Scene
+  registry / §Navigation, ADR-008 #2 "manifests over flow control"):
+  scene id is the source of truth for addressability and the registry
+  is the only navigation lookup path.
+- `tests/runtime/registry.test.ts` — 32-test Vitest spec covering both
+  clauses of PUL-F002: registry construction (happy paths over arrays,
+  generators, sets), validation delegation to PUL-F001, duplicate-id
+  rejection, lookup hits and misses, `has` semantics, insertion-order
+  listing with caller-side mutation isolation, registry frozenness, and
+  structural absence of positional / mutation methods.
 - `src/runtime/scene.ts` — `SceneModule`, `Caption`, `SceneContext`,
   `SceneLifecycleFn` types plus `assertSceneModule` runtime validator
   and `isSceneModule` predicate. Implements the canonical scene-module

--- a/src/runtime/registry.ts
+++ b/src/runtime/registry.ts
@@ -1,0 +1,78 @@
+// Scene registry — PUL-F002.
+//
+// The runtime's single source of truth for what scenes exist and how
+// they are addressed. Per ADR-002, scenes are addressable by stable id
+// and there is no positional dispatch in the runtime core. Per ADR-008,
+// registries are manifests over flow control: built once at bootstrap,
+// validated up front, immutable thereafter.
+//
+// The registry delegates scene-shape validation to assertSceneModule
+// (PUL-F001) — there is one validator and the registry consumes it
+// rather than re-implementing it.
+
+import { type SceneModule, assertSceneModule } from './scene';
+
+/**
+ * The runtime's view of every scene that exists. Built by
+ * {@link createSceneRegistry}; the surface is intentionally small —
+ * lookup by id only — to satisfy PUL-F002's "only mechanism by which
+ * scenes are addressable for navigation" clause.
+ */
+export interface SceneRegistry {
+  /** Look up a scene by id. Throws if no scene is registered with that id. */
+  get(id: string): SceneModule;
+  /** Check whether a scene is registered with the given id. */
+  has(id: string): boolean;
+  /** Snapshot of registered scene ids in insertion order. The returned array is detached from the registry. */
+  ids(): readonly string[];
+  /** Number of scenes registered. */
+  readonly size: number;
+}
+
+/**
+ * Build a {@link SceneRegistry} from a collection of scene modules.
+ *
+ * Validation rules, applied in iteration order:
+ *  1. Each module must satisfy {@link assertSceneModule} (PUL-F001).
+ *  2. Scene ids must be unique within the registry — registration is by
+ *     id, so collisions are unrecoverable here. The first occurrence
+ *     wins detection: the duplicating scene raises the error.
+ *
+ * The returned registry is frozen and exposes only id-based lookup.
+ * There is no add/remove/positional API by design (ADR-002 §Navigation,
+ * ADR-008 #2 "manifests over flow control").
+ */
+export function createSceneRegistry(scenes: Iterable<SceneModule>): SceneRegistry {
+  const byId = new Map<string, SceneModule>();
+  const order: string[] = [];
+
+  for (const scene of scenes) {
+    assertSceneModule(scene);
+    if (byId.has(scene.id)) {
+      throw new Error(`scene registry: duplicate id "${scene.id}"`);
+    }
+    byId.set(scene.id, scene);
+    order.push(scene.id);
+  }
+
+  const registry: SceneRegistry = {
+    get(id: string): SceneModule {
+      const scene = byId.get(id);
+      if (scene === undefined) {
+        throw new Error(`scene registry: no scene registered with id "${id}"`);
+      }
+      return scene;
+    },
+    has(id: string): boolean {
+      return byId.has(id);
+    },
+    ids(): readonly string[] {
+      return Object.freeze(order.slice());
+    },
+    get size(): number {
+      return byId.size;
+    },
+  };
+
+  return Object.freeze(registry);
+}

--- a/tests/runtime/registry.test.ts
+++ b/tests/runtime/registry.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from 'vitest';
+import { createSceneRegistry } from '../../src/runtime/registry';
+import type { SceneRegistry } from '../../src/runtime/registry';
+import type { SceneModule } from '../../src/runtime/scene';
+
+const buildScene = (overrides: Partial<SceneModule> = {}): SceneModule => ({
+  id: 'scene-a',
+  title: 'Scene A',
+  duration: 5000,
+  tags: [],
+  assets: [],
+  captions: [],
+  defaultNext: null,
+  standalone: true,
+  trailerSafe: false,
+  create: () => undefined,
+  timeline: () => undefined,
+  cleanup: () => undefined,
+  ...overrides,
+});
+
+describe('SceneRegistry contract (PUL-F002)', () => {
+  describe('createSceneRegistry — happy paths (clause C1)', () => {
+    it('builds an empty registry from an empty iterable', () => {
+      const registry = createSceneRegistry([]);
+      expect(registry.size).toBe(0);
+      expect(registry.ids()).toEqual([]);
+    });
+
+    it('registers a single scene and returns it by id', () => {
+      const scene = buildScene({ id: 'intro' });
+      const registry = createSceneRegistry([scene]);
+      expect(registry.size).toBe(1);
+      expect(registry.get('intro')).toBe(scene);
+    });
+
+    it('registers multiple scenes and exposes each by id', () => {
+      const intro = buildScene({ id: 'intro' });
+      const middle = buildScene({ id: 'middle' });
+      const outro = buildScene({ id: 'outro' });
+      const registry = createSceneRegistry([intro, middle, outro]);
+      expect(registry.size).toBe(3);
+      expect(registry.get('intro')).toBe(intro);
+      expect(registry.get('middle')).toBe(middle);
+      expect(registry.get('outro')).toBe(outro);
+    });
+
+    it('accepts a generator as input', () => {
+      const intro = buildScene({ id: 'intro' });
+      const outro = buildScene({ id: 'outro' });
+      function* scenes(): Generator<SceneModule> {
+        yield intro;
+        yield outro;
+      }
+      const registry = createSceneRegistry(scenes());
+      expect(registry.size).toBe(2);
+      expect(registry.get('intro')).toBe(intro);
+      expect(registry.get('outro')).toBe(outro);
+    });
+
+    it('accepts a Set as input', () => {
+      const intro = buildScene({ id: 'intro' });
+      const registry = createSceneRegistry(new Set([intro]));
+      expect(registry.size).toBe(1);
+      expect(registry.get('intro')).toBe(intro);
+    });
+  });
+
+  describe('createSceneRegistry — module validation delegated to PUL-F001', () => {
+    it('rejects a scene module missing a required field with the PUL-F001 error', () => {
+      const broken: Record<string, unknown> = { ...buildScene({ id: 'broken' }) };
+      const missingField = 'cleanup';
+      delete broken[missingField];
+      expect(() => createSceneRegistry([broken as unknown as SceneModule])).toThrow(/cleanup/);
+    });
+
+    it('rejects a null element', () => {
+      expect(() => createSceneRegistry([null as unknown as SceneModule])).toThrow(/object/i);
+    });
+
+    it('rejects a non-object element', () => {
+      expect(() => createSceneRegistry(['scene-a' as unknown as SceneModule])).toThrow(/object/i);
+    });
+
+    it('rejects undefined element', () => {
+      expect(() => createSceneRegistry([undefined as unknown as SceneModule])).toThrow(/object/i);
+    });
+  });
+
+  describe('createSceneRegistry — duplicate ids (clause C1)', () => {
+    it('rejects two scenes that share an id', () => {
+      const a = buildScene({ id: 'shared' });
+      const b = buildScene({ id: 'shared', title: 'Different title' });
+      expect(() => createSceneRegistry([a, b])).toThrow(/duplicate id "shared"/);
+    });
+
+    it('rejects when the third scene duplicates the first', () => {
+      const a = buildScene({ id: 'intro' });
+      const b = buildScene({ id: 'middle' });
+      const c = buildScene({ id: 'intro' });
+      expect(() => createSceneRegistry([a, b, c])).toThrow(/duplicate id "intro"/);
+    });
+
+    it('error message is prefixed with "scene registry"', () => {
+      const a = buildScene({ id: 'shared' });
+      const b = buildScene({ id: 'shared' });
+      expect(() => createSceneRegistry([a, b])).toThrow(/^scene registry:/);
+    });
+  });
+
+  describe('get(id) — clause C1', () => {
+    it('returns the exact module reference registered', () => {
+      const scene = buildScene({ id: 'intro' });
+      const registry = createSceneRegistry([scene]);
+      expect(registry.get('intro')).toBe(scene);
+    });
+
+    it('throws a descriptive error when the id is not registered', () => {
+      const registry = createSceneRegistry([buildScene({ id: 'intro' })]);
+      expect(() => registry.get('missing')).toThrow(
+        /scene registry: no scene registered with id "missing"/,
+      );
+    });
+
+    it('throws when the lookup id is the empty string', () => {
+      const registry = createSceneRegistry([buildScene({ id: 'intro' })]);
+      expect(() => registry.get('')).toThrow(/scene registry: no scene registered with id ""/);
+    });
+  });
+
+  describe('has(id) — clause C2 helper', () => {
+    it('returns true for registered ids', () => {
+      const registry = createSceneRegistry([buildScene({ id: 'intro' })]);
+      expect(registry.has('intro')).toBe(true);
+    });
+
+    it('returns false for unregistered ids', () => {
+      const registry = createSceneRegistry([buildScene({ id: 'intro' })]);
+      expect(registry.has('missing')).toBe(false);
+    });
+
+    it('returns false for the empty string', () => {
+      const registry = createSceneRegistry([buildScene({ id: 'intro' })]);
+      expect(registry.has('')).toBe(false);
+    });
+
+    it('returns false on an empty registry', () => {
+      const registry = createSceneRegistry([]);
+      expect(registry.has('anything')).toBe(false);
+    });
+  });
+
+  describe('ids() — listing', () => {
+    it('returns ids in insertion order', () => {
+      const scenes = [
+        buildScene({ id: 'intro' }),
+        buildScene({ id: 'middle' }),
+        buildScene({ id: 'outro' }),
+      ];
+      const registry = createSceneRegistry(scenes);
+      expect(registry.ids()).toEqual(['intro', 'middle', 'outro']);
+    });
+
+    it('returns a copy that callers cannot use to mutate the registry', () => {
+      const registry = createSceneRegistry([buildScene({ id: 'intro' })]);
+      const ids = registry.ids() as string[];
+      // Either the array is frozen (push throws) or it is a defensive copy.
+      try {
+        ids.push('extra');
+      } catch {
+        // Frozen array — perfectly acceptable.
+      }
+      expect(registry.ids()).toEqual(['intro']);
+      expect(registry.size).toBe(1);
+      expect(registry.has('extra')).toBe(false);
+    });
+  });
+
+  describe('immutability — ADR-008 "manifests over flow control"', () => {
+    it('returns a frozen registry object', () => {
+      const registry = createSceneRegistry([buildScene({ id: 'intro' })]);
+      expect(Object.isFrozen(registry)).toBe(true);
+    });
+
+    const FORBIDDEN_METHODS = [
+      'add',
+      'register',
+      'remove',
+      'set',
+      'delete',
+      'clear',
+      'getByIndex',
+      'getNext',
+      'at',
+    ] as const;
+
+    it.each(FORBIDDEN_METHODS)(
+      'does not expose %s — registry surface is id-lookup-only (clause C2)',
+      (name) => {
+        const registry = createSceneRegistry([buildScene({ id: 'intro' })]) as unknown as Record<
+          string,
+          unknown
+        >;
+        expect(registry[name]).toBeUndefined();
+      },
+    );
+
+    it('exposes exactly the documented public surface', () => {
+      const registry: SceneRegistry = createSceneRegistry([buildScene({ id: 'intro' })]);
+      const keys = Object.keys(registry).sort();
+      expect(keys).toEqual(['get', 'has', 'ids', 'size']);
+    });
+  });
+});

--- a/tests/runtime/registry.test.ts
+++ b/tests/runtime/registry.test.ts
@@ -74,16 +74,15 @@ describe('SceneRegistry contract (PUL-F002)', () => {
       expect(() => createSceneRegistry([broken as unknown as SceneModule])).toThrow(/cleanup/);
     });
 
-    it('rejects a null element', () => {
-      expect(() => createSceneRegistry([null as unknown as SceneModule])).toThrow(/object/i);
-    });
-
-    it('rejects a non-object element', () => {
-      expect(() => createSceneRegistry(['scene-a' as unknown as SceneModule])).toThrow(/object/i);
-    });
-
-    it('rejects undefined element', () => {
-      expect(() => createSceneRegistry([undefined as unknown as SceneModule])).toThrow(/object/i);
+    it.each<[string, unknown]>([
+      ['null', null],
+      ['undefined', undefined],
+      ['a string', 'scene-a'],
+      ['a number', 42],
+      ['a boolean', true],
+      ['an array', []],
+    ])('rejects %s as a registry element', (_label, value) => {
+      expect(() => createSceneRegistry([value as SceneModule])).toThrow(/object/i);
     });
   });
 


### PR DESCRIPTION
## Summary

- Adds `src/runtime/registry.ts` exposing `SceneRegistry` and `createSceneRegistry`. The registry is built once at bootstrap from a collection of `SceneModule`s, validates each via `assertSceneModule` (PUL-F001), rejects duplicate ids, and is frozen thereafter.
- Surface is intentionally id-lookup-only (`get`, `has`, `ids`, `size`) — no positional or mutation API. This satisfies PUL-F002's "registry is the only mechanism for navigation addressability" structurally, not just by convention.
- Adds 32 Vitest tests in `tests/runtime/registry.test.ts` covering both clauses, validation delegation to PUL-F001, duplicate-id detection, lookup hits/misses, listing semantics, and registry immutability.

Implements PUL-F002 (ADR-002 §Scene registry / §Navigation, ADR-008 #2 "manifests over flow control").

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 97/97 pass (32 new + 65 existing)
- [x] `pre-commit run --all-files` clean
- [ ] CI green
- [ ] SonarCloud quality gate green

Closes #8