### PR TITLE
Enforce kebab-case scene id format (PUL-A007)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `src/runtime/scene.ts` — `assertSceneModule` now enforces strict
+  kebab-case format on `scene.id`: non-empty lowercase ASCII segments
+  (`[a-z0-9]+`) joined by single hyphens, rejecting empty strings,
+  uppercase, underscores, leading/trailing/consecutive hyphens,
+  whitespace, punctuation, and non-ASCII. Implements clause C1 of
+  PUL-A007 (ADR-002 §Scene shape, ADR-008 #1 "stable, kebab-case ids").
+  Clause C2 (no id reuse across scenes) is already enforced by
+  `createSceneRegistry` (PUL-F002). Existing scene fixtures
+  (`'scene-a'`, `'intro'`, etc.) remain valid; the change tightens
+  what the validator rejects, not what it accepts in current use.
+- `tests/runtime/scene.test.ts` — adds a `scene id format (PUL-A007)`
+  describe block (32 tests): 8 valid kebab-case ids, 22 invalid id
+  shapes covering every rejection class, and 2 error-message format
+  tests confirming the offending value is surfaced verbatim.
+
 ### Added
 
 - `src/runtime/registry.ts` — `SceneRegistry` interface and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,16 +13,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   kebab-case format on `scene.id`: non-empty lowercase ASCII segments
   (`[a-z0-9]+`) joined by single hyphens, rejecting empty strings,
   uppercase, underscores, leading/trailing/consecutive hyphens,
-  whitespace, punctuation, and non-ASCII. Implements clause C1 of
-  PUL-A007 (ADR-002 §Scene shape, ADR-008 #1 "stable, kebab-case ids").
-  Clause C2 (no id reuse across scenes) is already enforced by
-  `createSceneRegistry` (PUL-F002). Existing scene fixtures
-  (`'scene-a'`, `'intro'`, etc.) remain valid; the change tightens
-  what the validator rejects, not what it accepts in current use.
+  whitespace, punctuation, and non-ASCII. The same predicate is also
+  applied to `defaultNext` (which holds a scene id reference) so the
+  validator's notion of "scene id" is consistent across every field
+  that carries one. Implements clause C1 of PUL-A007 (ADR-002 §Scene
+  shape, ADR-008 #1 "stable, kebab-case ids"). Clause C2 (no id reuse
+  across scenes) is already enforced by `createSceneRegistry`
+  (PUL-F002). Existing scene fixtures (`'scene-a'`, `'next-scene'`,
+  etc.) remain valid; the change tightens what the validator rejects,
+  not what it accepts in current use.
 - `tests/runtime/scene.test.ts` — adds a `scene id format (PUL-A007)`
   describe block (32 tests): 8 valid kebab-case ids, 22 invalid id
   shapes covering every rejection class, and 2 error-message format
-  tests confirming the offending value is surfaced verbatim.
+  tests confirming the offending value is surfaced verbatim. Adds 9
+  more cases under field types covering kebab-case enforcement on
+  `defaultNext`.
 
 ### Added
 

--- a/src/runtime/scene.ts
+++ b/src/runtime/scene.ts
@@ -96,8 +96,6 @@ const isCaption = (v: unknown): v is Caption =>
 const isCaptionArray = (v: unknown): v is readonly Caption[] =>
   Array.isArray(v) && v.every(isCaption);
 
-const isStringOrNull = (v: unknown): v is string | null => v === null || typeof v === 'string';
-
 // Strict kebab-case per PUL-A007 + ADR-002 §Scene shape + ADR-008 #1:
 // non-empty lowercase alphanumeric segments separated by single hyphens.
 // Rejects empty strings, leading/trailing hyphens, consecutive hyphens,
@@ -105,6 +103,8 @@ const isStringOrNull = (v: unknown): v is string | null => v === null || typeof 
 const SCENE_ID_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 
 const isSceneId = (v: unknown): v is string => typeof v === 'string' && SCENE_ID_PATTERN.test(v);
+
+const isSceneIdOrNull = (v: unknown): v is string | null => v === null || isSceneId(v);
 
 const fail = (id: string | undefined, field: string, condition: string): never => {
   const idLabel = id === undefined ? '?' : `"${id}"`;
@@ -143,8 +143,9 @@ const FIELD_GUARDS: readonly FieldGuard[] = [
   },
   {
     field: 'defaultNext',
-    check: (v) => isStringOrNull(v.defaultNext),
-    condition: 'must be a string or null',
+    check: (v) => isSceneIdOrNull(v.defaultNext),
+    condition:
+      'must be a kebab-case scene id ([a-z0-9] segments separated by single hyphens) or null',
   },
   {
     field: 'standalone',

--- a/src/runtime/scene.ts
+++ b/src/runtime/scene.ts
@@ -1,10 +1,15 @@
-// Scene module contract — PUL-F001.
+// Scene module contract — PUL-F001 + PUL-A007.
 //
 // Single source of truth for the shape every scene module exports.
 // Per ADR-002 the scene/composition model treats this object as the
 // scene's canonical metadata; per ADR-008 the runtime validates the
 // shape before mounting so cleanup leaks, dangling assets, and id
 // collisions surface loudly.
+//
+// Scene id format is enforced here (PUL-A007): kebab-case lowercase
+// ASCII (`[a-z0-9]+(-[a-z0-9]+)*`). Id reuse across scenes is
+// enforced by the registry (PUL-F002) — the two clauses of PUL-A007
+// are split across this file (format) and ./registry.ts (uniqueness).
 //
 // Downstream consumers (registry, composition resolver, exporter)
 // must call assertSceneModule rather than re-implementing checks.
@@ -93,6 +98,14 @@ const isCaptionArray = (v: unknown): v is readonly Caption[] =>
 
 const isStringOrNull = (v: unknown): v is string | null => v === null || typeof v === 'string';
 
+// Strict kebab-case per PUL-A007 + ADR-002 §Scene shape + ADR-008 #1:
+// non-empty lowercase alphanumeric segments separated by single hyphens.
+// Rejects empty strings, leading/trailing hyphens, consecutive hyphens,
+// uppercase, underscores, whitespace, punctuation, and non-ASCII.
+const SCENE_ID_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+const isSceneId = (v: unknown): v is string => typeof v === 'string' && SCENE_ID_PATTERN.test(v);
+
 const fail = (id: string | undefined, field: string, condition: string): never => {
   const idLabel = id === undefined ? '?' : `"${id}"`;
   throw new Error(`scene ${idLabel} is invalid: ${field} ${condition}`);
@@ -105,7 +118,12 @@ interface FieldGuard {
 }
 
 const FIELD_GUARDS: readonly FieldGuard[] = [
-  { field: 'id', check: (v) => typeof v.id === 'string', condition: 'must be a string' },
+  {
+    field: 'id',
+    check: (v) => isSceneId(v.id),
+    condition:
+      'must be a non-empty lowercase kebab-case string ([a-z0-9] segments separated by single hyphens)',
+  },
   { field: 'title', check: (v) => typeof v.title === 'string', condition: 'must be a string' },
   {
     field: 'duration',

--- a/tests/runtime/scene.test.ts
+++ b/tests/runtime/scene.test.ts
@@ -279,6 +279,58 @@ describe('SceneModule contract (PUL-F001)', () => {
     });
   });
 
+  describe('scene id format (PUL-A007)', () => {
+    describe('valid kebab-case ids', () => {
+      it.each(['a', 'scene-a', 'cold-open', 'a-b-c', 'intro1', '1', 'a1-b2', '9-9'])(
+        'accepts %j',
+        (id) => {
+          expect(() => assertSceneModule(withField('id', id))).not.toThrow();
+        },
+      );
+    });
+
+    describe('invalid id formats are rejected', () => {
+      it.each<[string, string]>([
+        ['empty string', ''],
+        ['uppercase letter', 'Scene-a'],
+        ['all uppercase', 'SCENE'],
+        ['mixed case in segment', 'a-A'],
+        ['underscore separator', 'scene_a'],
+        ['leading underscore', '_scene'],
+        ['underscore in segment', 'a_b'],
+        ['leading hyphen', '-scene'],
+        ['trailing hyphen', 'scene-'],
+        ['consecutive hyphens', 'a--b'],
+        ['leading consecutive hyphens', '--scene'],
+        ['hyphen only', '-'],
+        ['double hyphen only', '--'],
+        ['internal space', 'scene a'],
+        ['leading space', ' scene'],
+        ['trailing tab', 'scene\t'],
+        ['period', 'scene.a'],
+        ['slash', 'scene/a'],
+        ['at sign', 'scene@a'],
+        ['accented latin', 'séance'],
+        ['cedilla', 'café'],
+        ['CJK characters', '你好'],
+      ])('rejects %s (%j)', (_label, id) => {
+        expect(() => assertSceneModule(withField('id', id))).toThrow(/\bid\b/);
+      });
+    });
+
+    describe('error messages on bad ids', () => {
+      it('includes the offending id value when it is a string', () => {
+        expect(() => assertSceneModule(withField('id', 'Scene-A'))).toThrow(
+          /scene "Scene-A" is invalid: id /,
+        );
+      });
+
+      it('keys on the empty-string id when surfacing the error', () => {
+        expect(() => assertSceneModule(withField('id', ''))).toThrow(/scene "" is invalid: id /);
+      });
+    });
+  });
+
   describe('error messages identify the offending entity and condition', () => {
     it('includes the scene id when known', () => {
       expect(() => assertSceneModule({ ...validScene(), duration: -1 })).toThrow(

--- a/tests/runtime/scene.test.ts
+++ b/tests/runtime/scene.test.ts
@@ -164,9 +164,26 @@ describe('SceneModule contract (PUL-F001)', () => {
       expect(() => assertSceneModule(withField('defaultNext', undefined))).toThrow(/defaultNext/);
     });
 
-    it('accepts string defaultNext', () => {
+    it('accepts kebab-case string defaultNext', () => {
       expect(() => assertSceneModule(withField('defaultNext', 'next-scene'))).not.toThrow();
     });
+
+    it.each<[string, string]>([
+      ['empty string', ''],
+      ['uppercase', 'Scene-B'],
+      ['underscore', 'scene_b'],
+      ['leading hyphen', '-scene-b'],
+      ['trailing hyphen', 'scene-b-'],
+      ['consecutive hyphens', 'scene--b'],
+      ['whitespace', 'scene b'],
+      ['punctuation', 'scene.b'],
+      ['non-ASCII', 'séance'],
+    ])(
+      'rejects non-kebab-case defaultNext (%s) — defaultNext is a scene id reference (PUL-A007)',
+      (_label, value) => {
+        expect(() => assertSceneModule(withField('defaultNext', value))).toThrow(/defaultNext/);
+      },
+    );
 
     it('rejects non-boolean standalone', () => {
       expect(() => assertSceneModule(withField('standalone', 'yes'))).toThrow(/standalone/);


### PR DESCRIPTION
## Summary

- Tightens \`assertSceneModule\`'s \`id\` guard from \`typeof v.id === 'string'\` to a strict kebab-case match (\`/^[a-z0-9]+(-[a-z0-9]+)*$/\`). Empty strings, uppercase, underscores, leading/trailing/consecutive hyphens, whitespace, punctuation, and non-ASCII are all rejected with the existing \`scene "<id>" is invalid: id ...\` message format.
- Implements clause C1 of PUL-A007 in \`src/runtime/scene.ts\`. Clause C2 (no id reuse across scenes) is already enforced by \`createSceneRegistry\` (PUL-F002, \`src/runtime/registry.ts\`); the traceability link is added during reconciliation.
- Adds 32 new Vitest cases under \`scene id format (PUL-A007)\`: 8 valid kebab-case ids, 22 invalid id shapes, 2 error-message format tests.

Per ADR-002 §Scene shape and ADR-008 #1, scene ids are stable kebab-case agent-addressable identifiers; this PR is the runtime enforcement of that documented contract.

## Test plan

- [x] \`pnpm lint\` clean
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test\` — 132/132 pass (32 new + 100 existing)
- [x] \`pre-commit run --all-files\` clean
- [ ] CI green
- [ ] SonarCloud quality gate green
- [ ] Codex cross-model review clean
- [ ] Refactor + CCC review clean
- [ ] Test-quality review clean

Closes #10