### PR TITLE
Add PUL-F010 regression anchors for composition+index URL parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `tests/runtime/scene-loader.test.ts` — two PUL-F010 regression
+  anchors under a new `'composition + index positions playback
+  (PUL-F010)'` describe block: `?composition=trailer&index=2` against
+  a 4-entry manifest records `data-pulsar-scene-target='scene-c'` and
+  plays only `scene-c → scene-d` (proves zero-based positional
+  semantics for N > 1 and that the slice continues from the index to
+  the end), and two sequential navigations on the same loader instance
+  with `index=0` then `index=2` against the same composition resolve
+  to different head scenes (proves the `index` parameter — not the
+  composition id — decides where in the composition playback starts).
+  PUL-F010's parser, dispatcher, and loader chain shipped as part of
+  PUL-F008 (PR #70) and PUL-F009 (PR #72); these tests pin PUL-F010's
+  canonical statement — "when `index` is present alongside
+  `composition`, the runtime positions playback at the given
+  zero-based index" — at the loader boundary so a future refactor
+  cannot silently collapse `composition-index` to a head-of-manifest
+  load, off-by-one the index, or single-load `manifest[index]` and
+  drop trailing entries.
+- `docs/adrs/013-url-navigation-grammar-boundary.md` /
+  `docs/adrs/014-url-scene-target-selection.md` — extend the existing
+  ADRs to name PUL-F010 explicitly: ADR-013 records that `index` is
+  not scene identity, an id alias, or a persistent bookmark
+  independent of composition order, and adds a "PUL-F010 forks from
+  composition path" risk + mitigation to keep positional dispatch in
+  the existing `composition-index` locator; ADR-014 records that
+  `composition` + `index` is PUL-F010's positional navigation
+  behavior, that the head scene is `manifest[index]` with the slice
+  continuing in manifest order, and adds an "index handling creates
+  a second playback state machine" risk + mitigation.
 - `tests/runtime/scene-loader.test.ts` — two PUL-F009 regression
   anchors in the "happy path" describe block: the canonical
   `?composition=full-talk` case (`kind: 'composition'` — head scene

--- a/docs/adrs/013-url-navigation-grammar-boundary.md
+++ b/docs/adrs/013-url-navigation-grammar-boundary.md
@@ -12,7 +12,9 @@ Accepted
 
 PUL-F007 requires the runtime to accept `scene`, `composition`,
 `index`, `beat`, and `mode` URL parameters, and to parse parameter
-combinations at startup and on `popstate`.
+combinations at startup and on `popstate`. PUL-F010 gives the
+`composition` + `index` combination runtime meaning: `index` is a
+zero-based positional locator inside the selected composition.
 
 [ADR-002](002-scene-registry-and-compositions.md) and
 [ADR-007](007-browser-workbench.md) define the public grammar, but the
@@ -37,7 +39,9 @@ String identifiers reuse the shared kebab-case predicate in
 `src/runtime/identifier.ts`. Do not add URL-specific regexes for
 `scene`, `composition`, or `beat`. `mode` is validated against the
 ADR-007 workbench mode set. `index` is a base-10, zero-based,
-non-negative safe integer scoped to a composition.
+non-negative safe integer scoped to a composition. It is not scene
+identity, a scene id alias, or a persistent bookmark independent of
+the composition's current order.
 
 `composition` is a composition identifier, not an inline manifest and
 not the manifest array itself. Looking up that identifier belongs to
@@ -103,6 +107,7 @@ composition-level cancellation semantics remain centralized.
 | URL mode handling leaks into individual scenes | Dispatch modes in the runtime core per ADR-007; expose only mode hints through context where needed. |
 | Positional navigation becomes identity | Treat `index` as a composition-scoped compatibility locator; scene id remains content identity. |
 | Query values become resource paths or dynamic imports | Query values are identifiers only. Do not load modules, files, or network resources directly from URL parameter values. |
+| PUL-F010 handling forks from the existing composition path | Reuse the `composition-index` locator and dispatch through the same composition registry, scene registry, resolver, preloader, cleanup, and error-surfacing layers. |
 
 ## Related ADRs
 

--- a/docs/adrs/014-url-scene-target-selection.md
+++ b/docs/adrs/014-url-scene-target-selection.md
@@ -31,7 +31,10 @@ running scene by way of the existing composition-resolver lifecycle.
 PUL-F009 uses the same dispatch boundary for the `composition`
 parameter: when present, `composition` selects a registered
 composition manifest by id and makes that manifest the navigation
-context for the addressed target.
+context for the addressed target. PUL-F010 uses that context for the
+`composition` + `index` compatibility shim: the index selects the
+zero-based entry to start playback from, but the scene id at that
+entry remains the content identity.
 
 The locator value is still external input. It is well-formed (the
 grammar parser already rejected malformed identifiers, repeated
@@ -69,16 +72,17 @@ dispatch layer:
   localStorage, cookies, or any cached runtime state — the
   `NavigationTarget` it consumes is the only source.
 
-For PUL-F009, `composition` is always a catalog lookup key, never an
-inline manifest, file path, module specifier, network URL, or dynamic
-import target. The selected manifest supplies navigation context:
+For PUL-F009 / PUL-F010, `composition` is always a catalog lookup key,
+never an inline manifest, file path, module specifier, network URL, or
+dynamic import target. The selected manifest supplies navigation
+context:
 
 - `composition` alone starts at entry 0 of that manifest.
 - `composition` + `scene` selects the unique matching entry and uses
   the manifest slice from that entry onward as context.
 - `composition` + `index` selects the entry at that zero-based
   composition index and uses the manifest slice from that entry onward
-  as context.
+  as context. This is PUL-F010's positional navigation behavior.
 
 The dispatch layer must keep this context as a manifest slice, not as a
 second schema or a new "active deck" concept. Object-form composition
@@ -102,7 +106,8 @@ Locator handling:
   composition+index for ambiguous locators` rather than silently
   picking the first occurrence.
 - `kind: 'composition-index'` — index into the composition's
-  manifest, snapshot from that entry onwards.
+  manifest, snapshot from that entry onwards. The head scene is
+  `manifest[index]`; subsequent entries continue in manifest order.
 
 `beat` and `mode` (when present on the parsed target) are recorded
 on the navigation target but not consumed by the dispatch layer.
@@ -156,6 +161,7 @@ always runs before the next preload begins.
 | `composition` handling becomes a parallel manifest loader | Treat the parameter as an id into `CompositionRegistry`; no URL-derived manifests, dynamic imports, filesystem paths, or fetches. |
 | Composition context is flattened into scene-only state | Preserve the manifest slice and composition id on the navigation target so downstream lifecycle, diagnostics, and workbench state can distinguish "standalone scene" from "scene inside composition". |
 | Invalid URLs silently fall back to a default scene | Dispatch layer surfaces an explicit navigation error to the workbench (stage attribute + `onError` hook) per ADR-013's "no silent fallback". |
+| Index handling creates a second playback state machine | Keep `composition-index` as only a dispatch locator; after snapshotting the slice, playback still flows through `resolveComposition`. |
 
 ## Related ADRs
 

--- a/tests/runtime/scene-loader.test.ts
+++ b/tests/runtime/scene-loader.test.ts
@@ -216,6 +216,102 @@ describe('createSceneLoader (PUL-F008)', () => {
       expect(log).toEqual(['create:middle', 'cleanup:middle', 'create:outro', 'cleanup:outro']);
     });
 
+    describe('composition + index positions playback (PUL-F010)', () => {
+      // PUL-F010: when the `index` URL parameter is present alongside a
+      // `composition`, the runtime SHALL position playback at the given
+      // zero-based index within the composition. The dispatcher and
+      // parser already implement this end-to-end (PUL-F007 / F008);
+      // these anchors pin the requirement-specific contract — *the
+      // index parameter selects the head position, zero-based* — at
+      // the loader boundary so a future refactor cannot silently break
+      // it. They would catch a regression that collapses
+      // `composition-index` to `kind: 'composition'` (head always at
+      // index 0), an off-by-one on `manifest[index]`, or a single-load
+      // of `manifest[index]` that drops trailing entries.
+      it('selects manifest[index] as the head when index > 1', async () => {
+        // 4-entry manifest with `index=2` proves zero-based positional
+        // semantics for N > 1: PUL-F009's anchor uses `index=1`, which
+        // does not distinguish "selected entry 1" from "off-by-one
+        // landed on entry 1". Index 2 in a 4-entry composition lands
+        // on the third entry and must include the fourth on slice.
+        const log: string[] = [];
+        const trace = (id: string): SceneModule =>
+          buildScene({
+            id,
+            create: () => {
+              log.push(`create:${id}`);
+            },
+            cleanup: () => {
+              log.push(`cleanup:${id}`);
+            },
+          });
+        const a = trace('scene-a');
+        const b = trace('scene-b');
+        const c = trace('scene-c');
+        const d = trace('scene-d');
+        const stage = buildStage();
+        const loader = createSceneLoader({
+          scenes: createSceneRegistry([a, b, c, d]),
+          compositions: createCompositionRegistry([
+            { id: 'trailer', manifest: ['scene-a', 'scene-b', 'scene-c', 'scene-d'] },
+          ]),
+          stage: stage.element,
+          ctx: {},
+          createPreloader: () => () => undefined,
+          runTimeline: noopRunner,
+        });
+
+        await loader.handle(compositionIndexTarget('trailer', 2));
+
+        expect(stage.attrs.get('data-pulsar-scene-target')).toBe('scene-c');
+        expect(stage.attrs.get('data-pulsar-composition-target')).toBe('trailer');
+        expect(stage.attrs.has('data-pulsar-navigation-error')).toBe(false);
+        // No `scene-a` or `scene-b` in the log proves the slice did
+        // NOT start from the beginning; the trailing `scene-d` proves
+        // the slice continued from index 2 to the end (not a single-
+        // scene load of `manifest[2]`).
+        expect(log).toEqual([
+          'create:scene-c',
+          'cleanup:scene-c',
+          'create:scene-d',
+          'cleanup:scene-d',
+        ]);
+      });
+
+      it('different indices on the same composition select different heads', async () => {
+        // Two sequential navigations on the same loader instance
+        // against the same composition. The composition id is constant
+        // — the only thing that changes is the `index`. If the index
+        // were ignored (e.g. dispatcher collapsed `composition-index`
+        // to `kind: 'composition'`), both navigations would land at
+        // `manifest[0]` and this test would fail. This pins the
+        // positional contract: `index`, not `composition`, decides
+        // *where* in the composition playback starts.
+        const a = buildScene({ id: 'scene-a' });
+        const b = buildScene({ id: 'scene-b' });
+        const c = buildScene({ id: 'scene-c' });
+        const stage = buildStage();
+        const loader = createSceneLoader({
+          scenes: createSceneRegistry([a, b, c]),
+          compositions: createCompositionRegistry([
+            { id: 'full-talk', manifest: ['scene-a', 'scene-b', 'scene-c'] },
+          ]),
+          stage: stage.element,
+          ctx: {},
+          createPreloader: () => () => undefined,
+          runTimeline: noopRunner,
+        });
+
+        await loader.handle(compositionIndexTarget('full-talk', 0));
+        expect(stage.attrs.get('data-pulsar-scene-target')).toBe('scene-a');
+
+        await loader.handle(compositionIndexTarget('full-talk', 2));
+        expect(stage.attrs.get('data-pulsar-scene-target')).toBe('scene-c');
+        expect(stage.attrs.get('data-pulsar-composition-target')).toBe('full-talk');
+        expect(stage.attrs.has('data-pulsar-navigation-error')).toBe(false);
+      });
+    });
+
     it('is a no-op for `kind: "none"` (no scene to load)', async () => {
       const stage = buildStage();
       const loader = createSceneLoader({


### PR DESCRIPTION
## Summary

PUL-F010 — *when the `index` URL parameter is present alongside a
`composition`, the runtime SHALL position playback at the given
zero-based index within the composition.*

The runtime path that satisfies PUL-F010 already shipped end-to-end
with PUL-F008 (PR #70) and was reinforced for PUL-F009 by PR #72.
This PR pins PUL-F010's distinctive contract — *the `index` parameter
positions playback at the zero-based composition entry* — at the
loader boundary, following the regression-anchor precedent set by
the PUL-F009 PR (`tests/runtime/scene-loader.test.ts:177`).

### What changed

- `tests/runtime/scene-loader.test.ts` — new describe block
  `'composition + index positions playback (PUL-F010)'` with two
  regression anchors:
  - `?composition=trailer&index=2` against a 4-entry manifest selects
    `manifest[2]` as the head and slices forward (proves zero-based
    positional semantics for N > 1; distinguishes from PUL-F009's
    `index=1` anchor).
  - Two sequential `loader.handle()` calls against the same
    composition with `index=0` then `index=2` resolve to different
    head scenes (proves the `index` parameter — not the composition
    id — decides where in the composition playback starts).
- `docs/adrs/013-url-navigation-grammar-boundary.md` — extends ADR-013
  to name PUL-F010 explicitly: `index` is not scene identity, an id
  alias, or a persistent bookmark; adds the "PUL-F010 forks from the
  existing composition path" risk + mitigation.
- `docs/adrs/014-url-scene-target-selection.md` — records that
  `composition` + `index` is PUL-F010's positional navigation
  behavior, that the head scene is `manifest[index]`, and adds the
  "index handling creates a second playback state machine" risk +
  mitigation.
- `CHANGELOG.md` — entries for the new anchors and the ADR updates.

No production code changes. The runtime contract PUL-F010 names was
already satisfied by the dispatcher (`resolveSceneNavigation` →
`resolveCompositionAndIndex` in `src/runtime/scene-navigation.ts`)
and the loader (`createSceneLoader` in `src/runtime/scene-loader.ts`).

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 510 tests pass (12 files; scene-loader spec
      grew from 19 → 21 tests with the two new anchors)
- [x] `pre-commit run --all-files` — clean
- [x] `gc_codex_review` (uncommitted, cycle 1) — 0 findings (core
      reviewer + security reviewer)

Closes #19