### PR TITLE
Add URL navigation grammar parser (PUL-F007)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `src/runtime/navigation.ts` — `parseNavigationSearch`,
+  `subscribeNavigation`, the `NAVIGATION_MODES` tuple, and the
+  `NavigationTarget` / `NavigationLocator` / `NavigationMode` types.
+  Implements PUL-F007: the runtime accepts the five URL parameters
+  `scene`, `composition`, `index`, `beat`, `mode`, parses combinations
+  per ADR-013's five valid target shapes, and wires startup + `popstate`
+  through the same parser path with the same error semantics. The
+  parser is a boundary adapter only — it does not resolve scenes,
+  inspect composition manifests, or mutate browser history. Identifier
+  validation reuses `isKebabIdentifier` from `src/runtime/identifier.ts`
+  per ADR-008 #1; the seven workbench modes are the ADR-007 set
+  (`present`, `standalone`, `loop`, `paused`, `scrub`, `screenshot`,
+  `prompter`). Repeated grammar keys are rejected; unknown keys are
+  ignored. `index` is base-10, zero-based, non-negative, and a JS safe
+  integer. `subscribeNavigation` accepts a minimal injected
+  `Window`-like surface so tests do not depend on jsdom and runtime
+  callers can swap in stricter test doubles.
+- `tests/runtime/navigation.test.ts` — 80-test suite covering the
+  per-key grammar, the five valid / four invalid combination shapes,
+  repeated-key rejection, unknown-key tolerance, frozen target output,
+  the boundary discipline (no scene-existence validation), startup +
+  `popstate` parser routing, error routing, identical error semantics
+  across triggers, and dispose semantics.
+- `docs/adrs/013-url-navigation-grammar-boundary.md` — new ADR
+  recording the URL parsing boundary rules (target shapes, identifier
+  reuse, `popstate` semantics, "URL search string is the source of
+  truth" invariant). Indexed in `docs/adrs/README.md`.
+
 - `src/runtime/composition-resolver.ts` — `signal?: AbortSignal`
   field on both `ResolveCompositionOptions` and
   `SceneTimelineRunInput`. Implements PUL-F006's "skip rest of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `src/runtime/navigation.ts` — `parseNavigationSearch`,
-  `subscribeNavigation`, `bootstrapNavigation`, `PulsarNavigationEvent`,
-  `PulsarNavigationErrorEvent`, the `NAVIGATION_MODES` tuple, and the
+  `subscribeNavigation`, `bootstrapNavigation`, the `NAVIGATION_MODES`
+  tuple, the `PULSAR_NAVIGATE_EVENT_TYPE` /
+  `PULSAR_NAVIGATE_ERROR_EVENT_TYPE` event-type constants, and the
   `NavigationTarget` / `NavigationLocator` / `NavigationMode` /
-  `NavigationEventTarget` types. `src/main.ts` now calls
-  `bootstrapNavigation(window)` at runtime entry so URL parameters are
-  parsed at startup and on every `popstate`, with results published as
-  `'pulsar:navigate'` and `'pulsar:navigate-error'` events on `window`
-  for the future workbench bootstrap to consume.
+  `NavigationEventTarget` / `NavigationSubscriptionOptions` types.
+  `src/main.ts` now calls `bootstrapNavigation(window)` at runtime
+  entry so URL parameters are parsed at startup and on every
+  `popstate`. The startup parse is deferred to a microtask so
+  subscribers registered after `bootstrapNavigation` returns observe
+  the initial event. Successful parses are published as
+  `CustomEvent<NavigationTarget>` on `window` under
+  `'pulsar:navigate'`; parse errors as `CustomEvent<Error>` under
+  `'pulsar:navigate-error'`. `subscribeNavigation` accepts an optional
+  `deferStartup` flag (default `false`); `bootstrapNavigation` opts
+  in. Vite HMR re-evaluating the entry module disposes the previous
+  popstate listener via `import.meta.hot.dispose`.
   Implements PUL-F007: the runtime accepts the five URL parameters
   `scene`, `composition`, `index`, `beat`, `mode`, parses combinations
   per ADR-013's five valid target shapes, and wires startup + `popstate`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `src/runtime/navigation.ts` — `parseNavigationSearch`,
-  `subscribeNavigation`, the `NAVIGATION_MODES` tuple, and the
-  `NavigationTarget` / `NavigationLocator` / `NavigationMode` types.
+  `subscribeNavigation`, `bootstrapNavigation`, `PulsarNavigationEvent`,
+  `PulsarNavigationErrorEvent`, the `NAVIGATION_MODES` tuple, and the
+  `NavigationTarget` / `NavigationLocator` / `NavigationMode` /
+  `NavigationEventTarget` types. `src/main.ts` now calls
+  `bootstrapNavigation(window)` at runtime entry so URL parameters are
+  parsed at startup and on every `popstate`, with results published as
+  `'pulsar:navigate'` and `'pulsar:navigate-error'` events on `window`
+  for the future workbench bootstrap to consume.
   Implements PUL-F007: the runtime accepts the five URL parameters
   `scene`, `composition`, `index`, `beat`, `mode`, parses combinations
   per ADR-013's five valid target shapes, and wires startup + `popstate`

--- a/docs/adrs/013-url-navigation-grammar-boundary.md
+++ b/docs/adrs/013-url-navigation-grammar-boundary.md
@@ -1,0 +1,114 @@
+# ADR-013: URL Navigation Grammar Boundary
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-03
+
+## Context
+
+PUL-F007 requires the runtime to accept `scene`, `composition`,
+`index`, `beat`, and `mode` URL parameters, and to parse parameter
+combinations at startup and on `popstate`.
+
+[ADR-002](002-scene-registry-and-compositions.md) and
+[ADR-007](007-browser-workbench.md) define the public grammar, but the
+implementation still needs boundary rules. Without those rules, URL
+handling can turn into a second resolver: duplicated identifier
+validation, positional dispatch hidden in the parser, mode checks in
+scenes, or different behavior on initial load and browser back/forward.
+
+## Decision
+
+URL parsing is a boundary adapter from `URLSearchParams` to a plain
+navigation target. It does not resolve scenes, inspect composition
+manifests, run timelines, load assets, or mutate browser history.
+
+The parser accepts only the grammar keys named by PUL-F007:
+`scene`, `composition`, `index`, `beat`, and `mode`. Repeated grammar
+keys are invalid because `URLSearchParams.get()` would otherwise make
+ambiguous input look deterministic. Unknown query keys are ignored by
+the grammar parser; they must not affect navigation state.
+
+String identifiers reuse the shared kebab-case predicate in
+`src/runtime/identifier.ts`. Do not add URL-specific regexes for
+`scene`, `composition`, or `beat`. `mode` is validated against the
+ADR-007 workbench mode set. `index` is a base-10, zero-based,
+non-negative safe integer scoped to a composition.
+
+`composition` is a composition identifier, not an inline manifest and
+not the manifest array itself. Looking up that identifier belongs to
+the workbench/bootstrap layer that owns the available composition
+catalog; validating the manifest format still belongs to
+`assertCompositionManifest`.
+
+Valid target shapes are:
+
+- `scene` with optional `beat` and optional `mode`.
+- `composition` with optional `mode`.
+- `composition` + `scene` with optional `beat` and optional `mode`.
+- `composition` + `index` with optional `beat` and optional `mode`.
+- no explicit target, with optional `mode`, for whatever default target
+  the bootstrap layer owns.
+
+Invalid combinations include:
+
+- `index` without `composition`.
+- `scene` + `index` in the same URL.
+- `beat` without an explicit `scene` or `composition` + `index` target.
+- malformed identifiers, malformed indexes, unknown modes, and repeated
+  grammar keys.
+
+`composition` + `scene` is an id-based locator. The composition
+resolution layer must validate that the scene id exists in the selected
+composition. If the same scene id appears more than once in that
+composition, the locator is ambiguous and the URL must use `index`
+instead.
+
+Startup parsing and `popstate` parsing use the same path and the same
+error semantics. The URL search string is the source of truth on
+`popstate`; `history.state`, localStorage, cookies, and cached runtime
+state must not redefine the target. A navigation change hands off to
+the existing runtime orchestration layer so `cleanup(ctx)` and
+composition-level cancellation semantics remain centralized.
+
+## Consequences
+
+### Positive
+
+- The URL grammar remains an agent-stable contract without becoming a
+  router framework.
+- Identifier validation stays centralized in the existing runtime
+  predicate.
+- Composition existence, repeated-scene ambiguity, beat existence,
+  preloading, timeline execution, and cleanup stay with the layers that
+  already own those concerns.
+- Initial load and browser back/forward cannot drift.
+
+### Negative
+
+- Some URLs that could be guessed are intentionally rejected. In
+  particular, `scene` + `index` must be rewritten as one locator.
+- Repeated scene ids inside a composition require `index` for precise
+  URLs.
+
+### Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Parser starts resolving scenes or manifests | Keep URL parsing as a pure boundary step; resolve through the registry/composition orchestration layers. |
+| URL mode handling leaks into individual scenes | Dispatch modes in the runtime core per ADR-007; expose only mode hints through context where needed. |
+| Positional navigation becomes identity | Treat `index` as a composition-scoped compatibility locator; scene id remains content identity. |
+| Query values become resource paths or dynamic imports | Query values are identifiers only. Do not load modules, files, or network resources directly from URL parameter values. |
+
+## Related ADRs
+
+- [ADR-002](002-scene-registry-and-compositions.md) — defines the
+  scene/composition model and public URL examples.
+- [ADR-007](007-browser-workbench.md) — defines workbench modes and the
+  browser agent contract.
+- [ADR-011](011-composition-resolver-orchestration.md) — centralizes
+  composition lifecycle, cancellation, and cleanup behavior.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -38,3 +38,4 @@ Each ADR includes:
 | [010](010-issue-tag-taxonomy.md) | GitHub Issue Tag Taxonomy | Accepted |
 | [011](011-composition-resolver-orchestration.md) | Composition Resolver as a Pure Orchestrator with Injected Adapters | Accepted |
 | [012](012-asset-preloader-fetch-and-drain.md) | Asset Preloader — Warm Bytes via Fetch + Drain; Decode-Complete is Future Work | Accepted |
+| [013](013-url-navigation-grammar-boundary.md) | URL Navigation Grammar Boundary | Accepted |

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ import { bootstrapNavigation } from './runtime/navigation';
 const stage = document.querySelector('#stage');
 stage?.setAttribute('data-pulsar', 'placeholder');
 
-const disposeNavigation = bootstrapNavigation(window);
+const disposeNavigation = bootstrapNavigation(globalThis);
 
 // Dev-only: when Vite HMR replaces this entry module, dispose the
 // previous popstate listener so re-evaluation does not stack

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,13 @@
-// Workbench entry. The runtime mount lands once the scene contract
-// (PUL-F001) and the workbench mode dispatch (PUL-A008) are in place.
-// Until then this file marks the #stage element so the bundle has a
-// non-trivial entry to build.
+// Workbench entry. PUL-F007 wires the URL navigation grammar parser
+// into the browser runtime so parameter combinations are parsed at
+// startup and on `popstate`. The full workbench bootstrap (scene
+// registration per PUL-F001, mode dispatch per PUL-A008, composition
+// orchestration) consumes the `'pulsar:navigate'` /
+// `'pulsar:navigate-error'` events emitted by `bootstrapNavigation`
+// once those requirements land.
+import { bootstrapNavigation } from './runtime/navigation';
+
 const stage = document.querySelector('#stage');
 stage?.setAttribute('data-pulsar', 'placeholder');
+
+bootstrapNavigation(window);

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,4 +10,12 @@ import { bootstrapNavigation } from './runtime/navigation';
 const stage = document.querySelector('#stage');
 stage?.setAttribute('data-pulsar', 'placeholder');
 
-bootstrapNavigation(window);
+const disposeNavigation = bootstrapNavigation(window);
+
+// Dev-only: when Vite HMR replaces this entry module, dispose the
+// previous popstate listener so re-evaluation does not stack
+// duplicate listeners and emit duplicate navigation events.
+// `import.meta.hot` is undefined in production builds.
+import.meta.hot?.dispose(() => {
+  disposeNavigation();
+});

--- a/src/runtime/navigation.ts
+++ b/src/runtime/navigation.ts
@@ -1,0 +1,309 @@
+// URL navigation grammar — PUL-F007.
+//
+// Boundary adapter from `URLSearchParams` to a plain navigation
+// target. Per ADR-013 the parser does NOT resolve scenes, inspect
+// composition manifests, run timelines, load assets, or mutate
+// browser history — those concerns live in the runtime orchestration
+// layer this module hands off to.
+//
+// The parser accepts only the five grammar keys named by PUL-F007
+// (`scene`, `composition`, `index`, `beat`, `mode`). Repeated grammar
+// keys are invalid because `URLSearchParams.get()` would otherwise
+// make ambiguous input look deterministic. Unknown query keys are
+// ignored.
+//
+// Identifier validation reuses the shared kebab-case predicate in
+// `./identifier.ts` per ADR-013 / ADR-008 #1: there is one identifier
+// rule for scenes, compositions, beats, and assets.
+//
+// Mode is validated against the ADR-007 workbench mode set, exported
+// here as the frozen tuple {@link NAVIGATION_MODES}.
+//
+// Index is base-10, zero-based, non-negative, and a JS safe integer
+// (`Number.isSafeInteger`). It is composition-scoped — `index`
+// without `composition` is invalid; `scene` + `index` is invalid.
+//
+// Combination shapes (per ADR-013) — exactly five accepted:
+//
+//   1. no explicit target              + optional mode
+//   2. scene                           + optional beat + optional mode
+//   3. composition                     + optional mode
+//   4. composition + scene             + optional beat + optional mode
+//   5. composition + index             + optional beat + optional mode
+//
+// {@link subscribeNavigation} wires startup parsing + `popstate`
+// through the same parser path so error semantics match. Per ADR-013,
+// the URL search string is the source of truth on `popstate` —
+// `history.state`, localStorage, cookies, and cached runtime state
+// must not redefine the target.
+
+import { KEBAB_IDENTIFIER_FORM, isKebabIdentifier } from './identifier';
+
+/**
+ * Workbench mode set per ADR-007. The seven modes are the only values
+ * accepted for `mode=` URL parameters. Frozen so consumers cannot
+ * mutate the public allowlist in place.
+ */
+export const NAVIGATION_MODES = Object.freeze([
+  'present',
+  'standalone',
+  'loop',
+  'paused',
+  'scrub',
+  'screenshot',
+  'prompter',
+] as const);
+
+/**
+ * One of the seven {@link NAVIGATION_MODES} values.
+ */
+export type NavigationMode = (typeof NAVIGATION_MODES)[number];
+
+/**
+ * The locator portion of a {@link NavigationTarget}. Discriminated by
+ * `kind` so callers pattern-match against ADR-013's five accepted
+ * target shapes without re-deriving them from optional fields:
+ *
+ *  - `none`              — no explicit target; bootstrap chooses default.
+ *  - `scene`             — single scene by id.
+ *  - `composition`       — composition by id, no in-composition jump.
+ *  - `composition-scene` — composition + scene id (id-based locator).
+ *  - `composition-index` — composition + zero-based index (positional).
+ *
+ * `composition-scene` and `composition-index` are both id-based at the
+ * grammar layer. The composition resolution layer is responsible for
+ * existence and uniqueness checks per ADR-013.
+ */
+export type NavigationLocator =
+  | { readonly kind: 'none' }
+  | { readonly kind: 'scene'; readonly scene: string }
+  | { readonly kind: 'composition'; readonly composition: string }
+  | { readonly kind: 'composition-scene'; readonly composition: string; readonly scene: string }
+  | {
+      readonly kind: 'composition-index';
+      readonly composition: string;
+      readonly index: number;
+    };
+
+/**
+ * The result of {@link parseNavigationSearch}. The locator captures
+ * the addressed scene/composition/index target (or `none`); `beat` and
+ * `mode` are absent when the URL did not specify them. The bootstrap
+ * layer is responsible for substituting any defaults (e.g. mapping
+ * `mode === undefined` to `'present'`).
+ */
+export interface NavigationTarget {
+  readonly locator: NavigationLocator;
+  readonly beat?: string;
+  readonly mode?: NavigationMode;
+}
+
+const GRAMMAR_KEYS = ['scene', 'composition', 'index', 'beat', 'mode'] as const;
+
+const KEBAB_CONDITION = `must be a non-empty lowercase kebab-case string (${KEBAB_IDENTIFIER_FORM})`;
+
+const INDEX_PATTERN = /^(?:0|[1-9]\d*)$/;
+
+/**
+ * The thrown-error grammar matches `assertSceneModule` /
+ * `assertCompositionManifest`: a stable `"<noun> is invalid: ..."`
+ * prefix so callers can pattern-match on origin without parsing
+ * field-specific detail.
+ */
+function fail(condition: string): never {
+  throw new Error(`navigation grammar is invalid: ${condition}`);
+}
+
+function toSearchParams(input: URLSearchParams | string): URLSearchParams {
+  if (input instanceof URLSearchParams) return input;
+  // `new URLSearchParams('?foo=bar')` and `new URLSearchParams('foo=bar')`
+  // both yield the same map; the spec strips a leading `?` only when
+  // the input is parsed via `new URL(...)`. Strip explicitly so callers
+  // can pass `location.search` verbatim.
+  return new URLSearchParams(input.startsWith('?') ? input.slice(1) : input);
+}
+
+function rejectRepeats(params: URLSearchParams): void {
+  for (const key of GRAMMAR_KEYS) {
+    if (params.getAll(key).length > 1) {
+      fail(`repeated query parameter "${key}"`);
+    }
+  }
+}
+
+function validateKebab(field: string, value: string): void {
+  if (!isKebabIdentifier(value)) {
+    fail(`"${field}" ${KEBAB_CONDITION}`);
+  }
+}
+
+function parseIndex(raw: string): number {
+  if (!INDEX_PATTERN.test(raw)) {
+    fail('"index" must be a base-10 non-negative integer (e.g. 0, 1, 12)');
+  }
+  const value = Number.parseInt(raw, 10);
+  if (!Number.isSafeInteger(value) || value < 0) {
+    fail('"index" must be a non-negative safe integer');
+  }
+  return value;
+}
+
+function parseMode(raw: string): NavigationMode {
+  // The membership check is correct as written; the type assertion
+  // documents that callers receive a typed mode, not a bare string.
+  if ((NAVIGATION_MODES as readonly string[]).includes(raw)) {
+    return raw as NavigationMode;
+  }
+  fail(`"mode" unknown mode "${raw}" — allowed: ${NAVIGATION_MODES.join(', ')}`);
+}
+
+function buildLocator(
+  scene: string | undefined,
+  composition: string | undefined,
+  index: number | undefined,
+): NavigationLocator {
+  if (index !== undefined) {
+    // Order matters: "scene + index" is the more semantically
+    // informative violation, so it wins over the "index requires
+    // composition" message when both are technically true (e.g.
+    // `?scene=x&index=0`).
+    if (scene !== undefined) {
+      fail('"scene" and "index" cannot be used together — use one locator');
+    }
+    if (composition === undefined) {
+      fail('"index" requires "composition"');
+    }
+    return Object.freeze({ kind: 'composition-index', composition, index });
+  }
+  if (composition !== undefined && scene !== undefined) {
+    return Object.freeze({ kind: 'composition-scene', composition, scene });
+  }
+  if (composition !== undefined) {
+    return Object.freeze({ kind: 'composition', composition });
+  }
+  if (scene !== undefined) {
+    return Object.freeze({ kind: 'scene', scene });
+  }
+  return Object.freeze({ kind: 'none' });
+}
+
+function ensureBeatHasSceneLikeTarget(beat: string | undefined, locator: NavigationLocator): void {
+  if (beat === undefined) return;
+  if (
+    locator.kind === 'scene' ||
+    locator.kind === 'composition-scene' ||
+    locator.kind === 'composition-index'
+  ) {
+    return;
+  }
+  fail(
+    '"beat" requires a scene-like target ("scene", "composition" + "scene", or "composition" + "index")',
+  );
+}
+
+/**
+ * Parse a URL search string (or `URLSearchParams` instance) into a
+ * {@link NavigationTarget} per PUL-F007 / ADR-013.
+ *
+ * Accepts:
+ *  - the empty string and `'?'` (no explicit target).
+ *  - either `'?key=value'` or `'key=value'` form.
+ *  - a `URLSearchParams` instance (passed through unchanged).
+ *
+ * Throws an `Error` with the prefix `"navigation grammar is invalid: "`
+ * on:
+ *  - any repeated grammar key (`scene`, `composition`, `index`, `beat`,
+ *    `mode`).
+ *  - a malformed identifier (non-kebab-case `scene` / `composition` /
+ *    `beat`).
+ *  - a malformed `index` (not base-10, leading zero, negative,
+ *    decimal, exponent, hex, etc.).
+ *  - an unknown `mode`.
+ *  - any of the four invalid combination shapes ADR-013 names.
+ *
+ * Unknown query keys are ignored — the parser is a grammar boundary,
+ * not a filter.
+ */
+export function parseNavigationSearch(input: URLSearchParams | string): NavigationTarget {
+  const params = toSearchParams(input);
+  rejectRepeats(params);
+
+  const sceneRaw = params.get('scene');
+  const compositionRaw = params.get('composition');
+  const indexRaw = params.get('index');
+  const beatRaw = params.get('beat');
+  const modeRaw = params.get('mode');
+
+  if (sceneRaw !== null) validateKebab('scene', sceneRaw);
+  if (compositionRaw !== null) validateKebab('composition', compositionRaw);
+  if (beatRaw !== null) validateKebab('beat', beatRaw);
+  const index = indexRaw !== null ? parseIndex(indexRaw) : undefined;
+  const mode = modeRaw !== null ? parseMode(modeRaw) : undefined;
+
+  const locator = buildLocator(sceneRaw ?? undefined, compositionRaw ?? undefined, index);
+  const beat = beatRaw ?? undefined;
+  ensureBeatHasSceneLikeTarget(beat, locator);
+
+  const target: { -readonly [K in keyof NavigationTarget]: NavigationTarget[K] } = { locator };
+  if (beat !== undefined) target.beat = beat;
+  if (mode !== undefined) target.mode = mode;
+  return Object.freeze(target);
+}
+
+/**
+ * Minimal `Window`-like surface required by {@link subscribeNavigation}.
+ * Defined as a narrow shape — rather than `Pick<Window, ...>` — so the
+ * tests can inject a fake without standing up jsdom or pulling in DOM
+ * lib types just for `popstate` wiring.
+ */
+export interface NavigationWindowLike {
+  readonly addEventListener: (event: 'popstate', listener: () => void) => void;
+  readonly removeEventListener: (event: 'popstate', listener: () => void) => void;
+  readonly location: { readonly search: string };
+}
+
+/**
+ * Inputs for {@link subscribeNavigation}. Both callbacks are required:
+ * exactly one fires per parse — `onNavigate` on success, `onError` on
+ * grammar failure. The subscriber never throws out to the caller.
+ */
+export interface NavigationSubscriptionOptions {
+  readonly window: NavigationWindowLike;
+  readonly onNavigate: (target: NavigationTarget) => void;
+  readonly onError: (error: Error) => void;
+}
+
+/**
+ * Subscribe to URL navigation events.
+ *
+ * Wires the boundary parser to the two parsing triggers PUL-F007
+ * names: `at startup` (one synchronous parse before this function
+ * returns) and `on popstate` (one parse per `popstate` event,
+ * reading the current `location.search` each time). Both go through
+ * {@link parseNavigationSearch} so error semantics are identical.
+ *
+ * Returns a disposer that removes the `popstate` listener. The
+ * disposer is idempotent at the wiring level — calling it more than
+ * once is a no-op the underlying `removeEventListener` already
+ * handles.
+ */
+export function subscribeNavigation(options: NavigationSubscriptionOptions): () => void {
+  const { window: win, onNavigate, onError } = options;
+
+  const handle = (): void => {
+    let target: NavigationTarget;
+    try {
+      target = parseNavigationSearch(win.location.search);
+    } catch (err) {
+      onError(err instanceof Error ? err : new Error(String(err)));
+      return;
+    }
+    onNavigate(target);
+  };
+
+  win.addEventListener('popstate', handle);
+  handle();
+  return () => {
+    win.removeEventListener('popstate', handle);
+  };
+}

--- a/src/runtime/navigation.ts
+++ b/src/runtime/navigation.ts
@@ -327,7 +327,15 @@ export function subscribeNavigation(options: NavigationSubscriptionOptions): () 
   };
 
   win.addEventListener('popstate', handle);
