### PR TITLE
Add composition manifest format (PUL-F003)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"b2f06861-d81b-45fc-999c-4394bd457de8","pid":1293726,"procStart":"109349447","acquiredAt":1777779067696}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"b2f06861-d81b-45fc-999c-4394bd457de8","pid":1293726,"procStart":"109349447","acquiredAt":1777779067696}

--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ Thumbs.db
 # Local files
 archive/
 .codex
+
+# Claude Code harness runtime state (not implementation artifacts)
+.claude/scheduled_tasks.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   compositions, beats, and assets. Reused by `scene.ts` (scene id
   validation) and `composition.ts` (entry id and beat label
   validation).
+- `src/runtime/object.ts` — `isPlainRecord` predicate. Accepts only
+  `{ ... }` and `Object.create(null)` literals; rejects class
+  instances such as `Date`, `Map`, `Set`, `RegExp`, `Error`, and
+  user classes. Per ADR-008 #1 ("manifests are declarative data
+  only"), runtime payload validation must reject opaque object
+  instances that cannot be safely serialized, diffed, or treated as
+  records of keyed fields. Reused by both `scene.ts` (scene module
+  shape + caption shape) and `composition.ts` (entry shape +
+  behavior override).
 - `tests/runtime/composition.test.ts` — 103-test Vitest spec covering
   every PUL-F003 clause (top-level array shape, bare-string entries
   with kebab-case rule, object entries with `id` + `range` +
@@ -42,9 +51,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `src/runtime/scene.ts` — sources the kebab-case identifier
   predicate from the new `src/runtime/identifier.ts` instead of
-  carrying its own `SCENE_ID_PATTERN` constant. Behavior is
-  unchanged (same regex); the extraction keeps the ADR-008 #1 rule
-  in one place now that `composition.ts` is a second caller.
+  carrying its own `SCENE_ID_PATTERN` constant. Object-shape
+  validation now uses the shared `isPlainRecord` predicate from
+  `src/runtime/object.ts`, which tightens the previous loose check
+  to reject class instances (`Date`, `Map`, `Set`, etc.) — same
+  ADR-008 #1 declarative-data invariant the composition validator
+  enforces. Existing scene fixtures (object literals) remain valid;
+  the change rejects opaque object instances that should never have
+  satisfied the scene contract.
 
 - `docs/adrs/010-issue-tag-taxonomy.md` — defines a five-dimension,
   namespaced GitHub issue label taxonomy: type (`requirement` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `src/runtime/composition.ts` — `CompositionManifest`,
+  `CompositionEntry`, `CompositionEntryOverride`, `SubRange`, and
+  `BehaviorOverride` types plus `assertCompositionManifest` runtime
+  validator and `isCompositionManifest` predicate. Implements
+  PUL-F003 (the composition manifest format): a manifest is an
+  ordered array of entries; each entry is a bare kebab-case scene id
+  string or an object with `id` plus optional `range` (single beat
+  label or `[start, end]` label pair, per ADR-003 §Labels) and
+  `behavior` (per-entry override blob). Unknown override keys are
+  rejected so typos surface immediately. The validator owns the
+  *format* only — registry-existence and timeline-label-existence
+  checks belong to a later resolution requirement. Errors identify
+  the entry index and offending field/condition, matching the
+  `assertSceneModule` error grammar (PUL-Q005 spirit).
+- `src/runtime/identifier.ts` — `KEBAB_IDENTIFIER_PATTERN` and
+  `isKebabIdentifier`. Single source of truth for the kebab-case
+  identifier rule that ADR-008 #1 makes binding on scenes,
+  compositions, beats, and assets. Reused by `scene.ts` (scene id
+  validation) and `composition.ts` (entry id and beat label
+  validation).
+- `tests/runtime/composition.test.ts` — 103-test Vitest spec covering
+  every PUL-F003 clause (top-level array shape, bare-string entries
+  with kebab-case rule, object entries with `id` + `range` +
+  `behavior` overrides, unknown-key rejection per the codex
+  preflight guardrail), the AC1 mixed-entry contract using ADR-002's
+  literal `fullTalk` / `shortTalk` / `trailer` examples as fixtures,
+  AC2 actionable-error checks, and the `isCompositionManifest`
+  predicate.
+
+### Changed
+
+- `src/runtime/scene.ts` — sources the kebab-case identifier
+  predicate from the new `src/runtime/identifier.ts` instead of
+  carrying its own `SCENE_ID_PATTERN` constant. Behavior is
+  unchanged (same regex); the extraction keeps the ADR-008 #1 rule
+  in one place now that `composition.ts` is a second caller.
+
 - `docs/adrs/010-issue-tag-taxonomy.md` — defines a five-dimension,
   namespaced GitHub issue label taxonomy: type (`requirement` /
   `bug` / `enhancement` / `documentation` / `chore`),

--- a/src/runtime/composition.ts
+++ b/src/runtime/composition.ts
@@ -70,8 +70,19 @@ const KEBAB_CONDITION =
 const RANGE_CONDITION =
   'must be a kebab-case beat label or a [start, end] tuple of kebab-case beat labels';
 
-const isPlainObject = (v: unknown): v is Record<string, unknown> =>
-  typeof v === 'object' && v !== null && !Array.isArray(v);
+// Plain-record predicate. Matches `{}` / `Object.create(null)` literals
+// only and rejects class instances such as Date, Map, Set, RegExp, Error,
+// and user classes. The composition format is declarative data per the
+// codex architecture preflight (ADR-008 #1 / "manifests are declarative
+// data only"), so opaque object instances must not satisfy either the
+// entry-shape check or the `behavior` override check — otherwise the
+// downstream resolver receives values it cannot safely serialize, diff,
+// or treat as a record of override keys.
+const isPlainObject = (v: unknown): v is Record<string, unknown> => {
+  if (typeof v !== 'object' || v === null || Array.isArray(v)) return false;
+  const proto = Object.getPrototypeOf(v);
+  return proto === Object.prototype || proto === null;
+};
 
 const isValidSubRange = (v: unknown): v is SubRange => {
   if (isKebabIdentifier(v)) return true;

--- a/src/runtime/composition.ts
+++ b/src/runtime/composition.ts
@@ -1,0 +1,170 @@
+// Composition manifest format — PUL-F003.
+//
+// A composition manifest is a declarative ordered list of scene id
+// references. Each entry is either a bare scene id string or an
+// object carrying a scene id plus per-entry overrides. This module
+// owns the *format* — the data shape and the validator that rejects
+// malformed values. Resolution against a SceneRegistry (existence
+// checks, beat-label existence inside a scene's timeline, asset
+// preloading) belongs to a later requirement and is out of scope
+// here.
+//
+// References:
+//  - ADR-002 §Composition manifests — informal shape + canonical examples.
+//  - ADR-003 §Labels — sub-range labels addressed by name.
+//  - ADR-008 #1 — kebab-case ids for scenes, compositions, beats, assets.
+//  - PUL-A007 — scene id format (kebab-case).
+//
+// Per the codex architecture preflight (PUL-F003): the format is a
+// declarative data shape only. Override fields must not redefine,
+// inline, fork, or mutate the scene; unknown override keys are
+// rejected so typos surface immediately rather than silently
+// changing intent.
+
+import { isKebabIdentifier } from './identifier';
+
+/**
+ * A sub-range override referencing one or more beat labels inside the
+ * referenced scene's timeline (ADR-003 §Labels).
+ *
+ *  - `string` — a single beat label.
+ *  - `readonly [string, string]` — a `[start, end]` label pair.
+ *
+ * Beat labels share the kebab-case rule with scene ids per ADR-008 #1.
+ * Existence of the labels inside the referenced scene's timeline is
+ * NOT validated here — that is a resolution concern and requires the
+ * scene timeline to be inspected.
+ */
+export type SubRange = string | readonly [string, string];
+
+/**
+ * Per-entry behavior override blob. The format reserves this slot for
+ * runtime-defined behavior keys; this module does not constrain keys
+ * or values beyond "must be a plain object". Resolution layers that
+ * consume specific behavior keys validate them.
+ */
+export type BehaviorOverride = Readonly<Record<string, unknown>>;
+
+/**
+ * Object form of a composition entry: a scene id reference plus
+ * optional per-entry overrides for sub-range or behavior. Unknown
+ * keys are rejected by the validator — see module comment.
+ */
+export interface CompositionEntryOverride {
+  readonly id: string;
+  readonly range?: SubRange;
+  readonly behavior?: BehaviorOverride;
+}
+
+/** A single composition entry: bare scene-id string OR override object. */
+export type CompositionEntry = string | CompositionEntryOverride;
+
+/** A composition manifest: an ordered list of entries (PUL-F003 C1). */
+export type CompositionManifest = readonly CompositionEntry[];
+
+const ALLOWED_OBJECT_KEYS = new Set<keyof CompositionEntryOverride>(['id', 'range', 'behavior']);
+
+const KEBAB_CONDITION =
+  'must be a non-empty lowercase kebab-case string ([a-z0-9] segments separated by single hyphens)';
+
+const RANGE_CONDITION =
+  'must be a kebab-case beat label or a [start, end] tuple of kebab-case beat labels';
+
+const isPlainObject = (v: unknown): v is Record<string, unknown> =>
+  typeof v === 'object' && v !== null && !Array.isArray(v);
+
+const isValidSubRange = (v: unknown): v is SubRange => {
+  if (isKebabIdentifier(v)) return true;
+  if (!Array.isArray(v)) return false;
+  if (v.length !== 2) return false;
+  return isKebabIdentifier(v[0]) && isKebabIdentifier(v[1]);
+};
+
+function failManifest(condition: string): never {
+  throw new Error(`composition manifest is invalid: ${condition}`);
+}
+
+function failEntry(index: number, field: string, condition: string): never {
+  throw new Error(`composition entry [${index}] is invalid: ${field} ${condition}`);
+}
+
+const validateBareString = (index: number, entry: string): void => {
+  if (!isKebabIdentifier(entry)) {
+    failEntry(index, 'id', KEBAB_CONDITION);
+  }
+};
+
+const validateObjectEntry = (index: number, entry: Record<string, unknown>): void => {
+  if (!Object.hasOwn(entry, 'id')) {
+    failEntry(index, 'id', 'must be present');
+  }
+
+  if (!isKebabIdentifier(entry.id)) {
+    failEntry(index, 'id', KEBAB_CONDITION);
+  }
+
+  if (Object.hasOwn(entry, 'range') && !isValidSubRange(entry.range)) {
+    failEntry(index, 'range', RANGE_CONDITION);
+  }
+
+  if (Object.hasOwn(entry, 'behavior') && !isPlainObject(entry.behavior)) {
+    failEntry(index, 'behavior', 'must be a plain object');
+  }
+
+  for (const key of Object.keys(entry)) {
+    if (!ALLOWED_OBJECT_KEYS.has(key as keyof CompositionEntryOverride)) {
+      failEntry(index, `unknown key "${key}"`, '— allowed: id, range, behavior');
+    }
+  }
+};
+
+/**
+ * Validates that `value` is a well-formed {@link CompositionManifest}
+ * per PUL-F003. Throws `Error` with a message identifying the offending
+ * entry index and field/condition (matches the
+ * `assertSceneModule` error grammar with an entry index prefix).
+ *
+ * Iterates entries in order and stops at the first failure. Existence
+ * of referenced scene ids in the registry, and existence of referenced
+ * beat labels inside a scene's timeline, are NOT checked here; they
+ * belong to the resolution layer.
+ */
+export function assertCompositionManifest(value: unknown): asserts value is CompositionManifest {
+  if (!Array.isArray(value)) {
+    failManifest('must be an array');
+  }
+
+  for (let index = 0; index < value.length; index += 1) {
+    const entry: unknown = value[index];
+
+    if (typeof entry === 'string') {
+      validateBareString(index, entry);
+      continue;
+    }
+
+    if (!isPlainObject(entry)) {
+      failEntry(
+        index,
+        'entry',
+        'must be a kebab-case scene id string or a { id, range?, behavior? } object',
+      );
+    }
+
+    validateObjectEntry(index, entry);
+  }
+}
+
+/**
+ * Convenience type predicate. Returns `true` if `value` satisfies the
+ * composition manifest contract; `false` otherwise. Use
+ * {@link assertCompositionManifest} when the failure detail matters
+ * to the caller.
+ */
+export function isCompositionManifest(value: unknown): value is CompositionManifest {
+  try {
+    assertCompositionManifest(value);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/runtime/composition.ts
+++ b/src/runtime/composition.ts
@@ -21,7 +21,7 @@
 // rejected so typos surface immediately rather than silently
 // changing intent.
 
-import { isKebabIdentifier } from './identifier';
+import { KEBAB_IDENTIFIER_FORM, isKebabIdentifier } from './identifier';
 import { isPlainRecord } from './object';
 
 /**
@@ -65,8 +65,7 @@ export type CompositionManifest = readonly CompositionEntry[];
 
 const ALLOWED_OBJECT_KEYS = new Set<keyof CompositionEntryOverride>(['id', 'range', 'behavior']);
 
-const KEBAB_CONDITION =
-  'must be a non-empty lowercase kebab-case string ([a-z0-9] segments separated by single hyphens)';
+const KEBAB_CONDITION = `must be a non-empty lowercase kebab-case string (${KEBAB_IDENTIFIER_FORM})`;
 
 const RANGE_CONDITION =
   'must be a kebab-case beat label or a [start, end] tuple of kebab-case beat labels';

--- a/src/runtime/composition.ts
+++ b/src/runtime/composition.ts
@@ -22,6 +22,7 @@
 // changing intent.
 
 import { isKebabIdentifier } from './identifier';
+import { isPlainRecord } from './object';
 
 /**
  * A sub-range override referencing one or more beat labels inside the
@@ -70,20 +71,6 @@ const KEBAB_CONDITION =
 const RANGE_CONDITION =
   'must be a kebab-case beat label or a [start, end] tuple of kebab-case beat labels';
 
-// Plain-record predicate. Matches `{}` / `Object.create(null)` literals
-// only and rejects class instances such as Date, Map, Set, RegExp, Error,
-// and user classes. The composition format is declarative data per the
-// codex architecture preflight (ADR-008 #1 / "manifests are declarative
-// data only"), so opaque object instances must not satisfy either the
-// entry-shape check or the `behavior` override check — otherwise the
-// downstream resolver receives values it cannot safely serialize, diff,
-// or treat as a record of override keys.
-const isPlainObject = (v: unknown): v is Record<string, unknown> => {
-  if (typeof v !== 'object' || v === null || Array.isArray(v)) return false;
-  const proto = Object.getPrototypeOf(v);
-  return proto === Object.prototype || proto === null;
-};
-
 const isValidSubRange = (v: unknown): v is SubRange => {
   if (isKebabIdentifier(v)) return true;
   if (!Array.isArray(v)) return false;
@@ -118,7 +105,7 @@ const validateObjectEntry = (index: number, entry: Record<string, unknown>): voi
     failEntry(index, 'range', RANGE_CONDITION);
   }
 
-  if (Object.hasOwn(entry, 'behavior') && !isPlainObject(entry.behavior)) {
+  if (Object.hasOwn(entry, 'behavior') && !isPlainRecord(entry.behavior)) {
     failEntry(index, 'behavior', 'must be a plain object');
   }
 
@@ -153,7 +140,7 @@ export function assertCompositionManifest(value: unknown): asserts value is Comp
       continue;
     }
 
-    if (!isPlainObject(entry)) {
+    if (!isPlainRecord(entry)) {
       failEntry(
         index,
         'entry',

--- a/src/runtime/identifier.ts
+++ b/src/runtime/identifier.ts
@@ -21,6 +21,14 @@
 export const KEBAB_IDENTIFIER_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 
 /**
+ * Plain-English description of {@link KEBAB_IDENTIFIER_PATTERN} for
+ * use inside validator error messages. Exported so every caller
+ * composes a single source of truth — if the regex changes, the
+ * description changes here and every error message follows.
+ */
+export const KEBAB_IDENTIFIER_FORM = '[a-z0-9] segments separated by single hyphens';
+
+/**
  * Returns `true` when `value` is a string matching
  * {@link KEBAB_IDENTIFIER_PATTERN}.
  */

--- a/src/runtime/identifier.ts
+++ b/src/runtime/identifier.ts
@@ -1,0 +1,28 @@
+// Kebab-case identifier predicate — ADR-008 #1.
+//
+// Scenes, compositions, beats, and assets all share a single
+// identifier shape per ADR-008 #1 ("Stable, declarative identity.
+// Scenes, compositions, beats, and assets have stable, kebab-case
+// ids."). PUL-A007 formalizes the rule for scene ids and clause C1
+// of that requirement is enforced in `./scene.ts`.
+//
+// Multiple call sites (scene shape validation, composition manifest
+// validation, future beat / asset validators) need the same
+// predicate. This module is the single source of truth so the regex
+// is defined once and each caller can name the concept it is
+// validating without duplicating the rule.
+
+/**
+ * Strict kebab-case identifier pattern: non-empty lowercase ASCII
+ * alphanumeric segments separated by single hyphens. Rejects empty
+ * strings, leading/trailing hyphens, consecutive hyphens, uppercase,
+ * underscores, whitespace, punctuation, and non-ASCII.
+ */
+export const KEBAB_IDENTIFIER_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+/**
+ * Returns `true` when `value` is a string matching
+ * {@link KEBAB_IDENTIFIER_PATTERN}.
+ */
+export const isKebabIdentifier = (value: unknown): value is string =>
+  typeof value === 'string' && KEBAB_IDENTIFIER_PATTERN.test(value);

--- a/src/runtime/object.ts
+++ b/src/runtime/object.ts
@@ -1,0 +1,24 @@
+// Plain-record predicate for runtime validation.
+//
+// Pulsar's declarative-data invariant (ADR-008 #1, "manifests are
+// declarative data only") rules out class instances such as `Date`,
+// `Map`, `Set`, `RegExp`, `Error`, and user classes for any value
+// the runtime treats as an object payload — they cannot be safely
+// serialized, diffed, or treated as a record of keyed fields.
+//
+// Both the scene-shape validator (`./scene.ts`) and the composition
+// manifest validator (`./composition.ts`) need this check. The
+// predicate lives here so they share one definition, eliminating the
+// drift the original duplication produced.
+
+/**
+ * Returns `true` only when `value` is a plain object literal —
+ * `{ ... }` or `Object.create(null)`. Rejects `null`, arrays,
+ * primitives, and class instances (including built-ins like `Date`,
+ * `Map`, `Set`, `RegExp`, `Error`).
+ */
+export const isPlainRecord = (value: unknown): value is Record<string, unknown> => {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+};

--- a/src/runtime/scene.ts
+++ b/src/runtime/scene.ts
@@ -17,7 +17,7 @@
 // Downstream consumers (registry, composition resolver, exporter)
 // must call assertSceneModule rather than re-implementing checks.
 
-import { isKebabIdentifier } from './identifier';
+import { KEBAB_IDENTIFIER_FORM, isKebabIdentifier } from './identifier';
 import { isPlainRecord } from './object';
 
 /**
@@ -122,8 +122,7 @@ const FIELD_GUARDS: readonly FieldGuard[] = [
   {
     field: 'id',
     check: (v) => isSceneId(v.id),
-    condition:
-      'must be a non-empty lowercase kebab-case string ([a-z0-9] segments separated by single hyphens)',
+    condition: `must be a non-empty lowercase kebab-case string (${KEBAB_IDENTIFIER_FORM})`,
   },
   { field: 'title', check: (v) => typeof v.title === 'string', condition: 'must be a string' },
   {
@@ -145,8 +144,7 @@ const FIELD_GUARDS: readonly FieldGuard[] = [
   {
     field: 'defaultNext',
     check: (v) => isSceneIdOrNull(v.defaultNext),
-    condition:
-      'must be a kebab-case scene id ([a-z0-9] segments separated by single hyphens) or null',
+    condition: `must be a kebab-case scene id (${KEBAB_IDENTIFIER_FORM}) or null`,
   },
   {
     field: 'standalone',

--- a/src/runtime/scene.ts
+++ b/src/runtime/scene.ts
@@ -18,6 +18,7 @@
 // must call assertSceneModule rather than re-implementing checks.
 
 import { isKebabIdentifier } from './identifier';
+import { isPlainRecord } from './object';
 
 /**
  * Caption metadata. ADR-002 specifies `{ at: ms, text }`. The prompter,
@@ -86,9 +87,6 @@ const REQUIRED_FIELDS = [
   'cleanup',
 ] as const satisfies readonly (keyof SceneModule)[];
 
-const isPlainObject = (v: unknown): v is Record<string, unknown> =>
-  typeof v === 'object' && v !== null && !Array.isArray(v);
-
 const isStringArray = (v: unknown): v is readonly string[] =>
   Array.isArray(v) && v.every((e) => typeof e === 'string');
 
@@ -96,7 +94,7 @@ const isValidDuration = (v: unknown): v is number | null =>
   v === null || (typeof v === 'number' && Number.isInteger(v) && Number.isFinite(v) && v >= 0);
 
 const isCaption = (v: unknown): v is Caption =>
-  isPlainObject(v) && typeof v.at === 'number' && typeof v.text === 'string';
+  isPlainRecord(v) && typeof v.at === 'number' && typeof v.text === 'string';
 
 const isCaptionArray = (v: unknown): v is readonly Caption[] =>
   Array.isArray(v) && v.every(isCaption);
@@ -188,7 +186,7 @@ const FIELD_GUARDS: readonly FieldGuard[] = [
  * re-validating piecemeal.
  */
 export function assertSceneModule(value: unknown): asserts value is SceneModule {
-  if (!isPlainObject(value)) {
+  if (!isPlainRecord(value)) {
     throw new Error('scene ? is invalid: value must be a non-null object');
   }
 

--- a/src/runtime/scene.ts
+++ b/src/runtime/scene.ts
@@ -7,12 +7,17 @@
 // collisions surface loudly.
 //
 // Scene id format is enforced here (PUL-A007): kebab-case lowercase
-// ASCII (`[a-z0-9]+(-[a-z0-9]+)*`). Id reuse across scenes is
-// enforced by the registry (PUL-F002) — the two clauses of PUL-A007
-// are split across this file (format) and ./registry.ts (uniqueness).
+// ASCII (`[a-z0-9]+(-[a-z0-9]+)*`). The regex itself lives in
+// ./identifier.ts because ADR-008 #1 makes the same rule binding on
+// scenes, compositions, beats, and assets — see `isKebabIdentifier`.
+// Id reuse across scenes is enforced by the registry (PUL-F002) —
+// the two clauses of PUL-A007 are split across this file (format)
+// and ./registry.ts (uniqueness).
 //
 // Downstream consumers (registry, composition resolver, exporter)
 // must call assertSceneModule rather than re-implementing checks.
+
+import { isKebabIdentifier } from './identifier';
 
 /**
  * Caption metadata. ADR-002 specifies `{ at: ms, text }`. The prompter,
@@ -96,13 +101,11 @@ const isCaption = (v: unknown): v is Caption =>
 const isCaptionArray = (v: unknown): v is readonly Caption[] =>
   Array.isArray(v) && v.every(isCaption);
 
-// Strict kebab-case per PUL-A007 + ADR-002 §Scene shape + ADR-008 #1:
-// non-empty lowercase alphanumeric segments separated by single hyphens.
-// Rejects empty strings, leading/trailing hyphens, consecutive hyphens,
-// uppercase, underscores, whitespace, punctuation, and non-ASCII.
-const SCENE_ID_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
-
-const isSceneId = (v: unknown): v is string => typeof v === 'string' && SCENE_ID_PATTERN.test(v);
+// Scene ids share the kebab-case rule with all other Pulsar
+// identifiers per ADR-008 #1; the predicate lives in ./identifier.ts
+// so composition entries, beat labels, and future asset ids do not
+// each carry their own copy of the regex (PUL-A007 clause C1).
+const isSceneId = isKebabIdentifier;
 
 const isSceneIdOrNull = (v: unknown): v is string | null => v === null || isSceneId(v);
 

--- a/tests/runtime/composition.test.ts
+++ b/tests/runtime/composition.test.ts
@@ -89,17 +89,17 @@ describe('CompositionManifest format (PUL-F003)', () => {
       });
     });
 
-    it('rejects when the failing entry is in the middle of the manifest, reporting its index', () => {
+    it('rejects when the failing entry is in the middle of the manifest, reporting its index and field', () => {
       const manifest = ['scene-a', 'scene-b', 'Bad-Entry', 'scene-c'];
       expect(() => assertCompositionManifest(manifest)).toThrow(
-        /^composition entry \[2\] is invalid:/,
+        /^composition entry \[2\] is invalid: id must be a non-empty lowercase kebab-case string/,
       );
     });
 
     it('rejects when the failing entry is the last entry', () => {
       const manifest = ['scene-a', 'scene-b', ''];
       expect(() => assertCompositionManifest(manifest)).toThrow(
-        /^composition entry \[2\] is invalid:/,
+        /^composition entry \[2\] is invalid: id must be a non-empty lowercase kebab-case string/,
       );
     });
   });
@@ -309,6 +309,13 @@ describe('CompositionManifest format (PUL-F003)', () => {
     });
 
     describe('object entries — top-level shape rejections', () => {
+      // Note: `null` and `undefined` would normally route through the
+      // entry-shape branch (`!isPlainRecord`), but the validator's
+      // bare-string branch only fires for typeof === 'string', so
+      // these fall through to the same "entry must be ..." message.
+      // Numbers/booleans/arrays do the same. Lock the message verbatim
+      // so a regression that changes the field name (`entry`) or the
+      // condition text gets caught.
       it.each<[string, unknown]>([
         ['null', null],
         ['undefined', undefined],
@@ -317,7 +324,7 @@ describe('CompositionManifest format (PUL-F003)', () => {
         ['array', ['scene-a']],
       ])('rejects a non-plain-object entry (%s)', (_label, entry) => {
         expect(() => assertCompositionManifest([entry])).toThrow(
-          /^composition entry \[0\] is invalid:/,
+          /^composition entry \[0\] is invalid: entry must be a kebab-case scene id string or a \{ id, range\?, behavior\? \} object/,
         );
       });
 
@@ -341,7 +348,7 @@ describe('CompositionManifest format (PUL-F003)', () => {
         ],
       ])('rejects %s as an entry (must be a plain { id, ... } object)', (_label, makeEntry) => {
         expect(() => assertCompositionManifest([makeEntry()])).toThrow(
-          /^composition entry \[0\] is invalid:/,
+          /^composition entry \[0\] is invalid: entry must be a kebab-case scene id string or a \{ id, range\?, behavior\? \} object/,
         );
       });
     });

--- a/tests/runtime/composition.test.ts
+++ b/tests/runtime/composition.test.ts
@@ -225,6 +225,12 @@ describe('CompositionManifest format (PUL-F003)', () => {
         ).not.toThrow();
       });
 
+      it('accepts an Object.create(null) behavior dictionary', () => {
+        const behavior = Object.create(null) as Record<string, unknown>;
+        behavior.mute = true;
+        expect(() => assertCompositionManifest([{ id: 'scene-a', behavior }])).not.toThrow();
+      });
+
       it.each<[string, unknown]>([
         ['null', null],
         ['undefined-tagged value', 'not-an-object'],
@@ -235,6 +241,30 @@ describe('CompositionManifest format (PUL-F003)', () => {
         expect(() => assertCompositionManifest([{ id: 'scene-a', behavior }])).toThrow(
           /^composition entry \[0\] is invalid: behavior must be a plain object/,
         );
+      });
+
+      // Class instances and built-in non-record objects must not satisfy
+      // `behavior` — the contract is a serializable record, not an opaque
+      // object instance (codex review, ADR-008 #1).
+      it.each<[string, () => unknown]>([
+        ['Date', () => new Date()],
+        ['Map', () => new Map([['mute', true]])],
+        ['Set', () => new Set(['mute'])],
+        ['RegExp', () => /payoff/],
+        ['Error', () => new Error('boom')],
+        [
+          'class instance',
+          () => {
+            class Override {
+              mute = true;
+            }
+            return new Override();
+          },
+        ],
+      ])('rejects %s as behavior (must be a plain object)', (_label, makeBehavior) => {
+        expect(() =>
+          assertCompositionManifest([{ id: 'scene-a', behavior: makeBehavior() }]),
+        ).toThrow(/^composition entry \[0\] is invalid: behavior must be a plain object/);
       });
 
       it('does NOT inspect the contents of the behavior object', () => {
@@ -287,6 +317,30 @@ describe('CompositionManifest format (PUL-F003)', () => {
         ['array', ['scene-a']],
       ])('rejects a non-plain-object entry (%s)', (_label, entry) => {
         expect(() => assertCompositionManifest([entry])).toThrow(
+          /^composition entry \[0\] is invalid:/,
+        );
+      });
+
+      // Class instances and built-in non-record objects must not satisfy
+      // the entry shape — same reasoning as for `behavior` (codex review,
+      // ADR-008 #1: manifests are declarative data, not opaque objects).
+      it.each<[string, () => unknown]>([
+        ['Date', () => new Date()],
+        ['Map', () => new Map()],
+        ['Set', () => new Set()],
+        ['RegExp', () => /scene-a/],
+        ['Error', () => new Error('boom')],
+        [
+          'class instance',
+          () => {
+            class Entry {
+              id = 'scene-a';
+            }
+            return new Entry();
+          },
+        ],
+      ])('rejects %s as an entry (must be a plain { id, ... } object)', (_label, makeEntry) => {
+        expect(() => assertCompositionManifest([makeEntry()])).toThrow(
           /^composition entry \[0\] is invalid:/,
         );
       });

--- a/tests/runtime/composition.test.ts
+++ b/tests/runtime/composition.test.ts
@@ -1,0 +1,414 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type CompositionEntry,
+  type CompositionEntryOverride,
+  type CompositionManifest,
+  type SubRange,
+  assertCompositionManifest,
+  isCompositionManifest,
+} from '../../src/runtime/composition';
+
+// ADR-002 §Composition manifests example fixtures, kept literally so
+// that any drift between the validator and the canonical examples
+// surfaces immediately.
+const adr002FullTalk = ['scene-a', 'scene-b', 'scene-c', 'scene-d'] as const;
+const adr002ShortTalk = ['scene-a', 'scene-c'] as const;
+const adr002Trailer = [
+  { id: 'scene-a', range: ['intro', 'hook'] as const },
+  { id: 'scene-c', range: 'payoff' },
+] as const;
+
+describe('CompositionManifest format (PUL-F003)', () => {
+  describe('clause C1 — declarative ordered list (top-level shape)', () => {
+    it('accepts the empty array — the format does not preclude empty manifests', () => {
+      expect(() => assertCompositionManifest([])).not.toThrow();
+    });
+
+    it('accepts a single bare-string entry', () => {
+      expect(() => assertCompositionManifest(['scene-a'])).not.toThrow();
+    });
+
+    it('accepts an array of multiple entries (ADR-002 fullTalk fixture)', () => {
+      expect(() => assertCompositionManifest([...adr002FullTalk])).not.toThrow();
+    });
+
+    it.each<[string, unknown]>([
+      ['null', null],
+      ['undefined', undefined],
+      ['a string', 'scene-a'],
+      ['a number', 42],
+      ['a boolean', true],
+      ['a plain object', { id: 'scene-a' }],
+      ['a Set', new Set(['scene-a'])],
+      ['a Map', new Map()],
+    ])('rejects %s as a manifest (must be an array)', (_label, value) => {
+      expect(() => assertCompositionManifest(value)).toThrow(
+        /^composition manifest is invalid: must be an array/,
+      );
+    });
+
+    it('reports the top-level error without an entry index', () => {
+      expect(() => assertCompositionManifest('not an array')).toThrow(
+        /^composition manifest is invalid:/,
+      );
+      expect(() => assertCompositionManifest('not an array')).not.toThrow(/entry \[/);
+    });
+  });
+
+  describe('clause C2 — bare scene id string entries', () => {
+    describe('valid kebab-case ids', () => {
+      it.each(['a', 'scene-a', 'cold-open', 'a-b-c', 'intro1', '1', 'a1-b2', '9-9'])(
+        'accepts %j',
+        (id) => {
+          expect(() => assertCompositionManifest([id])).not.toThrow();
+        },
+      );
+    });
+
+    describe('invalid bare-string entries are rejected', () => {
+      it.each<[string, string]>([
+        ['empty string', ''],
+        ['uppercase letter', 'Scene-a'],
+        ['fully uppercase', 'SCENE-A'],
+        ['underscore separator', 'scene_a'],
+        ['leading hyphen', '-scene'],
+        ['trailing hyphen', 'scene-'],
+        ['consecutive hyphens', 'a--b'],
+        ['internal whitespace', 'scene a'],
+        ['leading whitespace', ' scene-a'],
+        ['trailing whitespace', 'scene-a '],
+        ['newline', 'scene-a\n'],
+        ['punctuation', 'scene.a'],
+        ['slash', 'scene/a'],
+        ['colon', 'scene:a'],
+        ['non-ASCII', 'séance'],
+      ])('rejects %s (%j) with a kebab-case condition', (_label, id) => {
+        expect(() => assertCompositionManifest([id])).toThrow(
+          /^composition entry \[0\] is invalid: id must be a non-empty lowercase kebab-case string/,
+        );
+      });
+    });
+
+    it('rejects when the failing entry is in the middle of the manifest, reporting its index', () => {
+      const manifest = ['scene-a', 'scene-b', 'Bad-Entry', 'scene-c'];
+      expect(() => assertCompositionManifest(manifest)).toThrow(
+        /^composition entry \[2\] is invalid:/,
+      );
+    });
+
+    it('rejects when the failing entry is the last entry', () => {
+      const manifest = ['scene-a', 'scene-b', ''];
+      expect(() => assertCompositionManifest(manifest)).toThrow(
+        /^composition entry \[2\] is invalid:/,
+      );
+    });
+  });
+
+  describe('clause C3 — object entries with overrides', () => {
+    describe('id field', () => {
+      it('accepts the minimal { id } object entry', () => {
+        expect(() => assertCompositionManifest([{ id: 'scene-a' }])).not.toThrow();
+      });
+
+      it('rejects when id is missing', () => {
+        expect(() => assertCompositionManifest([{}])).toThrow(
+          /^composition entry \[0\] is invalid: id must be present/,
+        );
+      });
+
+      it.each<[string, unknown]>([
+        ['null', null],
+        ['undefined', undefined],
+        ['a number', 42],
+        ['an array', ['scene-a']],
+        ['an object', { id: 'scene-a' }],
+        ['empty string', ''],
+        ['Uppercase', 'Scene-A'],
+        ['underscore_id', 'scene_a'],
+      ])('rejects when id is %s (%j)', (_label, badId) => {
+        expect(() => assertCompositionManifest([{ id: badId }])).toThrow(
+          /^composition entry \[0\] is invalid: id /,
+        );
+      });
+    });
+
+    describe('range override (sub-range — ADR-003 §Labels)', () => {
+      it('accepts a single-string range (single beat label)', () => {
+        expect(() => assertCompositionManifest([{ id: 'scene-a', range: 'payoff' }])).not.toThrow();
+      });
+
+      it('accepts a [start, end] tuple range', () => {
+        expect(() =>
+          assertCompositionManifest([{ id: 'scene-a', range: ['intro', 'hook'] }]),
+        ).not.toThrow();
+      });
+
+      it('accepts ranges using single-segment kebab labels', () => {
+        expect(() =>
+          assertCompositionManifest([{ id: 'scene-a', range: ['act1', 'act2'] }]),
+        ).not.toThrow();
+      });
+
+      it('accepts multi-segment kebab labels in ranges', () => {
+        expect(() =>
+          assertCompositionManifest([{ id: 'scene-a', range: ['cold-open', 'final-beat'] }]),
+        ).not.toThrow();
+      });
+
+      it.each<[string, unknown]>([
+        ['empty string', ''],
+        ['uppercase', 'Intro'],
+        ['underscore', 'in_tro'],
+        ['leading hyphen', '-intro'],
+        ['internal whitespace', 'in tro'],
+      ])('rejects single-string range %s (%j)', (_label, range) => {
+        expect(() => assertCompositionManifest([{ id: 'scene-a', range }])).toThrow(
+          /^composition entry \[0\] is invalid: range /,
+        );
+      });
+
+      it.each<[string, unknown]>([
+        ['number', 42],
+        ['boolean', true],
+        ['null', null],
+        ['plain object', { start: 'a', end: 'b' }],
+        ['Set', new Set(['intro', 'hook'])],
+      ])('rejects non-string non-array range value (%s)', (_label, range) => {
+        expect(() => assertCompositionManifest([{ id: 'scene-a', range }])).toThrow(
+          /^composition entry \[0\] is invalid: range /,
+        );
+      });
+
+      it('rejects a length-1 range array', () => {
+        expect(() => assertCompositionManifest([{ id: 'scene-a', range: ['intro'] }])).toThrow(
+          /^composition entry \[0\] is invalid: range /,
+        );
+      });
+
+      it('rejects a length-3 range array', () => {
+        expect(() =>
+          assertCompositionManifest([{ id: 'scene-a', range: ['intro', 'mid', 'hook'] }]),
+        ).toThrow(/^composition entry \[0\] is invalid: range /);
+      });
+
+      it('rejects an empty range array', () => {
+        expect(() => assertCompositionManifest([{ id: 'scene-a', range: [] }])).toThrow(
+          /^composition entry \[0\] is invalid: range /,
+        );
+      });
+
+      it.each<[string, unknown[]]>([
+        ['number element', [42, 'hook']],
+        ['null element', [null, 'hook']],
+        ['nested array', [['intro'], 'hook']],
+        ['object element', [{ label: 'intro' }, 'hook']],
+        ['empty string element', ['', 'hook']],
+        ['uppercase element', ['Intro', 'hook']],
+        ['second element invalid', ['intro', 'Hook']],
+      ])('rejects range array with %s', (_label, range) => {
+        expect(() => assertCompositionManifest([{ id: 'scene-a', range }])).toThrow(
+          /^composition entry \[0\] is invalid: range /,
+        );
+      });
+    });
+
+    describe('behavior override', () => {
+      it('accepts an empty behavior object', () => {
+        expect(() => assertCompositionManifest([{ id: 'scene-a', behavior: {} }])).not.toThrow();
+      });
+
+      it('accepts a behavior object with arbitrary keys (resolver-defined)', () => {
+        expect(() =>
+          assertCompositionManifest([
+            { id: 'scene-a', behavior: { mute: true, speed: 1.5, label: 'rehearsal' } },
+          ]),
+        ).not.toThrow();
+      });
+
+      it.each<[string, unknown]>([
+        ['null', null],
+        ['undefined-tagged value', 'not-an-object'],
+        ['number', 42],
+        ['boolean', true],
+        ['array', ['mute', true]],
+      ])('rejects non-object behavior (%s)', (_label, behavior) => {
+        expect(() => assertCompositionManifest([{ id: 'scene-a', behavior }])).toThrow(
+          /^composition entry \[0\] is invalid: behavior must be a plain object/,
+        );
+      });
+
+      it('does NOT inspect the contents of the behavior object', () => {
+        expect(() =>
+          assertCompositionManifest([
+            { id: 'scene-a', behavior: { nested: { weird: () => 'fine' } } },
+          ]),
+        ).not.toThrow();
+      });
+    });
+
+    describe('combined overrides', () => {
+      it('accepts an entry carrying both range and behavior', () => {
+        expect(() =>
+          assertCompositionManifest([
+            { id: 'scene-a', range: ['intro', 'hook'], behavior: { mute: true } },
+          ]),
+        ).not.toThrow();
+      });
+    });
+
+    describe('unknown override keys are rejected (codex preflight guardrail)', () => {
+      it('rejects an entry with an unknown override key', () => {
+        expect(() => assertCompositionManifest([{ id: 'scene-a', typo: 1 }] as unknown[])).toThrow(
+          /^composition entry \[0\] is invalid: unknown key "typo"/,
+        );
+      });
+
+      it('rejects an entry with multiple unknown keys, naming one of them', () => {
+        expect(() =>
+          assertCompositionManifest([{ id: 'scene-a', label: 'x', mode: 'y' }] as unknown[]),
+        ).toThrow(/^composition entry \[0\] is invalid: unknown key "/);
+      });
+
+      it('rejects an entry that mixes a known and an unknown override slot', () => {
+        expect(() =>
+          assertCompositionManifest([
+            { id: 'scene-a', range: 'intro', duration: 1000 },
+          ] as unknown[]),
+        ).toThrow(/^composition entry \[0\] is invalid: unknown key "duration"/);
+      });
+    });
+
+    describe('object entries — top-level shape rejections', () => {
+      it.each<[string, unknown]>([
+        ['null', null],
+        ['undefined', undefined],
+        ['number', 42],
+        ['boolean', true],
+        ['array', ['scene-a']],
+      ])('rejects a non-plain-object entry (%s)', (_label, entry) => {
+        expect(() => assertCompositionManifest([entry])).toThrow(
+          /^composition entry \[0\] is invalid:/,
+        );
+      });
+    });
+  });
+
+  describe('AC1 — bare and object entries can mix freely (ADR-002 trailer fixture)', () => {
+    it('accepts the literal ADR-002 fullTalk example', () => {
+      expect(() => assertCompositionManifest([...adr002FullTalk])).not.toThrow();
+    });
+
+    it('accepts the literal ADR-002 shortTalk example', () => {
+      expect(() => assertCompositionManifest([...adr002ShortTalk])).not.toThrow();
+    });
+
+    it('accepts the literal ADR-002 trailer example (mixed object overrides)', () => {
+      expect(() => assertCompositionManifest([...adr002Trailer])).not.toThrow();
+    });
+
+    it('accepts arbitrary mixes of bare strings and override objects', () => {
+      const mixed: CompositionEntry[] = [
+        'scene-a',
+        { id: 'scene-b', range: 'hook' },
+        'scene-c',
+        { id: 'scene-d', range: ['intro', 'outro'], behavior: { speed: 1.25 } },
+      ];
+      expect(() => assertCompositionManifest(mixed)).not.toThrow();
+    });
+
+    it('reports the correct index when a bad entry sits among valid mixed entries', () => {
+      const mixed = ['scene-a', { id: 'scene-b' }, 'Bad-Entry', { id: 'scene-d' }];
+      expect(() => assertCompositionManifest(mixed)).toThrow(
+        /^composition entry \[2\] is invalid:/,
+      );
+    });
+
+    it('does not reject duplicate scene references — recomposition may reuse scenes', () => {
+      // Per codex preflight guardrail: duplicate references are intentional.
+      expect(() =>
+        assertCompositionManifest(['scene-a', 'scene-b', 'scene-a', { id: 'scene-a' }]),
+      ).not.toThrow();
+    });
+  });
+
+  describe('AC2 — actionable error messages', () => {
+    it('reports field name and human-readable condition for id', () => {
+      expect(() => assertCompositionManifest([{ id: 'Scene-A' }])).toThrow(
+        /id must be a non-empty lowercase kebab-case string/,
+      );
+    });
+
+    it('reports field name and human-readable condition for range', () => {
+      expect(() => assertCompositionManifest([{ id: 'scene-a', range: 42 }])).toThrow(
+        /range must be a kebab-case beat label or a \[start, end\] tuple of kebab-case beat labels/,
+      );
+    });
+
+    it('reports field name and human-readable condition for behavior', () => {
+      expect(() => assertCompositionManifest([{ id: 'scene-a', behavior: 'no' }])).toThrow(
+        /behavior must be a plain object/,
+      );
+    });
+
+    it('stops at the first failing entry (does not aggregate)', () => {
+      const manifest = ['Bad-One', 'Bad-Two'];
+      // Should report index [0], not [1].
+      expect(() => assertCompositionManifest(manifest)).toThrow(/entry \[0\]/);
+      expect(() => assertCompositionManifest(manifest)).not.toThrow(/entry \[1\]/);
+    });
+  });
+
+  describe('isCompositionManifest predicate', () => {
+    it('returns true for valid manifests', () => {
+      expect(isCompositionManifest([])).toBe(true);
+      expect(isCompositionManifest([...adr002FullTalk])).toBe(true);
+      expect(isCompositionManifest([...adr002Trailer])).toBe(true);
+      expect(isCompositionManifest([{ id: 'scene-a', range: ['intro', 'hook'] }])).toBe(true);
+    });
+
+    it('returns false for invalid manifests without throwing', () => {
+      expect(isCompositionManifest(null)).toBe(false);
+      expect(isCompositionManifest('scene-a')).toBe(false);
+      expect(isCompositionManifest([{ id: 'Bad-Id' }])).toBe(false);
+      expect(isCompositionManifest([{ id: 'scene-a', range: 42 }])).toBe(false);
+      expect(isCompositionManifest([{ id: 'scene-a', typo: 1 }])).toBe(false);
+    });
+
+    it('does not throw on any input', () => {
+      const adversarial: unknown[] = [
+        undefined,
+        null,
+        42,
+        'string',
+        {},
+        [],
+        [null],
+        [{ id: 'x', range: 'y', extra: 'z' }],
+      ];
+      for (const input of adversarial) {
+        expect(() => isCompositionManifest(input)).not.toThrow();
+      }
+    });
+  });
+
+  describe('exported types compile (smoke check)', () => {
+    it('SubRange union covers string and tuple shapes', () => {
+      const single: SubRange = 'intro';
+      const tuple: SubRange = ['intro', 'hook'];
+      expect([single, tuple]).toEqual(['intro', ['intro', 'hook']]);
+    });
+
+    it('CompositionEntryOverride permits id alone, with range, with behavior, or with both', () => {
+      const a: CompositionEntryOverride = { id: 'scene-a' };
+      const b: CompositionEntryOverride = { id: 'scene-a', range: 'hook' };
+      const c: CompositionEntryOverride = { id: 'scene-a', behavior: { speed: 2 } };
+      const d: CompositionEntryOverride = {
+        id: 'scene-a',
+        range: ['intro', 'hook'],
+        behavior: { speed: 2 },
+      };
+      const manifest: CompositionManifest = [a, b, c, d];
+      expect(manifest).toHaveLength(4);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements **PUL-F003** — the composition manifest format. Defines the
data shape for arranging scenes into talks / short cuts / trailers and
provides a runtime validator that rejects malformed manifests.

A composition manifest is an ordered array of entries; each entry is
either a bare kebab-case scene id string or an object carrying `id`
plus optional `range` (sub-range — single beat label or `[start, end]`
label pair, per ADR-003 §Labels) and `behavior` (per-entry override
blob). Unknown override keys are rejected so typos surface immediately
(per the codex architecture preflight guardrail).

This module owns the **format** only — registry-existence checks,
beat-label-existence checks against a scene's timeline, and asset
preloading belong to the resolution layer (separate requirement) and
are deliberately out of scope here.

### Files

- `src/runtime/composition.ts` — types + `assertCompositionManifest` + `isCompositionManifest`.
- `src/runtime/identifier.ts` — extracted kebab-case identifier predicate. ADR-008 #1 makes the same rule binding on scenes, compositions, beats, and assets, so the regex now lives in one place that both `scene.ts` and `composition.ts` consume.
- `src/runtime/scene.ts` — refactored to source the kebab-case predicate from `identifier.ts`. No public-API change; same regex.
- `tests/runtime/composition.test.ts` — 103-test Vitest spec covering every PUL-F003 clause + the codex-guardrail unknown-key rejection + ADR-002's literal `fullTalk`/`shortTalk`/`trailer` examples as fixtures.
- `CHANGELOG.md` — Unreleased entries.

## Test plan

- [x] `pnpm lint` clean.
- [x] `pnpm typecheck` clean.
- [x] `pnpm test` — 244 passing (141 existing + 103 new); the existing scene + registry specs still pass after the `scene.ts` extraction, proving the refactor is behavior-preserving.
- [x] `pre-commit run --all-files` clean.
- [ ] CI green on the PR.
- [ ] SonarCloud quality gate green; no new issues / hotspots.

Closes #12