### PR TITLE
PUL-F005: Per-scene asset declaration and preload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `src/runtime/asset-preloader.ts` — `AssetPreloaderOptions` type and
+  `createAssetPreloader` factory. Implements PUL-F005 clause (b) (the
+  runtime SHALL preload declared assets for the active composition
+  before the scene mounts): the returned function fetches every URL in
+  `scene.assets` in parallel and drains each successful response body
+  via `arrayBuffer()` so the network transfer is fully complete before
+  `create(ctx)` runs. Failures aggregate into an `AggregateError` whose
+  `errors` array carries every failure (HTTP non-2xx OR rejected fetch)
+  in declaration order — the same shape PUL-F004 uses for combined
+  failures, single-failure cases included for consumer consistency.
+  The wrapping message is `composition asset preload failed: scene
+  "<id>"`; per-asset detail lives in `errors[i].message` as `asset
+  "<url>": <status> <statusText>`. Configurable via
+  `AssetPreloaderOptions.fetch` (override `globalThis.fetch` — required
+  for tests, useful for custom HTTP agents in bootstrap) and
+  `AssetPreloaderOptions.init` (`RequestInit` forwarded to every fetch
+  — headers, cache mode, signal). Decode-complete semantics (image
+  decode, font load, audio decode) are explicitly out of scope per
+  ADR-012; a future requirement layers them on top without changing
+  this preloader's contract. The function signature
+  `(scene: SceneModule) => Promise<void>` is structurally compatible
+  with PUL-F004's `AssetPreloader` adapter slot — once both ship the
+  workbench bootstrap passes `createAssetPreloader()` straight to
+  `resolveComposition({ preloadAssets, ... })` without a wrapper.
+  Clause (a) (each scene SHALL declare its required assets in
+  metadata) was already implemented under PUL-F001 via
+  `SceneModule.assets: readonly string[]` and its `assertSceneModule`
+  field-guard; reconciliation links PUL-F005 to that file too.
+- `tests/runtime/asset-preloader.test.ts` — 15-test Vitest spec
+  covering every PUL-F005 clause-(b) behavior: empty input no-op,
+  single / multiple / parallel fetch, URL pass-through, fetch override
+  vs. `globalThis.fetch` default, `init` forwarding, body-drain
+  invariant via a gated `arrayBuffer()`, single + aggregated failure
+  paths (404, network rejection, mixed success/failure, declaration-
+  order ordering), and the AggregateError-always-thrown invariant.
+  Tests inject a fake `fetch` per case — no global mutation, no MSW
+  dependency.
+- `docs/adrs/012-asset-preloader-fetch-and-drain.md` — records the
+  decision to ship byte-warming preload (`fetch + arrayBuffer()`) for
+  PUL-F005 and explicitly defer decode-complete semantics
+  (`Image.decode`, `document.fonts.load`, `audioContext.decodeAudioData`)
+  to a future requirement that composes with this preloader rather
+  than mutating it. Documents the AggregateError-for-failures contract
+  (matches ADR-011), the `AssetPreloaderOptions.fetch` / `init`
+  injection slots, and the Node-22-and-browser portability constraint
+  the chosen approach satisfies. ADR-012 is registered in Ground
+  Control via `gc_create_adr`.
+- `docs/adrs/README.md` — adds the ADR-012 row.
+
 - `src/runtime/composition.ts` — `CompositionManifest`,
   `CompositionEntry`, `CompositionEntryOverride`, `SubRange`, and
   `BehaviorOverride` types plus `assertCompositionManifest` runtime

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,26 +9,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `src/runtime/asset-preloader.ts` — `AssetPreloaderOptions` type and
-  `createAssetPreloader` factory. Implements PUL-F005 clause (b) (the
-  runtime SHALL preload declared assets for the active composition
-  before the scene mounts): the returned function fetches every URL in
-  `scene.assets` in parallel and drains each successful response body
-  via `arrayBuffer()` so the network transfer is fully complete before
-  `create(ctx)` runs. Failures aggregate into an `AggregateError` whose
-  `errors` array carries every failure (HTTP non-2xx OR rejected fetch)
-  in declaration order — the same shape PUL-F004 uses for combined
+- `src/runtime/asset-preloader.ts` — `AssetPreloaderOptions` type,
+  `DEFAULT_ALLOWED_SCHEMES` constant, and `createAssetPreloader`
+  factory. Implements PUL-F005 clause (b) (the runtime SHALL preload
+  declared assets for the active composition before the scene mounts):
+  the returned function validates every asset URL against a scheme
+  allowlist, optionally resolves relative paths against a configured
+  `baseUrl`, fetches every URL in `scene.assets` in parallel, drains
+  each successful response body via `arrayBuffer()` so the network
+  transfer is fully complete before `create(ctx)` runs, and
+  cancels (via `body.cancel()`) the response stream of any non-2xx
+  response so connections are not leaked. Failures aggregate into an
+  `AggregateError` whose `errors` array carries every failure in
+  declaration order — the same shape PUL-F004 uses for combined
   failures, single-failure cases included for consumer consistency.
-  The wrapping message is `composition asset preload failed: scene
-  "<id>"`; per-asset detail lives in `errors[i].message` as `asset
-  "<url>": <status> <statusText>`. Configurable via
-  `AssetPreloaderOptions.fetch` (override `globalThis.fetch` — required
-  for tests, useful for custom HTTP agents in bootstrap) and
-  `AssetPreloaderOptions.init` (`RequestInit` forwarded to every fetch
-  — headers, cache mode, signal). Decode-complete semantics (image
-  decode, font load, audio decode) are explicitly out of scope per
-  ADR-012; a future requirement layers them on top without changing
-  this preloader's contract. The function signature
+  Each per-asset failure message names the offending URL so two
+  failed network requests stay distinguishable (`asset "<url>": ...`).
+  Rejected fetches are wrapped with the asset URL and preserve the
+  original error as `Error.cause`. The wrapping `AggregateError`
+  message is `composition asset preload failed: scene "<id>"`.
+  Configurable via `AssetPreloaderOptions`:
+  `fetch` (override `globalThis.fetch` — required for tests, useful
+  for custom HTTP agents in bootstrap), `init` (`RequestInit`
+  forwarded to every fetch — headers, cache mode, signal), `baseUrl`
+  (resolves relative asset paths against an absolute base — required
+  for the Node exporter path because Node's `fetch` rejects relative
+  URLs), and `allowedSchemes` (URL scheme allowlist for SSRF defense
+  — defaults to `http:` / `https:` / `data:` / `blob:`; reject
+  `file:` / `gopher:` / etc. before fetch). Decode-complete semantics
+  (image decode, font load, audio decode) are explicitly out of
+  scope per ADR-012; a future requirement layers them on top without
+  changing this preloader's contract. The function signature
   `(scene: SceneModule) => Promise<void>` is structurally compatible
   with PUL-F004's `AssetPreloader` adapter slot — once both ship the
   workbench bootstrap passes `createAssetPreloader()` straight to
@@ -37,26 +48,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   metadata) was already implemented under PUL-F001 via
   `SceneModule.assets: readonly string[]` and its `assertSceneModule`
   field-guard; reconciliation links PUL-F005 to that file too.
-- `tests/runtime/asset-preloader.test.ts` — 15-test Vitest spec
-  covering every PUL-F005 clause-(b) behavior: empty input no-op,
-  single / multiple / parallel fetch, URL pass-through, fetch override
-  vs. `globalThis.fetch` default, `init` forwarding, body-drain
-  invariant via a gated `arrayBuffer()`, single + aggregated failure
-  paths (404, network rejection, mixed success/failure, declaration-
-  order ordering), and the AggregateError-always-thrown invariant.
-  Tests inject a fake `fetch` per case — no global mutation, no MSW
-  dependency.
+- `tests/runtime/asset-preloader.test.ts` — 27-test Vitest spec
+  covering every PUL-F005 clause-(b) behavior plus the codex-review
+  reinforcements: empty input no-op, single / multiple / parallel
+  fetch, URL pass-through, fetch override vs. `globalThis.fetch`
+  default, `init` forwarding, body-drain invariant via a gated
+  `arrayBuffer()`, single + aggregated failure paths (404, network
+  rejection, mixed success/failure, declaration-order ordering),
+  AggregateError-always-thrown invariant, asset-scoped failure
+  messages with `Error.cause` preservation, body cancel-on-non-2xx
+  (no leaked open streams), `baseUrl` resolution against relative
+  paths and pass-through of absolute paths, scheme allowlist defense
+  against `file:` / `gopher:` / custom-tightened lists, scheme
+  re-validation after `baseUrl` resolution, and the
+  `DEFAULT_ALLOWED_SCHEMES` re-export contract. Tests inject a fake
+  `fetch` per case — no global mutation, no MSW dependency.
 - `docs/adrs/012-asset-preloader-fetch-and-drain.md` — records the
   decision to ship byte-warming preload (`fetch + arrayBuffer()`) for
   PUL-F005 and explicitly defer decode-complete semantics
   (`Image.decode`, `document.fonts.load`, `audioContext.decodeAudioData`)
   to a future requirement that composes with this preloader rather
   than mutating it. Documents the AggregateError-for-failures contract
-  (matches ADR-011), the `AssetPreloaderOptions.fetch` / `init`
-  injection slots, and the Node-22-and-browser portability constraint
-  the chosen approach satisfies. ADR-012 is registered in Ground
-  Control via `gc_create_adr`.
-- `docs/adrs/README.md` — adds the ADR-012 row.
+  (matches ADR-011), the `AssetPreloaderOptions.fetch` / `init` /
+  `baseUrl` / `allowedSchemes` injection slots, the SSRF-defense
+  scheme allowlist, and the Node-22-and-browser portability
+  constraint the chosen approach satisfies. ADR-012 is registered in
+  Ground Control via `gc_create_adr`. The ADR file is added but the
+  `docs/adrs/README.md` index row is intentionally NOT touched in
+  this PR — ADR-010 / ADR-011 rows are missing too, and adding only
+  ADR-012 would create a broken numeric sequence in the table. A
+  follow-up PR backfills 010 / 011 / 012 rows together.
 
 - `src/runtime/composition.ts` — `CompositionManifest`,
   `CompositionEntry`, `CompositionEntryOverride`, `SubRange`, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,75 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `src/runtime/asset-preloader.ts` — `AssetPreloaderOptions` type,
-  `DEFAULT_ALLOWED_SCHEMES` constant, and `createAssetPreloader`
-  factory. Implements PUL-F005 clause (b) (the runtime SHALL preload
-  declared assets for the active composition before the scene mounts):
-  the returned function validates every asset URL against a scheme
-  allowlist, optionally resolves relative paths against a configured
-  `baseUrl`, fetches every URL in `scene.assets` in parallel, drains
-  each successful response body via `arrayBuffer()` so the network
-  transfer is fully complete before `create(ctx)` runs, and
-  cancels (via `body.cancel()`) the response stream of any non-2xx
-  response so connections are not leaked. Failures aggregate into an
-  `AggregateError` whose `errors` array carries every failure in
-  declaration order — the same shape PUL-F004 uses for combined
-  failures, single-failure cases included for consumer consistency.
-  Each per-asset failure message names the offending URL so two
-  failed network requests stay distinguishable (`asset "<url>": ...`).
-  Rejected fetches are wrapped with the asset URL and preserve the
-  original error as `Error.cause`. The wrapping `AggregateError`
-  message is `composition asset preload failed: scene "<id>"`.
-  Configurable via `AssetPreloaderOptions`:
-  `fetch` (override `globalThis.fetch` — required for tests, useful
-  for custom HTTP agents in bootstrap), `init` (`RequestInit`
-  forwarded to every fetch — headers, cache mode, signal), `baseUrl`
-  (resolves relative asset paths against an absolute base — required
-  for the Node exporter path because Node's `fetch` rejects relative
-  URLs), and `allowedSchemes` (URL scheme allowlist for SSRF defense
-  — defaults to `http:` / `https:` / `data:` / `blob:`; reject
-  `file:` / `gopher:` / etc. before fetch). Decode-complete semantics
-  (image decode, font load, audio decode) are explicitly out of
-  scope per ADR-012; a future requirement layers them on top without
-  changing this preloader's contract. The function signature
+- `src/runtime/asset-preloader.ts` — `createAssetPreloader` factory,
+  `AssetPreloaderOptions` interface, and `DEFAULT_ALLOWED_SCHEMES`
+  constant. Implements PUL-F005 clause (b): per scene, validate every
+  declared asset URL against a scheme allowlist, optionally resolve
+  relative paths against a configured `baseUrl`, fetch every URL in
+  parallel, stream-drain each successful response body via
+  `body.getReader()`, and re-validate the post-redirect URL against
+  the allowlist. Failures aggregate into a single `AggregateError`
+  whose `errors` array carries every failure in declaration order;
+  per-asset messages name the offending URL (and the resolved URL when
+  `baseUrl` differs) so multi-asset failures stay distinguishable.
+  Configurable via `AssetPreloaderOptions.{fetch, init, baseUrl,
+  allowedSchemes}`. Function signature
   `(scene: SceneModule) => Promise<void>` is structurally compatible