+  // The disposed flag is captured by the queued startup so a caller
+  // that disposes before the microtask runs cannot still observe the
+  // initial event. Without it, an aborted bootstrap (e.g. Vite HMR
+  // swapping the entry module synchronously) would dispatch a stale
+  // startup navigation/error after teardown.
+  let disposed = false;
   const dispose = (): void => {
+    if (disposed) return;
+    disposed = true;
     win.removeEventListener('popstate', handle);
   };
 
@@ -343,6 +351,7 @@ export function subscribeNavigation(options: NavigationSubscriptionOptions): () 
   // `subscribeNavigation` has already returned), but the popstate
   // listener is still removed.
   const startup = (): void => {
+    if (disposed) return;
     try {
       handle();
     } catch (err) {

--- a/src/runtime/navigation.ts
+++ b/src/runtime/navigation.ts
@@ -102,7 +102,12 @@ const GRAMMAR_KEYS = ['scene', 'composition', 'index', 'beat', 'mode'] as const;
 
 const KEBAB_CONDITION = `must be a non-empty lowercase kebab-case string (${KEBAB_IDENTIFIER_FORM})`;
 
-const INDEX_PATTERN = /^(?:0|[1-9]\d*)$/;
+// ADR-013 defines `index` as "base-10, zero-based, non-negative safe
+// integer." The pattern enforces only the base-10 digit set; leading
+// zeros (e.g. `01`) are accepted because the ADR does not forbid
+// them. Negatives, signs, decimals, exponents, and non-decimal
+// notations are all rejected.
+const INDEX_PATTERN = /^[0-9]+$/;
 
 /**
  * The thrown-error grammar matches `assertSceneModule` /
@@ -270,12 +275,27 @@ export interface NavigationWindowLike {
 /**
  * Inputs for {@link subscribeNavigation}. Both callbacks are required:
  * exactly one fires per parse — `onNavigate` on success, `onError` on
- * grammar failure. The subscriber never throws out to the caller.
+ * grammar failure.
+ *
+ * Grammar failures are routed to `onError` and never thrown out to the
+ * caller. User-callback errors thrown from `onNavigate` / `onError`
+ * propagate; in the synchronous-startup path the popstate listener is
+ * removed first so a buggy startup callback does not leak the
+ * listener.
  */
 export interface NavigationSubscriptionOptions {
   readonly window: NavigationWindowLike;
   readonly onNavigate: (target: NavigationTarget) => void;
   readonly onError: (error: Error) => void;
+  /**
+   * When `true`, the startup parse is deferred to a microtask
+   * (`queueMicrotask`) so synchronous module code that runs after
+   * {@link subscribeNavigation} returns has a chance to register
+   * additional subscribers before the first event fires. The popstate
+   * listener is registered synchronously either way. Default `false`
+   * — the startup parse runs inline.
+   */
+  readonly deferStartup?: boolean;
 }
 
 /**
@@ -293,7 +313,7 @@ export interface NavigationSubscriptionOptions {
  * handles.
  */
 export function subscribeNavigation(options: NavigationSubscriptionOptions): () => void {
-  const { window: win, onNavigate, onError } = options;
+  const { window: win, onNavigate, onError, deferStartup = false } = options;
 
   const handle = (_evt?: Event): void => {
     let target: NavigationTarget;
@@ -310,50 +330,49 @@ export function subscribeNavigation(options: NavigationSubscriptionOptions): () 
   const dispose = (): void => {
     win.removeEventListener('popstate', handle);
   };
+
   // If `onNavigate` / `onError` itself throws during the startup parse,
   // remove the popstate listener before the exception escapes. Without
   // this, the disposer never returns and the listener leaks across the
   // entire window lifetime. Grammar failures during startup never reach
   // this catch — those route through `onError` and return normally.
-  try {
-    handle();
-  } catch (err) {
-    dispose();
-    throw err;
+  //
+  // Deferred path: the same cleanup-on-throw runs inside the
+  // microtask. The thrown exception surfaces via the platform's
+  // unhandled-error handler (the caller cannot catch it because
+  // `subscribeNavigation` has already returned), but the popstate
+  // listener is still removed.
+  const startup = (): void => {
+    try {
+      handle();
+    } catch (err) {
+      dispose();
+      throw err;
+    }
+  };
+  if (deferStartup) {
+    queueMicrotask(startup);
+  } else {
+    startup();
   }
   return dispose;
 }
 
 /**
- * Event dispatched on a successful navigation parse. Future workbench
- * bootstrap layers subscribe to `'pulsar:navigate'` to receive parsed
- * targets without coupling to the runtime entry point.
- *
- * Subclasses `Event` (rather than using `CustomEvent`) so the helper
- * works on Node 18, where `CustomEvent` is not yet a global.
+ * Event type for successful navigation parses, dispatched as a
+ * `CustomEvent<NavigationTarget>` whose `detail` is the parsed target.
+ * Workbench bootstrap layers subscribe to this type on `window` to
+ * receive parsed targets without coupling to the runtime entry script.
  */
-export class PulsarNavigationEvent extends Event {
-  readonly navigationTarget: NavigationTarget;
-  constructor(target: NavigationTarget) {
-    super(PulsarNavigationEvent.TYPE);
-    this.navigationTarget = target;
-  }
-  static readonly TYPE = 'pulsar:navigate';
-}
+export const PULSAR_NAVIGATE_EVENT_TYPE = 'pulsar:navigate';
 
 /**
- * Event dispatched when URL grammar parsing fails. Future workbench
- * bootstrap layers subscribe to `'pulsar:navigate-error'` to surface
- * malformed URLs to the operator.
+ * Event type for parse failures, dispatched as a `CustomEvent<Error>`
+ * whose `detail` is the grammar `Error`. Workbench bootstrap layers
+ * subscribe to this type on `window` to surface malformed URLs to the
+ * operator.
  */
-export class PulsarNavigationErrorEvent extends Event {
-  readonly navigationError: Error;
-  constructor(error: Error) {
-    super(PulsarNavigationErrorEvent.TYPE);
-    this.navigationError = error;
-  }
-  static readonly TYPE = 'pulsar:navigate-error';
-}
+export const PULSAR_NAVIGATE_ERROR_EVENT_TYPE = 'pulsar:navigate-error';
 
 /**
  * Browser-target shape required by {@link bootstrapNavigation}: every
@@ -369,23 +388,31 @@ export interface NavigationEventTarget extends NavigationWindowLike {
  * Bootstrap navigation parsing for the runtime entry point.
  *
  * Subscribes the URL grammar parser to the supplied target's
- * `popstate` and runs it once at startup (PUL-F007 clause 2). Every
- * successful parse fires a {@link PulsarNavigationEvent}; every parse
- * failure fires a {@link PulsarNavigationErrorEvent}. Returns a
- * disposer that removes the listener.
+ * `popstate` and schedules the startup parse as a microtask (so
+ * synchronous module code that runs after `bootstrapNavigation`
+ * returns has time to register subscribers before the first event
+ * fires). PUL-F007 clause 2 — parsed at startup and on `popstate`.
  *
- * The future workbench bootstrap (scene catalog, mode dispatch,
- * composition orchestration) subscribes to these events on `window`
- * to receive parsed targets without coupling to the entry script.
+ * Every successful parse fires `'pulsar:navigate'` as a
+ * `CustomEvent<NavigationTarget>`; every parse failure fires
+ * `'pulsar:navigate-error'` as a `CustomEvent<Error>`. The standard
+ * `event.detail` envelope is used so consumers can read the payload
+ * with the platform-idiomatic API. Returns a disposer that removes
+ * the listener.
  */
 export function bootstrapNavigation(target: NavigationEventTarget): () => void {
   return subscribeNavigation({
     window: target,
     onNavigate: (parsed) => {
-      target.dispatchEvent(new PulsarNavigationEvent(parsed));
+      target.dispatchEvent(
+        new CustomEvent<NavigationTarget>(PULSAR_NAVIGATE_EVENT_TYPE, { detail: parsed }),
+      );
     },
     onError: (error) => {
-      target.dispatchEvent(new PulsarNavigationErrorEvent(error));
+      target.dispatchEvent(
+        new CustomEvent<Error>(PULSAR_NAVIGATE_ERROR_EVENT_TYPE, { detail: error }),
+      );
     },
+    deferStartup: true,
   });
 }

--- a/src/runtime/navigation.ts
+++ b/src/runtime/navigation.ts
@@ -105,7 +105,7 @@ const GRAMMAR_KEYS = ['scene', 'composition', 'index', 'beat', 'mode'] as const;
 // zeros (e.g. `01`) are accepted because the ADR does not forbid
 // them. Negatives, signs, decimals, exponents, and non-decimal
 // notations are all rejected.
-const INDEX_PATTERN = /^[0-9]+$/;
+const INDEX_PATTERN = /^\d+$/;
 
 /**
  * The thrown-error grammar matches `assertSceneModule` /

--- a/src/runtime/navigation.ts
+++ b/src/runtime/navigation.ts
@@ -255,10 +255,15 @@ export function parseNavigationSearch(input: URLSearchParams | string): Navigati
  * Defined as a narrow shape — rather than `Pick<Window, ...>` — so the
  * tests can inject a fake without standing up jsdom or pulling in DOM
  * lib types just for `popstate` wiring.
+ *
+ * The listener is typed as `(evt: Event) => void` so the actual browser
+ * `window` is structurally assignable to this interface — DOM
+ * `addEventListener` requires the listener to handle an `Event` arg.
+ * The internal handler ignores the arg.
  */
 export interface NavigationWindowLike {
-  readonly addEventListener: (event: 'popstate', listener: () => void) => void;
-  readonly removeEventListener: (event: 'popstate', listener: () => void) => void;
+  readonly addEventListener: (event: 'popstate', listener: (evt: Event) => void) => void;
+  readonly removeEventListener: (event: 'popstate', listener: (evt: Event) => void) => void;
   readonly location: { readonly search: string };
 }
 
@@ -290,7 +295,7 @@ export interface NavigationSubscriptionOptions {
 export function subscribeNavigation(options: NavigationSubscriptionOptions): () => void {
   const { window: win, onNavigate, onError } = options;
 
-  const handle = (): void => {
+  const handle = (_evt?: Event): void => {
     let target: NavigationTarget;
     try {
       target = parseNavigationSearch(win.location.search);
@@ -306,4 +311,70 @@ export function subscribeNavigation(options: NavigationSubscriptionOptions): () 
   return () => {
     win.removeEventListener('popstate', handle);
   };
+}
+
+/**
+ * Event dispatched on a successful navigation parse. Future workbench
+ * bootstrap layers subscribe to `'pulsar:navigate'` to receive parsed
+ * targets without coupling to the runtime entry point.
+ *
+ * Subclasses `Event` (rather than using `CustomEvent`) so the helper
+ * works on Node 18, where `CustomEvent` is not yet a global.
+ */
+export class PulsarNavigationEvent extends Event {
+  readonly navigationTarget: NavigationTarget;
+  constructor(target: NavigationTarget) {
+    super(PulsarNavigationEvent.TYPE);
+    this.navigationTarget = target;
+  }
+  static readonly TYPE = 'pulsar:navigate';
+}
+
+/**
+ * Event dispatched when URL grammar parsing fails. Future workbench
+ * bootstrap layers subscribe to `'pulsar:navigate-error'` to surface
+ * malformed URLs to the operator.
+ */
+export class PulsarNavigationErrorEvent extends Event {
+  readonly navigationError: Error;
+  constructor(error: Error) {
+    super(PulsarNavigationErrorEvent.TYPE);
+    this.navigationError = error;
+  }
+  static readonly TYPE = 'pulsar:navigate-error';
+}
+
+/**
+ * Browser-target shape required by {@link bootstrapNavigation}: every
+ * member of {@link NavigationWindowLike} plus a DOM-shaped
+ * `dispatchEvent` so the helper can publish parsed targets and parse
+ * errors as events on the same target.
+ */
+export interface NavigationEventTarget extends NavigationWindowLike {
+  dispatchEvent(event: Event): boolean;
+}
+
+/**
+ * Bootstrap navigation parsing for the runtime entry point.
+ *
+ * Subscribes the URL grammar parser to the supplied target's
+ * `popstate` and runs it once at startup (PUL-F007 clause 2). Every
+ * successful parse fires a {@link PulsarNavigationEvent}; every parse
+ * failure fires a {@link PulsarNavigationErrorEvent}. Returns a
+ * disposer that removes the listener.
+ *
+ * The future workbench bootstrap (scene catalog, mode dispatch,
+ * composition orchestration) subscribes to these events on `window`
+ * to receive parsed targets without coupling to the entry script.
+ */
+export function bootstrapNavigation(target: NavigationEventTarget): () => void {
+  return subscribeNavigation({
+    window: target,
+    onNavigate: (parsed) => {
+      target.dispatchEvent(new PulsarNavigationEvent(parsed));
+    },
+    onError: (error) => {
+      target.dispatchEvent(new PulsarNavigationErrorEvent(error));
+    },
+  });
 }

--- a/src/runtime/navigation.ts
+++ b/src/runtime/navigation.ts
@@ -100,8 +100,6 @@ export interface NavigationTarget {
 
 const GRAMMAR_KEYS = ['scene', 'composition', 'index', 'beat', 'mode'] as const;
 
-const KEBAB_CONDITION = `must be a non-empty lowercase kebab-case string (${KEBAB_IDENTIFIER_FORM})`;
-
 // ADR-013 defines `index` as "base-10, zero-based, non-negative safe
 // integer." The pattern enforces only the base-10 digit set; leading
 // zeros (e.g. `01`) are accepted because the ADR does not forbid
@@ -138,7 +136,7 @@ function rejectRepeats(params: URLSearchParams): void {
 
 function validateKebab(field: string, value: string): void {
   if (!isKebabIdentifier(value)) {
-    fail(`"${field}" ${KEBAB_CONDITION}`);
+    fail(`"${field}" must be a non-empty lowercase kebab-case string (${KEBAB_IDENTIFIER_FORM})`);
   }
 }
 
@@ -146,8 +144,12 @@ function parseIndex(raw: string): number {
   if (!INDEX_PATTERN.test(raw)) {
     fail('"index" must be a base-10 non-negative integer (e.g. 0, 1, 12)');
   }
+  // The regex excludes negatives, signs, decimals, and exponents, so
+  // `parseInt` always returns a non-negative number here. Only the
+  // safe-integer bound needs a runtime check (very long digit strings
+  // can overflow `Number.MAX_SAFE_INTEGER`).
   const value = Number.parseInt(raw, 10);
-  if (!Number.isSafeInteger(value) || value < 0) {
+  if (!Number.isSafeInteger(value)) {
     fail('"index" must be a non-negative safe integer');
   }
   return value;

--- a/src/runtime/navigation.ts
+++ b/src/runtime/navigation.ts
@@ -307,10 +307,21 @@ export function subscribeNavigation(options: NavigationSubscriptionOptions): () 
   };
 
   win.addEventListener('popstate', handle);
-  handle();
-  return () => {
+  const dispose = (): void => {
     win.removeEventListener('popstate', handle);
   };
+  // If `onNavigate` / `onError` itself throws during the startup parse,
+  // remove the popstate listener before the exception escapes. Without
+  // this, the disposer never returns and the listener leaks across the
+  // entire window lifetime. Grammar failures during startup never reach
+  // this catch — those route through `onError` and return normally.
+  try {
+    handle();
+  } catch (err) {
+    dispose();
+    throw err;
+  }
+  return dispose;
 }
 
 /**

--- a/src/runtime/navigation.ts
+++ b/src/runtime/navigation.ts
@@ -237,8 +237,8 @@ export function parseNavigationSearch(input: URLSearchParams | string): Navigati
   if (sceneRaw !== null) validateKebab('scene', sceneRaw);
   if (compositionRaw !== null) validateKebab('composition', compositionRaw);
   if (beatRaw !== null) validateKebab('beat', beatRaw);
-  const index = indexRaw !== null ? parseIndex(indexRaw) : undefined;
-  const mode = modeRaw !== null ? parseMode(modeRaw) : undefined;
+  const index = indexRaw === null ? undefined : parseIndex(indexRaw);
+  const mode = modeRaw === null ? undefined : parseMode(modeRaw);
 
   const locator = buildLocator(sceneRaw ?? undefined, compositionRaw ?? undefined, index);
   const beat = beatRaw ?? undefined;

--- a/tests/runtime/navigation.test.ts
+++ b/tests/runtime/navigation.test.ts
@@ -1,0 +1,467 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  NAVIGATION_MODES,
+  type NavigationMode,
+  type NavigationSubscriptionOptions,
+  type NavigationTarget,
+  parseNavigationSearch,
+  subscribeNavigation,
+} from '../../src/runtime/navigation';
+
+// PUL-F007 — URL navigation grammar.
+//
+// The parser is a boundary adapter from URLSearchParams to a plain
+// navigation target (ADR-013). It accepts only the five named keys
+// (`scene`, `composition`, `index`, `beat`, `mode`), validates each
+// in isolation, validates the combination shape, and rejects repeats
+// of any named key. Unknown keys are ignored.
+//
+// `subscribeNavigation` wires startup parsing + `popstate` through the
+// same parser path with the same error semantics — clause 2 of the
+// requirement statement.
+//
+// Tests below are organized by clause:
+//  - Clause 1: accepts and validates the five grammar keys.
+//  - Clause 2: parses at startup and on `popstate`.
+// Plus ADR-013 invariants (repeated keys rejected, unknown keys ignored,
+// and the five valid + four invalid combination shapes).
+
+const ALL_MODES: readonly NavigationMode[] = [
+  'present',
+  'standalone',
+  'loop',
+  'paused',
+  'scrub',
+  'screenshot',
+  'prompter',
+];
+
+describe('parseNavigationSearch — clause 1: accepts the five grammar keys', () => {
+  describe('input shape', () => {
+    it('accepts a leading-? string', () => {
+      expect(() => parseNavigationSearch('?scene=intro')).not.toThrow();
+    });
+
+    it('accepts a no-? string', () => {
+      expect(() => parseNavigationSearch('scene=intro')).not.toThrow();
+    });
+
+    it('accepts a URLSearchParams instance', () => {
+      const params = new URLSearchParams({ scene: 'intro' });
+      expect(parseNavigationSearch(params).locator).toEqual({
+        kind: 'scene',
+        scene: 'intro',
+      });
+    });
+
+    it('accepts the empty string', () => {
+      expect(parseNavigationSearch('')).toEqual({ locator: { kind: 'none' } });
+    });
+
+    it('accepts the bare ?', () => {
+      expect(parseNavigationSearch('?')).toEqual({ locator: { kind: 'none' } });
+    });
+  });
+
+  describe('scene', () => {
+    it.each(['intro', 'cold-open', 'a', 'a1-b2', 'scene-1', '1', '9-9'])(
+      'accepts kebab-case scene id %j',
+      (id) => {
+        expect(parseNavigationSearch(`scene=${id}`).locator).toEqual({
+          kind: 'scene',
+          scene: id,
+        });
+      },
+    );
+
+    it.each([
+      ['empty string', ''],
+      ['uppercase', 'Scene-A'],
+      ['underscore', 'scene_a'],
+      ['leading hyphen', '-scene'],
+      ['trailing hyphen', 'scene-'],
+      ['consecutive hyphens', 'a--b'],
+      ['internal whitespace (encoded)', 'scene%20a'],
+      ['unicode', 'sc%C3%A9ne'],
+    ])('rejects malformed scene id (%s)', (_label, encoded) => {
+      expect(() => parseNavigationSearch(`scene=${encoded}`)).toThrow(
+        /^navigation grammar is invalid:/,
+      );
+    });
+  });
+
+  describe('composition', () => {
+    it('accepts a kebab-case composition id', () => {
+      expect(parseNavigationSearch('composition=full-talk').locator).toEqual({
+        kind: 'composition',
+        composition: 'full-talk',
+      });
+    });
+
+    it('rejects malformed composition id', () => {
+      expect(() => parseNavigationSearch('composition=Full-Talk')).toThrow(
+        /^navigation grammar is invalid: "composition"/,
+      );
+    });
+  });
+
+  describe('beat', () => {
+    it('accepts a kebab-case beat label with a scene target', () => {
+      expect(parseNavigationSearch('scene=intro&beat=hook')).toEqual({
+        locator: { kind: 'scene', scene: 'intro' },
+        beat: 'hook',
+      });
+    });
+
+    it('accepts a beat with composition+scene', () => {
+      expect(parseNavigationSearch('composition=full-talk&scene=intro&beat=hook')).toEqual({
+        locator: { kind: 'composition-scene', composition: 'full-talk', scene: 'intro' },
+        beat: 'hook',
+      });
+    });
+
+    it('accepts a beat with composition+index', () => {
+      expect(parseNavigationSearch('composition=full-talk&index=0&beat=hook')).toEqual({
+        locator: { kind: 'composition-index', composition: 'full-talk', index: 0 },
+        beat: 'hook',
+      });
+    });
+
+    it('rejects a malformed beat label', () => {
+      expect(() => parseNavigationSearch('scene=intro&beat=Hook')).toThrow(
+        /^navigation grammar is invalid: "beat"/,
+      );
+    });
+  });
+
+  describe('index', () => {
+    it.each([
+      ['0', 0],
+      ['1', 1],
+      ['12', 12],
+      ['123', 123],
+    ])('accepts non-negative base-10 index %s', (encoded, expected) => {
+      expect(parseNavigationSearch(`composition=t&index=${encoded}`).locator).toEqual({
+        kind: 'composition-index',
+        composition: 't',
+        index: expected,
+      });
+    });
+
+    it.each([
+      ['negative', '-1'],
+      ['leading zero', '01'],
+      ['decimal', '1.5'],
+      ['hex', '0x1'],
+      ['plus sign', '+1'],
+      ['whitespace', ' 1 '],
+      ['empty', ''],
+      ['letters', 'one'],
+      ['exponent', '1e2'],
+    ])('rejects malformed index (%s)', (_label, encoded) => {
+      expect(() =>
+        parseNavigationSearch(`composition=t&index=${encodeURIComponent(encoded)}`),
+      ).toThrow(/^navigation grammar is invalid: "index"/);
+    });
+
+    it('rejects an index above Number.MAX_SAFE_INTEGER', () => {
+      const big = '9'.repeat(40);
+      expect(() => parseNavigationSearch(`composition=t&index=${big}`)).toThrow(
+        /^navigation grammar is invalid: "index"/,
+      );
+    });
+  });
+
+  describe('mode', () => {
+    it.each(ALL_MODES)('accepts mode=%s', (mode) => {
+      expect(parseNavigationSearch(`mode=${mode}`).mode).toBe(mode);
+    });
+
+    it('NAVIGATION_MODES is the public allowlist and is frozen', () => {
+      expect([...NAVIGATION_MODES]).toEqual([...ALL_MODES]);
+      expect(Object.isFrozen(NAVIGATION_MODES)).toBe(true);
+    });
+
+    it('rejects an unknown mode and names every allowed mode', () => {
+      let caught: Error | undefined;
+      try {
+        parseNavigationSearch('mode=blah');
+      } catch (err) {
+        caught = err as Error;
+      }
+      expect(caught).toBeDefined();
+      expect(caught?.message).toMatch(/^navigation grammar is invalid: "mode"/);
+      for (const mode of ALL_MODES) {
+        expect(caught?.message).toContain(mode);
+      }
+    });
+  });
+});
+
+describe('parseNavigationSearch — ADR-013: combination shapes', () => {
+  describe('valid target shapes', () => {
+    it('no explicit target with no mode', () => {
+      expect(parseNavigationSearch('')).toEqual({ locator: { kind: 'none' } });
+    });
+
+    it('no explicit target with optional mode', () => {
+      expect(parseNavigationSearch('mode=screenshot')).toEqual({
+        locator: { kind: 'none' },
+        mode: 'screenshot',
+      });
+    });
+
+    it('scene only', () => {
+      expect(parseNavigationSearch('scene=intro')).toEqual({
+        locator: { kind: 'scene', scene: 'intro' },
+      });
+    });
+
+    it('scene with mode', () => {
+      expect(parseNavigationSearch('scene=intro&mode=standalone')).toEqual({
+        locator: { kind: 'scene', scene: 'intro' },
+        mode: 'standalone',
+      });
+    });
+
+    it('composition only', () => {
+      expect(parseNavigationSearch('composition=full-talk')).toEqual({
+        locator: { kind: 'composition', composition: 'full-talk' },
+      });
+    });
+
+    it('composition with mode', () => {
+      expect(parseNavigationSearch('composition=full-talk&mode=present')).toEqual({
+        locator: { kind: 'composition', composition: 'full-talk' },
+        mode: 'present',
+      });
+    });
+
+    it('composition + scene', () => {
+      expect(parseNavigationSearch('composition=full-talk&scene=intro')).toEqual({
+        locator: { kind: 'composition-scene', composition: 'full-talk', scene: 'intro' },
+      });
+    });
+
+    it('composition + scene + beat + mode', () => {
+      expect(
+        parseNavigationSearch('composition=full-talk&scene=intro&beat=hook&mode=scrub'),
+      ).toEqual({
+        locator: { kind: 'composition-scene', composition: 'full-talk', scene: 'intro' },
+        beat: 'hook',
+        mode: 'scrub',
+      });
+    });
+
+    it('composition + index', () => {
+      expect(parseNavigationSearch('composition=full-talk&index=2')).toEqual({
+        locator: { kind: 'composition-index', composition: 'full-talk', index: 2 },
+      });
+    });
+
+    it('composition + index + beat + mode', () => {
+      expect(parseNavigationSearch('composition=full-talk&index=2&beat=hook&mode=loop')).toEqual({
+        locator: { kind: 'composition-index', composition: 'full-talk', index: 2 },
+        beat: 'hook',
+        mode: 'loop',
+      });
+    });
+  });
+
+  describe('invalid combinations', () => {
+    it('rejects scene + index together', () => {
+      expect(() => parseNavigationSearch('scene=intro&index=0')).toThrow(
+        /^navigation grammar is invalid: "scene" and "index" cannot be used together/,
+      );
+    });
+
+    it('rejects scene + index even with composition', () => {
+      expect(() => parseNavigationSearch('composition=t&scene=intro&index=0')).toThrow(
+        /^navigation grammar is invalid: "scene" and "index" cannot be used together/,
+      );
+    });
+
+    it('rejects index without composition', () => {
+      expect(() => parseNavigationSearch('index=0')).toThrow(
+        /^navigation grammar is invalid: "index" requires "composition"/,
+      );
+    });
+
+    it('rejects beat with no target', () => {
+      expect(() => parseNavigationSearch('beat=hook')).toThrow(
+        /^navigation grammar is invalid: "beat"/,
+      );
+    });
+
+    it('rejects beat with composition only (no scene-like target)', () => {
+      expect(() => parseNavigationSearch('composition=t&beat=hook')).toThrow(
+        /^navigation grammar is invalid: "beat"/,
+      );
+    });
+  });
+});
+
+describe('parseNavigationSearch — ADR-013: repeated keys & unknown keys', () => {
+  it.each(['scene', 'composition', 'index', 'beat', 'mode'])(
+    'rejects repeated grammar key %s',
+    (key) => {
+      const search = `${key}=a&${key}=b`;
+      expect(() => parseNavigationSearch(search)).toThrow(
+        new RegExp(`^navigation grammar is invalid: repeated query parameter "${key}"`),
+      );
+    },
+  );
+
+  it('reports the first repeated grammar key it encounters', () => {
+    expect(() => parseNavigationSearch('scene=a&scene=b&mode=loop&mode=present')).toThrow(
+      /repeated query parameter "scene"/,
+    );
+  });
+
+  it('ignores unknown query keys', () => {
+    expect(parseNavigationSearch('scene=intro&random=1&another=2')).toEqual({
+      locator: { kind: 'scene', scene: 'intro' },
+    });
+  });
+
+  it('allows repeated unknown keys (unknown is ignored, including repeats)', () => {
+    expect(parseNavigationSearch('scene=intro&random=a&random=b')).toEqual({
+      locator: { kind: 'scene', scene: 'intro' },
+    });
+  });
+});
+
+describe('parseNavigationSearch — boundary discipline', () => {
+  it('does NOT validate scene existence (resolution-layer concern)', () => {
+    // ADR-013: composition + scene is id-based; existence/uniqueness in
+    // a composition is resolution-layer work, not grammar.
+    expect(() => parseNavigationSearch('composition=full-talk&scene=does-not-exist')).not.toThrow();
+  });
+
+  it('returns frozen targets so callers cannot mutate the parser output', () => {
+    const target = parseNavigationSearch('composition=t&index=0&beat=hook&mode=loop');
+    expect(Object.isFrozen(target)).toBe(true);
+    expect(Object.isFrozen(target.locator)).toBe(true);
+  });
+});
+
+describe('subscribeNavigation — clause 2: parse at startup and on popstate', () => {
+  interface FakeWindow {
+    readonly addEventListener: ReturnType<typeof vi.fn>;
+    readonly removeEventListener: ReturnType<typeof vi.fn>;
+    readonly location: { search: string };
+  }
+
+  const buildFakeWindow = (search: string): FakeWindow => ({
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    location: { search },
+  });
+
+  const captureListener = (fake: FakeWindow): (() => void) => {
+    expect(fake.addEventListener).toHaveBeenCalledTimes(1);
+    const args = fake.addEventListener.mock.calls[0] as readonly unknown[];
+    expect(args[0]).toBe('popstate');
+    return args[1] as () => void;
+  };
+
+  let onNavigate: ReturnType<typeof vi.fn>;
+  let onError: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    onNavigate = vi.fn();
+    onError = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const buildOptions = (fake: FakeWindow): NavigationSubscriptionOptions => ({
+    window: fake,
+    onNavigate,
+    onError,
+  });
+
+  it('parses the URL once at startup and routes to onNavigate', () => {
+    const fake = buildFakeWindow('?scene=intro');
+    subscribeNavigation(buildOptions(fake));
+
+    expect(onNavigate).toHaveBeenCalledTimes(1);
+    expect(onNavigate).toHaveBeenCalledWith({
+      locator: { kind: 'scene', scene: 'intro' },
+    } satisfies NavigationTarget);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('routes startup parser errors to onError', () => {
+    const fake = buildFakeWindow('?scene=Bad');
+    subscribeNavigation(buildOptions(fake));
+
+    expect(onNavigate).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledTimes(1);
+    const err = onError.mock.calls[0]?.[0] as Error;
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toMatch(/^navigation grammar is invalid:/);
+  });
+
+  it('parses again on every popstate using the current location.search', () => {
+    const fake = buildFakeWindow('?scene=intro');
+    subscribeNavigation(buildOptions(fake));
+    onNavigate.mockClear();
+
+    const handler = captureListener(fake);
+
+    fake.location.search = '?scene=outro';
+    handler();
+    fake.location.search = '?composition=full-talk&index=2';
+    handler();
+
+    expect(onNavigate).toHaveBeenNthCalledWith(1, {
+      locator: { kind: 'scene', scene: 'outro' },
+    } satisfies NavigationTarget);
+    expect(onNavigate).toHaveBeenNthCalledWith(2, {
+      locator: { kind: 'composition-index', composition: 'full-talk', index: 2 },
+    } satisfies NavigationTarget);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('routes popstate parser errors to onError without throwing', () => {
+    const fake = buildFakeWindow('?scene=intro');
+    subscribeNavigation(buildOptions(fake));
+    onNavigate.mockClear();
+
+    const handler = captureListener(fake);
+    fake.location.search = '?scene=Bad';
+    expect(() => handler()).not.toThrow();
+    expect(onNavigate).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the same parser path for startup and popstate (same error semantics)', () => {
+    // Both checkpoints emit identical Error.message text for the same
+    // malformed URL — the behavior ADR-013 names "same path, same
+    // error semantics."
+    const fake = buildFakeWindow('?scene=Bad');
+    subscribeNavigation(buildOptions(fake));
+    const startupErr = onError.mock.calls[0]?.[0] as Error;
+    onError.mockClear();
+    const handler = captureListener(fake);
+    fake.location.search = '?scene=Bad';
+    handler();
+    const popstateErr = onError.mock.calls[0]?.[0] as Error;
+
+    expect(popstateErr.message).toBe(startupErr.message);
+  });
+
+  it('disposer removes the popstate listener', () => {
+    const fake = buildFakeWindow('');
+    const dispose = subscribeNavigation(buildOptions(fake));
+    const handler = captureListener(fake);
+
+    dispose();
+
+    expect(fake.removeEventListener).toHaveBeenCalledTimes(1);
+    expect(fake.removeEventListener).toHaveBeenCalledWith('popstate', handler);
+  });
+});

--- a/tests/runtime/navigation.test.ts
+++ b/tests/runtime/navigation.test.ts
@@ -473,6 +473,35 @@ describe('subscribeNavigation — clause 2: parse at startup and on popstate', (
     expect(fake.removeEventListener).toHaveBeenCalledWith('popstate', handler);
   });
 
+  it('deferStartup + dispose() before microtask flush suppresses the queued startup', async () => {
+    // Without the disposed flag, an HMR swap that disposes the old
+    // subscription before its queued microtask runs would still
+    // dispatch a stale startup event. Codex review (cycle 4) flagged
+    // this race; this test pins the contract.
+    const fake = buildFakeWindow('?scene=intro');
+    const dispose = subscribeNavigation({
+      window: fake,
+      onNavigate,
+      onError,
+      deferStartup: true,
+    });
+    dispose();
+
+    await Promise.resolve();
+    expect(onNavigate).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+    expect(fake.removeEventListener).toHaveBeenCalledTimes(1);
+  });
+
+  it('dispose() is idempotent — removeEventListener is called at most once', () => {
+    const fake = buildFakeWindow('?scene=intro');
+    const dispose = subscribeNavigation(buildOptions(fake));
+    dispose();
+    dispose();
+    dispose();
+    expect(fake.removeEventListener).toHaveBeenCalledTimes(1);
+  });
+
   it('deferStartup: defers the startup parse to a microtask but registers popstate immediately', async () => {
     // Subscribers registered AFTER subscribeNavigation returns can
     // still observe the initial event when deferStartup is true. The

--- a/tests/runtime/navigation.test.ts
+++ b/tests/runtime/navigation.test.ts
@@ -468,6 +468,30 @@ describe('subscribeNavigation — clause 2: parse at startup and on popstate', (
     expect(fake.removeEventListener).toHaveBeenCalledTimes(1);
     expect(fake.removeEventListener).toHaveBeenCalledWith('popstate', handler);
   });
+
+  it('removes the popstate listener if the startup user-callback throws', () => {
+    // Without cleanup-on-startup-throw, the disposer never returns and
+    // the popstate listener leaks for the entire window lifetime.
+    // Codex review (cycle 2) caught this; this test pins the contract.
+    const fake = buildFakeWindow('?scene=intro');
+    const onNavigateThatThrows = vi.fn(() => {
+      throw new Error('user callback bug');
+    });
+    expect(() =>
+      subscribeNavigation({
+        window: fake,
+        onNavigate: onNavigateThatThrows,
+        onError,
+      }),
+    ).toThrow('user callback bug');
+    expect(onNavigateThatThrows).toHaveBeenCalledTimes(1);
+    expect(fake.addEventListener).toHaveBeenCalledTimes(1);
+    expect(fake.removeEventListener).toHaveBeenCalledTimes(1);
+    const addArgs = fake.addEventListener.mock.calls[0];
+    const removeArgs = fake.removeEventListener.mock.calls[0];
+    expect(removeArgs?.[0]).toBe('popstate');
+    expect(removeArgs?.[1]).toBe(addArgs?.[1]);
+  });
 });
 
 describe('bootstrapNavigation — runtime entry wiring', () => {

--- a/tests/runtime/navigation.test.ts
+++ b/tests/runtime/navigation.test.ts
@@ -42,12 +42,22 @@ const ALL_MODES: readonly NavigationMode[] = [
 
 describe('parseNavigationSearch — clause 1: accepts the five grammar keys', () => {
   describe('input shape', () => {
-    it('accepts a leading-? string', () => {
-      expect(() => parseNavigationSearch('?scene=intro')).not.toThrow();
+    it('accepts a leading-? string and parses identically to no-? form', () => {
+      // The parser must strip the leading `?` rather than treating it as
+      // part of a key. Without an assertion on the parsed locator a
+      // mis-handled `?` (e.g. URLSearchParams kept `?scene` as a
+      // distinct key) would still satisfy a `.not.toThrow()` check.
+      expect(parseNavigationSearch('?scene=intro').locator).toEqual({
+        kind: 'scene',
+        scene: 'intro',
+      });
     });
 
     it('accepts a no-? string', () => {
-      expect(() => parseNavigationSearch('scene=intro')).not.toThrow();
+      expect(parseNavigationSearch('scene=intro').locator).toEqual({
+        kind: 'scene',
+        scene: 'intro',
+      });
     });
 
     it('accepts a URLSearchParams instance', () => {
@@ -88,8 +98,11 @@ describe('parseNavigationSearch — clause 1: accepts the five grammar keys', ()
       ['internal whitespace (encoded)', 'scene%20a'],
       ['unicode', 'sc%C3%A9ne'],
     ])('rejects malformed scene id (%s)', (_label, encoded) => {
+      // Pin the field name in the error so a regression that fires a
+      // different field's error (e.g. the index validator triggering
+      // first) does not pass.
       expect(() => parseNavigationSearch(`scene=${encoded}`)).toThrow(
-        /^navigation grammar is invalid:/,
+        /^navigation grammar is invalid: "scene"/,
       );
     });
   });

--- a/tests/runtime/navigation.test.ts
+++ b/tests/runtime/navigation.test.ts
@@ -5,8 +5,8 @@ import {
   type NavigationMode,
   type NavigationSubscriptionOptions,
   type NavigationTarget,
-  PulsarNavigationErrorEvent,
-  PulsarNavigationEvent,
+  PULSAR_NAVIGATE_ERROR_EVENT_TYPE,
+  PULSAR_NAVIGATE_EVENT_TYPE,
   bootstrapNavigation,
   parseNavigationSearch,
   subscribeNavigation,
@@ -144,6 +144,11 @@ describe('parseNavigationSearch — clause 1: accepts the five grammar keys', ()
       ['1', 1],
       ['12', 12],
       ['123', 123],
+      // ADR-013 defines `index` as base-10 / non-negative / safe
+      // integer — it does not forbid leading zeros, so `01` parses
+      // as 1 and `0007` parses as 7.
+      ['01', 1],
+      ['0007', 7],
     ])('accepts non-negative base-10 index %s', (encoded, expected) => {
       expect(parseNavigationSearch(`composition=t&index=${encoded}`).locator).toEqual({
         kind: 'composition-index',
@@ -154,7 +159,6 @@ describe('parseNavigationSearch — clause 1: accepts the five grammar keys', ()
 
     it.each([
       ['negative', '-1'],
-      ['leading zero', '01'],
       ['decimal', '1.5'],
       ['hex', '0x1'],
       ['plus sign', '+1'],
@@ -469,6 +473,29 @@ describe('subscribeNavigation — clause 2: parse at startup and on popstate', (
     expect(fake.removeEventListener).toHaveBeenCalledWith('popstate', handler);
   });
 
+  it('deferStartup: defers the startup parse to a microtask but registers popstate immediately', async () => {
+    // Subscribers registered AFTER subscribeNavigation returns can
+    // still observe the initial event when deferStartup is true. The
+    // popstate listener is still added synchronously so an event that
+    // fires between subscribe and the microtask flush is not missed.
+    const fake = buildFakeWindow('?scene=intro');
+    subscribeNavigation({
+      window: fake,
+      onNavigate,
+      onError,
+      deferStartup: true,
+    });
+
+    expect(fake.addEventListener).toHaveBeenCalledTimes(1);
+    expect(onNavigate).not.toHaveBeenCalled();
+
+    await Promise.resolve();
+    expect(onNavigate).toHaveBeenCalledTimes(1);
+    expect(onNavigate).toHaveBeenCalledWith({
+      locator: { kind: 'scene', scene: 'intro' },
+    } satisfies NavigationTarget);
+  });
+
   it('removes the popstate listener if the startup user-callback throws', () => {
     // Without cleanup-on-startup-throw, the disposer never returns and
     // the popstate listener leaks for the entire window lifetime.
@@ -536,41 +563,54 @@ describe('bootstrapNavigation — runtime entry wiring', () => {
     };
   };
 
-  const collectNavigateEvents = (browser: FakeBrowser): PulsarNavigationEvent[] => {
-    const out: PulsarNavigationEvent[] = [];
-    browser.events.addEventListener(PulsarNavigationEvent.TYPE, (evt) => {
-      out.push(evt as PulsarNavigationEvent);
+  const collectNavigateEvents = (browser: FakeBrowser): CustomEvent<NavigationTarget>[] => {
+    const out: CustomEvent<NavigationTarget>[] = [];
+    browser.events.addEventListener(PULSAR_NAVIGATE_EVENT_TYPE, (evt) => {
+      out.push(evt as CustomEvent<NavigationTarget>);
     });
     return out;
   };
 
-  const collectErrorEvents = (browser: FakeBrowser): PulsarNavigationErrorEvent[] => {
-    const out: PulsarNavigationErrorEvent[] = [];
-    browser.events.addEventListener(PulsarNavigationErrorEvent.TYPE, (evt) => {
-      out.push(evt as PulsarNavigationErrorEvent);
+  const collectErrorEvents = (browser: FakeBrowser): CustomEvent<Error>[] => {
+    const out: CustomEvent<Error>[] = [];
+    browser.events.addEventListener(PULSAR_NAVIGATE_ERROR_EVENT_TYPE, (evt) => {
+      out.push(evt as CustomEvent<Error>);
     });
     return out;
   };
 
-  it('dispatches PulsarNavigationEvent on startup with the parsed target', () => {
+  // bootstrapNavigation defers the startup parse to a microtask; flush
+  // it before asserting on the first event. Microtasks run before any
+  // awaited promise resolves, so a single `await Promise.resolve()` is
+  // enough.
+  const flushMicrotasks = async (): Promise<void> => {
+    await Promise.resolve();
+  };
+
+  it('defers the startup parse so subscribers can register before the first event', async () => {
+    // The subscriber registered AFTER bootstrapNavigation returns must
+    // still observe the initial event. Without microtask deferral this
+    // would miss the startup dispatch.
     const browser = buildFakeBrowser('?scene=intro');
+    bootstrapNavigation(browser.target);
     const navigate = collectNavigateEvents(browser);
 
-    bootstrapNavigation(browser.target);
-
+    expect(navigate).toHaveLength(0); // not fired yet
+    await flushMicrotasks();
     expect(navigate).toHaveLength(1);
     const evt = navigate[0];
     if (!evt) throw new Error('expected at least one navigate event');
     expect(evt.type).toBe('pulsar:navigate');
-    expect(evt.navigationTarget).toEqual({
+    expect(evt.detail).toEqual({
       locator: { kind: 'scene', scene: 'intro' },
     } satisfies NavigationTarget);
   });
 
-  it('dispatches PulsarNavigationEvent on each popstate using the current search', () => {
+  it('dispatches CustomEvent<NavigationTarget> on each popstate using the current search', async () => {
     const browser = buildFakeBrowser('?scene=intro');
     const navigate = collectNavigateEvents(browser);
     bootstrapNavigation(browser.target);
+    await flushMicrotasks();
     navigate.length = 0; // discard startup event
 
     browser.setSearch('?scene=outro');
@@ -578,23 +618,24 @@ describe('bootstrapNavigation — runtime entry wiring', () => {
     browser.setSearch('?composition=full-talk&index=2');
     browser.firePopstate();
 
-    expect(navigate.map((evt) => evt.navigationTarget)).toEqual([
+    expect(navigate.map((evt) => evt.detail)).toEqual([
       { locator: { kind: 'scene', scene: 'outro' } },
       { locator: { kind: 'composition-index', composition: 'full-talk', index: 2 } },
     ]);
   });
 
-  it('dispatches PulsarNavigationErrorEvent on parse failure (startup or popstate)', () => {
+  it('dispatches CustomEvent<Error> on parse failure (startup or popstate)', async () => {
     const browser = buildFakeBrowser('?scene=Bad');
     const errors = collectErrorEvents(browser);
     bootstrapNavigation(browser.target);
+    await flushMicrotasks();
 
     expect(errors).toHaveLength(1);
     const startup = errors[0];
     if (!startup) throw new Error('expected at least one error event');
     expect(startup.type).toBe('pulsar:navigate-error');
-    expect(startup.navigationError).toBeInstanceOf(Error);
-    expect(startup.navigationError.message).toMatch(/^navigation grammar is invalid:/);
+    expect(startup.detail).toBeInstanceOf(Error);
+    expect(startup.detail.message).toMatch(/^navigation grammar is invalid:/);
 
     errors.length = 0;
     browser.setSearch('?index=1');
@@ -602,13 +643,14 @@ describe('bootstrapNavigation — runtime entry wiring', () => {
     expect(errors).toHaveLength(1);
     const popstateErr = errors[0];
     if (!popstateErr) throw new Error('expected popstate error event');
-    expect(popstateErr.navigationError.message).toMatch(/^navigation grammar is invalid:/);
+    expect(popstateErr.detail.message).toMatch(/^navigation grammar is invalid:/);
   });
 
-  it('disposer stops further popstate dispatch', () => {
+  it('disposer stops further popstate dispatch', async () => {
     const browser = buildFakeBrowser('');
     const navigate = collectNavigateEvents(browser);
     const dispose = bootstrapNavigation(browser.target);
+    await flushMicrotasks();
     navigate.length = 0;
 
     dispose();
@@ -618,8 +660,8 @@ describe('bootstrapNavigation — runtime entry wiring', () => {
     expect(navigate).toHaveLength(0);
   });
 
-  it('static TYPE constants match the event type strings', () => {
-    expect(PulsarNavigationEvent.TYPE).toBe('pulsar:navigate');
-    expect(PulsarNavigationErrorEvent.TYPE).toBe('pulsar:navigate-error');
+  it('event-type constants match the dispatched event types', () => {
+    expect(PULSAR_NAVIGATE_EVENT_TYPE).toBe('pulsar:navigate');
+    expect(PULSAR_NAVIGATE_ERROR_EVENT_TYPE).toBe('pulsar:navigate-error');
   });
 });

--- a/tests/runtime/navigation.test.ts
+++ b/tests/runtime/navigation.test.ts
@@ -1,9 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   NAVIGATION_MODES,
+  type NavigationEventTarget,
   type NavigationMode,
   type NavigationSubscriptionOptions,
   type NavigationTarget,
+  PulsarNavigationErrorEvent,
+  PulsarNavigationEvent,
+  bootstrapNavigation,
   parseNavigationSearch,
   subscribeNavigation,
 } from '../../src/runtime/navigation';
@@ -463,5 +467,135 @@ describe('subscribeNavigation — clause 2: parse at startup and on popstate', (
 
     expect(fake.removeEventListener).toHaveBeenCalledTimes(1);
     expect(fake.removeEventListener).toHaveBeenCalledWith('popstate', handler);
+  });
+});
+
+describe('bootstrapNavigation — runtime entry wiring', () => {
+  // Browser-shaped fake: a real `EventTarget` wrapped with the
+  // `location.search` property the parser needs. Using a real
+  // EventTarget (rather than vi.fn stubs) proves the popstate dispatch
+  // flows through the helper end-to-end. The fake exposes its
+  // underlying EventTarget so tests can register listeners for
+  // 'pulsar:navigate' / 'pulsar:navigate-error' without fighting the
+  // narrow popstate-only listener typing on NavigationEventTarget.
+  interface FakeBrowser {
+    readonly target: NavigationEventTarget;
+    readonly events: EventTarget;
+    setSearch(value: string): void;
+    firePopstate(): void;
+  }
+
+  const buildFakeBrowser = (initial: string): FakeBrowser => {
+    const events = new EventTarget();
+    let search = initial;
+    const target: NavigationEventTarget = {
+      addEventListener: (event, listener) => {
+        events.addEventListener(event, listener as EventListener);
+      },
+      removeEventListener: (event, listener) => {
+        events.removeEventListener(event, listener as EventListener);
+      },
+      dispatchEvent: (event) => events.dispatchEvent(event),
+      get location() {
+        return { search };
+      },
+    };
+    return {
+      target,
+      events,
+      setSearch(value) {
+        search = value;
+      },
+      firePopstate() {
+        events.dispatchEvent(new Event('popstate'));
+      },
+    };
+  };
+
+  const collectNavigateEvents = (browser: FakeBrowser): PulsarNavigationEvent[] => {
+    const out: PulsarNavigationEvent[] = [];
+    browser.events.addEventListener(PulsarNavigationEvent.TYPE, (evt) => {
+      out.push(evt as PulsarNavigationEvent);
+    });
+    return out;
+  };
+
+  const collectErrorEvents = (browser: FakeBrowser): PulsarNavigationErrorEvent[] => {
+    const out: PulsarNavigationErrorEvent[] = [];
+    browser.events.addEventListener(PulsarNavigationErrorEvent.TYPE, (evt) => {
+      out.push(evt as PulsarNavigationErrorEvent);
+    });
+    return out;
+  };
+
+  it('dispatches PulsarNavigationEvent on startup with the parsed target', () => {
+    const browser = buildFakeBrowser('?scene=intro');
+    const navigate = collectNavigateEvents(browser);
+
+    bootstrapNavigation(browser.target);
+
+    expect(navigate).toHaveLength(1);
+    const evt = navigate[0];
+    if (!evt) throw new Error('expected at least one navigate event');
+    expect(evt.type).toBe('pulsar:navigate');
+    expect(evt.navigationTarget).toEqual({
+      locator: { kind: 'scene', scene: 'intro' },
+    } satisfies NavigationTarget);
+  });
+
+  it('dispatches PulsarNavigationEvent on each popstate using the current search', () => {
+    const browser = buildFakeBrowser('?scene=intro');
+    const navigate = collectNavigateEvents(browser);
+    bootstrapNavigation(browser.target);
+    navigate.length = 0; // discard startup event
+
+    browser.setSearch('?scene=outro');
+    browser.firePopstate();
+    browser.setSearch('?composition=full-talk&index=2');
+    browser.firePopstate();
+
+    expect(navigate.map((evt) => evt.navigationTarget)).toEqual([
+      { locator: { kind: 'scene', scene: 'outro' } },
+      { locator: { kind: 'composition-index', composition: 'full-talk', index: 2 } },
+    ]);
+  });
+
+  it('dispatches PulsarNavigationErrorEvent on parse failure (startup or popstate)', () => {
+    const browser = buildFakeBrowser('?scene=Bad');
+    const errors = collectErrorEvents(browser);
+    bootstrapNavigation(browser.target);
+
+    expect(errors).toHaveLength(1);
+    const startup = errors[0];
+    if (!startup) throw new Error('expected at least one error event');
+    expect(startup.type).toBe('pulsar:navigate-error');
+    expect(startup.navigationError).toBeInstanceOf(Error);
+    expect(startup.navigationError.message).toMatch(/^navigation grammar is invalid:/);
+
+    errors.length = 0;
+    browser.setSearch('?index=1');
+    browser.firePopstate();
+    expect(errors).toHaveLength(1);
+    const popstateErr = errors[0];
+    if (!popstateErr) throw new Error('expected popstate error event');
+    expect(popstateErr.navigationError.message).toMatch(/^navigation grammar is invalid:/);
+  });
+
+  it('disposer stops further popstate dispatch', () => {
+    const browser = buildFakeBrowser('');
+    const navigate = collectNavigateEvents(browser);
+    const dispose = bootstrapNavigation(browser.target);
+    navigate.length = 0;
+
+    dispose();
+    browser.setSearch('?scene=outro');
+    browser.firePopstate();
+
+    expect(navigate).toHaveLength(0);
+  });
+
+  it('static TYPE constants match the event type strings', () => {
+    expect(PulsarNavigationEvent.TYPE).toBe('pulsar:navigate');
+    expect(PulsarNavigationErrorEvent.TYPE).toBe('pulsar:navigate-error');
   });
 });

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,23 @@
+// Vitest global setup.
+//
+// `CustomEvent` became a Node global without a flag in Node 19. The
+// repo's declared engine is Node 22, but contributors running tests on
+// older Node versions (e.g. 18.x with the `--experimental-global-...`
+// flag absent) would otherwise hit a ReferenceError. This polyfill is
+// a one-liner aligned with the WHATWG / DOM spec for `CustomEvent` and
+// is a no-op when the global is already defined.
+
+if (typeof globalThis.CustomEvent === 'undefined') {
+  class CustomEventPolyfill<T> extends Event {
+    readonly detail: T;
+    constructor(type: string, init?: { detail?: T }) {
+      super(type);
+      this.detail = init?.detail as T;
+    }
+  }
+  Object.defineProperty(globalThis, 'CustomEvent', {
+    configurable: true,
+    writable: true,
+    value: CustomEventPolyfill,
+  });
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default mergeConfig(
     test: {
       include: ['tests/**/*.test.ts'],
       environment: 'node',
+      setupFiles: ['./tests/setup.ts'],
       coverage: {
         provider: 'v8',
         reporter: ['text', 'lcov'],


### PR DESCRIPTION
## Summary

Implements PUL-F007 — URL navigation grammar.

- New `src/runtime/navigation.ts` exposing `parseNavigationSearch` (boundary parser) and `subscribeNavigation` (startup + `popstate` wiring), plus the `NAVIGATION_MODES` tuple and the `NavigationTarget` / `NavigationLocator` / `NavigationMode` types.
- New `tests/runtime/navigation.test.ts` (80 tests) covering each of the five grammar keys, the five valid + four invalid combination shapes, repeated-key rejection, unknown-key tolerance, frozen output, boundary discipline, and identical error semantics across startup and `popstate`.
- New ADR-013 `docs/adrs/013-url-navigation-grammar-boundary.md` (created in the codex architecture preflight) recording the boundary rules: parser does not resolve scenes, inspect manifests, mutate history, or load assets; URL search string is the source of truth on `popstate`; identifier validation reuses `isKebabIdentifier` per ADR-008 #1.
- CHANGELOG entry.

Plan comment: https://github.com/KeplerOps/pulsar/issues/16#issuecomment-4366616766

Closes #16