### PR TITLE
PUL-F009: pin composition URL parameter as navigation context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `tests/runtime/scene-loader.test.ts` — two PUL-F009 regression
+  anchors in the "happy path" describe block: the canonical
+  `?composition=full-talk` case (`kind: 'composition'` — head scene
+  is `manifest[0]`, `data-pulsar-composition-target` records the
+  composition id, lifecycle runs through the existing dispatch
+  chain) and the `?composition=full-talk&index=1` case
+  (`kind: 'composition-index'` — head scene is the addressed entry).
+  PUL-F009's parser, dispatcher, and loader chain shipped as part of
+  PUL-F008 (PR #70); these tests pin PUL-F009's canonical statement —
+  "the composition URL parameter resolves the addressed manifest and
+  uses it as the navigation context" — at the loader boundary so a
+  future refactor cannot silently break the composition-only or
+  composition-index path while keeping the composition+scene path
+  green.
+
 - `src/runtime/scene-navigation.ts` — `SceneNavigationTarget` /
   `SceneNavigationCompositionContext` interfaces,
   `resolveSceneNavigation` dispatcher, and

--- a/docs/adrs/014-url-scene-target-selection.md
+++ b/docs/adrs/014-url-scene-target-selection.md
@@ -28,6 +28,10 @@ URL grammar and the boundary parser (`parseNavigationSearch` in
 ADR-013 deliberately stops at the grammar boundary. PUL-F008 picks up
 where the parser leaves off: turn each scene-targeting locator into a
 running scene by way of the existing composition-resolver lifecycle.
+PUL-F009 uses the same dispatch boundary for the `composition`
+parameter: when present, `composition` selects a registered
+composition manifest by id and makes that manifest the navigation
+context for the addressed target.
 
 The locator value is still external input. It is well-formed (the
 grammar parser already rejected malformed identifiers, repeated
@@ -64,6 +68,23 @@ dispatch layer:
 - Keeps URL state authoritative. The dispatch layer never reads
   localStorage, cookies, or any cached runtime state — the
   `NavigationTarget` it consumes is the only source.
+
+For PUL-F009, `composition` is always a catalog lookup key, never an
+inline manifest, file path, module specifier, network URL, or dynamic
+import target. The selected manifest supplies navigation context:
+
+- `composition` alone starts at entry 0 of that manifest.
+- `composition` + `scene` selects the unique matching entry and uses
+  the manifest slice from that entry onward as context.
+- `composition` + `index` selects the entry at that zero-based
+  composition index and uses the manifest slice from that entry onward
+  as context.
+
+The dispatch layer must keep this context as a manifest slice, not as a
+second schema or a new "active deck" concept. Object-form composition
+entries retain their `range` and `behavior` overrides unchanged so the
+existing resolver and timeline runner contract remain the only place
+that can interpret them.
 
 Locator handling:
 
@@ -132,6 +153,8 @@ always runs before the next preload begins.
 | Composition + scene re-resolves modules and substitutes scenes mid-flight | Snapshot the manifest slice and the matching scene modules at resolve time; the bridge plays the snapshot, never re-resolving by id against an outside registry. |
 | Composition + scene plays a scene that was never in the composition | Verify membership at dispatch time; non-member combinations are navigation errors before any lifecycle hook runs. |
 | Composition + index points outside the manifest | Range-check before snapshotting; out-of-bounds is a navigation error. |
+| `composition` handling becomes a parallel manifest loader | Treat the parameter as an id into `CompositionRegistry`; no URL-derived manifests, dynamic imports, filesystem paths, or fetches. |
+| Composition context is flattened into scene-only state | Preserve the manifest slice and composition id on the navigation target so downstream lifecycle, diagnostics, and workbench state can distinguish "standalone scene" from "scene inside composition". |
 | Invalid URLs silently fall back to a default scene | Dispatch layer surfaces an explicit navigation error to the workbench (stage attribute + `onError` hook) per ADR-013's "no silent fallback". |
 
 ## Related ADRs

--- a/tests/runtime/scene-loader.test.ts
+++ b/tests/runtime/scene-loader.test.ts
@@ -59,8 +59,14 @@ const buildStage = (): FakeStage => {
 const sceneTarget = (id: string): NavigationTarget => ({
   locator: { kind: 'scene', scene: id },
 });
+const compositionTarget = (composition: string): NavigationTarget => ({
+  locator: { kind: 'composition', composition },
+});
 const compositionSceneTarget = (composition: string, scene: string): NavigationTarget => ({
   locator: { kind: 'composition-scene', composition, scene },
+});
+const compositionIndexTarget = (composition: string, index: number): NavigationTarget => ({
+  locator: { kind: 'composition-index', composition, index },
 });
 const noneTarget: NavigationTarget = { locator: { kind: 'none' } };
 
@@ -115,6 +121,99 @@ describe('createSceneLoader (PUL-F008)', () => {
 
       expect(stage.attrs.get('data-pulsar-scene-target')).toBe('middle');
       expect(stage.attrs.get('data-pulsar-composition-target')).toBe('full-talk');
+    });
+
+    it('loads the composition manifest from index 0 when the locator is `kind: "composition"` (PUL-F009)', async () => {
+      // Canonical PUL-F009 case: `?composition=full-talk` (no scene,
+      // no index). The runtime resolves the addressed composition
+      // manifest and uses it as the navigation context — every entry
+      // in the slice runs through the existing PUL-F004 lifecycle in
+      // manifest order, the head scene is recorded on the stage
+      // (`manifest[0]`), and the composition stage attribute records
+      // the composition id. Each scene's create/cleanup is observed so
+      // the test would catch a regression that collapsed the locator
+      // into a single-scene load and dropped the manifest slice.
+      const log: string[] = [];
+      const trace = (id: string): SceneModule =>
+        buildScene({
+          id,
+          create: () => {
+            log.push(`create:${id}`);
+          },
+          cleanup: () => {
+            log.push(`cleanup:${id}`);
+          },
+        });
+      const intro = trace('intro');
+      const middle = trace('middle');
+      const outro = trace('outro');
+      const stage = buildStage();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([intro, middle, outro]),
+        compositions: createCompositionRegistry([
+          { id: 'full-talk', manifest: ['intro', 'middle', 'outro'] },
+        ]),
+        stage: stage.element,
+        ctx: {},
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+      });
+
+      await loader.handle(compositionTarget('full-talk'));
+
+      expect(stage.attrs.get('data-pulsar-scene-target')).toBe('intro');
+      expect(stage.attrs.get('data-pulsar-composition-target')).toBe('full-talk');
+      expect(stage.attrs.has('data-pulsar-navigation-error')).toBe(false);
+      expect(log).toEqual([
+        'create:intro',
+        'cleanup:intro',
+        'create:middle',
+        'cleanup:middle',
+        'create:outro',
+        'cleanup:outro',
+      ]);
+    });
+
+    it('loads the composition slice from the addressed index when the locator is `kind: "composition-index"` (PUL-F009)', async () => {
+      // PUL-F009 with `?composition=full-talk&index=1`: the manifest
+      // slice starts at the addressed entry and continues to the end,
+      // so head scene is `manifest[1]` and every entry from there
+      // forward runs in order. The 3-entry manifest with `index=1`
+      // distinguishes "slice from addressed index onward" from a
+      // single-scene load of `manifest[1]`: the latter would skip
+      // `outro`.
+      const log: string[] = [];
+      const trace = (id: string): SceneModule =>
+        buildScene({
+          id,
+          create: () => {
+            log.push(`create:${id}`);
+          },
+          cleanup: () => {
+            log.push(`cleanup:${id}`);
+          },
+        });
+      const intro = trace('intro');
+      const middle = trace('middle');
+      const outro = trace('outro');
+      const stage = buildStage();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([intro, middle, outro]),
+        compositions: createCompositionRegistry([
+          { id: 'full-talk', manifest: ['intro', 'middle', 'outro'] },
+        ]),
+        stage: stage.element,
+        ctx: {},
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+      });
+
+      await loader.handle(compositionIndexTarget('full-talk', 1));
+
+      expect(stage.attrs.get('data-pulsar-scene-target')).toBe('middle');
+      expect(stage.attrs.get('data-pulsar-composition-target')).toBe('full-talk');
+      expect(stage.attrs.has('data-pulsar-navigation-error')).toBe(false);
+      expect(log).toEqual(['create:middle', 'cleanup:middle', 'create:outro', 'cleanup:outro']);
     });
 
     it('is a no-op for `kind: "none"` (no scene to load)', async () => {


### PR DESCRIPTION
## Summary

Anchors PUL-F009 — *"When the `composition` URL parameter is present, the runtime SHALL resolve the addressed composition manifest and use it as the navigation context"* — at the loader boundary.

The parser, dispatcher, loader, and bootstrap chain that satisfies PUL-F009 shipped end-to-end with PUL-F008 (PR #70). This PR adds the requirement-anchored regression tests that pin PUL-F009's canonical cases — `?composition=foo` (head from manifest[0]) and `?composition=foo&index=N` (head from addressed slice index) — so a future refactor cannot silently break the composition-only or composition-index paths while keeping the composition+scene path green.

Each new test uses a 3-entry manifest and asserts every entry's `create`/`cleanup` runs in manifest order, distinguishing a true manifest-slice play from a single-scene load.

## Changes

- `tests/runtime/scene-loader.test.ts` — two PUL-F009-anchored tests in the existing happy-path describe block.
- `CHANGELOG.md` — entry under [Unreleased]/Added recording the new anchors and PUL-F009 coverage.
- `docs/adrs/014-url-scene-target-selection.md` — preflight extended ADR-014 to record explicitly that PUL-F009 reuses the PUL-F008 dispatch boundary.

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 508 / 508 passing (was 506; +2 PUL-F009 anchors)
- [x] Pre-push codex review (cycles 1–2) — cycle 1 surfaced two assertion-strength findings (single-scene-collapse blind spots), both fixed; cycle 2 returned 0 findings
- [ ] CI green
- [ ] SonarCloud quality gate `OK` with 0 open issues for this PR
- [ ] Post-push codex review — 0 findings
- [ ] `review-tests` skill — 0 findings

Closes #18