### PR TITLE
PUL-F004: Composition resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,25 +10,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `src/runtime/composition-resolver.ts` — `resolveComposition` async
-  function plus `ResolveCompositionOptions`, `AssetPreloader`, and
-  `SceneTimelineRunner` types. Implements PUL-F004 (composition
-  resolution): given a `SceneRegistry` and a `CompositionManifest`, the
-  runtime (a) calls `assertCompositionManifest` defensively then
-  aggregates every missing scene id into a single actionable error
-  before any side effect; (b) per scene, `await`s the injected
-  `preloadAssets(scene)` adapter; (c) `await`s `scene.create(ctx)`;
-  (d) `await`s `runTimeline(scene, scene.timeline(ctx))`; (e) always
-  `await`s `scene.cleanup(ctx)` whenever the scene was touched
-  (mandatory cleanup per ADR-008 / PUL-P001 — runs after `create`
-  failure when resources may have been partially acquired, and after
-  timeline failure). Errors carry a `composition resolution failed:`
-  prefix; original errors are preserved as `Error.cause`; when both a
-  lifecycle phase AND cleanup throw, the wrapping message names both
-  and the cleanup error is chained onto the phase error
-  (`phaseError.cause = cleanupError`) so neither is silently swallowed.
-  Scene `ctx`, `range`, and `behavior` are opaque to the resolver —
-  sub-range / behavior interpretation is delegated to the timeline
-  runner adapter (ADR-011).
+  function plus `ResolveCompositionOptions`, `AssetPreloader`,
+  `SceneTimelineRunInput`, and `SceneTimelineRunner` types. Implements
+  PUL-F004 (composition resolution): given a `SceneRegistry` and a
+  `CompositionManifest`, the runtime (a) calls
+  `assertCompositionManifest` defensively then aggregates every missing
+  scene id into a single actionable error before any side effect; (b)
+  per scene, `await`s the injected `preloadAssets(scene)` adapter; (c)
+  `await`s `scene.create(ctx)`; (d) `await`s the value of
+  `scene.timeline(ctx)` (so async timeline factories resolve to a
+  concrete timeline) then `await`s
+  `runTimeline({ scene, timeline, range?, behavior? })` — `range` and
+  `behavior` overrides from object entries flow through the runner
+  input unchanged so the future GSAP runner can honor sub-range cuts
+  and behavior overrides without another resolver-signature change;
+  (e) always `await`s `scene.cleanup(ctx)` whenever the scene was
+  touched (mandatory cleanup per ADR-008 / PUL-P001 — runs after
+  `create` failure when resources may have been partially acquired,
+  and after timeline failure). Errors carry a `composition resolution
+  failed:` prefix; single-failure errors preserve the original as
+  `Error.cause`; combined lifecycle-phase + cleanup failures throw an
+  `AggregateError` whose `errors` array carries both errors in order
+  (the resolver does not mutate caller-supplied errors). Scene `ctx`
+  is opaque to the resolver and passed straight through.
 - `tests/runtime/composition-resolver.test.ts` — 27-test Vitest spec
   covering every clause of PUL-F004: manifest-defense boundary;
   clause-(a) pre-flight existence with single, multiple, and object-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `src/runtime/composition-resolver.ts` — `resolveComposition` async