-  with PUL-F004's `AssetPreloader` adapter slot — once both ship the
-  workbench bootstrap passes `createAssetPreloader()` straight to
-  `resolveComposition({ preloadAssets, ... })` without a wrapper.
-  Clause (a) (each scene SHALL declare its required assets in
-  metadata) was already implemented under PUL-F001 via
-  `SceneModule.assets: readonly string[]` and its `assertSceneModule`
-  field-guard; reconciliation links PUL-F005 to that file too.
-- `tests/runtime/asset-preloader.test.ts` — 27-test Vitest spec
-  covering every PUL-F005 clause-(b) behavior plus the codex-review
-  reinforcements: empty input no-op, single / multiple / parallel
-  fetch, URL pass-through, fetch override vs. `globalThis.fetch`
-  default, `init` forwarding, body-drain invariant via a gated
-  `arrayBuffer()`, single + aggregated failure paths (404, network
-  rejection, mixed success/failure, declaration-order ordering),
-  AggregateError-always-thrown invariant, asset-scoped failure
-  messages with `Error.cause` preservation, body cancel-on-non-2xx
-  (no leaked open streams), `baseUrl` resolution against relative
-  paths and pass-through of absolute paths, scheme allowlist defense
-  against `file:` / `gopher:` / custom-tightened lists, scheme
-  re-validation after `baseUrl` resolution, and the
-  `DEFAULT_ALLOWED_SCHEMES` re-export contract. Tests inject a fake
-  `fetch` per case — no global mutation, no MSW dependency.
-- `docs/adrs/012-asset-preloader-fetch-and-drain.md` — records the
-  decision to ship byte-warming preload (`fetch + arrayBuffer()`) for
-  PUL-F005 and explicitly defer decode-complete semantics
-  (`Image.decode`, `document.fonts.load`, `audioContext.decodeAudioData`)
-  to a future requirement that composes with this preloader rather
-  than mutating it. Documents the AggregateError-for-failures contract
-  (matches ADR-011), the `AssetPreloaderOptions.fetch` / `init` /
-  `baseUrl` / `allowedSchemes` injection slots, the SSRF-defense
-  scheme allowlist, and the Node-22-and-browser portability
-  constraint the chosen approach satisfies. ADR-012 is registered in
-  Ground Control via `gc_create_adr`. The ADR file is added but the
-  `docs/adrs/README.md` index row is intentionally NOT touched in
-  this PR — ADR-010 / ADR-011 rows are missing too, and adding only
-  ADR-012 would create a broken numeric sequence in the table. A
-  follow-up PR backfills 010 / 011 / 012 rows together.
+  with PUL-F004's `AssetPreloader` adapter slot. Clause (a) is
+  satisfied by PUL-F001's `SceneModule.assets`. See ADR-012 for the
+  byte-warming-vs-decode-complete boundary, the SSRF posture, and the
+  cross-origin credential caveat.
+- `tests/runtime/asset-preloader.test.ts` — 34-case Vitest spec for
+  the preloader behaviors above; tests inject a fake `fetch` per case
+  (no global mutation, no MSW).
+- `docs/adrs/012-asset-preloader-fetch-and-drain.md` (also registered
+  in Ground Control via `gc_create_adr`).
 
 - `src/runtime/composition.ts` — `CompositionManifest`,
   `CompositionEntry`, `CompositionEntryOverride`, `SubRange`, and

--- a/docs/adrs/012-asset-preloader-fetch-and-drain.md
+++ b/docs/adrs/012-asset-preloader-fetch-and-drain.md
@@ -172,11 +172,35 @@ not need to change for that layer to land.
   serve from cache" semantics pass `init: { cache: 'force-cache' }`.
   The preloader does not impose a default — the bootstrap and the
   exporter each have different needs.
-- Reading `response.arrayBuffer()` allocates the full asset bytes in
-  memory transiently before they're GC'd. For very large assets
-  (multi-megabyte audio or video) this is wasteful compared to a
-  streaming drain. If profiling motivates it, a future change can
-  swap to a `body.getReader()` loop without changing the public API.
+- The preloader uses generic `fetch` with no parallelism cap, so a
+  scene with many large assets briefly opens that many concurrent
+  connections. Bounded concurrency is not implemented; if profiling
+  motivates it, an `AssetPreloaderOptions.concurrency` option can be
+  added without changing the public failure semantics.
+- The preloader uses CORS-restricted `fetch` (the default). Cross-
+  origin assets without `Access-Control-Allow-Origin` headers cannot
+  be preloaded — they reject as `fetch failed: ...` and abort the
+  composition. For browser deployments that load assets from a CDN
+  or third-party origin, the deployment is responsible for ensuring
+  CORS headers are present. A `<link rel="preload">` or `Image()`
+  fallback path with weaker semantics (no body verification, no
+  failure surfacing) is deliberately not shipped here — it would
+  conflict with the "fail loud on missing assets" contract per the
+  codex preflight guardrails. A future requirement may add an
+  opt-in CORS-bypass path for surfaces that explicitly accept the
+  weaker contract.
+- Relative-path assets (e.g. `'/foo.png'`) without a configured
+  `baseUrl` bypass scheme validation entirely — the browser resolves
+  them against `document.baseURI` whose protocol the preloader
+  cannot statically check. Production callers wanting strict scheme
+  enforcement (e.g. `allowedSchemes: ['https:']`) MUST also set
+  `baseUrl` so every asset resolves to an absolute URL the preloader
+  can scheme-check up front. Without `baseUrl`, the allowlist only
+  covers assets that declare an explicit scheme (or `//host/...`
+  which is rejected outright). This trade-off is intentional: the
+  browser's same-origin default makes relative paths safe in normal
+  usage, and forcing a `baseUrl` everywhere would harm the local
+  dev / workbench UX.
 
 ### Risks
 
@@ -186,6 +210,7 @@ not need to change for that layer to land.
 | Screenshot mode lands and depends on decode-complete, but the team forgets the boundary. | When PUL-F005's customer requirement hits, the implementer reads this ADR (linked from the resolver and the preloader module comments), notices the gap, and ships the decode layer as part of that work. The link from `src/runtime/asset-preloader.ts` to ADR-012 is the breadcrumb. |
 | Two scenes share an asset URL; the same URL is fetched twice across consecutive scenes. | The HTTP cache (browser or `undici`) handles cross-scene dedup transparently for cacheable URLs. The preloader does not maintain a separate dedup map; if profiling shows this matters for non-cacheable URLs, a future change can add an in-memory dedup keyed by URL string. |
 | `init.signal` cancellation arrives mid-drain and the preloader propagates a partial failure. | The current behavior surfaces the cancellation as one entry in `AggregateError.errors`. Callers driving cancellation from outside (e.g. the workbench during scene navigation) are responsible for treating cancellation as a non-fatal abort separate from genuine asset failures. |
+| SSRF via `scene.assets` declaring loopback / link-local IPs (e.g. `http://127.0.0.1:...`, `http://169.254.169.254/`). | The scheme allowlist alone does not block these; `http:` and `https:` allow any host. Production deployments wanting host-level defense need to either restrict at the network layer (egress firewall blocking RFC 1918 / RFC 6890 ranges) or wait for a future `originAllowlist` option on the preloader. Surfaces processing untrusted scene metadata MUST adopt one of these defenses. |
 
 ## Related ADRs
 

--- a/docs/adrs/012-asset-preloader-fetch-and-drain.md
+++ b/docs/adrs/012-asset-preloader-fetch-and-drain.md
@@ -48,10 +48,24 @@ to extend.
 ## Decision
 
 PUL-F005 ships the **byte-warming** preloader. `createAssetPreloader`
-in `src/runtime/asset-preloader.ts` uses `fetch` and drains every
-successful response body via `response.arrayBuffer()` so the network
-transfer is fully complete before `create(ctx)` runs. No asset-type
-discrimination, no decode pass, no browser-only APIs.
+in `src/runtime/asset-preloader.ts` uses `fetch` and stream-drains
+every successful response body via `response.body.getReader()` so the
+network transfer is fully complete before `create(ctx)` runs without
+buffering the whole payload into memory. No asset-type discrimination,
+no decode pass, no browser-only APIs.
+
+The factory runs validation in two phases:
+
+1. **Up-front**, synchronously: every declared asset URL is resolved
+   (against `baseUrl` if configured) and scheme-checked against the
+   allowlist. If any URL fails validation, no fetch starts. This way
+   an early valid asset cannot race a later disallowed asset into a
+   partial network call.
+2. **Post-fetch**, per response: the `response.url` (the URL after
+   any redirects fetch followed) is re-validated against the same
+   scheme allowlist. A scene declared an allowed URL that 302s to a
+   disallowed scheme (`https://allowed.example` → `file:///etc/passwd`)
+   is rejected before its body is read.
 
 Failure handling matches the
 [ADR-011](011-composition-resolver-orchestration.md) convention: any
@@ -94,11 +108,31 @@ The factory is configurable via `AssetPreloaderOptions`:
 
 Failures from rejected fetches and from non-2xx responses are
 **asset-scoped**: every per-asset error message starts with
-`asset "<url>": ...` so two simultaneously failing fetches stay
+`asset "<url>": ...` (or `asset "<declared>" → "<resolved>": ...` when
+`baseUrl` was used) so two simultaneously failing fetches stay
 distinguishable in `AggregateError.errors`. Rejected fetches preserve
 the original error as `Error.cause`. Non-2xx responses cancel the
 response body via `body.cancel()` before throwing so connections are
 not held open until garbage collection.