+  function plus `ResolveCompositionOptions`, `AssetPreloader`, and
+  `SceneTimelineRunner` types. Implements PUL-F004 (composition
+  resolution): given a `SceneRegistry` and a `CompositionManifest`, the
+  runtime (a) calls `assertCompositionManifest` defensively then
+  aggregates every missing scene id into a single actionable error
+  before any side effect; (b) per scene, `await`s the injected
+  `preloadAssets(scene)` adapter; (c) `await`s `scene.create(ctx)`;
+  (d) `await`s `runTimeline(scene, scene.timeline(ctx))`; (e) always
+  `await`s `scene.cleanup(ctx)` whenever the scene was touched
+  (mandatory cleanup per ADR-008 / PUL-P001 — runs after `create`
+  failure when resources may have been partially acquired, and after
+  timeline failure). Errors carry a `composition resolution failed:`
+  prefix; original errors are preserved as `Error.cause`; when both a
+  lifecycle phase AND cleanup throw, the wrapping message names both
+  and the cleanup error is chained onto the phase error
+  (`phaseError.cause = cleanupError`) so neither is silently swallowed.
+  Scene `ctx`, `range`, and `behavior` are opaque to the resolver —
+  sub-range / behavior interpretation is delegated to the timeline
+  runner adapter (ADR-011).
+- `tests/runtime/composition-resolver.test.ts` — 27-test Vitest spec
+  covering every clause of PUL-F004: manifest-defense boundary;
+  clause-(a) pre-flight existence with single, multiple, and object-
+  entry missing ids plus the "no side effect before pre-flight"
+  invariant; clause-(b) preload order, async-await ordering, and abort
+  semantics; clause-(c) `create(ctx)` ordering plus the "still calls
+  cleanup when create rejects" rule; clause-(d) timeline-value
+  pass-through, async-await ordering, and the timeline-throws-cleanup-
+  still-runs rule (separately for `scene.timeline(ctx)` itself
+  throwing and for the runner adapter rejecting); clause-(e) cleanup
+  ordering across a 3-scene happy path, cleanup-only failures,
+  combined timeline+cleanup failures with cause chaining, and combined
+  create+cleanup failures; sync vs async lifecycle hook handling; the
+  range/behavior pass-through deferral; the codex-preflight no-dedup
+  invariant for repeated scene ids; and the ADR-002 `trailer` fixture
+  driven end-to-end with mixed bare-string and object entries.
+- `docs/adrs/011-composition-resolver-orchestration.md` — records the
+  decision that the composition resolver is a pure orchestrator that
+  owns lifecycle order, mandatory-cleanup invariant, and aggregated
+  failure semantics, while delegating asset preloading and timeline
+  execution to injected callbacks (`AssetPreloader`,
+  `SceneTimelineRunner`). Documents the deferral of `range` /
+  `behavior` interpretation to the timeline runner adapter so the
+  resolver does not weld itself to one timeline engine (keeping
+  ADR-003's swappable `ctx.gsap` decision intact). ADR-011 is
+  registered in Ground Control via `gc_create_adr`.
+- `docs/adrs/README.md` index — backfills missing rows for ADR-010
+  (Issue Tag Taxonomy) and ADR-011 (Composition Resolver
+  Orchestration) so the table stays in sync with the files on disk.
 - `src/runtime/composition.ts` — `CompositionManifest`,
   `CompositionEntry`, `CompositionEntryOverride`, `SubRange`, and
   `BehaviorOverride` types plus `assertCompositionManifest` runtime

--- a/docs/adrs/011-composition-resolver-orchestration.md
+++ b/docs/adrs/011-composition-resolver-orchestration.md
@@ -1,0 +1,132 @@
+# ADR-011: Composition Resolver as a Pure Orchestrator with Injected Adapters
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-03
+
+## Context
+
+[ADR-002](002-scene-registry-and-compositions.md) §Resolution defines
+the runtime's lifecycle for playing a composition: validate every
+referenced scene id, preload assets, mount each scene via `create(ctx)`,
+run its timeline, tear it down via `cleanup(ctx)`, advance. PUL-F004 is
+the requirement that ships that lifecycle.
+
+Two of the five clauses depend on subsystems that do not yet exist:
+
+- The asset preloader is first mentioned in PUL-F004 itself; there is
+  no implementation yet (PUL-F005+ will land one).
+- The GSAP timeline engine is decided in
+  [ADR-003](003-gsap-timeline-engine.md) but no `gsap` import exists in
+  the repo and no master-timeline runner has landed.
+
+The resolver is the single call site for both subsystems. Its shape now
+determines how much churn the asset loader and the GSAP runner cause
+when they land. It is also the call site for any future presenter-
+interrupt or sub-range cut behavior — so we want a shape that does not
+have to change every time the runtime gains a new orthogonal concern.
+
+The default temptation is to inline a stub asset loader and a stub GSAP
+shim into the resolver "for now" and revisit when the real subsystems
+arrive. That conflates the manifest-execution requirement with the
+asset/timeline subsystem requirements and welds the resolver to one
+particular timeline engine (defeating ADR-003's swappable
+`ctx.gsap` decision and ADR-008's "manifests over flow control"
+principle).
+
+## Decision
+
+The composition resolver in
+[`src/runtime/composition-resolver.ts`](../../src/runtime/composition-resolver.ts)
+is a **pure orchestrator**. It owns:
+
+1. The lifecycle order: validate → pre-flight existence → preload →
+   create → timeline → cleanup, strictly sequential, in manifest order.
+2. The failure rules: missing-id pre-flight aggregates ALL offenders
+   into a single error before any side effect; cleanup is mandatory
+   whenever a scene was touched (including failure paths after `create`
+   or timeline execution); when a lifecycle phase AND cleanup both
+   throw, the wrapping `Error` carries both — the phase error as
+   `Error.cause` and the cleanup error chained onto it
+   (`phaseError.cause = cleanupError`) — so neither is silently
+   swallowed (PUL-Q005 spirit).
+3. The boundary defensiveness pattern: the resolver calls
+   `assertCompositionManifest` itself, mirroring how
+   `createSceneRegistry` calls `assertSceneModule` (PUL-F002 / PUL-F001
+   relationship).
+
+The resolver delegates the *work* of preloading and of running a
+timeline to **injected callbacks**:
+
+- `AssetPreloader = (scene: SceneModule) => void | Promise<void>`
+- `SceneTimelineRunner = (scene: SceneModule, timeline: unknown) => void | Promise<void>`
+
+The scene `ctx` is opaque to the resolver — it is passed straight
+through to every lifecycle hook. The resolver does not depend on,
+import, or feature-detect any specific asset library, GSAP, Howler, or
+DOM API.
+
+`range` and `behavior` overrides on object entries (PUL-F003) are
+accepted at the boundary by `assertCompositionManifest` but are NOT
+read or interpreted by the resolver in PUL-F004. Their interpretation
+belongs to the timeline runner adapter (sub-range cuts use GSAP labels;
+behavior overrides are runner-defined). The resolver simply hands the
+scene module to the runner; the runner decides what to do with the
+entry-level overrides when it is ready to support them.
+
+## Consequences
+
+### Positive
+
+- Subsystems stay swappable per ADR-003 / ADR-004. The asset loader
+  and the GSAP timeline runner can be implemented, reimplemented, or
+  swapped without touching `composition-resolver.ts`.
+- PUL-F004 ships without dragging in a stub asset loader or a stub
+  GSAP wrapper. The requirement-to-module mapping stays one-to-one.
+- Failure semantics are explicit and individually testable. Each
+  failure mode (preload reject, create reject, timeline reject,
+  cleanup reject, double-fault) has its own test in
+  `tests/runtime/composition-resolver.test.ts`.
+- Cleanup-mandatory behavior is enforced at the orchestration layer
+  rather than re-implemented per scene, satisfying PUL-P001 with one
+  audited code path.
+- The resolver is a useful primitive for the export pipeline (ADR-006)
+  and the workbench (ADR-007) — both can plug their own preloader and
+  runner adapters in without forking the lifecycle code.
+
+### Negative
+
+- Callers must wire two callbacks instead of "just calling play". The
+  workbench bootstrap and the export pipeline each have a one-time
+  wiring cost when they land.
+- The resolver does not "know" about GSAP, so error messages from a
+  failing timeline are only as informative as the runner adapter's
+  error reporting. Mitigated: the resolver wraps with
+  `composition resolution failed: scene "<id>" timeline threw: <cause>`
+  and preserves the cause chain so the underlying error remains
+  inspectable.
+
+### Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| Future presenter-interrupt support might need state the resolver currently does not own. | The orchestrator's small surface (one async function, two callbacks) is easy to extend; cancellation can land as an `AbortSignal` option without changing the failure semantics. Re-evaluate when PUL-F005+ specifies presenter controls. |
+| The "do not interpret `range` / `behavior`" deferral could be missed by future work, leading to silent acceptance of overrides that don't do anything. | Test `'accepts object entries with range / behavior overrides without reading either field'` pins the deferral; any future change that starts interpreting them must adjust this test, surfacing the intent explicitly. |
+| Two failing hooks (timeline + cleanup) could surface as a confusing single error. | The wrapping error message names both, and the cause chain (top → phase → cleanup) preserves both error objects for programmatic inspection; tests pin both surfaces. |
+
+## Related ADRs
+
+- [ADR-002](002-scene-registry-and-compositions.md) — defines the
+  resolution algorithm this ADR operationalizes.
+- [ADR-003](003-gsap-timeline-engine.md) — the timeline engine the
+  `SceneTimelineRunner` adapter targets.
+- [ADR-004](004-howler-audio-engine.md) — the audio engine handle that
+  will arrive on `ctx.audio`; the resolver passes `ctx` through
+  unchanged.
+- [ADR-008](008-agent-native-authoring.md) — mandatory-cleanup,
+  declarative-data, manifests-over-flow-control invariants the
+  resolver enforces.

--- a/docs/adrs/011-composition-resolver-orchestration.md
+++ b/docs/adrs/011-composition-resolver-orchestration.md
@@ -125,7 +125,7 @@ identity, so synchronous timeline factories are unaffected.
 |------|-----------|
 | Future presenter-interrupt support might need state the resolver currently does not own. | The orchestrator's small surface (one async function, two callbacks) is easy to extend; cancellation can land as an `AbortSignal` option without changing the failure semantics. Re-evaluate when PUL-F005+ specifies presenter controls. |
 | The "do not interpret `range` / `behavior`" deferral could be missed by future work, leading to silent acceptance of overrides that don't do anything. | Test `'accepts object entries with range / behavior overrides without reading either field'` pins the deferral; any future change that starts interpreting them must adjust this test, surfacing the intent explicitly. |
-| Two failing hooks (timeline + cleanup) could surface as a confusing single error. | The wrapping error message names both, and the cause chain (top → phase → cleanup) preserves both error objects for programmatic inspection; tests pin both surfaces. |
+| Two failing hooks (timeline + cleanup) could surface as a confusing single error. | The wrapping error message names both, and the `AggregateError.errors` array carries both error objects in order for programmatic inspection (no `Error.cause` chain — `errors[]` is the public contract). Neither caller-supplied error is mutated. Tests pin both surfaces. |
 
 ## Related ADRs
 

--- a/docs/adrs/011-composition-resolver-orchestration.md
+++ b/docs/adrs/011-composition-resolver-orchestration.md
@@ -50,10 +50,10 @@ is a **pure orchestrator**. It owns:
    into a single error before any side effect; cleanup is mandatory
    whenever a scene was touched (including failure paths after `create`
    or timeline execution); when a lifecycle phase AND cleanup both
-   throw, the wrapping `Error` carries both — the phase error as
-   `Error.cause` and the cleanup error chained onto it
-   (`phaseError.cause = cleanupError`) — so neither is silently
-   swallowed (PUL-Q005 spirit).
+   throw, the wrapping error is an `AggregateError` whose `errors`
+   array carries both the phase error and the cleanup error in order
+   — neither caller-supplied error is mutated and both are
+   programmatically recoverable (PUL-Q005 spirit).
 3. The boundary defensiveness pattern: the resolver calls
    `assertCompositionManifest` itself, mirroring how
    `createSceneRegistry` calls `assertSceneModule` (PUL-F002 / PUL-F001
@@ -63,7 +63,8 @@ The resolver delegates the *work* of preloading and of running a
 timeline to **injected callbacks**:
 
 - `AssetPreloader = (scene: SceneModule) => void | Promise<void>`
-- `SceneTimelineRunner = (scene: SceneModule, timeline: unknown) => void | Promise<void>`
+- `SceneTimelineRunner = (input: SceneTimelineRunInput) => void | Promise<void>`
+  where `SceneTimelineRunInput` is `{ scene, timeline, range?, behavior? }`.
 
 The scene `ctx` is opaque to the resolver — it is passed straight
 through to every lifecycle hook. The resolver does not depend on,
@@ -71,12 +72,20 @@ import, or feature-detect any specific asset library, GSAP, Howler, or
 DOM API.
 
 `range` and `behavior` overrides on object entries (PUL-F003) are
-accepted at the boundary by `assertCompositionManifest` but are NOT
-read or interpreted by the resolver in PUL-F004. Their interpretation
-belongs to the timeline runner adapter (sub-range cuts use GSAP labels;
-behavior overrides are runner-defined). The resolver simply hands the
-scene module to the runner; the runner decides what to do with the
-entry-level overrides when it is ready to support them.
+accepted at the boundary by `assertCompositionManifest`. The resolver
+does NOT read or interpret either field — but it does forward both to
+the runner adapter unchanged through `SceneTimelineRunInput`. Carrying
+them on the runner input now (rather than only inside the manifest the
+resolver consumes) means the future GSAP runner can honor sub-range
+cuts and behavior overrides without another resolver-signature change.
+The resolver hands `range` / `behavior` to the runner; the runner
+decides what to do with them when it is ready to support them.
+
+`scene.timeline(ctx)` is `await`ed before its return value is handed to
+the runner so async timeline factories (e.g. ones that load a beat
+script before constructing the GSAP timeline) resolve to a concrete
+timeline before the runner sees them. Awaiting a non-Promise value is
+identity, so synchronous timeline factories are unaffected.
 
 ## Consequences
 

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -35,3 +35,5 @@ Each ADR includes:
 | [007](007-browser-workbench.md) | Browser as the Default Workbench and Agent Collaboration Surface | Accepted |
 | [008](008-agent-native-authoring.md) | Agent-Native Authoring as a First-Class Architectural Constraint | Accepted |
 | [009](009-repo-layout-and-build-tooling.md) | Repo Layout and Build Tooling | Accepted |
+| [010](010-issue-tag-taxonomy.md) | GitHub Issue Tag Taxonomy | Accepted |
+| [011](011-composition-resolver-orchestration.md) | Composition Resolver as a Pure Orchestrator with Injected Adapters | Accepted |

--- a/src/runtime/composition-resolver.ts
+++ b/src/runtime/composition-resolver.ts
@@ -111,6 +111,19 @@ const describe = (value: unknown): string =>
   value instanceof Error ? value.message : String(value);
 
 /**
+ * One entry of the resolver's internal execution plan. Built once at
+ * preflight time and iterated during lifecycle execution so the
+ * resolver is immune to caller-owned manifest mutations performed
+ * inside lifecycle callbacks (codex review: snapshot the manifest
+ * before lifecycle side effects).
+ */
+interface PlanStep {
+  readonly scene: SceneModule;
+  readonly range: SubRange | undefined;
+  readonly behavior: BehaviorOverride | undefined;
+}
+
+/**
  * Build the resolver's wrapping `Error`. Every public failure carries
  * the `composition resolution failed:` prefix so callers can pattern-
  * match on origin without parsing scene-specific detail.
@@ -130,23 +143,18 @@ const failAggregate = (detail: string, errors: readonly unknown[]): AggregateErr
   new AggregateError(errors, `composition resolution failed: ${detail}`);
 
 /**
- * Build the {@link SceneTimelineRunInput} for one entry. Bare-string
- * entries omit `range` / `behavior` entirely; object entries forward
- * whatever the validator accepted (which already rejects unknown
- * override keys per PUL-F003).
+ * Build the {@link SceneTimelineRunInput} for one plan step. Omits
+ * `range` / `behavior` from the output object when absent on the
+ * source entry rather than emitting `range: undefined` keys, so the
+ * runner's `range in input` checks behave intuitively.
  */
-function buildRunInput(
-  scene: SceneModule,
-  entry: CompositionEntry,
-  timeline: unknown,
-): SceneTimelineRunInput {
-  if (typeof entry === 'string') return { scene, timeline };
+function buildRunInput(step: PlanStep, timeline: unknown): SceneTimelineRunInput {
   const input: { -readonly [K in keyof SceneTimelineRunInput]: SceneTimelineRunInput[K] } = {
-    scene,
+    scene: step.scene,
     timeline,
   };
-  if (entry.range !== undefined) input.range = entry.range;
-  if (entry.behavior !== undefined) input.behavior = entry.behavior;
+  if (step.range !== undefined) input.range = step.range;
+  if (step.behavior !== undefined) input.behavior = step.behavior;
   return input;
 }
 
@@ -196,35 +204,48 @@ export async function resolveComposition(options: ResolveCompositionOptions): Pr
   const { registry, manifest, ctx, preloadAssets, runTimeline } = options;
 
   assertCompositionManifest(manifest);
-  preflightSceneIds(manifest, registry);
+  const plan = buildPlan(manifest, registry);
 
   // Per-scene lifecycle, strictly sequential. Each iteration runs
   // preload → create → timeline → cleanup before the next iteration's
-  // preload begins (clause e of PUL-F004).
-  for (const entry of manifest) {
-    const scene = registry.get(entryId(entry));
-    await preloadScene(scene, preloadAssets);
-    await runScene(scene, entry, ctx, runTimeline);
+  // preload begins (clause e of PUL-F004). Iterating the resolver-
+  // owned `plan` snapshot means lifecycle callbacks cannot mutate the
+  // execution path mid-flight by reaching back into the caller's
+  // manifest.
+  for (const step of plan) {
+    await preloadScene(step.scene, preloadAssets);
+    await runScene(step, ctx, runTimeline);
   }
 }
 
 /**
- * Clause (a): walk every entry, aggregate ALL missing scene ids into
- * a single error before any side effect, and throw if any are missing.
- * Aggregating beats fail-on-first because a manifest author fixes
- * every typo in one pass.
+ * Clause (a) plus snapshot capture: walk every entry exactly once,
+ * resolve every scene id against the registry, snapshot per-entry
+ * `range` / `behavior` overrides, and aggregate ALL missing ids into
+ * one error before any side effect. Aggregating beats fail-on-first
+ * because a manifest author fixes every typo in one pass; snapshotting
+ * means lifecycle callbacks cannot retroactively alter the plan by
+ * mutating the caller's manifest array (codex review).
  */
-function preflightSceneIds(manifest: CompositionManifest, registry: SceneRegistry): void {
+function buildPlan(manifest: CompositionManifest, registry: SceneRegistry): readonly PlanStep[] {
   const missing: { readonly index: number; readonly id: string }[] = [];
+  const plan: PlanStep[] = [];
   for (const [index, entry] of manifest.entries()) {
     const id = entryId(entry);
     if (!registry.has(id)) {
       missing.push({ index, id });
+      continue;
     }
+    const scene = registry.get(id);
+    const range = typeof entry === 'string' ? undefined : entry.range;
+    const behavior = typeof entry === 'string' ? undefined : entry.behavior;
+    plan.push({ scene, range, behavior });
   }
-  if (missing.length === 0) return;
-  const list = missing.map(({ id, index }) => `"${id}" (entry [${index}])`).join(', ');
-  throw fail(`unknown scene id(s): ${list} — not registered`, undefined);
+  if (missing.length > 0) {
+    const list = missing.map(({ id, index }) => `"${id}" (entry [${index}])`).join(', ');
+    throw fail(`unknown scene id(s): ${list} — not registered`, undefined);
+  }
+  return Object.freeze(plan);
 }
 
 /**
@@ -248,8 +269,7 @@ async function preloadScene(scene: SceneModule, preloadAssets: AssetPreloader): 
  * Cleanup failures are surfaced through {@link finalizeSceneFailure}.
  */
 async function runScene(
-  scene: SceneModule,
-  entry: CompositionEntry,
+  step: PlanStep,
   ctx: unknown,
   runTimeline: SceneTimelineRunner,
 ): Promise<void> {
@@ -257,6 +277,7 @@ async function runScene(
   // `Promise.reject(undefined)` are still treated as failures. Using
   // `phaseError !== undefined` as the sentinel would silently swallow
   // those (legal JS) cases.
+  const { scene } = step;
   let phase: 'create' | 'timeline' = 'create';
   let phaseFailed = false;
   let phaseError: unknown;
@@ -268,7 +289,7 @@ async function runScene(
     // non-Promise value is identity, so synchronous timeline factories
     // are unaffected.
     const timeline = await scene.timeline(ctx);
-    await runTimeline(buildRunInput(scene, entry, timeline));
+    await runTimeline(buildRunInput(step, timeline));
   } catch (err) {
     phaseFailed = true;
     phaseError = err;

--- a/src/runtime/composition-resolver.ts
+++ b/src/runtime/composition-resolver.ts
@@ -1,0 +1,214 @@
+// Composition resolver — PUL-F004.
+//
+// Plays a composition manifest end-to-end against a scene registry.
+// Given a manifest, the runtime SHALL: (a) verify every referenced
+// scene id exists in the registry; (b) preload assets declared by each
+// scene; (c) mount each scene in order via `create(ctx)`; (d) run its
+// timeline; (e) tear it down via `cleanup(ctx)` before mounting the
+// next scene.
+//
+// References:
+//  - ADR-002 §Resolution — the canonical 5-step lifecycle this module
+//    implements.
+//  - ADR-008 — mandatory cleanup invariant (cleanup runs whenever the
+//    scene was touched, including failure paths after `create(ctx)` or
+//    timeline execution).
+//  - ADR-011 — composition resolver as a pure orchestrator; asset
+//    preloading and timeline execution are injected adapters so the
+//    resolver does not depend on the asset loader (PUL-F005+) or the
+//    GSAP timeline engine (ADR-003).
+//  - PUL-P001 — cleanup is a policy-level invariant.
+//
+// Per the codex architecture preflight: this module is orchestration
+// only. It does not own scene shape (PUL-F001), the registry (PUL-F002),
+// the manifest format (PUL-F003), the asset loader, or the timeline
+// engine. Manifest entries with `range` or `behavior` overrides are
+// accepted at the boundary (PUL-F003) but their interpretation belongs
+// to the timeline runner adapter; the resolver does not read either
+// field.
+
+import {
+  type CompositionEntry,
+  type CompositionManifest,
+  assertCompositionManifest,
+} from './composition';
+import type { SceneRegistry } from './registry';
+import type { SceneModule } from './scene';
+
+/**
+ * Adapter that preloads the assets declared by a scene before its
+ * `create(ctx)` runs (clause b of PUL-F004). Receives the validated
+ * scene module so it can read both `scene.assets` and `scene.id` (the
+ * latter is useful for diagnostic logging inside the adapter).
+ *
+ * May return synchronously (`void`) or asynchronously
+ * (`Promise<void>`); the resolver awaits the result before proceeding
+ * to `create`. Throwing or rejecting aborts the composition; subsequent
+ * scenes are not visited.
+ */
+export type AssetPreloader = (scene: SceneModule) => void | Promise<void>;
+
+/**
+ * Adapter that runs a single scene's timeline (clause d of PUL-F004).
+ * Receives the scene module plus whatever value `scene.timeline(ctx)`
+ * returned (typically a GSAP timeline per ADR-003, but the resolver
+ * does not assume any specific shape). Resolves when the timeline has
+ * ended; the resolver then runs `cleanup(ctx)` (clause e).
+ */
+export type SceneTimelineRunner = (scene: SceneModule, timeline: unknown) => void | Promise<void>;
+
+/**
+ * Inputs to {@link resolveComposition}. All fields are required: the
+ * resolver does not provide defaults so the caller's wiring is
+ * explicit at the call site (workbench bootstrap, export pipeline, or
+ * test harness).
+ */
+export interface ResolveCompositionOptions {
+  /** Source of truth for which scenes exist (PUL-F002). */
+  readonly registry: SceneRegistry;
+  /** The ordered manifest to play (PUL-F003). */
+  readonly manifest: CompositionManifest;
+  /**
+   * Opaque scene context passed straight through to every lifecycle
+   * hook. Per ADR-003 / ADR-004 this will carry `ctx.gsap`, `ctx.audio`
+   * and similar engine handles when those subsystems land; the resolver
+   * itself does not inspect or extend it.
+   */
+  readonly ctx: unknown;
+  /** Preload adapter — see {@link AssetPreloader}. */
+  readonly preloadAssets: AssetPreloader;
+  /** Timeline-execution adapter — see {@link SceneTimelineRunner}. */
+  readonly runTimeline: SceneTimelineRunner;
+}
+
+const entryId = (entry: CompositionEntry): string => (typeof entry === 'string' ? entry : entry.id);
+
+const describe = (value: unknown): string =>
+  value instanceof Error ? value.message : String(value);
+
+/**
+ * Build the resolver's wrapping `Error`. Every public failure carries
+ * the `composition resolution failed:` prefix so callers can pattern-
+ * match on origin without parsing scene-specific detail.
+ */
+const fail = (detail: string, cause: unknown): Error =>
+  // ES2024 has Error.cause natively per tsconfig target; verbatimModule
+  // syntax is happy without runtime feature detection.
+  new Error(`composition resolution failed: ${detail}`, { cause });
+
+/**
+ * Resolves and plays `manifest` against `registry`.
+ *
+ * Algorithm (PUL-F004):
+ *  1. Defensively call {@link assertCompositionManifest} (boundary
+ *     validation; the same pattern `createSceneRegistry` uses for
+ *     `assertSceneModule`).
+ *  2. Walk every entry and aggregate ALL missing scene ids into a
+ *     single error before any side effect — clause (a). This is
+ *     friendlier than fail-on-first because a manifest author fixes
+ *     every typo in one pass.
+ *  3. For each entry in order:
+ *       a. `await preloadAssets(scene)` — clause (b). Failure aborts
+ *          the composition; create / timeline / cleanup do not run for
+ *          the failing scene and subsequent scenes are not visited.
+ *       b. `await scene.create(ctx)` — clause (c).
+ *       c. `await runTimeline(scene, scene.timeline(ctx))` — clause
+ *          (d).
+ *       d. `await scene.cleanup(ctx)` — clause (e). Cleanup runs
+ *          whenever step (b) was attempted — including when create
+ *          itself threw (resources may have been partially acquired)
+ *          and when timeline execution threw. This is the
+ *          mandatory-cleanup invariant from ADR-008 / PUL-P001.
+ *
+ * Failure semantics:
+ *  - A failing preload, create, or timeline aborts the composition;
+ *    the original error is attached as `Error.cause` of the wrapping
+ *    error so it is never silently dropped.
+ *  - When both the lifecycle phase AND cleanup throw, the wrapping
+ *    error reports the lifecycle phase as the cause and chains the
+ *    cleanup error onto the lifecycle error itself
+ *    (`lifecycleError.cause = cleanupError`) so neither is lost.
+ *  - A cleanup-only failure (timeline succeeded) is re-raised with
+ *    `Error.cause` set to the original cleanup error.
+ *
+ * Out of scope here: cancellation / presenter interrupts, sub-range
+ * (`range`) interpretation, and per-entry `behavior` overrides. Those
+ * are timeline-runner concerns (see ADR-011).
+ */
+export async function resolveComposition(options: ResolveCompositionOptions): Promise<void> {
+  const { registry, manifest, ctx, preloadAssets, runTimeline } = options;
+
+  assertCompositionManifest(manifest);
+
+  // Clause (a): aggregate every missing id in entry order.
+  const missing: { readonly index: number; readonly id: string }[] = [];
+  for (let index = 0; index < manifest.length; index += 1) {
+    const entry = manifest[index];
+    if (entry === undefined) continue; // unreachable: assertCompositionManifest accepted it
+    const id = entryId(entry);
+    if (!registry.has(id)) {
+      missing.push({ index, id });
+    }
+  }
+  if (missing.length > 0) {
+    const list = missing.map(({ id, index }) => `"${id}" (entry [${index}])`).join(', ');
+    throw fail(`unknown scene id(s): ${list} — not registered`, undefined);
+  }
+
+  // Per-scene lifecycle, strictly sequential.
+  for (let index = 0; index < manifest.length; index += 1) {
+    const entry = manifest[index];
+    if (entry === undefined) continue; // unreachable per the assert above
+    const scene = registry.get(entryId(entry));
+
+    // Clause (b) — preload before any lifecycle hook touches the scene.
+    try {
+      await preloadAssets(scene);
+    } catch (cause) {
+      throw fail(`scene "${scene.id}" preloadAssets threw: ${describe(cause)}`, cause);
+    }
+
+    // Clauses (c), (d), (e). Both `create` and `timeline` execute
+    // inside a single try so the cleanup branch fires whenever the
+    // scene was touched (codex preflight: cleanup must run after
+    // create OR timeline if resources may have been acquired).
+    let phase: 'create' | 'timeline' = 'create';
+    let phaseError: unknown;
+    try {
+      await scene.create(ctx);
+      phase = 'timeline';
+      const timeline = scene.timeline(ctx);
+      await runTimeline(scene, timeline);
+    } catch (err) {
+      phaseError = err;
+    }
+
+    let cleanupError: unknown;
+    try {
+      await scene.cleanup(ctx);
+    } catch (err) {
+      cleanupError = err;
+    }
+
+    if (phaseError !== undefined && cleanupError !== undefined) {
+      // Surface BOTH failures: the wrapping message names both, the
+      // cause-chain (top → phase → cleanup) makes them programmatically
+      // recoverable. Attaching cleanupError onto phaseError mutates the
+      // caller's error object, but only when its `cause` is currently
+      // unset — never overwrites an existing chain.
+      if (phaseError instanceof Error && phaseError.cause === undefined) {
+        phaseError.cause = cleanupError;
+      }
+      throw fail(
+        `scene "${scene.id}" ${phase} threw: ${describe(phaseError)} (cleanup also failed: ${describe(cleanupError)})`,
+        phaseError,
+      );
+    }
+    if (phaseError !== undefined) {
+      throw fail(`scene "${scene.id}" ${phase} threw: ${describe(phaseError)}`, phaseError);
+    }
+    if (cleanupError !== undefined) {
+      throw fail(`scene "${scene.id}" cleanup threw: ${describe(cleanupError)}`, cleanupError);
+    }
+  }
+}

--- a/src/runtime/composition-resolver.ts
+++ b/src/runtime/composition-resolver.ts
@@ -16,20 +16,17 @@
 //  - ADR-011 — composition resolver as a pure orchestrator; asset
 //    preloading and timeline execution are injected adapters so the
 //    resolver does not depend on the asset loader (PUL-F005+) or the
-//    GSAP timeline engine (ADR-003).
+//    GSAP timeline engine (ADR-003). Per-entry `range` and `behavior`
+//    overrides flow through the runner adapter input so the future
+//    GSAP runner can honor sub-range cuts and behavior overrides
+//    without another resolver-signature change.
 //  - PUL-P001 — cleanup is a policy-level invariant.
-//
-// Per the codex architecture preflight: this module is orchestration
-// only. It does not own scene shape (PUL-F001), the registry (PUL-F002),
-// the manifest format (PUL-F003), the asset loader, or the timeline
-// engine. Manifest entries with `range` or `behavior` overrides are
-// accepted at the boundary (PUL-F003) but their interpretation belongs
-// to the timeline runner adapter; the resolver does not read either
-// field.
 
 import {
+  type BehaviorOverride,
   type CompositionEntry,
   type CompositionManifest,
+  type SubRange,
   assertCompositionManifest,
 } from './composition';
 import type { SceneRegistry } from './registry';
@@ -49,13 +46,40 @@ import type { SceneModule } from './scene';
 export type AssetPreloader = (scene: SceneModule) => void | Promise<void>;
 
 /**
- * Adapter that runs a single scene's timeline (clause d of PUL-F004).
- * Receives the scene module plus whatever value `scene.timeline(ctx)`
- * returned (typically a GSAP timeline per ADR-003, but the resolver
- * does not assume any specific shape). Resolves when the timeline has
- * ended; the resolver then runs `cleanup(ctx)` (clause e).
+ * Inputs the resolver passes to the {@link SceneTimelineRunner} for
+ * one scene. The shape carries everything the runner needs to honor
+ * per-entry overrides without forcing the resolver to interpret them
+ * itself:
+ *
+ *  - `scene` — the validated scene module (ADR-008's "stable, addressable
+ *    identity").
+ *  - `timeline` — the value `scene.timeline(ctx)` returned, awaited so
+ *    async timeline factories resolve to a concrete timeline before the
+ *    runner sees them.
+ *  - `range` — optional sub-range from an object entry's
+ *    `CompositionEntryOverride.range` (PUL-F003); the runner interprets
+ *    the labels against its own timeline implementation (ADR-003 §Labels).
+ *  - `behavior` — optional behavior-override blob from an object entry's
+ *    `CompositionEntryOverride.behavior`; key semantics are the runner's
+ *    contract with its callers (ADR-011).
+ *
+ * `range` and `behavior` are absent when the entry is a bare string.
  */
-export type SceneTimelineRunner = (scene: SceneModule, timeline: unknown) => void | Promise<void>;
+export interface SceneTimelineRunInput {
+  readonly scene: SceneModule;
+  readonly timeline: unknown;
+  readonly range?: SubRange;
+  readonly behavior?: BehaviorOverride;
+}
+
+/**
+ * Adapter that runs a single scene's timeline (clause d of PUL-F004).
+ * Receives a {@link SceneTimelineRunInput} bundle. Resolves when the
+ * scene's timeline has ended; the resolver then runs `cleanup(ctx)`
+ * (clause e). Throwing or rejecting aborts the composition; cleanup
+ * still runs for the failing scene.
+ */
+export type SceneTimelineRunner = (input: SceneTimelineRunInput) => void | Promise<void>;
 
 /**
  * Inputs to {@link resolveComposition}. All fields are required: the
@@ -97,6 +121,36 @@ const fail = (detail: string, cause: unknown): Error =>
   new Error(`composition resolution failed: ${detail}`, { cause });
 
 /**
+ * Build the resolver's wrapping `AggregateError` for a combined
+ * lifecycle + cleanup failure. The `errors` array preserves both
+ * failures programmatically without mutating either error's
+ * `cause` chain.
+ */
+const failAggregate = (detail: string, errors: readonly unknown[]): AggregateError =>
+  new AggregateError(errors, `composition resolution failed: ${detail}`);
+
+/**
+ * Build the {@link SceneTimelineRunInput} for one entry. Bare-string
+ * entries omit `range` / `behavior` entirely; object entries forward
+ * whatever the validator accepted (which already rejects unknown
+ * override keys per PUL-F003).
+ */
+function buildRunInput(
+  scene: SceneModule,
+  entry: CompositionEntry,
+  timeline: unknown,
+): SceneTimelineRunInput {
+  if (typeof entry === 'string') return { scene, timeline };
+  const input: { -readonly [K in keyof SceneTimelineRunInput]: SceneTimelineRunInput[K] } = {
+    scene,
+    timeline,
+  };
+  if (entry.range !== undefined) input.range = entry.range;
+  if (entry.behavior !== undefined) input.behavior = entry.behavior;
+  return input;
+}
+
+/**
  * Resolves and plays `manifest` against `registry`.
  *
  * Algorithm (PUL-F004):
@@ -112,8 +166,10 @@ const fail = (detail: string, cause: unknown): Error =>
  *          the composition; create / timeline / cleanup do not run for
  *          the failing scene and subsequent scenes are not visited.
  *       b. `await scene.create(ctx)` — clause (c).
- *       c. `await runTimeline(scene, scene.timeline(ctx))` — clause
- *          (d).
+ *       c. `await runTimeline({ scene, timeline, range?, behavior? })`
+ *          — clause (d). The timeline value is awaited before being
+ *          handed to the runner so async timeline factories resolve to
+ *          a concrete timeline.
  *       d. `await scene.cleanup(ctx)` — clause (e). Cleanup runs
  *          whenever step (b) was attempted — including when create
  *          itself threw (resources may have been partially acquired)
@@ -125,15 +181,16 @@ const fail = (detail: string, cause: unknown): Error =>
  *    the original error is attached as `Error.cause` of the wrapping
  *    error so it is never silently dropped.
  *  - When both the lifecycle phase AND cleanup throw, the wrapping
- *    error reports the lifecycle phase as the cause and chains the
- *    cleanup error onto the lifecycle error itself
- *    (`lifecycleError.cause = cleanupError`) so neither is lost.
+ *    error is an `AggregateError` whose `errors` array carries both
+ *    the phase error and the cleanup error in order. Neither is
+ *    mutated; both are programmatically recoverable.
  *  - A cleanup-only failure (timeline succeeded) is re-raised with
  *    `Error.cause` set to the original cleanup error.
  *
- * Out of scope here: cancellation / presenter interrupts, sub-range
- * (`range`) interpretation, and per-entry `behavior` overrides. Those
- * are timeline-runner concerns (see ADR-011).
+ * Out of scope here: cancellation / presenter interrupts. `range` and
+ * `behavior` overrides are forwarded to the runner adapter unchanged
+ * (the resolver does not interpret them — that is the runner's job
+ * per ADR-011).
  */
 export async function resolveComposition(options: ResolveCompositionOptions): Promise<void> {
   const { registry, manifest, ctx, preloadAssets, runTimeline } = options;
@@ -147,7 +204,7 @@ export async function resolveComposition(options: ResolveCompositionOptions): Pr
   for (const entry of manifest) {
     const scene = registry.get(entryId(entry));
     await preloadScene(scene, preloadAssets);
-    await runScene(scene, ctx, runTimeline);
+    await runScene(scene, entry, ctx, runTimeline);
   }
 }
 
@@ -192,6 +249,7 @@ async function preloadScene(scene: SceneModule, preloadAssets: AssetPreloader): 
  */
 async function runScene(
   scene: SceneModule,
+  entry: CompositionEntry,
   ctx: unknown,
   runTimeline: SceneTimelineRunner,
 ): Promise<void> {
@@ -200,8 +258,12 @@ async function runScene(
   try {
     await scene.create(ctx);
     phase = 'timeline';
-    const timeline = scene.timeline(ctx);
-    await runTimeline(scene, timeline);
+    // Await the timeline factory so async timeline constructors resolve
+    // to a concrete timeline before the runner sees them. Awaiting a
+    // non-Promise value is identity, so synchronous timeline factories
+    // are unaffected.
+    const timeline = await scene.timeline(ctx);
+    await runTimeline(buildRunInput(scene, entry, timeline));
   } catch (err) {
     phaseError = err;
   }
@@ -218,14 +280,13 @@ async function runScene(
 
 /**
  * Convert the pair `(phaseError, cleanupError)` into a thrown wrapping
- * `Error`, or return cleanly when both are absent.
+ * error, or return cleanly when both are absent.
  *
- * - Both present: wrapping message names both; the cause-chain top →
- *   phase → cleanup makes both errors programmatically recoverable.
- *   Attaching `cleanupError` onto `phaseError` mutates the caller's
- *   error object, but only when its `cause` is currently unset —
- *   never overwrites an existing chain.
- * - Only `phaseError`: rethrown wrapped, with the original as cause.
+ * - Both present: throws an `AggregateError` whose `errors` array
+ *   carries both the phase error and the cleanup error in order. The
+ *   message names both. Neither caller-supplied error is mutated.
+ * - Only `phaseError`: rethrown wrapped, with the original as
+ *   `Error.cause`.
  * - Only `cleanupError`: rethrown wrapped as a cleanup-only failure.
  */
 function finalizeSceneFailure(
@@ -235,12 +296,9 @@ function finalizeSceneFailure(
   cleanupError: unknown,
 ): void {
   if (phaseError !== undefined && cleanupError !== undefined) {
-    if (phaseError instanceof Error && phaseError.cause === undefined) {
-      phaseError.cause = cleanupError;
-    }
-    throw fail(
+    throw failAggregate(
       `scene "${scene.id}" ${phase} threw: ${describe(phaseError)} (cleanup also failed: ${describe(cleanupError)})`,
-      phaseError,
+      [phaseError, cleanupError],
     );
   }
   if (phaseError !== undefined) {

--- a/src/runtime/composition-resolver.ts
+++ b/src/runtime/composition-resolver.ts
@@ -253,7 +253,12 @@ async function runScene(
   ctx: unknown,
   runTimeline: SceneTimelineRunner,
 ): Promise<void> {
+  // Track failure with explicit booleans so `throw undefined` /
+  // `Promise.reject(undefined)` are still treated as failures. Using
+  // `phaseError !== undefined` as the sentinel would silently swallow
+  // those (legal JS) cases.
   let phase: 'create' | 'timeline' = 'create';
+  let phaseFailed = false;
   let phaseError: unknown;
   try {
     await scene.create(ctx);
@@ -265,46 +270,53 @@ async function runScene(
     const timeline = await scene.timeline(ctx);
     await runTimeline(buildRunInput(scene, entry, timeline));
   } catch (err) {
+    phaseFailed = true;
     phaseError = err;
   }
 
+  let cleanupFailed = false;
   let cleanupError: unknown;
   try {
     await scene.cleanup(ctx);
   } catch (err) {
+    cleanupFailed = true;
     cleanupError = err;
   }
 
-  finalizeSceneFailure(scene, phase, phaseError, cleanupError);
+  finalizeSceneFailure(scene, phase, phaseFailed, phaseError, cleanupFailed, cleanupError);
 }
 
 /**
- * Convert the pair `(phaseError, cleanupError)` into a thrown wrapping
- * error, or return cleanly when both are absent.
+ * Convert the failure flags into a thrown wrapping error, or return
+ * cleanly when neither phase nor cleanup failed.
  *
- * - Both present: throws an `AggregateError` whose `errors` array
+ * - Both failed: throws an `AggregateError` whose `errors` array
  *   carries both the phase error and the cleanup error in order. The
- *   message names both. Neither caller-supplied error is mutated.
- * - Only `phaseError`: rethrown wrapped, with the original as
+ *   message names both. Neither caller-supplied error is mutated. The
+ *   `errors` array — NOT `Error.cause` — is the public contract for
+ *   double-fault recovery.
+ * - Only phase failed: rethrown wrapped, with the original as
  *   `Error.cause`.
- * - Only `cleanupError`: rethrown wrapped as a cleanup-only failure.
+ * - Only cleanup failed: rethrown wrapped as a cleanup-only failure.
  */
 function finalizeSceneFailure(
   scene: SceneModule,
   phase: 'create' | 'timeline',
+  phaseFailed: boolean,
   phaseError: unknown,
+  cleanupFailed: boolean,
   cleanupError: unknown,
 ): void {
-  if (phaseError !== undefined && cleanupError !== undefined) {
+  if (phaseFailed && cleanupFailed) {
     throw failAggregate(
       `scene "${scene.id}" ${phase} threw: ${describe(phaseError)} (cleanup also failed: ${describe(cleanupError)})`,
       [phaseError, cleanupError],
     );
   }
-  if (phaseError !== undefined) {
+  if (phaseFailed) {
     throw fail(`scene "${scene.id}" ${phase} threw: ${describe(phaseError)}`, phaseError);
   }
-  if (cleanupError !== undefined) {
+  if (cleanupFailed) {
     throw fail(`scene "${scene.id}" cleanup threw: ${describe(cleanupError)}`, cleanupError);
   }
 }

--- a/src/runtime/composition-resolver.ts
+++ b/src/runtime/composition-resolver.ts
@@ -139,76 +139,114 @@ export async function resolveComposition(options: ResolveCompositionOptions): Pr
   const { registry, manifest, ctx, preloadAssets, runTimeline } = options;
 
   assertCompositionManifest(manifest);
+  preflightSceneIds(manifest, registry);
 
-  // Clause (a): aggregate every missing id in entry order.
+  // Per-scene lifecycle, strictly sequential. Each iteration runs
+  // preload → create → timeline → cleanup before the next iteration's
+  // preload begins (clause e of PUL-F004).
+  for (const entry of manifest) {
+    const scene = registry.get(entryId(entry));
+    await preloadScene(scene, preloadAssets);
+    await runScene(scene, ctx, runTimeline);
+  }
+}
+
+/**
+ * Clause (a): walk every entry, aggregate ALL missing scene ids into
+ * a single error before any side effect, and throw if any are missing.
+ * Aggregating beats fail-on-first because a manifest author fixes
+ * every typo in one pass.
+ */
+function preflightSceneIds(manifest: CompositionManifest, registry: SceneRegistry): void {
   const missing: { readonly index: number; readonly id: string }[] = [];
-  for (let index = 0; index < manifest.length; index += 1) {
-    const entry = manifest[index];
-    if (entry === undefined) continue; // unreachable: assertCompositionManifest accepted it
+  for (const [index, entry] of manifest.entries()) {
     const id = entryId(entry);
     if (!registry.has(id)) {
       missing.push({ index, id });
     }
   }
-  if (missing.length > 0) {
-    const list = missing.map(({ id, index }) => `"${id}" (entry [${index}])`).join(', ');
-    throw fail(`unknown scene id(s): ${list} — not registered`, undefined);
+  if (missing.length === 0) return;
+  const list = missing.map(({ id, index }) => `"${id}" (entry [${index}])`).join(', ');
+  throw fail(`unknown scene id(s): ${list} — not registered`, undefined);
+}
+
+/**
+ * Clause (b): await the injected asset preloader for one scene. A
+ * preload failure aborts before any lifecycle hook touches the scene
+ * — neither `create` nor `cleanup` runs.
+ */
+async function preloadScene(scene: SceneModule, preloadAssets: AssetPreloader): Promise<void> {
+  try {
+    await preloadAssets(scene);
+  } catch (cause) {
+    throw fail(`scene "${scene.id}" preloadAssets threw: ${describe(cause)}`, cause);
+  }
+}
+
+/**
+ * Clauses (c), (d), (e): mount, run timeline, cleanup. Both `create`
+ * and `timeline` run inside a single try so cleanup fires whenever
+ * the scene was touched (codex preflight: cleanup must run after
+ * `create` OR timeline execution if resources may have been acquired).
+ * Cleanup failures are surfaced through {@link finalizeSceneFailure}.
+ */
+async function runScene(
+  scene: SceneModule,
+  ctx: unknown,
+  runTimeline: SceneTimelineRunner,
+): Promise<void> {
+  let phase: 'create' | 'timeline' = 'create';
+  let phaseError: unknown;
+  try {
+    await scene.create(ctx);
+    phase = 'timeline';
+    const timeline = scene.timeline(ctx);
+    await runTimeline(scene, timeline);
+  } catch (err) {
+    phaseError = err;
   }
 
-  // Per-scene lifecycle, strictly sequential.
-  for (let index = 0; index < manifest.length; index += 1) {
-    const entry = manifest[index];
-    if (entry === undefined) continue; // unreachable per the assert above
-    const scene = registry.get(entryId(entry));
+  let cleanupError: unknown;
+  try {
+    await scene.cleanup(ctx);
+  } catch (err) {
+    cleanupError = err;
+  }
 
-    // Clause (b) — preload before any lifecycle hook touches the scene.
-    try {
-      await preloadAssets(scene);
-    } catch (cause) {
-      throw fail(`scene "${scene.id}" preloadAssets threw: ${describe(cause)}`, cause);
-    }
+  finalizeSceneFailure(scene, phase, phaseError, cleanupError);
+}
 
-    // Clauses (c), (d), (e). Both `create` and `timeline` execute
-    // inside a single try so the cleanup branch fires whenever the
-    // scene was touched (codex preflight: cleanup must run after
-    // create OR timeline if resources may have been acquired).
-    let phase: 'create' | 'timeline' = 'create';
-    let phaseError: unknown;
-    try {
-      await scene.create(ctx);
-      phase = 'timeline';
-      const timeline = scene.timeline(ctx);
-      await runTimeline(scene, timeline);
-    } catch (err) {
-      phaseError = err;
+/**
+ * Convert the pair `(phaseError, cleanupError)` into a thrown wrapping
+ * `Error`, or return cleanly when both are absent.
+ *
+ * - Both present: wrapping message names both; the cause-chain top →
+ *   phase → cleanup makes both errors programmatically recoverable.
+ *   Attaching `cleanupError` onto `phaseError` mutates the caller's
+ *   error object, but only when its `cause` is currently unset —
+ *   never overwrites an existing chain.
+ * - Only `phaseError`: rethrown wrapped, with the original as cause.
+ * - Only `cleanupError`: rethrown wrapped as a cleanup-only failure.
+ */
+function finalizeSceneFailure(
+  scene: SceneModule,
+  phase: 'create' | 'timeline',
+  phaseError: unknown,
+  cleanupError: unknown,
+): void {
+  if (phaseError !== undefined && cleanupError !== undefined) {
+    if (phaseError instanceof Error && phaseError.cause === undefined) {
+      phaseError.cause = cleanupError;
     }
-
-    let cleanupError: unknown;
-    try {
-      await scene.cleanup(ctx);
-    } catch (err) {
-      cleanupError = err;
-    }
-
-    if (phaseError !== undefined && cleanupError !== undefined) {
-      // Surface BOTH failures: the wrapping message names both, the
-      // cause-chain (top → phase → cleanup) makes them programmatically
-      // recoverable. Attaching cleanupError onto phaseError mutates the
-      // caller's error object, but only when its `cause` is currently
-      // unset — never overwrites an existing chain.
-      if (phaseError instanceof Error && phaseError.cause === undefined) {
-        phaseError.cause = cleanupError;
-      }
-      throw fail(
-        `scene "${scene.id}" ${phase} threw: ${describe(phaseError)} (cleanup also failed: ${describe(cleanupError)})`,
-        phaseError,
-      );
-    }
-    if (phaseError !== undefined) {
-      throw fail(`scene "${scene.id}" ${phase} threw: ${describe(phaseError)}`, phaseError);
-    }
-    if (cleanupError !== undefined) {
-      throw fail(`scene "${scene.id}" cleanup threw: ${describe(cleanupError)}`, cleanupError);
-    }
+    throw fail(
+      `scene "${scene.id}" ${phase} threw: ${describe(phaseError)} (cleanup also failed: ${describe(cleanupError)})`,
+      phaseError,
+    );
+  }
+  if (phaseError !== undefined) {
+    throw fail(`scene "${scene.id}" ${phase} threw: ${describe(phaseError)}`, phaseError);
+  }
+  if (cleanupError !== undefined) {
+    throw fail(`scene "${scene.id}" cleanup threw: ${describe(cleanupError)}`, cleanupError);
   }
 }

--- a/tests/runtime/composition-resolver.test.ts
+++ b/tests/runtime/composition-resolver.test.ts
@@ -707,6 +707,50 @@ describe('resolveComposition (PUL-F004)', () => {
     });
   });
 
+  describe('manifest snapshot (codex review: snapshot before lifecycle side effects)', () => {
+    it('iterates a snapshot of the manifest — caller mutations during a lifecycle hook do not retarget later entries', async () => {
+      const visited: string[] = [];
+      // Mutable manifest the test will retarget mid-flight.
+      const mutableManifest: { id: string }[] = [
+        { id: 'scene-a' },
+        { id: 'scene-b' },
+        { id: 'scene-c' },
+      ];
+      const { options } = buildHarness({
+        scenes: [
+          {
+            id: 'scene-a',
+            create: () => {
+              visited.push('scene-a');
+              // Mutate the caller-owned manifest after the resolver has
+              // already started iterating it. If the resolver re-read
+              // the manifest for steps 1 and 2 we'd see "unknown scene
+              // id" failures here. The snapshot path makes this a
+              // no-op for the resolver.
+              mutableManifest[1] = { id: 'unregistered-substitute' };
+              mutableManifest[2] = { id: 'also-unregistered' };
+            },
+          },
+          {
+            id: 'scene-b',
+            create: () => {
+              visited.push('scene-b');
+            },
+          },
+          {
+            id: 'scene-c',
+            create: () => {
+              visited.push('scene-c');
+            },
+          },
+        ],
+        manifest: mutableManifest as unknown as CompositionManifest,
+      });
+      await expect(resolveComposition(options)).resolves.toBeUndefined();
+      expect(visited).toEqual(['scene-a', 'scene-b', 'scene-c']);
+    });
+  });
+
   describe('non-Error throw paths (codex review: do not use undefined as failure sentinel)', () => {
     // `throw undefined` and `Promise.reject(undefined)` are both legal
     // JS. The resolver must still treat them as failures. These tests

--- a/tests/runtime/composition-resolver.test.ts
+++ b/tests/runtime/composition-resolver.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import type { CompositionManifest } from '../../src/runtime/composition';
 import {
   type AssetPreloader,
@@ -956,21 +956,4 @@ describe('resolveComposition (PUL-F004)', () => {
       ]);
     });
   });
-
-  describe('contract surfaces', () => {
-    it('exports resolveComposition as an async function', () => {
-      // ResolveCompositionOptions / AssetPreloader / SceneTimelineRunner
-      // type imports above pin the public surface — if they are removed
-      // or renamed this test file fails to type-check.
-      expect(typeof resolveComposition).toBe('function');
-      // Calling with no arg blows up at runtime — deliberately not
-      // testing that path (TypeScript catches it at compile time and
-      // we don't add runtime guards beyond assertCompositionManifest's
-      // boundary check).
-    });
-  });
 });
-
-// Silence unused-import warnings for vi (kept available for future fakes
-// that need vi.useFakeTimers or vi.spyOn).
-void vi;

--- a/tests/runtime/composition-resolver.test.ts
+++ b/tests/runtime/composition-resolver.test.ts
@@ -3,6 +3,7 @@ import type { CompositionManifest } from '../../src/runtime/composition';
 import {
   type AssetPreloader,
   type ResolveCompositionOptions,
+  type SceneTimelineRunInput,
   type SceneTimelineRunner,
   resolveComposition,
 } from '../../src/runtime/composition-resolver';
@@ -92,8 +93,8 @@ const buildHarness = (opts: HarnessOpts): Harness => {
     });
   const runTimeline: SceneTimelineRunner =
     opts.runTimeline ??
-    ((scene, timelineValue) => {
-      log.push({ hook: 'runTimeline', sceneId: scene.id, value: timelineValue });
+    (({ scene, timeline }) => {
+      log.push({ hook: 'runTimeline', sceneId: scene.id, value: timeline });
     });
   return {
     log,
@@ -358,12 +359,60 @@ describe('resolveComposition (PUL-F004)', () => {
           },
         ],
         manifest: ['scene-a'],
-        runTimeline: (scene, value) => {
-          runCalls.push({ sceneId: scene.id, value });
+        runTimeline: ({ scene, timeline }) => {
+          runCalls.push({ sceneId: scene.id, value: timeline });
         },
       });
       await resolveComposition(options);
       expect(runCalls).toEqual([{ sceneId: 'scene-a', value: sentinel }]);
+    });
+
+    it('awaits an async (Promise-returning) scene.timeline factory before handing the resolved value to runTimeline', async () => {
+      const sentinel = { kind: 'resolved-timeline' };
+      const runCalls: { sceneId: string; value: unknown }[] = [];
+      const { options } = buildHarness({
+        scenes: [
+          {
+            id: 'scene-a',
+            timeline: async () => sentinel,
+          },
+        ],
+        manifest: ['scene-a'],
+        runTimeline: ({ scene, timeline }) => {
+          runCalls.push({ sceneId: scene.id, value: timeline });
+        },
+      });
+      await resolveComposition(options);
+      // Runner must receive the resolved sentinel object, not a Promise.
+      expect(runCalls).toHaveLength(1);
+      const onlyCall = runCalls[0];
+      expect(onlyCall).toBeDefined();
+      expect(onlyCall?.sceneId).toBe('scene-a');
+      expect(onlyCall?.value).toBe(sentinel);
+      expect(onlyCall?.value instanceof Promise).toBe(false);
+    });
+
+    it('forwards range / behavior overrides from object entries to runTimeline', async () => {
+      const runCalls: SceneTimelineRunInput[] = [];
+      const { options } = buildHarness({
+        scenes: [{ id: 'scene-a' }, { id: 'scene-b' }],
+        manifest: ['scene-a', { id: 'scene-b', range: ['intro', 'outro'], behavior: { speed: 2 } }],
+        runTimeline: (input) => {
+          runCalls.push(input);
+        },
+      });
+      await resolveComposition(options);
+      expect(runCalls).toHaveLength(2);
+      const aCall = runCalls[0];
+      const bCall = runCalls[1];
+      expect(aCall).toBeDefined();
+      expect(aCall?.scene.id).toBe('scene-a');
+      expect(aCall?.range).toBeUndefined();
+      expect(aCall?.behavior).toBeUndefined();
+      expect(bCall).toBeDefined();
+      expect(bCall?.scene.id).toBe('scene-b');
+      expect(bCall?.range).toEqual(['intro', 'outro']);
+      expect(bCall?.behavior).toEqual({ speed: 2 });
     });
 
     it('awaits runTimeline before calling cleanup', async () => {
@@ -382,7 +431,7 @@ describe('resolveComposition (PUL-F004)', () => {
           },
         ],
         manifest: ['scene-a'],
-        runTimeline: async (scene) => {
+        runTimeline: async ({ scene }) => {
           log.push(`runTimeline-${scene.id}-start`);
           await runGate;
           log.push(`runTimeline-${scene.id}-end`);
@@ -419,7 +468,7 @@ describe('resolveComposition (PUL-F004)', () => {
           },
         ],
         manifest: ['scene-a', 'scene-b'],
-        runTimeline: (scene) => {
+        runTimeline: ({ scene }) => {
           if (scene.id === 'scene-a') {
             throw new Error('gsap exploded');
           }
@@ -524,7 +573,7 @@ describe('resolveComposition (PUL-F004)', () => {
       }
     });
 
-    it('chains the cleanup error as Error.cause when both timeline and cleanup fail (timeline error wins as the message)', async () => {
+    it('throws an AggregateError carrying both the timeline error and the cleanup error when both fail (no caller-error mutation)', async () => {
       const timelineErr = new Error('runner failed');
       const cleanupErr = new Error('and so did cleanup');
       const { options } = buildHarness({
@@ -545,19 +594,19 @@ describe('resolveComposition (PUL-F004)', () => {
         await resolveComposition(options);
         expect.unreachable('expected combined failure to propagate');
       } catch (err) {
-        expect(err).toBeInstanceOf(Error);
-        expect((err as Error).message).toMatch(
+        expect(err).toBeInstanceOf(AggregateError);
+        const top = err as AggregateError;
+        expect(top.message).toMatch(
           /^composition resolution failed: scene "scene-a" timeline threw: runner failed \(cleanup also failed: and so did cleanup\)$/,
         );
-        // Cause chain: top-level Error.cause is the timeline error; its
-        // .cause is the cleanup error so neither is silently dropped.
-        const top = err as Error & { cause?: unknown };
-        expect(top.cause).toBe(timelineErr);
-        expect((timelineErr as Error & { cause?: unknown }).cause).toBe(cleanupErr);
+        expect(top.errors).toEqual([timelineErr, cleanupErr]);
+        // The resolver must NOT mutate the caller-supplied errors.
+        expect((timelineErr as Error & { cause?: unknown }).cause).toBeUndefined();
+        expect((cleanupErr as Error & { cause?: unknown }).cause).toBeUndefined();
       }
     });
 
-    it('chains the cleanup error as Error.cause when both create and cleanup fail', async () => {
+    it('throws an AggregateError carrying both the create error and the cleanup error when both fail (no caller-error mutation)', async () => {
       const createErr = new Error('mount blew up');
       const cleanupErr = new Error('cleanup also blew up');
       const { options } = buildHarness({
@@ -578,12 +627,46 @@ describe('resolveComposition (PUL-F004)', () => {
         await resolveComposition(options);
         expect.unreachable('expected combined failure to propagate');
       } catch (err) {
-        const top = err as Error & { cause?: unknown };
+        expect(err).toBeInstanceOf(AggregateError);
+        const top = err as AggregateError;
         expect(top.message).toMatch(
           /^composition resolution failed: scene "scene-a" create threw: mount blew up \(cleanup also failed: cleanup also blew up\)$/,
         );
-        expect(top.cause).toBe(createErr);
-        expect((createErr as Error & { cause?: unknown }).cause).toBe(cleanupErr);
+        expect(top.errors).toEqual([createErr, cleanupErr]);
+        expect((createErr as Error & { cause?: unknown }).cause).toBeUndefined();
+        expect((cleanupErr as Error & { cause?: unknown }).cause).toBeUndefined();
+      }
+    });
+
+    it('preserves a non-Error throw + cleanup failure together (no upcasting required)', async () => {
+      const stringThrow = 'create blew up but threw a string, not an Error';
+      const cleanupErr = new Error('cleanup error');
+      const { options } = buildHarness({
+        scenes: [
+          {
+            id: 'scene-a',
+            create: () => {
+              throw stringThrow;
+            },
+            cleanup: () => {
+              throw cleanupErr;
+            },
+          },
+        ],
+        manifest: ['scene-a'],
+      });
+      try {
+        await resolveComposition(options);
+        expect.unreachable('expected combined failure to propagate');
+      } catch (err) {
+        expect(err).toBeInstanceOf(AggregateError);
+        const top = err as AggregateError;
+        // String throw appears in the message verbatim and is preserved
+        // in errors[] alongside the cleanup error.
+        expect(top.message).toMatch(
+          /^composition resolution failed: scene "scene-a" create threw: create blew up but threw a string, not an Error \(cleanup also failed: cleanup error\)$/,
+        );
+        expect(top.errors).toEqual([stringThrow, cleanupErr]);
       }
     });
   });
@@ -610,8 +693,8 @@ describe('resolveComposition (PUL-F004)', () => {
           },
         ],
         manifest: ['scene-a'],
-        runTimeline: (_scene, value) => {
-          log.push(`runTimeline-received-${String(value)}`);
+        runTimeline: ({ timeline }) => {
+          log.push(`runTimeline-received-${String(timeline)}`);
         },
       });
       await resolveComposition(options);

--- a/tests/runtime/composition-resolver.test.ts
+++ b/tests/runtime/composition-resolver.test.ts
@@ -1,0 +1,717 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { CompositionManifest } from '../../src/runtime/composition';
+import {
+  type AssetPreloader,
+  type ResolveCompositionOptions,
+  type SceneTimelineRunner,
+  resolveComposition,
+} from '../../src/runtime/composition-resolver';
+import { createSceneRegistry } from '../../src/runtime/registry';
+import type { SceneModule } from '../../src/runtime/scene';
+
+// Each lifecycle hook + preloader + runner pushes a record into a
+// shared array so tests can assert ordering directly. The shape carries
+// just enough to identify which hook fired for which scene.
+interface CallRecord {
+  readonly hook: 'preload' | 'create' | 'timeline' | 'runTimeline' | 'cleanup';
+  readonly sceneId: string;
+  readonly ctx?: unknown;
+  readonly value?: unknown;
+}
+
+interface BuildSceneOpts {
+  readonly id: string;
+  readonly assets?: readonly string[];
+  readonly create?: SceneModule['create'];
+  readonly timeline?: SceneModule['timeline'];
+  readonly cleanup?: SceneModule['cleanup'];
+}
+
+const buildScene = (opts: BuildSceneOpts): SceneModule => ({
+  id: opts.id,
+  title: opts.id,
+  duration: 1000,
+  tags: [],
+  assets: opts.assets ?? [],
+  captions: [],
+  defaultNext: null,
+  standalone: false,
+  trailerSafe: false,
+  create: opts.create ?? (() => undefined),
+  timeline: opts.timeline ?? (() => undefined),
+  cleanup: opts.cleanup ?? (() => undefined),
+});
+
+interface Harness {
+  readonly log: CallRecord[];
+  readonly options: ResolveCompositionOptions;
+}
+
+interface HarnessOpts {
+  readonly scenes: readonly BuildSceneOpts[];
+  readonly manifest: CompositionManifest;
+  readonly ctx?: unknown;
+  readonly preloadAssets?: AssetPreloader;
+  readonly runTimeline?: SceneTimelineRunner;
+}
+
+const buildHarness = (opts: HarnessOpts): Harness => {
+  const log: CallRecord[] = [];
+  const sceneById = new Map<string, SceneModule>();
+  const wrappedScenes = opts.scenes.map((s) => {
+    const create =
+      s.create ??
+      ((ctx) => {
+        log.push({ hook: 'create', sceneId: s.id, ctx });
+      });
+    const timeline =
+      s.timeline ??
+      ((ctx) => {
+        log.push({ hook: 'timeline', sceneId: s.id, ctx });
+        return `${s.id}-timeline-value`;
+      });
+    const cleanup =
+      s.cleanup ??
+      ((ctx) => {
+        log.push({ hook: 'cleanup', sceneId: s.id, ctx });
+      });
+    const scene = buildScene(
+      s.assets === undefined
+        ? { id: s.id, create, timeline, cleanup }
+        : { id: s.id, assets: s.assets, create, timeline, cleanup },
+    );
+    sceneById.set(s.id, scene);
+    return scene;
+  });
+  const registry = createSceneRegistry(wrappedScenes);
+  const ctx = opts.ctx ?? { tag: 'ctx' };
+  const preloadAssets: AssetPreloader =
+    opts.preloadAssets ??
+    ((scene) => {
+      log.push({ hook: 'preload', sceneId: scene.id });
+    });
+  const runTimeline: SceneTimelineRunner =
+    opts.runTimeline ??
+    ((scene, timelineValue) => {
+      log.push({ hook: 'runTimeline', sceneId: scene.id, value: timelineValue });
+    });
+  return {
+    log,
+    options: { registry, manifest: opts.manifest, ctx, preloadAssets, runTimeline },
+  };
+};
+
+describe('resolveComposition (PUL-F004)', () => {
+  describe('manifest defense (boundary)', () => {
+    it('throws the assertCompositionManifest grammar when the manifest is not an array', async () => {
+      const { options } = buildHarness({ scenes: [], manifest: [] });
+      await expect(
+        resolveComposition({
+          ...options,
+          manifest: 'not an array' as unknown as CompositionManifest,
+        }),
+      ).rejects.toThrow(/^composition manifest is invalid:/);
+    });
+
+    it('throws the assertCompositionManifest grammar when an entry is malformed', async () => {
+      const { options } = buildHarness({ scenes: [], manifest: [] });
+      await expect(
+        resolveComposition({
+          ...options,
+          manifest: ['NOT-KEBAB'] as unknown as CompositionManifest,
+        }),
+      ).rejects.toThrow(/^composition entry \[0\] is invalid: id must be/);
+    });
+  });
+
+  describe('clause (a) — every referenced scene id exists in the registry', () => {
+    it('resolves an empty manifest with no preload / runner / scene-hook calls', async () => {
+      const { log, options } = buildHarness({ scenes: [], manifest: [] });
+      await expect(resolveComposition(options)).resolves.toBeUndefined();
+      expect(log).toEqual([]);
+    });
+
+    it('throws an actionable error naming a single missing id and its entry index', async () => {
+      const { options } = buildHarness({
+        scenes: [{ id: 'scene-a' }],
+        manifest: ['scene-a', 'missing-scene'],
+      });
+      await expect(resolveComposition(options)).rejects.toThrow(
+        /^composition resolution failed: unknown scene id\(s\): "missing-scene" \(entry \[1\]\) — not registered$/,
+      );
+    });
+
+    it('aggregates every missing id (in entry order) in a single error', async () => {
+      const { options } = buildHarness({
+        scenes: [{ id: 'scene-a' }],
+        manifest: ['missing-x', 'scene-a', { id: 'missing-y' }, 'missing-z'],
+      });
+      await expect(resolveComposition(options)).rejects.toThrow(
+        /^composition resolution failed: unknown scene id\(s\): "missing-x" \(entry \[0\]\), "missing-y" \(entry \[2\]\), "missing-z" \(entry \[3\]\) — not registered$/,
+      );
+    });
+
+    it('catches a missing id on an object entry the same as a bare-string entry', async () => {
+      const { options } = buildHarness({
+        scenes: [{ id: 'scene-a' }],
+        manifest: [{ id: 'object-missing' }],
+      });
+      await expect(resolveComposition(options)).rejects.toThrow(
+        /^composition resolution failed: unknown scene id\(s\): "object-missing" \(entry \[0\]\) — not registered$/,
+      );
+    });
+
+    it('runs id pre-flight before any preload / create / timeline / cleanup', async () => {
+      const { log, options } = buildHarness({
+        scenes: [{ id: 'scene-a' }],
+        manifest: ['scene-a', 'missing-scene'],
+      });
+      await expect(resolveComposition(options)).rejects.toThrow();
+      expect(log).toEqual([]);
+    });
+  });
+
+  describe('clause (b) — preload assets declared by each scene', () => {
+    it('calls preloadAssets once per entry, with the scene module, in manifest order', async () => {
+      const preloadCalls: SceneModule[] = [];
+      const { options } = buildHarness({
+        scenes: [
+          { id: 'scene-a', assets: ['a1.png'] },
+          { id: 'scene-b', assets: ['b1.png', 'b2.png'] },
+        ],
+        manifest: ['scene-a', 'scene-b'],
+        preloadAssets: (scene) => {
+          preloadCalls.push(scene);
+        },
+      });
+      await resolveComposition(options);
+      expect(preloadCalls.map((s) => ({ id: s.id, assets: s.assets }))).toEqual([
+        { id: 'scene-a', assets: ['a1.png'] },
+        { id: 'scene-b', assets: ['b1.png', 'b2.png'] },
+      ]);
+    });
+
+    it("completes scene N's preload before calling scene N's create", async () => {
+      const log: string[] = [];
+      let resolvePreloadA: (() => void) | undefined;
+      const preloadAGate = new Promise<void>((res) => {
+        resolvePreloadA = res;
+      });
+      const { options } = buildHarness({
+        scenes: [
+          {
+            id: 'scene-a',
+            create: () => {
+              log.push('create-a');
+            },
+          },
+        ],
+        manifest: ['scene-a'],
+        preloadAssets: async (scene) => {
+          log.push(`preload-${scene.id}-start`);
+          if (scene.id === 'scene-a') {
+            await preloadAGate;
+          }
+          log.push(`preload-${scene.id}-end`);
+        },
+      });
+      const resolverPromise = resolveComposition(options);
+      // microtask flush: preload should have started but not yet finished
+      await Promise.resolve();
+      expect(log).toEqual(['preload-scene-a-start']);
+      resolvePreloadA?.();
+      await resolverPromise;
+      expect(log).toEqual(['preload-scene-a-start', 'preload-scene-a-end', 'create-a']);
+    });
+
+    it('aborts when preloadAssets rejects: no create / timeline / cleanup; subsequent scenes not visited', async () => {
+      const log: string[] = [];
+      const { options } = buildHarness({
+        scenes: [
+          {
+            id: 'scene-a',
+            create: () => {
+              log.push('create-a');
+            },
+            timeline: () => {
+              log.push('timeline-a');
+            },
+            cleanup: () => {
+              log.push('cleanup-a');
+            },
+          },
+          {
+            id: 'scene-b',
+            create: () => {
+              log.push('create-b');
+            },
+          },
+        ],
+        manifest: ['scene-a', 'scene-b'],
+        preloadAssets: (scene) => {
+          log.push(`preload-${scene.id}`);
+          if (scene.id === 'scene-a') {
+            throw new Error('asset 404');
+          }
+        },
+      });
+      await expect(resolveComposition(options)).rejects.toThrow(
+        /^composition resolution failed: scene "scene-a" preloadAssets threw: asset 404$/,
+      );
+      expect(log).toEqual(['preload-scene-a']);
+    });
+
+    it('preserves the original preload error as Error.cause', async () => {
+      const root = new Error('asset 404');
+      const { options } = buildHarness({
+        scenes: [{ id: 'scene-a' }],
+        manifest: ['scene-a'],
+        preloadAssets: () => {
+          throw root;
+        },
+      });
+      try {
+        await resolveComposition(options);
+        expect.unreachable('expected preload error to propagate');
+      } catch (err) {
+        expect(err).toBeInstanceOf(Error);
+        expect((err as Error).cause).toBe(root);
+      }
+    });
+  });
+
+  describe('clause (c) — mount each scene via create(ctx)', () => {
+    it('calls create with ctx, in manifest order, after that scene preload completes', async () => {
+      const ctx = { id: 'shared-ctx' };
+      const createCalls: { sceneId: string; ctx: unknown }[] = [];
+      const { options } = buildHarness({
+        scenes: [
+          {
+            id: 'scene-a',
+            create: (c) => {
+              createCalls.push({ sceneId: 'scene-a', ctx: c });
+            },
+          },
+          {
+            id: 'scene-b',
+            create: (c) => {
+              createCalls.push({ sceneId: 'scene-b', ctx: c });
+            },
+          },
+        ],
+        manifest: ['scene-a', 'scene-b'],
+        ctx,
+      });
+      await resolveComposition(options);
+      expect(createCalls).toEqual([
+        { sceneId: 'scene-a', ctx },
+        { sceneId: 'scene-b', ctx },
+      ]);
+    });
+
+    it('still calls cleanup when create rejects (resources may have been partially acquired); subsequent scenes not visited; create error re-raised', async () => {
+      const log: string[] = [];
+      const { options } = buildHarness({
+        scenes: [
+          {
+            id: 'scene-a',
+            create: () => {
+              log.push('create-a');
+              throw new Error('mount failed');
+            },
+            timeline: () => {
+              log.push('timeline-a');
+            },
+            cleanup: () => {
+              log.push('cleanup-a');
+            },
+          },
+          {
+            id: 'scene-b',
+            create: () => {
+              log.push('create-b');
+            },
+          },
+        ],
+        manifest: ['scene-a', 'scene-b'],
+      });
+      await expect(resolveComposition(options)).rejects.toThrow(
+        /^composition resolution failed: scene "scene-a" create threw: mount failed$/,
+      );
+      expect(log).toEqual(['create-a', 'cleanup-a']);
+    });
+  });
+
+  describe('clause (d) — run its timeline', () => {
+    it('passes scene.timeline(ctx) value through to runTimeline(scene, value)', async () => {
+      const sentinel = { kind: 'timeline-handle', label: 'fake-gsap-timeline' };
+      const runCalls: { sceneId: string; value: unknown }[] = [];
+      const { options } = buildHarness({
+        scenes: [
+          {
+            id: 'scene-a',
+            timeline: () => sentinel,
+          },
+        ],
+        manifest: ['scene-a'],
+        runTimeline: (scene, value) => {
+          runCalls.push({ sceneId: scene.id, value });
+        },
+      });
+      await resolveComposition(options);
+      expect(runCalls).toEqual([{ sceneId: 'scene-a', value: sentinel }]);
+    });
+
+    it('awaits runTimeline before calling cleanup', async () => {
+      const log: string[] = [];
+      let resolveRun: (() => void) | undefined;
+      const runGate = new Promise<void>((res) => {
+        resolveRun = res;
+      });
+      const { options } = buildHarness({
+        scenes: [
+          {
+            id: 'scene-a',
+            cleanup: () => {
+              log.push('cleanup-a');
+            },
+          },
+        ],
+        manifest: ['scene-a'],
+        runTimeline: async (scene) => {
+          log.push(`runTimeline-${scene.id}-start`);
+          await runGate;
+          log.push(`runTimeline-${scene.id}-end`);
+        },
+      });
+      const resolverPromise = resolveComposition(options);
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(log).toEqual(['runTimeline-scene-a-start']);
+      resolveRun?.();
+      await resolverPromise;
+      expect(log).toEqual(['runTimeline-scene-a-start', 'runTimeline-scene-a-end', 'cleanup-a']);
+    });
+
+    it('still calls cleanup when runTimeline rejects; subsequent scenes not visited; timeline error re-raised', async () => {
+      const log: string[] = [];
+      const { options } = buildHarness({
+        scenes: [
+          {
+            id: 'scene-a',
+            cleanup: () => {
+              log.push('cleanup-a');
+            },
+          },
+          {
+            id: 'scene-b',
+            create: () => {
+              log.push('create-b');
+            },
+          },
+        ],
+        manifest: ['scene-a', 'scene-b'],
+        runTimeline: (scene) => {
+          if (scene.id === 'scene-a') {
+            throw new Error('gsap exploded');
+          }
+        },
+      });
+      await expect(resolveComposition(options)).rejects.toThrow(
+        /^composition resolution failed: scene "scene-a" timeline threw: gsap exploded$/,
+      );
+      expect(log).toEqual(['cleanup-a']);
+    });
+
+    it('still calls cleanup when scene.timeline(ctx) itself throws', async () => {
+      const log: string[] = [];
+      const { options } = buildHarness({
+        scenes: [
+          {
+            id: 'scene-a',
+            timeline: () => {
+              throw new Error('timeline ctor failed');
+            },
+            cleanup: () => {
+              log.push('cleanup-a');
+            },
+          },
+        ],
+        manifest: ['scene-a'],
+      });
+      await expect(resolveComposition(options)).rejects.toThrow(
+        /^composition resolution failed: scene "scene-a" timeline threw: timeline ctor failed$/,
+      );
+      expect(log).toEqual(['cleanup-a']);
+    });
+  });
+
+  describe('clause (e) — cleanup before next mount', () => {
+    it('calls cleanup with ctx after a successful timeline', async () => {
+      const ctx = { id: 'cleanup-ctx' };
+      const cleanupArgs: unknown[] = [];
+      const { options } = buildHarness({
+        scenes: [
+          {
+            id: 'scene-a',
+            cleanup: (c) => {
+              cleanupArgs.push(c);
+            },
+          },
+        ],
+        manifest: ['scene-a'],
+        ctx,
+      });
+      await resolveComposition(options);
+      expect(cleanupArgs).toEqual([ctx]);
+    });
+
+    it('orders preload → create → timeline → runTimeline → cleanup before the next preload (3-scene happy path)', async () => {
+      const { log, options } = buildHarness({
+        scenes: [{ id: 'scene-a' }, { id: 'scene-b' }, { id: 'scene-c' }],
+        manifest: ['scene-a', 'scene-b', 'scene-c'],
+      });
+      await resolveComposition(options);
+      expect(log.map((c) => `${c.hook}:${c.sceneId}`)).toEqual([
+        'preload:scene-a',
+        'create:scene-a',
+        'timeline:scene-a',
+        'runTimeline:scene-a',
+        'cleanup:scene-a',
+        'preload:scene-b',
+        'create:scene-b',
+        'timeline:scene-b',
+        'runTimeline:scene-b',
+        'cleanup:scene-b',
+        'preload:scene-c',
+        'create:scene-c',
+        'timeline:scene-c',
+        'runTimeline:scene-c',
+        'cleanup:scene-c',
+      ]);
+    });
+
+    it('re-raises a cleanup-only failure (timeline succeeded)', async () => {
+      const root = new Error('cleanup boom');
+      const { options } = buildHarness({
+        scenes: [
+          {
+            id: 'scene-a',
+            cleanup: () => {
+              throw root;
+            },
+          },
+        ],
+        manifest: ['scene-a'],
+      });
+      try {
+        await resolveComposition(options);
+        expect.unreachable('expected cleanup-only failure to propagate');
+      } catch (err) {
+        expect(err).toBeInstanceOf(Error);
+        expect((err as Error).message).toMatch(
+          /^composition resolution failed: scene "scene-a" cleanup threw: cleanup boom$/,
+        );
+        expect((err as Error).cause).toBe(root);
+      }
+    });
+
+    it('chains the cleanup error as Error.cause when both timeline and cleanup fail (timeline error wins as the message)', async () => {
+      const timelineErr = new Error('runner failed');
+      const cleanupErr = new Error('and so did cleanup');
+      const { options } = buildHarness({
+        scenes: [
+          {
+            id: 'scene-a',
+            cleanup: () => {
+              throw cleanupErr;
+            },
+          },
+        ],
+        manifest: ['scene-a'],
+        runTimeline: () => {
+          throw timelineErr;
+        },
+      });
+      try {
+        await resolveComposition(options);
+        expect.unreachable('expected combined failure to propagate');
+      } catch (err) {
+        expect(err).toBeInstanceOf(Error);
+        expect((err as Error).message).toMatch(
+          /^composition resolution failed: scene "scene-a" timeline threw: runner failed \(cleanup also failed: and so did cleanup\)$/,
+        );
+        // Cause chain: top-level Error.cause is the timeline error; its
+        // .cause is the cleanup error so neither is silently dropped.
+        const top = err as Error & { cause?: unknown };
+        expect(top.cause).toBe(timelineErr);
+        expect((timelineErr as Error & { cause?: unknown }).cause).toBe(cleanupErr);
+      }
+    });
+
+    it('chains the cleanup error as Error.cause when both create and cleanup fail', async () => {
+      const createErr = new Error('mount blew up');
+      const cleanupErr = new Error('cleanup also blew up');
+      const { options } = buildHarness({
+        scenes: [
+          {
+            id: 'scene-a',
+            create: () => {
+              throw createErr;
+            },
+            cleanup: () => {
+              throw cleanupErr;
+            },
+          },
+        ],
+        manifest: ['scene-a'],
+      });
+      try {
+        await resolveComposition(options);
+        expect.unreachable('expected combined failure to propagate');
+      } catch (err) {
+        const top = err as Error & { cause?: unknown };
+        expect(top.message).toMatch(
+          /^composition resolution failed: scene "scene-a" create threw: mount blew up \(cleanup also failed: cleanup also blew up\)$/,
+        );
+        expect(top.cause).toBe(createErr);
+        expect((createErr as Error & { cause?: unknown }).cause).toBe(cleanupErr);
+      }
+    });
+  });
+
+  describe('lifecycle hook return-value handling', () => {
+    it('handles synchronous (non-Promise) return values for create / timeline / cleanup the same as async ones', async () => {
+      const log: string[] = [];
+      const { options } = buildHarness({
+        scenes: [
+          {
+            id: 'scene-a',
+            create: () => {
+              log.push('sync-create');
+              return undefined;
+            },
+            timeline: () => {
+              log.push('sync-timeline');
+              return 42;
+            },
+            cleanup: () => {
+              log.push('sync-cleanup');
+              return undefined;
+            },
+          },
+        ],
+        manifest: ['scene-a'],
+        runTimeline: (_scene, value) => {
+          log.push(`runTimeline-received-${String(value)}`);
+        },
+      });
+      await resolveComposition(options);
+      expect(log).toEqual([
+        'sync-create',
+        'sync-timeline',
+        'runTimeline-received-42',
+        'sync-cleanup',
+      ]);
+    });
+  });
+
+  describe('manifest entry shapes', () => {
+    it('accepts object entries with range / behavior overrides without reading either field', async () => {
+      const log: string[] = [];
+      const { options } = buildHarness({
+        scenes: [
+          {
+            id: 'scene-a',
+            create: () => {
+              log.push('create-a');
+            },
+            cleanup: () => {
+              log.push('cleanup-a');
+            },
+          },
+        ],
+        manifest: [
+          {
+            id: 'scene-a',
+            range: ['intro', 'outro'],
+            behavior: { speed: 2, loop: true },
+          },
+        ],
+      });
+      await resolveComposition(options);
+      // The resolver must not interpret range/behavior in PUL-F004 — it
+      // just runs the scene's normal lifecycle. Lifecycle hooks fire
+      // exactly once (no special handling triggered by the override
+      // fields).
+      expect(log).toEqual(['create-a', 'cleanup-a']);
+    });
+
+    it('runs repeated scene ids as repeated lifecycle entries (no dedup) — codex preflight invariant', async () => {
+      const calls: string[] = [];
+      const { options } = buildHarness({
+        scenes: [
+          {
+            id: 'scene-a',
+            create: () => {
+              calls.push('create-a');
+            },
+            cleanup: () => {
+              calls.push('cleanup-a');
+            },
+          },
+        ],
+        manifest: ['scene-a', 'scene-a', 'scene-a'],
+      });
+      await resolveComposition(options);
+      expect(calls).toEqual([
+        'create-a',
+        'cleanup-a',
+        'create-a',
+        'cleanup-a',
+        'create-a',
+        'cleanup-a',
+      ]);
+    });
+
+    it('drives the ADR-002 trailer fixture (mixed bare-string + object entries) end-to-end in order', async () => {
+      const { log, options } = buildHarness({
+        scenes: [{ id: 'scene-a' }, { id: 'scene-c' }],
+        manifest: [
+          { id: 'scene-a', range: ['intro', 'hook'] },
+          { id: 'scene-c', range: 'payoff' },
+        ],
+      });
+      await resolveComposition(options);
+      expect(log.map((c) => `${c.hook}:${c.sceneId}`)).toEqual([
+        'preload:scene-a',
+        'create:scene-a',
+        'timeline:scene-a',
+        'runTimeline:scene-a',
+        'cleanup:scene-a',
+        'preload:scene-c',
+        'create:scene-c',
+        'timeline:scene-c',
+        'runTimeline:scene-c',
+        'cleanup:scene-c',
+      ]);
+    });
+  });
+
+  describe('contract surfaces', () => {
+    it('exports resolveComposition as an async function', () => {
+      // ResolveCompositionOptions / AssetPreloader / SceneTimelineRunner
+      // type imports above pin the public surface — if they are removed
+      // or renamed this test file fails to type-check.
+      expect(typeof resolveComposition).toBe('function');
+      // Calling with no arg blows up at runtime — deliberately not
+      // testing that path (TypeScript catches it at compile time and
+      // we don't add runtime guards beyond assertCompositionManifest's
+      // boundary check).
+    });
+  });
+});
+
+// Silence unused-import warnings for vi (kept available for future fakes
+// that need vi.useFakeTimers or vi.spyOn).
+void vi;

--- a/tests/runtime/composition-resolver.test.ts
+++ b/tests/runtime/composition-resolver.test.ts
@@ -707,6 +707,97 @@ describe('resolveComposition (PUL-F004)', () => {
     });
   });
 
+  describe('non-Error throw paths (codex review: do not use undefined as failure sentinel)', () => {
+    // `throw undefined` and `Promise.reject(undefined)` are both legal
+    // JS. The resolver must still treat them as failures. These tests
+    // pin that: dropping the boolean failure flags in favor of
+    // `phaseError !== undefined` would silently swallow these cases.
+    it('treats `throw undefined` from create as a failure (no scene-completed pretense)', async () => {
+      const cleanupCalls: number[] = [];
+      const { options } = buildHarness({
+        scenes: [
+          {
+            id: 'scene-a',
+            create: () => {
+              throw undefined;
+            },
+            cleanup: () => {
+              cleanupCalls.push(1);
+            },
+          },
+        ],
+        manifest: ['scene-a'],
+      });
+      await expect(resolveComposition(options)).rejects.toThrow(
+        /^composition resolution failed: scene "scene-a" create threw: undefined$/,
+      );
+      // Cleanup must still run because create was attempted.
+      expect(cleanupCalls).toEqual([1]);
+    });
+
+    it('treats `Promise.reject(undefined)` from runTimeline as a failure', async () => {
+      const cleanupCalls: number[] = [];
+      const { options } = buildHarness({
+        scenes: [
+          {
+            id: 'scene-a',
+            cleanup: () => {
+              cleanupCalls.push(1);
+            },
+          },
+        ],
+        manifest: ['scene-a'],
+        runTimeline: () => Promise.reject(undefined),
+      });
+      await expect(resolveComposition(options)).rejects.toThrow(
+        /^composition resolution failed: scene "scene-a" timeline threw: undefined$/,
+      );
+      expect(cleanupCalls).toEqual([1]);
+    });
+
+    it('treats `throw undefined` from cleanup as a failure', async () => {
+      const { options } = buildHarness({
+        scenes: [
+          {
+            id: 'scene-a',
+            cleanup: () => {
+              throw undefined;
+            },
+          },
+        ],
+        manifest: ['scene-a'],
+      });
+      await expect(resolveComposition(options)).rejects.toThrow(
+        /^composition resolution failed: scene "scene-a" cleanup threw: undefined$/,
+      );
+    });
+
+    it('treats `throw undefined` from preloadAssets as a failure (no create / cleanup)', async () => {
+      const log: string[] = [];
+      const { options } = buildHarness({
+        scenes: [
+          {
+            id: 'scene-a',
+            create: () => {
+              log.push('create');
+            },
+            cleanup: () => {
+              log.push('cleanup');
+            },
+          },
+        ],
+        manifest: ['scene-a'],
+        preloadAssets: () => {
+          throw undefined;
+        },
+      });
+      await expect(resolveComposition(options)).rejects.toThrow(
+        /^composition resolution failed: scene "scene-a" preloadAssets threw: undefined$/,
+      );
+      expect(log).toEqual([]);
+    });
+  });
+
   describe('manifest entry shapes', () => {
     it('accepts object entries with range / behavior overrides without reading either field', async () => {
       const log: string[] = [];
@@ -765,9 +856,13 @@ describe('resolveComposition (PUL-F004)', () => {
       ]);
     });
 
-    it('drives the ADR-002 trailer fixture (mixed bare-string + object entries) end-to-end in order', async () => {
+    it('drives the ADR-002 trailer fixture (object entries with range overrides) end-to-end in order', async () => {
       const { log, options } = buildHarness({
         scenes: [{ id: 'scene-a' }, { id: 'scene-c' }],
+        // Literal copy of ADR-002 §Composition manifests `trailer`
+        // example. Both entries are object form; bare-string mixing is
+        // exercised separately below to keep this assertion honest
+        // about which fixture path it pins.
         manifest: [
           { id: 'scene-a', range: ['intro', 'hook'] },
           { id: 'scene-c', range: 'payoff' },
@@ -780,6 +875,35 @@ describe('resolveComposition (PUL-F004)', () => {
         'timeline:scene-a',
         'runTimeline:scene-a',
         'cleanup:scene-a',
+        'preload:scene-c',
+        'create:scene-c',
+        'timeline:scene-c',
+        'runTimeline:scene-c',
+        'cleanup:scene-c',
+      ]);
+    });
+
+    it('drives a manifest mixing bare-string and object entries end-to-end in declared order', async () => {
+      const { log, options } = buildHarness({
+        scenes: [{ id: 'scene-a' }, { id: 'scene-b' }, { id: 'scene-c' }],
+        manifest: [
+          'scene-a',
+          { id: 'scene-b', range: 'beat-1', behavior: { mode: 'demo' } },
+          'scene-c',
+        ],
+      });
+      await resolveComposition(options);
+      expect(log.map((c) => `${c.hook}:${c.sceneId}`)).toEqual([
+        'preload:scene-a',
+        'create:scene-a',
+        'timeline:scene-a',
+        'runTimeline:scene-a',
+        'cleanup:scene-a',
+        'preload:scene-b',
+        'create:scene-b',
+        'timeline:scene-b',
+        'runTimeline:scene-b',
+        'cleanup:scene-b',
         'preload:scene-c',
         'create:scene-c',
         'timeline:scene-c',

--- a/tests/runtime/composition-resolver.test.ts
+++ b/tests/runtime/composition-resolver.test.ts
@@ -216,8 +216,12 @@ describe('resolveComposition (PUL-F004)', () => {
         },
       });
       const resolverPromise = resolveComposition(options);
-      // microtask flush: preload should have started but not yet finished
-      await Promise.resolve();
+      // Flush microtasks until the preloader adapter has started, so the
+      // assertion does not depend on the number of internal await hops
+      // between resolveComposition and the adapter.
+      while (log.length === 0) {
+        await Promise.resolve();
+      }
       expect(log).toEqual(['preload-scene-a-start']);
       resolvePreloadA?.();
       await resolverPromise;
@@ -385,8 +389,12 @@ describe('resolveComposition (PUL-F004)', () => {
         },
       });
       const resolverPromise = resolveComposition(options);
-      await Promise.resolve();
-      await Promise.resolve();
+      // Flush microtasks until runTimeline has started executing, so
+      // the assertion does not depend on the number of internal await
+      // hops between resolveComposition and the runner adapter.
+      while (log.length === 0) {
+        await Promise.resolve();
+      }
       expect(log).toEqual(['runTimeline-scene-a-start']);
       resolveRun?.();
       await resolverPromise;


### PR DESCRIPTION
## Summary

- Adds `resolveComposition(options)` in `src/runtime/composition-resolver.ts` — the runtime's "play a composition" entry point. Wires together the scene registry (PUL-F002) and the composition manifest (PUL-F003) by validating references up front, then per-scene calling injected `preloadAssets(scene)`, `scene.create(ctx)`, injected `runTimeline(scene, scene.timeline(ctx))`, and `scene.cleanup(ctx)` — strictly sequential, in manifest order.
- Cleanup is mandatory whenever the scene was touched (including failure paths after `create` or timeline execution); when a lifecycle phase AND cleanup both fail, the wrapping error names both and the cleanup error is chained as `phaseError.cause` so neither is silently swallowed.
- Adds `docs/adrs/011-composition-resolver-orchestration.md` + Ground Control ADR record: documents why the resolver stays a pure orchestrator with `AssetPreloader` / `SceneTimelineRunner` injected callbacks (so the asset loader and the GSAP runner can ship independently without resolver churn) and why `range` / `behavior` overrides are deferred to the timeline runner.
- Adds 27 Vitest cases in `tests/runtime/composition-resolver.test.ts` covering every clause of PUL-F004 plus the codex-preflight no-dedup invariant for repeated scene ids and the ADR-002 `trailer` fixture end-to-end.
- Backfills missing ADR-010 / ADR-011 rows in `docs/adrs/README.md`.

## Test plan

- [x] `pnpm lint && pnpm typecheck && pnpm test` — green (284 tests across 6 files)
- [x] `pre-commit run --all-files` — green
- [ ] CI green on this PR
- [ ] SonarCloud quality gate green
- [ ] Codex cross-model review clean
- [ ] Test-quality review clean

Closes #13