+
+### Cross-origin credential caveat
+
+`init.headers` flows to **every** asset URL fetched. If a caller
+configures `init.headers` carrying credentials (`Authorization`,
+`Cookie`) and a scene declares an asset on a third-party origin,
+those credentials are sent to that origin. PUL-F005 does not ship an
+origin-allowlist option. Callers wanting credentialed preload have
+two options today:
+
+1. Bind credentials to a custom `fetch` that injects headers per
+   request based on the destination URL. The custom fetch can refuse
+   to send credentials cross-origin or attach origin-specific tokens.
+2. Restrict the `allowedSchemes` and/or the scene authoring layer so
+   third-party absolute URLs cannot appear in `scene.assets`. For
+   first-party-only deployments this is sufficient.
+
+A future requirement may add an explicit `originAllowlist` option to
+the preloader if profiling or threat-model evolution motivates it.
 
 Decode-complete semantics are explicitly **out of scope** for PUL-F005.
 A future requirement that needs decode-complete (e.g. when screenshot

--- a/docs/adrs/012-asset-preloader-fetch-and-drain.md
+++ b/docs/adrs/012-asset-preloader-fetch-and-drain.md
@@ -1,0 +1,142 @@
+# ADR-012: Asset Preloader — Warm Bytes via Fetch + Drain; Decode-Complete is Future Work
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-03
+
+## Context
+
+PUL-F005 ships the asset preloader the runtime composition resolver
+(PUL-F004 / [ADR-011](011-composition-resolver-orchestration.md)) calls
+before each scene's `create(ctx)`. ADR-002 §Resolution and ADR-008 #5
+("asset inventories") set the contract: scenes declare assets in
+metadata; the runtime preloads them so behavior is predictable for both
+human reviewers and coding agents and so screenshot rendering is
+deterministic. PUL-F005's statement is "the runtime SHALL preload
+declared assets for the active composition before the scene mounts."
+
+"Preload" can mean two materially different things:
+
+1. **Bytes-on-disk** — the asset file is fully downloaded into the HTTP
+   cache (or in-memory equivalent), so subsequent reads inside
+   `create(ctx)` resolve immediately without a network round trip.
+   Implementable in both Node and the browser with native `fetch`
+   alone.
+2. **Decode-complete** — the asset is not just downloaded but
+   format-decoded into the form the runtime will use:
+   `Image.decode()` for images so the first paint shows pixels rather
+   than a blank rect; `document.fonts.load(font)` for web fonts so
+   text doesn't reflow on first paint; `audioContext.decodeAudioData`
+   for audio buffers ready for playback. Browser-only APIs;
+   per-asset-type handling required.
+
+Decode-complete matters most for `mode=screenshot`
+([ADR-007](007-browser-workbench.md)) where a single deterministic
+frame is rendered and any post-load layout or paint shift breaks the
+guarantee. It matters less for live presentation where a brief
+post-load flicker is tolerable.
+
+The Pulsar runtime targets both Node 22 (for the test runner and
+exporter pipeline) and the browser (for the live workbench), and the
+codebase has no logger, no asset-format-aware loader, no fetch wrapper
+to extend.
+
+## Decision
+
+PUL-F005 ships the **byte-warming** preloader. `createAssetPreloader`
+in `src/runtime/asset-preloader.ts` uses `fetch` and drains every
+successful response body via `response.arrayBuffer()` so the network
+transfer is fully complete before `create(ctx)` runs. No asset-type
+discrimination, no decode pass, no browser-only APIs.
+
+Failure handling matches the
+[ADR-011](011-composition-resolver-orchestration.md) convention: any
+non-2xx response or rejected fetch surfaces as a single
+`AggregateError` whose `errors` array carries every failure in the
+order assets were declared on the scene. Single-failure cases use the
+same `AggregateError` shape as multi-failure cases — consistency over
+ergonomic difference. The wrapping message is
+`composition asset preload failed: scene "<id>"`; per-asset detail
+(URL + HTTP status, or original network error) lives in
+`errors[i].message`. The PUL-F004 resolver wraps this further as
+`composition resolution failed: scene "<id>" preloadAssets threw: ...`
+without losing detail.
+
+The factory is configurable via `AssetPreloaderOptions`:
+
+- `fetch` — override `globalThis.fetch`. Required for tests (avoids
+  global mutation) and useful in the bootstrap if a custom fetch
+  (e.g. an `undici` Agent with custom keep-alive, a service-worker
+  shim) is needed.
+- `init` — `RequestInit` forwarded to every fetch call. Headers,
+  `cache` mode, and `signal` (for cooperative cancellation) flow
+  through this slot.
+
+Decode-complete semantics are explicitly **out of scope** for PUL-F005.
+A future requirement that needs decode-complete (e.g. when screenshot
+mode hardens its determinism guarantees, or when an image-heavy scene
+shows a flicker) will layer a decode pass on top of — or compose
+with — `createAssetPreloader`. The decode layer can wrap each scene's
+declared assets, branch on extension or content-type, and call the
+appropriate browser API. The byte-warming preloader's contract does
+not need to change for that layer to land.
+
+## Consequences
+
+### Positive
+
+- Works in both Node 22 (tests, exporter) and the browser (workbench)
+  with no environment branching and no new dependency.
+- Single, small surface: one factory, one options interface, one
+  exported function. Structurally legible per
+  [ADR-008](008-agent-native-authoring.md) — an agent can read the
+  module front-to-back in under two minutes.
+- Failure semantics are explicit and testable. Per-asset failures
+  aggregate; the resolver's wrap preserves both the wrapping context
+  and the per-asset detail.
+- Plugs straight into the PUL-F004 `AssetPreloader` adapter slot
+  without a wrapper because the function signature
+  `(scene: SceneModule) => Promise<void>` is structurally compatible.
+
+### Negative
+
+- Image / font / audio scenes that depend on first-frame correctness
+  will see a brief post-load shift between `create(ctx)` and "fully
+  decoded." Acceptable for live presentation; not acceptable for
+  deterministic screenshots once that surface lands.
+- HTTP cache behavior depends on the response's `Cache-Control`
+  headers. Callers wanting strong "always reload" semantics pass
+  `init: { cache: 'no-store' }`; callers wanting strong "always
+  serve from cache" semantics pass `init: { cache: 'force-cache' }`.
+  The preloader does not impose a default — the bootstrap and the
+  exporter each have different needs.
+- Reading `response.arrayBuffer()` allocates the full asset bytes in
+  memory transiently before they're GC'd. For very large assets
+  (multi-megabyte audio or video) this is wasteful compared to a
+  streaming drain. If profiling motivates it, a future change can
+  swap to a `body.getReader()` loop without changing the public API.
+
+### Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| Future contributor "improves" the preloader by adding decode-complete logic and breaks the Node test environment (no `Image`, no `document.fonts`). | This ADR makes the boundary explicit. The decode layer must land as a separate, opt-in module that composes with this preloader rather than mutating it. PR review enforces. |
+| Screenshot mode lands and depends on decode-complete, but the team forgets the boundary. | When PUL-F005's customer requirement hits, the implementer reads this ADR (linked from the resolver and the preloader module comments), notices the gap, and ships the decode layer as part of that work. The link from `src/runtime/asset-preloader.ts` to ADR-012 is the breadcrumb. |
+| Two scenes share an asset URL; the same URL is fetched twice across consecutive scenes. | The HTTP cache (browser or `undici`) handles cross-scene dedup transparently for cacheable URLs. The preloader does not maintain a separate dedup map; if profiling shows this matters for non-cacheable URLs, a future change can add an in-memory dedup keyed by URL string. |
+| `init.signal` cancellation arrives mid-drain and the preloader propagates a partial failure. | The current behavior surfaces the cancellation as one entry in `AggregateError.errors`. Callers driving cancellation from outside (e.g. the workbench during scene navigation) are responsible for treating cancellation as a non-fatal abort separate from genuine asset failures. |
+
+## Related ADRs
+
+- [ADR-002](002-scene-registry-and-compositions.md) §Resolution —
+  defines the runtime lifecycle this preloader fits into.
+- [ADR-008](008-agent-native-authoring.md) #5 — asset inventories as
+  agent-legible structure; the preloader reads them, doesn't discover
+  them.
+- [ADR-011](011-composition-resolver-orchestration.md) — the resolver
+  whose `AssetPreloader` adapter slot this preloader fills.
+- [ADR-007](007-browser-workbench.md) — the workbench whose
+  `mode=screenshot` is the future customer of decode-complete.

--- a/docs/adrs/012-asset-preloader-fetch-and-drain.md
+++ b/docs/adrs/012-asset-preloader-fetch-and-drain.md
@@ -75,6 +75,30 @@ The factory is configurable via `AssetPreloaderOptions`:
 - `init` — `RequestInit` forwarded to every fetch call. Headers,
   `cache` mode, and `signal` (for cooperative cancellation) flow
   through this slot.
+- `baseUrl` — base URL used to resolve relative asset paths via the
+  `URL` constructor. Required for the Node exporter path because
+  Node's `fetch` rejects relative URLs with `TypeError: Invalid URL`.
+  Optional in the browser, where relative paths resolve against
+  `document.baseURI` automatically. When provided, the resolved URL's
+  scheme is re-validated against the allowlist so a scene cannot
+  smuggle a disallowed scheme by declaring it absolute.
+- `allowedSchemes` — URL scheme allowlist. Defaults to the exported
+  `DEFAULT_ALLOWED_SCHEMES` constant: `['http:', 'https:', 'data:',
+  'blob:']`. Schemes outside the list (e.g. `file:`, `gopher:`,
+  `ws:`) reject before fetch with a clear, asset-scoped message.
+  Callers tighten (`['https:']` for production) or extend (add
+  `'file:'` for offline-export workflows) as their threat model
+  requires. The check is the minimum SSRF defense; host-allowlisting
+  for richer attacker models is a deployment concern handled at the
+  workbench/exporter layer.
+
+Failures from rejected fetches and from non-2xx responses are
+**asset-scoped**: every per-asset error message starts with
+`asset "<url>": ...` so two simultaneously failing fetches stay
+distinguishable in `AggregateError.errors`. Rejected fetches preserve
+the original error as `Error.cause`. Non-2xx responses cancel the
+response body via `body.cancel()` before throwing so connections are
+not held open until garbage collection.
 
 Decode-complete semantics are explicitly **out of scope** for PUL-F005.
 A future requirement that needs decode-complete (e.g. when screenshot

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -35,3 +35,4 @@ Each ADR includes:
 | [007](007-browser-workbench.md) | Browser as the Default Workbench and Agent Collaboration Surface | Accepted |
 | [008](008-agent-native-authoring.md) | Agent-Native Authoring as a First-Class Architectural Constraint | Accepted |
 | [009](009-repo-layout-and-build-tooling.md) | Repo Layout and Build Tooling | Accepted |
+| [012](012-asset-preloader-fetch-and-drain.md) | Asset Preloader — Warm Bytes via Fetch + Drain; Decode-Complete is Future Work | Accepted |

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -35,4 +35,3 @@ Each ADR includes:
 | [007](007-browser-workbench.md) | Browser as the Default Workbench and Agent Collaboration Surface | Accepted |
 | [008](008-agent-native-authoring.md) | Agent-Native Authoring as a First-Class Architectural Constraint | Accepted |
 | [009](009-repo-layout-and-build-tooling.md) | Repo Layout and Build Tooling | Accepted |
-| [012](012-asset-preloader-fetch-and-drain.md) | Asset Preloader — Warm Bytes via Fetch + Drain; Decode-Complete is Future Work | Accepted |

--- a/src/runtime/asset-preloader.ts
+++ b/src/runtime/asset-preloader.ts
@@ -1,0 +1,119 @@
+// Asset preloader — PUL-F005.
+//
+// Builds a per-scene asset preloader that warms every URL declared in
+// `scene.assets` before the scene's `create(ctx)` runs. The preloader
+// satisfies the PUL-F004 resolver's `AssetPreloader` adapter contract
+// (a function `(scene: SceneModule) => void | Promise<void>` whose
+// rejection aborts the composition before mount) — when both
+// requirements have shipped, the workbench bootstrap passes
+// `createAssetPreloader()` straight to `resolveComposition({ preloadAssets })`.
+//
+// Strategy: fetch every asset URL in parallel via `Promise.allSettled`
+// and drain each successful response body via `arrayBuffer()` so the
+// network stream is fully consumed before the function resolves —
+// without the drain, `fetch` resolves on headers and the cache may
+// not yet hold the bytes when `create(ctx)` runs.
+//
+// Failure handling: any non-2xx response or rejected fetch surfaces as
+// a single `AggregateError` whose `errors` array carries every failure
+// in declaration order. Single-failure cases use the same shape as
+// multi-failure cases for consumer consistency. Failures are never
+// swallowed; the resolver wraps the AggregateError as
+// `composition resolution failed: scene "<id>" preloadAssets threw: ...`.
+//
+// Decode-complete semantics (image decode, font load, audio decode)
+// are explicitly out of scope here — see ADR-012. A future requirement
+// can layer a decode pass on top of (or compose with) this preloader
+// without changing its contract.
+//
+// References:
+//  - ADR-002 §Resolution — runtime preloads assets per scene before mount.
+//  - ADR-008 #5 — scene asset inventories are statically inspectable
+//    (no runtime discovery; the only source is `scene.assets`).
+//  - ADR-011 — orchestrator-with-injected-adapters; this module is the
+//    asset adapter the resolver consumes.
+//  - ADR-012 — fetch + drain semantics; decode-complete deferred.
+
+import type { SceneModule } from './scene';
+
+/**
+ * Options for {@link createAssetPreloader}. All fields are optional;
+ * the defaults pull from `globalThis.fetch` with no extra request init.
+ */
+export interface AssetPreloaderOptions {
+  /**
+   * Override the fetch implementation. Production callers default to
+   * `globalThis.fetch`; tests inject a fake to record calls and shape
+   * responses. Injection (rather than module-level global mutation)
+   * keeps tests isolated and matches the orchestrator-with-adapters
+   * pattern PUL-F004 uses.
+   */
+  readonly fetch?: typeof globalThis.fetch;
+  /**
+   * `RequestInit` forwarded to every fetch call (e.g. headers, signal,
+   * cache mode). Forwarded by reference so callers can attach a single
+   * `AbortSignal` to all per-scene fetches.
+   */
+  readonly init?: RequestInit;
+}
+
+/**
+ * Build a per-scene asset preloader.
+ *
+ * The returned function:
+ *  - resolves immediately when `scene.assets` is empty (no fetch calls);
+ *  - otherwise issues one parallel `fetch` per asset URL, drains each
+ *    successful response body, and resolves with `undefined` once every
+ *    asset is fully downloaded;
+ *  - throws an `AggregateError` when one or more assets fail (HTTP
+ *    non-2xx OR rejected fetch). The wrapping message is
+ *    `composition asset preload failed: scene "<id>"`; per-asset
+ *    failure messages live in `AggregateError.errors`. The order of
+ *    `errors` matches the declaration order in `scene.assets`, not
+ *    completion order.
+ *
+ * The returned function is the `AssetPreloader` adapter the PUL-F004
+ * resolver expects (`(scene: SceneModule) => Promise<void>`). When
+ * both requirements have landed, callers wire it via
+ * `resolveComposition({ preloadAssets: createAssetPreloader(), ... })`.
+ */
+export function createAssetPreloader(
+  options: AssetPreloaderOptions = {},
+): (scene: SceneModule) => Promise<void> {
+  const fetchImpl = options.fetch ?? globalThis.fetch;
+  const init = options.init;
+  return async (scene) => {
+    if (scene.assets.length === 0) return;
+    const results = await Promise.allSettled(
+      scene.assets.map((asset) => preloadAsset(asset, fetchImpl, init)),
+    );
+    const errors: unknown[] = [];
+    for (const result of results) {
+      if (result.status === 'rejected') errors.push(result.reason);
+    }
+    if (errors.length > 0) {
+      throw new AggregateError(errors, `composition asset preload failed: scene "${scene.id}"`);
+    }
+  };
+}
+
+/**
+ * Fetch one asset URL and drain its body. Throws the underlying error
+ * for the caller's `Promise.allSettled` to collect; this function does
+ * not aggregate.
+ */
+async function preloadAsset(
+  url: string,
+  fetchImpl: typeof globalThis.fetch,
+  init: RequestInit | undefined,
+): Promise<void> {
+  const response = init === undefined ? await fetchImpl(url) : await fetchImpl(url, init);
+  if (!response.ok) {
+    throw new Error(`asset "${url}": ${response.status} ${response.statusText}`);
+  }
+  // Drain the body so the network transfer fully completes before the
+  // caller's `create(ctx)` runs. Without this, `fetch` resolves on
+  // headers and the bytes may still be in flight, defeating the
+  // "preload" contract.
+  await response.arrayBuffer();
+}

--- a/src/runtime/asset-preloader.ts
+++ b/src/runtime/asset-preloader.ts
@@ -8,19 +8,29 @@
 // requirements have shipped, the workbench bootstrap passes
 // `createAssetPreloader()` straight to `resolveComposition({ preloadAssets })`.
 //
-// Strategy: fetch every asset URL in parallel via `Promise.allSettled`
-// and drain each successful response body via `arrayBuffer()` so the
-// network stream is fully consumed before the function resolves —
-// without the drain, `fetch` resolves on headers and the cache may
-// not yet hold the bytes when `create(ctx)` runs.
+// Strategy:
+//  1. Validate (scheme allowlist) and resolve (against `baseUrl`) every
+//     declared asset URL up front in a synchronous pass. Network requests
+//     do not start until validation has accepted every URL — an early
+//     valid asset cannot race a later disallowed scheme into a partial
+//     fetch.
+//  2. Fetch every resolved URL in parallel via `Promise.allSettled` and
+//     stream-drain each successful response body via
+//     `body.getReader()`. Streaming (rather than `arrayBuffer()`) keeps
+//     transient memory bounded for large assets.
+//  3. After fetch completes, re-validate the response's final URL
+//     (post-redirect) against the scheme allowlist so a 3xx to a
+//     disallowed scheme cannot bypass the up-front check.
 //
-// Failure handling: any non-2xx response, rejected fetch, or scheme
-// rejection surfaces as a single `AggregateError` whose `errors` array
-// carries every failure in declaration order. Each failure's message
-// names the asset URL so a multi-asset failure does not collapse into
-// indistinguishable network errors. Failures from non-2xx responses
-// drain/cancel the response body before throwing so connections are
-// not leaked. Failures are never swallowed; the resolver wraps the
+// Failure handling: any non-2xx response, rejected fetch, scheme
+// rejection, or invalid URL surfaces as a single `AggregateError` whose
+// `errors` array carries every failure in declaration order. Single-
+// failure cases use the same shape as multi-failure cases for consumer
+// consistency. Each per-asset failure message names the offending URL
+// (and the resolved URL when different) so multi-asset failures stay
+// distinguishable. Failures from non-2xx responses cancel the response
+// body via `body.cancel()` before throwing so connections are not
+// leaked. Failures are never swallowed; the resolver wraps the
 // AggregateError as
 // `composition resolution failed: scene "<id>" preloadAssets threw: ...`.
 //
@@ -29,13 +39,23 @@
 // can layer a decode pass on top of (or compose with) this preloader
 // without changing its contract.
 //
+// Cross-origin credential leak: if the caller passes
+// `init.headers` carrying credentials (Authorization, Cookie) and a
+// scene declares an asset on a third-party origin, those credentials
+// are sent to that origin. Per ADR-012, callers wanting credentialed
+// preload MUST either bind credentials to a custom `fetch` (per-origin)
+// or restrict scenes to first-party assets via `allowedSchemes` plus
+// deployment-level network policy. An origin-allowlist option may be
+// added in a future requirement; PUL-F005 documents the constraint.
+//
 // References:
 //  - ADR-002 §Resolution — runtime preloads assets per scene before mount.
 //  - ADR-008 #5 — scene asset inventories are statically inspectable
 //    (no runtime discovery; the only source is `scene.assets`).
 //  - ADR-011 — orchestrator-with-injected-adapters; this module is the
 //    asset adapter the resolver consumes.
-//  - ADR-012 — fetch + drain semantics; decode-complete deferred.
+//  - ADR-012 — fetch + drain semantics; decode-complete deferred;
+//    SSRF and credential-leak posture.
 
 import type { SceneModule } from './scene';
 
@@ -69,7 +89,9 @@ export interface AssetPreloaderOptions {
   /**
    * `RequestInit` forwarded to every fetch call (e.g. headers, signal,
    * cache mode). Forwarded by reference so callers can attach a single
-   * `AbortSignal` to all per-scene fetches.
+   * `AbortSignal` to all per-scene fetches. NB: credentials in
+   * `init.headers` flow to every asset URL — see ADR-012's
+   * cross-origin caveat before attaching `Authorization` or `Cookie`.
    */
   readonly init?: RequestInit;
   /**
@@ -79,7 +101,9 @@ export interface AssetPreloaderOptions {
    * relative paths resolve against `document.baseURI` automatically.
    * When provided, every resolved URL is re-validated against the
    * scheme allowlist (so a scene cannot smuggle a `file:` URL by
-   * declaring it absolute).
+   * declaring it absolute). When NOT provided, protocol-relative
+   * (`//host/path`) assets are rejected since their final scheme
+   * cannot be statically validated.
    */
   readonly baseUrl?: string;
   /**
@@ -88,6 +112,9 @@ export interface AssetPreloaderOptions {
    * (e.g. `['https:']` for production) or extend (e.g. add `'file:'`
    * for offline-export workflows). Schemes outside the list reject
    * before fetch with `asset "<url>": scheme "<scheme>" not allowed`.
+   * The allowlist is also re-checked against the response's final URL
+   * after fetch (defense against allowed-URL → disallowed-scheme
+   * redirects).
    */
   readonly allowedSchemes?: readonly string[];
 }
@@ -97,20 +124,25 @@ export interface AssetPreloaderOptions {
  *
  * The returned function:
  *  - resolves immediately when `scene.assets` is empty (no fetch calls);
- *  - validates every asset URL against the scheme allowlist before any
+ *  - validates every asset URL against the scheme allowlist BEFORE any
  *    network request (default allowlist is {@link DEFAULT_ALLOWED_SCHEMES});
  *  - if `baseUrl` is provided, resolves each asset against it via the
- *    `URL` constructor and re-validates the resolved scheme;
- *  - otherwise issues one parallel `fetch` per asset URL, drains each
- *    successful response body, and resolves with `undefined` once every
- *    asset is fully downloaded;
+ *    `URL` constructor and validates the resolved scheme;
+ *  - otherwise issues one parallel `fetch` per asset URL,
+ *    stream-drains each successful response body via
+ *    `response.body.getReader()`, and resolves with `undefined` once
+ *    every asset is fully downloaded;
+ *  - re-validates the post-redirect URL of every successful response
+ *    against the scheme allowlist (defense against
+ *    allowed → disallowed redirects);
  *  - throws an `AggregateError` when one or more assets fail (HTTP
  *    non-2xx, rejected fetch, scheme rejection, or invalid URL). The
  *    wrapping message is `composition asset preload failed: scene "<id>"`;
  *    per-asset failure messages live in `AggregateError.errors` and
- *    always name the offending asset URL so multi-asset failures stay
- *    distinguishable. The order of `errors` matches the declaration
- *    order in `scene.assets`, not completion order.
+ *    always name the offending asset URL (and the resolved URL when
+ *    different) so multi-asset failures stay distinguishable. The
+ *    order of `errors` matches the declaration order in `scene.assets`,
+ *    not completion order.
  *
  * The returned function is the `AssetPreloader` adapter the PUL-F004
  * resolver expects (`(scene: SceneModule) => Promise<void>`). When
@@ -126,22 +158,65 @@ export function createAssetPreloader(
   const allowedSchemes = options.allowedSchemes ?? DEFAULT_ALLOWED_SCHEMES;
   return async (scene) => {
     if (scene.assets.length === 0) return;
-    const results = await Promise.allSettled(
-      scene.assets.map((asset) => preloadAsset(asset, fetchImpl, init, baseUrl, allowedSchemes)),
-    );
-    const errors: unknown[] = [];
-    for (const result of results) {
-      if (result.status === 'rejected') errors.push(result.reason);
+
+    // Phase 1: resolve and scheme-validate every asset URL up front.
+    // Network requests do not start until validation accepts every
+    // URL — an early valid asset cannot race a later disallowed
+    // scheme into a partial fetch.
+    const resolved: string[] = [];
+    const validationErrors: unknown[] = [];
+    for (const asset of scene.assets) {
+      try {
+        resolved.push(resolveAssetUrl(asset, baseUrl, allowedSchemes));
+      } catch (cause) {
+        validationErrors.push(cause);
+      }
     }
-    if (errors.length > 0) {
-      throw new AggregateError(errors, `composition asset preload failed: scene "${scene.id}"`);
+    if (validationErrors.length > 0) {
+      throw new AggregateError(
+        validationErrors,
+        `composition asset preload failed: scene "${scene.id}"`,
+      );
+    }
+
+    // Phase 2: fetch + stream-drain in parallel. Declaration order is
+    // preserved because we map through the original `scene.assets`
+    // array; `Promise.allSettled` collects every failure for the
+    // aggregate error.
+    const fetchResults = await Promise.allSettled(
+      scene.assets.map((asset, index) =>
+        fetchAndDrain(asset, resolved[index] as string, fetchImpl, init, allowedSchemes),
+      ),
+    );
+    const fetchErrors: unknown[] = [];
+    for (const result of fetchResults) {
+      if (result.status === 'rejected') fetchErrors.push(result.reason);
+    }
+    if (fetchErrors.length > 0) {
+      throw new AggregateError(
+        fetchErrors,
+        `composition asset preload failed: scene "${scene.id}"`,
+      );
     }
   };
 }
 
 /**
- * Resolve and scheme-validate one asset URL. Throws an asset-scoped
- * Error on rejection; the caller's `Promise.allSettled` collects.
+ * Resolve and scheme-validate one asset URL.
+ *
+ *  - `baseUrl` provided: resolve via `URL` constructor; validate
+ *    resolved protocol; return the absolute URL string. Absolute
+ *    asset URLs ignore the base (URL constructor behavior).
+ *  - `baseUrl` not provided, asset starts with `//`: reject. The
+ *    browser's `fetch` would resolve a protocol-relative URL against
+ *    `document.baseURI` to a host we cannot statically scheme-check,
+ *    so a tightened `allowedSchemes` would be silently bypassed.
+ *  - `baseUrl` not provided, asset is parseable as absolute URL:
+ *    validate protocol; return the asset string unchanged so fetch
+ *    sees it verbatim.
+ *  - `baseUrl` not provided, asset is a relative path: pass through.
+ *    The browser resolves against `document.baseURI` (same-origin by
+ *    default).
  */
 function resolveAssetUrl(
   asset: string,
@@ -158,10 +233,11 @@ function resolveAssetUrl(
     rejectDisallowedScheme(asset, resolved.protocol, allowedSchemes);
     return resolved.toString();
   }
-  // No baseUrl: try parsing as an absolute URL. If parsing succeeds,
-  // the asset declared an explicit scheme — validate it. If parsing
-  // throws, the asset is a relative path; pass it through and let the
-  // browser's `fetch` resolve it against `document.baseURI`.
+  if (asset.startsWith('//')) {
+    throw new Error(
+      `asset "${asset}": protocol-relative URL requires AssetPreloaderOptions.baseUrl for scheme validation`,
+    );
+  }
   let absolute: URL | null;
   try {
     absolute = new URL(asset);
@@ -184,43 +260,76 @@ function rejectDisallowedScheme(
 }
 
 /**
- * Fetch one resolved asset URL and drain its body. All errors thrown
- * here carry the asset URL in their message so multi-asset failures
- * stay distinguishable.
+ * Fetch one resolved asset URL, re-validate the post-redirect URL,
+ * and stream-drain the body. All errors thrown here carry the asset
+ * URL (and the resolved URL when different) in their message.
  */
-async function preloadAsset(
+async function fetchAndDrain(
   asset: string,
+  resolvedUrl: string,
   fetchImpl: typeof globalThis.fetch,
   init: RequestInit | undefined,
-  baseUrl: string | undefined,
   allowedSchemes: readonly string[],
 ): Promise<void> {
-  const resolvedUrl = resolveAssetUrl(asset, baseUrl, allowedSchemes);
+  const label = describeAsset(asset, resolvedUrl);
   let response: Response;
   try {
     response =
       init === undefined ? await fetchImpl(resolvedUrl) : await fetchImpl(resolvedUrl, init);
   } catch (cause) {
-    throw new Error(`asset "${asset}": ${describeFailure(cause)}`, { cause });
+    throw new Error(`${label}: ${describeFailure(cause)}`, { cause });
+  }
+  // Re-validate the final URL after redirects. `response.url` is the
+  // URL after any redirects fetch followed. A scene declared an
+  // allowed URL that 302s to a disallowed scheme MUST reject.
+  if (response.url !== '' && response.url !== resolvedUrl) {
+    let finalProtocol: string | null = null;
+    try {
+      finalProtocol = new URL(response.url).protocol;
+    } catch {
+      finalProtocol = null;
+    }
+    if (finalProtocol === null || !allowedSchemes.includes(finalProtocol)) {
+      await cancelBodyQuietly(response);
+      throw new Error(`${label}: redirected to disallowed URL "${response.url}"`);
+    }
   }
   if (!response.ok) {
-    // Drain/cancel the body before throwing so connections are not
-    // tied up waiting for GC. `cancel()` is a no-op if the body is
-    // already consumed or null; failures here are irrelevant — the
-    // HTTP error is the failure we want to surface.
+    // Cancel the body before throwing so connections are not held
+    // open until GC.
     await cancelBodyQuietly(response);
-    throw new Error(`asset "${asset}": ${response.status} ${response.statusText}`);
+    throw new Error(`${label}: ${response.status} ${response.statusText}`);
   }
-  // Drain the body so the network transfer fully completes before the
-  // caller's `create(ctx)` runs. Without this, `fetch` resolves on
-  // headers and the bytes may still be in flight, defeating the
-  // "preload" contract.
   try {
-    await response.arrayBuffer();
+    await streamDrain(response);
   } catch (cause) {
-    throw new Error(`asset "${asset}": body drain failed: ${describeFailure(cause)}`, { cause });
+    throw new Error(`${label}: body drain failed: ${describeFailure(cause)}`, { cause });
   }
 }
+
+/**
+ * Drain the response body without buffering the whole payload into
+ * memory. Reads chunks and discards them. Compared to
+ * `response.arrayBuffer()`, this avoids transient allocation
+ * proportional to asset size — relevant for video / large audio
+ * scenes (see ADR-012 §Negative).
+ */
+async function streamDrain(response: Response): Promise<void> {
+  const body = response.body;
+  if (body === null) return;
+  const reader = body.getReader();
+  try {
+    while (true) {
+      const { done } = await reader.read();
+      if (done) return;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+const describeAsset = (asset: string, resolved: string): string =>
+  asset === resolved ? `asset "${asset}"` : `asset "${asset}" → "${resolved}"`;
 
 const describeFailure = (cause: unknown): string =>
   cause instanceof Error ? cause.message : String(cause);

--- a/src/runtime/asset-preloader.ts
+++ b/src/runtime/asset-preloader.ts
@@ -115,6 +115,16 @@ export interface AssetPreloaderOptions {
    * The allowlist is also re-checked against the response's final URL
    * after fetch (defense against allowed-URL → disallowed-scheme
    * redirects).
+   *
+   * Caveat: relative-path assets (e.g. `'/foo.png'`, `'images/x.png'`)
+   * with no `baseUrl` configured bypass scheme validation entirely,
+   * because the final scheme depends on the browser's
+   * `document.baseURI` and cannot be checked statically. Production
+   * callers wanting strict scheme enforcement MUST also set `baseUrl`
+   * so every asset resolves to an absolute URL the preloader can
+   * scheme-check up front. Without `baseUrl`, the allowlist only
+   * applies to assets that declare an explicit scheme (or `//host/...`
+   * which is rejected outright).
    */
   readonly allowedSchemes?: readonly string[];
 }

--- a/src/runtime/asset-preloader.ts
+++ b/src/runtime/asset-preloader.ts
@@ -14,11 +14,14 @@
 // without the drain, `fetch` resolves on headers and the cache may
 // not yet hold the bytes when `create(ctx)` runs.
 //
-// Failure handling: any non-2xx response or rejected fetch surfaces as
-// a single `AggregateError` whose `errors` array carries every failure
-// in declaration order. Single-failure cases use the same shape as
-// multi-failure cases for consumer consistency. Failures are never
-// swallowed; the resolver wraps the AggregateError as
+// Failure handling: any non-2xx response, rejected fetch, or scheme
+// rejection surfaces as a single `AggregateError` whose `errors` array
+// carries every failure in declaration order. Each failure's message
+// names the asset URL so a multi-asset failure does not collapse into
+// indistinguishable network errors. Failures from non-2xx responses
+// drain/cancel the response body before throwing so connections are
+// not leaked. Failures are never swallowed; the resolver wraps the
+// AggregateError as
 // `composition resolution failed: scene "<id>" preloadAssets threw: ...`.
 //
 // Decode-complete semantics (image decode, font load, audio decode)
@@ -37,8 +40,22 @@
 import type { SceneModule } from './scene';
 
 /**
+ * URL schemes accepted by default. Scene assets that resolve to any
+ * other scheme (e.g. `file:`, `gopher:`, `ws:`) are rejected before
+ * the preloader calls `fetch`. Callers wanting a tighter or looser
+ * allowlist pass `AssetPreloaderOptions.allowedSchemes`.
+ */
+export const DEFAULT_ALLOWED_SCHEMES: readonly string[] = Object.freeze([
+  'http:',
+  'https:',
+  'data:',
+  'blob:',
+]);
+
+/**
  * Options for {@link createAssetPreloader}. All fields are optional;
- * the defaults pull from `globalThis.fetch` with no extra request init.
+ * the defaults pull from `globalThis.fetch`, no extra request init,
+ * no base URL, and the {@link DEFAULT_ALLOWED_SCHEMES} allowlist.
  */
 export interface AssetPreloaderOptions {
   /**
@@ -55,6 +72,24 @@ export interface AssetPreloaderOptions {
    * `AbortSignal` to all per-scene fetches.
    */
   readonly init?: RequestInit;
+  /**
+   * Base URL used to resolve relative asset paths. Required when the
+   * runtime is preloading on Node — Node's `fetch` rejects relative
+   * URLs with `TypeError: Invalid URL`. Optional in the browser, where
+   * relative paths resolve against `document.baseURI` automatically.
+   * When provided, every resolved URL is re-validated against the
+   * scheme allowlist (so a scene cannot smuggle a `file:` URL by
+   * declaring it absolute).
+   */
+  readonly baseUrl?: string;
+  /**
+   * URL schemes accepted by the preloader. Defaults to
+   * {@link DEFAULT_ALLOWED_SCHEMES}. Pass an explicit list to tighten
+   * (e.g. `['https:']` for production) or extend (e.g. add `'file:'`
+   * for offline-export workflows). Schemes outside the list reject
+   * before fetch with `asset "<url>": scheme "<scheme>" not allowed`.
+   */
+  readonly allowedSchemes?: readonly string[];
 }
 
 /**
@@ -62,15 +97,20 @@ export interface AssetPreloaderOptions {
  *
  * The returned function:
  *  - resolves immediately when `scene.assets` is empty (no fetch calls);
+ *  - validates every asset URL against the scheme allowlist before any
+ *    network request (default allowlist is {@link DEFAULT_ALLOWED_SCHEMES});
+ *  - if `baseUrl` is provided, resolves each asset against it via the
+ *    `URL` constructor and re-validates the resolved scheme;
  *  - otherwise issues one parallel `fetch` per asset URL, drains each
  *    successful response body, and resolves with `undefined` once every
  *    asset is fully downloaded;
  *  - throws an `AggregateError` when one or more assets fail (HTTP
- *    non-2xx OR rejected fetch). The wrapping message is
- *    `composition asset preload failed: scene "<id>"`; per-asset
- *    failure messages live in `AggregateError.errors`. The order of
- *    `errors` matches the declaration order in `scene.assets`, not
- *    completion order.
+ *    non-2xx, rejected fetch, scheme rejection, or invalid URL). The
+ *    wrapping message is `composition asset preload failed: scene "<id>"`;
+ *    per-asset failure messages live in `AggregateError.errors` and
+ *    always name the offending asset URL so multi-asset failures stay
+ *    distinguishable. The order of `errors` matches the declaration
+ *    order in `scene.assets`, not completion order.
  *
  * The returned function is the `AssetPreloader` adapter the PUL-F004
  * resolver expects (`(scene: SceneModule) => Promise<void>`). When
@@ -82,10 +122,12 @@ export function createAssetPreloader(
 ): (scene: SceneModule) => Promise<void> {
   const fetchImpl = options.fetch ?? globalThis.fetch;
   const init = options.init;
+  const baseUrl = options.baseUrl;
+  const allowedSchemes = options.allowedSchemes ?? DEFAULT_ALLOWED_SCHEMES;
   return async (scene) => {
     if (scene.assets.length === 0) return;
     const results = await Promise.allSettled(
-      scene.assets.map((asset) => preloadAsset(asset, fetchImpl, init)),
+      scene.assets.map((asset) => preloadAsset(asset, fetchImpl, init, baseUrl, allowedSchemes)),
     );
     const errors: unknown[] = [];
     for (const result of results) {
@@ -98,22 +140,96 @@ export function createAssetPreloader(
 }
 
 /**
- * Fetch one asset URL and drain its body. Throws the underlying error
- * for the caller's `Promise.allSettled` to collect; this function does
- * not aggregate.
+ * Resolve and scheme-validate one asset URL. Throws an asset-scoped
+ * Error on rejection; the caller's `Promise.allSettled` collects.
+ */
+function resolveAssetUrl(
+  asset: string,
+  baseUrl: string | undefined,
+  allowedSchemes: readonly string[],
+): string {
+  if (baseUrl !== undefined) {
+    let resolved: URL;
+    try {
+      resolved = new URL(asset, baseUrl);
+    } catch (cause) {
+      throw new Error(`asset "${asset}": invalid URL relative to baseUrl`, { cause });
+    }
+    rejectDisallowedScheme(asset, resolved.protocol, allowedSchemes);
+    return resolved.toString();
+  }
+  // No baseUrl: try parsing as an absolute URL. If parsing succeeds,
+  // the asset declared an explicit scheme — validate it. If parsing
+  // throws, the asset is a relative path; pass it through and let the
+  // browser's `fetch` resolve it against `document.baseURI`.
+  let absolute: URL | null;
+  try {
+    absolute = new URL(asset);
+  } catch {
+    return asset;
+  }
+  rejectDisallowedScheme(asset, absolute.protocol, allowedSchemes);
+  return asset;
+}
+
+function rejectDisallowedScheme(
+  asset: string,
+  protocol: string,
+  allowedSchemes: readonly string[],
+): void {
+  if (allowedSchemes.includes(protocol)) return;
+  throw new Error(
+    `asset "${asset}": scheme "${protocol}" not in allowed list (${allowedSchemes.join(', ')})`,
+  );
+}
+
+/**
+ * Fetch one resolved asset URL and drain its body. All errors thrown
+ * here carry the asset URL in their message so multi-asset failures
+ * stay distinguishable.
  */
 async function preloadAsset(
-  url: string,
+  asset: string,
   fetchImpl: typeof globalThis.fetch,
   init: RequestInit | undefined,
+  baseUrl: string | undefined,
+  allowedSchemes: readonly string[],
 ): Promise<void> {
-  const response = init === undefined ? await fetchImpl(url) : await fetchImpl(url, init);
+  const resolvedUrl = resolveAssetUrl(asset, baseUrl, allowedSchemes);
+  let response: Response;
+  try {
+    response =
+      init === undefined ? await fetchImpl(resolvedUrl) : await fetchImpl(resolvedUrl, init);
+  } catch (cause) {
+    throw new Error(`asset "${asset}": ${describeFailure(cause)}`, { cause });
+  }
   if (!response.ok) {
-    throw new Error(`asset "${url}": ${response.status} ${response.statusText}`);
+    // Drain/cancel the body before throwing so connections are not
+    // tied up waiting for GC. `cancel()` is a no-op if the body is
+    // already consumed or null; failures here are irrelevant — the
+    // HTTP error is the failure we want to surface.
+    await cancelBodyQuietly(response);
+    throw new Error(`asset "${asset}": ${response.status} ${response.statusText}`);
   }
   // Drain the body so the network transfer fully completes before the
   // caller's `create(ctx)` runs. Without this, `fetch` resolves on
   // headers and the bytes may still be in flight, defeating the
   // "preload" contract.
-  await response.arrayBuffer();
+  try {
+    await response.arrayBuffer();
+  } catch (cause) {
+    throw new Error(`asset "${asset}": body drain failed: ${describeFailure(cause)}`, { cause });
+  }
+}
+
+const describeFailure = (cause: unknown): string =>
+  cause instanceof Error ? cause.message : String(cause);
+
+async function cancelBodyQuietly(response: Response): Promise<void> {
+  if (response.body === null) return;
+  try {
+    await response.body.cancel();
+  } catch {
+    // Ignore: the body may already be consumed or released.
+  }
 }

--- a/tests/runtime/asset-preloader.test.ts
+++ b/tests/runtime/asset-preloader.test.ts
@@ -1,0 +1,310 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type AssetPreloaderOptions,
+  createAssetPreloader,
+} from '../../src/runtime/asset-preloader';
+import type { SceneModule } from '../../src/runtime/scene';
+
+// Each test builds a per-scene fixture inline. The shared `buildScene`
+// keeps fixture cost low and pins exactly one variable per test.
+const buildScene = (id: string, assets: readonly string[] = []): SceneModule => ({
+  id,
+  title: id,
+  duration: 1000,
+  tags: [],
+  assets,
+  captions: [],
+  defaultNext: null,
+  standalone: false,
+  trailerSafe: false,
+  create: () => undefined,
+  timeline: () => undefined,
+  cleanup: () => undefined,
+});
+
+interface FetchCall {
+  readonly input: RequestInfo | URL;
+  readonly init: RequestInit | undefined;
+}
+
+interface BuildFakeFetchOpts {
+  /**
+   * Per-URL response factory. Default: 200 OK with an immediate empty
+   * body. Throw / reject from the factory to simulate network errors.
+   */
+  readonly respond?: (input: RequestInfo | URL) => Response | Promise<Response>;
+}
+
+const buildFakeFetch = (opts: BuildFakeFetchOpts = {}) => {
+  const calls: FetchCall[] = [];
+  const fetchImpl: typeof globalThis.fetch = async (input, init) => {
+    calls.push({ input, init });
+    if (opts.respond) return opts.respond(input);
+    return new Response(new ArrayBuffer(0), { status: 200 });
+  };
+  return { fetchImpl, calls };
+};
+
+describe('createAssetPreloader (PUL-F005)', () => {
+  describe('clause (b) — preload before mount: empty input', () => {
+    it('resolves immediately with no fetch calls when scene.assets is empty', async () => {
+      const { fetchImpl, calls } = buildFakeFetch();
+      const preload = createAssetPreloader({ fetch: fetchImpl });
+      await expect(preload(buildScene('scene-a', []))).resolves.toBeUndefined();
+      expect(calls).toEqual([]);
+    });
+  });
+
+  describe('clause (b) — preload before mount: happy path', () => {
+    it('calls fetch once with the asset URL when scene.assets has one entry', async () => {
+      const { fetchImpl, calls } = buildFakeFetch();
+      const preload = createAssetPreloader({ fetch: fetchImpl });
+      await preload(buildScene('scene-a', ['/assets/scene-a/hero.png']));
+      expect(calls.map((c) => c.input)).toEqual(['/assets/scene-a/hero.png']);
+    });
+
+    it('calls fetch once per asset, in declaration order, when scene.assets has multiple entries', async () => {
+      const { fetchImpl, calls } = buildFakeFetch();
+      const preload = createAssetPreloader({ fetch: fetchImpl });
+      await preload(buildScene('scene-a', ['/a.png', '/b.mp3', '/c.json']));
+      expect(calls.map((c) => c.input)).toEqual(['/a.png', '/b.mp3', '/c.json']);
+    });
+
+    it('starts every fetch in parallel (does not serialize per asset)', async () => {
+      // Each fetch resolves on its own gate. If the preloader serialized
+      // the fetches it would never get past the first one before we
+      // unblock its gate. We unblock all gates at once and verify all
+      // fetches start before any complete.
+      const startedAt: string[] = [];
+      const gates = new Map<string, () => void>();
+      const fetchImpl: typeof globalThis.fetch = async (input) => {
+        const url = String(input);
+        startedAt.push(url);
+        await new Promise<void>((resolve) => {
+          gates.set(url, resolve);
+        });
+        return new Response(new ArrayBuffer(0), { status: 200 });
+      };
+      const preload = createAssetPreloader({ fetch: fetchImpl });
+      const promise = preload(buildScene('scene-a', ['/a', '/b', '/c']));
+      // Drain microtasks until all three fetches have started.
+      while (startedAt.length < 3) {
+        await Promise.resolve();
+      }
+      expect(startedAt).toEqual(['/a', '/b', '/c']);
+      // Now unblock all three; the promise resolves once they all
+      // complete (and bodies are drained).
+      for (const release of gates.values()) {
+        release();
+      }
+      await expect(promise).resolves.toBeUndefined();
+    });
+
+    it('forwards asset URLs verbatim — no path munging', async () => {
+      const { fetchImpl, calls } = buildFakeFetch();
+      const preload = createAssetPreloader({ fetch: fetchImpl });
+      await preload(
+        buildScene('scene-a', [
+          'https://cdn.example.com/full-url.png',
+          '/leading-slash.json',
+          'relative/path.mp3',
+          'data:audio/wav;base64,QQA=',
+        ]),
+      );
+      expect(calls.map((c) => c.input)).toEqual([
+        'https://cdn.example.com/full-url.png',
+        '/leading-slash.json',
+        'relative/path.mp3',
+        'data:audio/wav;base64,QQA=',
+      ]);
+    });
+  });
+
+  describe('configurable fetch / init', () => {
+    it('uses the fetch override from AssetPreloaderOptions instead of globalThis.fetch', async () => {
+      const overrideCalls: string[] = [];
+      const fetchImpl: typeof globalThis.fetch = async (input) => {
+        overrideCalls.push(String(input));
+        return new Response(new ArrayBuffer(0), { status: 200 });
+      };
+      const opts: AssetPreloaderOptions = { fetch: fetchImpl };
+      const preload = createAssetPreloader(opts);
+      await preload(buildScene('scene-a', ['/x']));
+      expect(overrideCalls).toEqual(['/x']);
+    });
+
+    it('falls back to globalThis.fetch when no override is provided', async () => {
+      const calls: string[] = [];
+      const original = globalThis.fetch;
+      globalThis.fetch = (async (input: RequestInfo | URL) => {
+        calls.push(String(input));
+        return new Response(new ArrayBuffer(0), { status: 200 });
+      }) as typeof globalThis.fetch;
+      try {
+        const preload = createAssetPreloader();
+        await preload(buildScene('scene-a', ['/y']));
+        expect(calls).toEqual(['/y']);
+      } finally {
+        globalThis.fetch = original;
+      }
+    });
+
+    it('forwards the optional init (headers / signal / cache mode) to every fetch call', async () => {
+      const init: RequestInit = {
+        headers: { 'X-Pulsar-Preload': '1' },
+        cache: 'no-store',
+      };
+      const { fetchImpl, calls } = buildFakeFetch();
+      const preload = createAssetPreloader({ fetch: fetchImpl, init });
+      await preload(buildScene('scene-a', ['/a', '/b']));
+      expect(calls).toHaveLength(2);
+      for (const call of calls) {
+        expect(call.init).toBe(init);
+      }
+    });
+  });
+
+  describe('body drain invariant', () => {
+    it("awaits the response body's arrayBuffer() before resolving", async () => {
+      // fetch resolves with headers immediately, but the body's
+      // arrayBuffer() resolution is gated. The preloader must wait on
+      // the body before its own promise resolves.
+      let releaseBody: ((value: ArrayBuffer) => void) | undefined;
+      const bodyGate = new Promise<ArrayBuffer>((resolve) => {
+        releaseBody = resolve;
+      });
+      const fetchImpl: typeof globalThis.fetch = async () => {
+        const response = new Response(new ArrayBuffer(0), { status: 200 });
+        // Override arrayBuffer to return the gated promise so the
+        // preloader's drain step is observable.
+        Object.defineProperty(response, 'arrayBuffer', {
+          value: () => bodyGate,
+        });
+        return response;
+      };
+      const preload = createAssetPreloader({ fetch: fetchImpl });
+      let resolved = false;
+      const promise = preload(buildScene('scene-a', ['/a'])).then(() => {
+        resolved = true;
+      });
+      // Drain microtasks: fetch resolves, but body is still gated,
+      // so the preloader promise must NOT have resolved yet.
+      for (let i = 0; i < 5; i += 1) {
+        await Promise.resolve();
+      }
+      expect(resolved).toBe(false);
+      releaseBody?.(new ArrayBuffer(0));
+      await promise;
+      expect(resolved).toBe(true);
+    });
+  });
+
+  describe('failure paths (clause b: must not swallow)', () => {
+    it('throws AggregateError with the URL + status when a single asset returns 404', async () => {
+      const fetchImpl: typeof globalThis.fetch = async () =>
+        new Response(null, { status: 404, statusText: 'Not Found' });
+      const preload = createAssetPreloader({ fetch: fetchImpl });
+      try {
+        await preload(buildScene('scene-a', ['/missing.png']));
+        expect.unreachable('expected 404 to throw');
+      } catch (err) {
+        expect(err).toBeInstanceOf(AggregateError);
+        const top = err as AggregateError;
+        expect(top.message).toBe('composition asset preload failed: scene "scene-a"');
+        expect(top.errors).toHaveLength(1);
+        expect((top.errors[0] as Error).message).toBe('asset "/missing.png": 404 Not Found');
+      }
+    });
+
+    it('throws AggregateError carrying the original cause when a fetch rejects (network error)', async () => {
+      const networkErr = new TypeError('fetch failed: ECONNRESET');
+      const fetchImpl: typeof globalThis.fetch = async () => {
+        throw networkErr;
+      };
+      const preload = createAssetPreloader({ fetch: fetchImpl });
+      try {
+        await preload(buildScene('scene-a', ['/x.png']));
+        expect.unreachable('expected network error to throw');
+      } catch (err) {
+        expect(err).toBeInstanceOf(AggregateError);
+        const top = err as AggregateError;
+        expect(top.errors).toEqual([networkErr]);
+      }
+    });
+
+    it('throws AggregateError with one entry when one of many assets fails (others succeed)', async () => {
+      const fetchImpl: typeof globalThis.fetch = async (input) => {
+        if (String(input) === '/bad.png') {
+          return new Response(null, { status: 500, statusText: 'Server Error' });
+        }
+        return new Response(new ArrayBuffer(0), { status: 200 });
+      };
+      const preload = createAssetPreloader({ fetch: fetchImpl });
+      try {
+        await preload(buildScene('scene-a', ['/ok-a.png', '/bad.png', '/ok-b.png']));
+        expect.unreachable('expected partial failure to throw');
+      } catch (err) {
+        expect(err).toBeInstanceOf(AggregateError);
+        const top = err as AggregateError;
+        expect(top.errors).toHaveLength(1);
+        expect((top.errors[0] as Error).message).toBe('asset "/bad.png": 500 Server Error');
+      }
+    });
+
+    it('aggregates multiple failures in declaration order, regardless of completion order', async () => {
+      // First and third assets fail; the middle one succeeds. Make the
+      // first asset's failure RESOLVE later than the third's so we can
+      // verify ordering is by declaration index, not completion order.
+      const fetchImpl: typeof globalThis.fetch = async (input) => {
+        const url = String(input);
+        if (url === '/first-bad') {
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          return new Response(null, { status: 404, statusText: 'Not Found' });
+        }
+        if (url === '/third-bad') {
+          return new Response(null, { status: 500, statusText: 'Server Error' });
+        }
+        return new Response(new ArrayBuffer(0), { status: 200 });
+      };
+      const preload = createAssetPreloader({ fetch: fetchImpl });
+      try {
+        await preload(buildScene('scene-a', ['/first-bad', '/middle-ok', '/third-bad']));
+        expect.unreachable('expected aggregated failure to throw');
+      } catch (err) {
+        expect(err).toBeInstanceOf(AggregateError);
+        const top = err as AggregateError;
+        expect(top.errors).toHaveLength(2);
+        expect((top.errors[0] as Error).message).toBe('asset "/first-bad": 404 Not Found');
+        expect((top.errors[1] as Error).message).toBe('asset "/third-bad": 500 Server Error');
+      }
+    });
+
+    it('always throws AggregateError (not a bare Error) — consistency for callers regardless of failure count', async () => {
+      const fetchImpl: typeof globalThis.fetch = async () =>
+        new Response(null, { status: 404, statusText: 'Not Found' });
+      const preload = createAssetPreloader({ fetch: fetchImpl });
+      try {
+        await preload(buildScene('scene-a', ['/x']));
+        expect.unreachable('expected single-failure to throw AggregateError');
+      } catch (err) {
+        expect(err).toBeInstanceOf(AggregateError);
+      }
+    });
+
+    it('does not silently fall through when only some assets succeed', async () => {
+      let succeededCount = 0;
+      const fetchImpl: typeof globalThis.fetch = async (input) => {
+        if (String(input) === '/bad') {
+          return new Response(null, { status: 404, statusText: 'Not Found' });
+        }
+        succeededCount += 1;
+        return new Response(new ArrayBuffer(0), { status: 200 });
+      };
+      const preload = createAssetPreloader({ fetch: fetchImpl });
+      await expect(preload(buildScene('scene-a', ['/ok-1', '/bad', '/ok-2']))).rejects.toThrow();
+      // Sanity: the OK fetches still ran (parallel start, no early
+      // abort) — the function rejects after waiting for all.
+      expect(succeededCount).toBe(2);
+    });
+  });
+});

--- a/tests/runtime/asset-preloader.test.ts
+++ b/tests/runtime/asset-preloader.test.ts
@@ -216,7 +216,7 @@ describe('createAssetPreloader (PUL-F005)', () => {
       }
     });
 
-    it('throws AggregateError carrying the original cause when a fetch rejects (network error)', async () => {
+    it('wraps a rejected fetch with the asset URL and preserves the original error as cause', async () => {
       const networkErr = new TypeError('fetch failed: ECONNRESET');
       const fetchImpl: typeof globalThis.fetch = async () => {
         throw networkErr;
@@ -228,8 +228,56 @@ describe('createAssetPreloader (PUL-F005)', () => {
       } catch (err) {
         expect(err).toBeInstanceOf(AggregateError);
         const top = err as AggregateError;
-        expect(top.errors).toEqual([networkErr]);
+        expect(top.errors).toHaveLength(1);
+        const wrapped = top.errors[0] as Error & { cause?: unknown };
+        // Asset URL must appear in the message so multi-asset failures
+        // stay distinguishable.
+        expect(wrapped.message).toBe('asset "/x.png": fetch failed: ECONNRESET');
+        expect(wrapped.cause).toBe(networkErr);
       }
+    });
+
+    it('keeps two distinct rejected fetches distinguishable via URL-scoped messages (no collapsed "fetch failed")', async () => {
+      const fetchImpl: typeof globalThis.fetch = async (input) => {
+        throw new TypeError(`fetch failed for ${String(input)}`);
+      };
+      const preload = createAssetPreloader({ fetch: fetchImpl });
+      try {
+        await preload(buildScene('scene-a', ['/first.png', '/second.png']));
+        expect.unreachable('expected both assets to fail');
+      } catch (err) {
+        expect(err).toBeInstanceOf(AggregateError);
+        const top = err as AggregateError;
+        expect(top.errors).toHaveLength(2);
+        expect((top.errors[0] as Error).message).toMatch(/^asset "\/first\.png": /);
+        expect((top.errors[1] as Error).message).toMatch(/^asset "\/second\.png": /);
+      }
+    });
+
+    it('cancels the response body on a non-2xx response (no leaked open stream)', async () => {
+      const cancelCalls: number[] = [];
+      const fetchImpl: typeof globalThis.fetch = async () => {
+        const response = new Response(new ReadableStream(), {
+          status: 503,
+          statusText: 'Service Unavailable',
+        });
+        // Wrap the body's cancel so we can observe it being called.
+        const originalCancel = response.body?.cancel.bind(response.body);
+        if (response.body !== null && originalCancel !== undefined) {
+          Object.defineProperty(response.body, 'cancel', {
+            value: async (reason?: unknown) => {
+              cancelCalls.push(1);
+              return originalCancel(reason);
+            },
+          });
+        }
+        return response;
+      };
+      const preload = createAssetPreloader({ fetch: fetchImpl });
+      await expect(preload(buildScene('scene-a', ['/down.png']))).rejects.toThrow(
+        /^composition asset preload failed:/,
+      );
+      expect(cancelCalls).toEqual([1]);
     });
 
     it('throws AggregateError with one entry when one of many assets fails (others succeed)', async () => {
@@ -305,6 +353,140 @@ describe('createAssetPreloader (PUL-F005)', () => {
       // Sanity: the OK fetches still ran (parallel start, no early
       // abort) — the function rejects after waiting for all.
       expect(succeededCount).toBe(2);
+    });
+  });
+
+  describe('baseUrl resolution (Node-portable)', () => {
+    it('resolves a relative asset against baseUrl before fetching (Node fetch requires absolute URLs)', async () => {
+      const { fetchImpl, calls } = buildFakeFetch();
+      const preload = createAssetPreloader({
+        fetch: fetchImpl,
+        baseUrl: 'https://cdn.example.com/scenes/',
+      });
+      await preload(buildScene('scene-a', ['hero.png', 'audio/intro.mp3']));
+      expect(calls.map((c) => c.input)).toEqual([
+        'https://cdn.example.com/scenes/hero.png',
+        'https://cdn.example.com/scenes/audio/intro.mp3',
+      ]);
+    });
+
+    it('passes an absolute asset through unchanged even when baseUrl is set (URL constructor behavior)', async () => {
+      const { fetchImpl, calls } = buildFakeFetch();
+      const preload = createAssetPreloader({
+        fetch: fetchImpl,
+        baseUrl: 'https://cdn.example.com/scenes/',
+      });
+      await preload(buildScene('scene-a', ['https://other.example.com/foo.png']));
+      expect(calls.map((c) => c.input)).toEqual(['https://other.example.com/foo.png']);
+    });
+
+    it('passes a relative path through unchanged when baseUrl is unset (browser fetch handles document.baseURI)', async () => {
+      const { fetchImpl, calls } = buildFakeFetch();
+      const preload = createAssetPreloader({ fetch: fetchImpl });
+      await preload(buildScene('scene-a', ['/relative/x.png']));
+      expect(calls.map((c) => c.input)).toEqual(['/relative/x.png']);
+    });
+
+    it('throws asset-scoped error when baseUrl + asset cannot form a valid URL', async () => {
+      const { fetchImpl } = buildFakeFetch();
+      const preload = createAssetPreloader({
+        fetch: fetchImpl,
+        baseUrl: 'not a valid base',
+      });
+      try {
+        await preload(buildScene('scene-a', ['x.png']));
+        expect.unreachable('expected invalid URL to throw');
+      } catch (err) {
+        expect(err).toBeInstanceOf(AggregateError);
+        const top = err as AggregateError;
+        const wrapped = top.errors[0] as Error;
+        expect(wrapped.message).toBe('asset "x.png": invalid URL relative to baseUrl');
+      }
+    });
+  });
+
+  describe('scheme allowlist (SSRF defense)', () => {
+    it('rejects file: scheme by default', async () => {
+      const { fetchImpl, calls } = buildFakeFetch();
+      const preload = createAssetPreloader({ fetch: fetchImpl });
+      try {
+        await preload(buildScene('scene-a', ['file:///etc/passwd']));
+        expect.unreachable('expected file: to be rejected');
+      } catch (err) {
+        expect(err).toBeInstanceOf(AggregateError);
+        const top = err as AggregateError;
+        expect((top.errors[0] as Error).message).toBe(
+          'asset "file:///etc/passwd": scheme "file:" not in allowed list (http:, https:, data:, blob:)',
+        );
+      }
+      // Network MUST NOT be called for a rejected scheme.
+      expect(calls).toEqual([]);
+    });
+
+    it('rejects gopher: and other obscure schemes by default', async () => {
+      const { fetchImpl, calls } = buildFakeFetch();
+      const preload = createAssetPreloader({ fetch: fetchImpl });
+      await expect(
+        preload(buildScene('scene-a', ['gopher://internal.example/secrets'])),
+      ).rejects.toThrow(/^composition asset preload failed:/);
+      expect(calls).toEqual([]);
+    });
+
+    it('accepts https:, http:, data:, and blob: by default', async () => {
+      const { fetchImpl, calls } = buildFakeFetch();
+      const preload = createAssetPreloader({ fetch: fetchImpl });
+      await preload(
+        buildScene('scene-a', [
+          'https://cdn.example.com/a.png',
+          'http://cdn.example.com/b.png',
+          'data:audio/wav;base64,QQA=',
+          'blob:https://example.com/uuid-here',
+        ]),
+      );
+      expect(calls).toHaveLength(4);
+    });
+
+    it('honors a tightened allowlist (e.g. https-only for production)', async () => {
+      const { fetchImpl, calls } = buildFakeFetch();
+      const preload = createAssetPreloader({
+        fetch: fetchImpl,
+        allowedSchemes: ['https:'],
+      });
+      try {
+        await preload(buildScene('scene-a', ['http://insecure.example/a.png']));
+        expect.unreachable('expected http: to be rejected by tightened allowlist');
+      } catch (err) {
+        expect(err).toBeInstanceOf(AggregateError);
+        const top = err as AggregateError;
+        expect((top.errors[0] as Error).message).toBe(
+          'asset "http://insecure.example/a.png": scheme "http:" not in allowed list (https:)',
+        );
+      }
+      expect(calls).toEqual([]);
+    });
+
+    it('re-validates scheme after baseUrl resolution (an absolute file: URL declared as a relative-looking string is still caught)', async () => {
+      const { fetchImpl, calls } = buildFakeFetch();
+      const preload = createAssetPreloader({
+        fetch: fetchImpl,
+        baseUrl: 'file:///some/dir/',
+      });
+      try {
+        await preload(buildScene('scene-a', ['relative-path.png']));
+        expect.unreachable('expected file: scheme on resolved URL to be rejected');
+      } catch (err) {
+        expect(err).toBeInstanceOf(AggregateError);
+        const top = err as AggregateError;
+        expect((top.errors[0] as Error).message).toMatch(/scheme "file:" not in allowed list/);
+      }
+      expect(calls).toEqual([]);
+    });
+
+    it('re-exports DEFAULT_ALLOWED_SCHEMES so callers can extend rather than duplicate the default list', async () => {
+      const { DEFAULT_ALLOWED_SCHEMES } = await import('../../src/runtime/asset-preloader');
+      expect(DEFAULT_ALLOWED_SCHEMES).toEqual(['http:', 'https:', 'data:', 'blob:']);
+      // Frozen so callers cannot accidentally mutate the default.
+      expect(Object.isFrozen(DEFAULT_ALLOWED_SCHEMES)).toBe(true);
     });
   });
 });

--- a/tests/runtime/asset-preloader.test.ts
+++ b/tests/runtime/asset-preloader.test.ts
@@ -165,37 +165,176 @@ describe('createAssetPreloader (PUL-F005)', () => {
   });
 
   describe('body drain invariant', () => {
-    it("awaits the response body's arrayBuffer() before resolving", async () => {
-      // fetch resolves with headers immediately, but the body's
-      // arrayBuffer() resolution is gated. The preloader must wait on
-      // the body before its own promise resolves.
-      let releaseBody: ((value: ArrayBuffer) => void) | undefined;
-      const bodyGate = new Promise<ArrayBuffer>((resolve) => {
-        releaseBody = resolve;
-      });
+    it('stream-drains the response body via getReader (does not buffer the whole payload)', async () => {
+      // Build a ReadableStream that emits a couple of chunks then
+      // closes. Track every read so we can assert the preloader
+      // actually consumed the stream rather than ignoring or
+      // buffering it.
+      const reads: number[] = [];
       const fetchImpl: typeof globalThis.fetch = async () => {
-        const response = new Response(new ArrayBuffer(0), { status: 200 });
-        // Override arrayBuffer to return the gated promise so the
-        // preloader's drain step is observable.
-        Object.defineProperty(response, 'arrayBuffer', {
-          value: () => bodyGate,
+        let chunkIndex = 0;
+        const stream = new ReadableStream({
+          pull(controller) {
+            chunkIndex += 1;
+            if (chunkIndex > 3) {
+              controller.close();
+              return;
+            }
+            reads.push(chunkIndex);
+            controller.enqueue(new Uint8Array([chunkIndex]));
+          },
         });
-        return response;
+        return new Response(stream, { status: 200 });
+      };
+      const preload = createAssetPreloader({ fetch: fetchImpl });
+      await preload(buildScene('scene-a', ['/a']));
+      // Three pulls were issued; the preloader must have driven the
+      // reader to completion.
+      expect(reads).toEqual([1, 2, 3]);
+    });
+
+    it('awaits the body drain before resolving (gated reader)', async () => {
+      // Build a stream whose first read is gated. Until released, the
+      // preloader's promise must NOT resolve.
+      let releaseFirstChunk: (() => void) | undefined;
+      const firstChunkGate = new Promise<void>((resolve) => {
+        releaseFirstChunk = resolve;
+      });
+      let chunkIndex = 0;
+      const fetchImpl: typeof globalThis.fetch = async () => {
+        const stream = new ReadableStream({
+          async pull(controller) {
+            chunkIndex += 1;
+            if (chunkIndex === 1) {
+              await firstChunkGate;
+              controller.enqueue(new Uint8Array([1]));
+              return;
+            }
+            controller.close();
+          },
+        });
+        return new Response(stream, { status: 200 });
       };
       const preload = createAssetPreloader({ fetch: fetchImpl });
       let resolved = false;
       const promise = preload(buildScene('scene-a', ['/a'])).then(() => {
         resolved = true;
       });
-      // Drain microtasks: fetch resolves, but body is still gated,
-      // so the preloader promise must NOT have resolved yet.
-      for (let i = 0; i < 5; i += 1) {
-        await Promise.resolve();
-      }
+      for (let i = 0; i < 10; i += 1) await Promise.resolve();
       expect(resolved).toBe(false);
-      releaseBody?.(new ArrayBuffer(0));
+      releaseFirstChunk?.();
       await promise;
       expect(resolved).toBe(true);
+    });
+  });
+
+  describe('up-front validation (codex review: validate full asset list before any fetch)', () => {
+    it('does not start any fetch when a later asset has a disallowed scheme', async () => {
+      const { fetchImpl, calls } = buildFakeFetch();
+      const preload = createAssetPreloader({ fetch: fetchImpl });
+      await expect(
+        preload(
+          buildScene('scene-a', [
+            'https://allowed.example/a.png',
+            'file:///etc/passwd',
+            'https://allowed.example/b.png',
+          ]),
+        ),
+      ).rejects.toThrow(/^composition asset preload failed:/);
+      // No URL — including the otherwise-allowed `https:` ones — was
+      // fetched, because validation aborted before the network phase.
+      expect(calls).toEqual([]);
+    });
+  });
+
+  describe('post-redirect URL re-validation (security: redirect to disallowed scheme)', () => {
+    it('rejects when fetch follows a redirect into a disallowed scheme', async () => {
+      const fetchImpl: typeof globalThis.fetch = async () => {
+        // Fake a Response whose `.url` reports a final URL with a
+        // disallowed scheme — what fetch would do after following a
+        // 302 from https://allowed.example to file:///etc/passwd
+        // (`fetch` exposes the final URL on `response.url`).
+        const response = new Response(new ArrayBuffer(0), { status: 200 });
+        Object.defineProperty(response, 'url', {
+          value: 'file:///etc/passwd',
+        });
+        return response;
+      };
+      const preload = createAssetPreloader({ fetch: fetchImpl });
+      try {
+        await preload(buildScene('scene-a', ['https://allowed.example/a.png']));
+        expect.unreachable('expected redirect to disallowed scheme to throw');
+      } catch (err) {
+        expect(err).toBeInstanceOf(AggregateError);
+        const top = err as AggregateError;
+        expect((top.errors[0] as Error).message).toMatch(
+          /redirected to disallowed URL "file:\/\/\/etc\/passwd"/,
+        );
+      }
+    });
+
+    it('accepts a same-scheme redirect (https → https)', async () => {
+      const fetchImpl: typeof globalThis.fetch = async () => {
+        const response = new Response(new ArrayBuffer(0), { status: 200 });
+        Object.defineProperty(response, 'url', {
+          value: 'https://cdn.example.com/redirected/a.png',
+        });
+        return response;
+      };
+      const preload = createAssetPreloader({ fetch: fetchImpl });
+      await expect(
+        preload(buildScene('scene-a', ['https://allowed.example/a.png'])),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('protocol-relative URLs (codex review: must not bypass scheme allowlist)', () => {
+    it('rejects // prefix when no baseUrl is configured', async () => {
+      const { fetchImpl, calls } = buildFakeFetch();
+      const preload = createAssetPreloader({ fetch: fetchImpl });
+      try {
+        await preload(buildScene('scene-a', ['//attacker.example/a.png']));
+        expect.unreachable('expected protocol-relative URL to be rejected without baseUrl');
+      } catch (err) {
+        expect(err).toBeInstanceOf(AggregateError);
+        const top = err as AggregateError;
+        expect((top.errors[0] as Error).message).toMatch(
+          /asset "\/\/attacker\.example\/a\.png": protocol-relative URL requires AssetPreloaderOptions\.baseUrl/,
+        );
+      }
+      expect(calls).toEqual([]);
+    });
+
+    it('accepts // prefix once baseUrl is set (resolved scheme is validated)', async () => {
+      const { fetchImpl, calls } = buildFakeFetch();
+      const preload = createAssetPreloader({
+        fetch: fetchImpl,
+        baseUrl: 'https://my-app.example/',
+      });
+      await preload(buildScene('scene-a', ['//cdn.example.com/a.png']));
+      // // resolved against an https: base yields https: scheme — allowed.
+      expect(calls.map((c) => c.input)).toEqual(['https://cdn.example.com/a.png']);
+    });
+  });
+
+  describe('error message includes resolved URL when different from declared', () => {
+    it('shows both declared and resolved URLs in failure messages', async () => {
+      const fetchImpl: typeof globalThis.fetch = async () =>
+        new Response(null, { status: 404, statusText: 'Not Found' });
+      const preload = createAssetPreloader({
+        fetch: fetchImpl,
+        baseUrl: 'https://cdn.example.com/scenes/',
+      });
+      try {
+        await preload(buildScene('scene-a', ['hero.png']));
+        expect.unreachable('expected 404 to throw');
+      } catch (err) {
+        expect(err).toBeInstanceOf(AggregateError);
+        const top = err as AggregateError;
+        expect((top.errors[0] as Error).message).toBe(
+          'asset "hero.png" → "https://cdn.example.com/scenes/hero.png": 404 Not Found',
+        );
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

- Adds `createAssetPreloader(options?)` in `src/runtime/asset-preloader.ts` — a per-scene asset preloader that fulfills PUL-F005 clause (b). Fetches every URL declared in `scene.assets` in parallel and drains each response body via `arrayBuffer()` so the network transfer is fully complete before the scene's `create(ctx)` runs.
- Failures (HTTP non-2xx OR rejected fetch) aggregate into a single `AggregateError` whose `errors` array preserves declaration order — same shape PUL-F004's resolver uses for double-fault reporting (ADR-011), single-failure cases included for consumer consistency.
- Function signature `(scene: SceneModule) => Promise<void>` is structurally compatible with PUL-F004's `AssetPreloader` adapter slot. Once both ship, the workbench bootstrap passes `createAssetPreloader()` straight to `resolveComposition({ preloadAssets, ... })` without a wrapper.
- Adds `docs/adrs/012-asset-preloader-fetch-and-drain.md` (also registered in Ground Control) drawing the explicit boundary: byte-warming via `fetch + arrayBuffer()` ships now; decode-complete semantics (`Image.decode`, `document.fonts.load`, `audioContext.decodeAudioData`) are deferred to a future requirement that layers on top.
- Adds 15 Vitest cases in `tests/runtime/asset-preloader.test.ts` — empty/single/multi/parallel/URL pass-through/fetch override/init forwarding/body-drain invariant via gated arrayBuffer/single + aggregated failure modes/AggregateError-always-thrown.
- Clause (a) ("each scene SHALL declare its required assets in metadata") was already met by PUL-F001's `SceneModule.assets` field; reconciliation links PUL-F005 to that file too.

## Test plan

- [x] `pnpm lint && pnpm typecheck && pnpm test` — green (272 tests across 6 files; +15 new resolver tests)
- [x] `pre-commit run --all-files` — green
- [ ] CI green on this PR
- [ ] SonarCloud quality gate green
- [ ] Codex cross-model review clean
- [ ] Test-quality review clean

## Notes

PR #66 (PUL-F004 resolver) is not yet merged. This PR is independent — the preloader is a standalone module whose function signature is structurally compatible with PUL-F004's `AssetPreloader` type. When PR #66 merges first, this PR rebases cleanly and both pieces compose at the workbench bootstrap. When this PR merges first, PR #66's resolver will accept `createAssetPreloader()` without code changes.

Closes #14