### PR TITLE
Implement URL beat positioning runtime contract (PUL-F011)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `src/runtime/composition-resolver.ts` / `src/runtime/scene-navigation.ts`
+  — both now reject `headBeat` / `beat` supplied without a paired
+  `onBeatMissing` callback. PUL-F011 / ADR-015 makes the callback the
+  runner's only error channel for missing labels (the runner MUST NOT
+  throw — that triggers cleanup), so a beat without the diagnostic
+  surface would silently lose missing-label errors. The resolver and
+  bridge now fail fast at the boundary rather than running a doomed
+  lifecycle. The error message names which option is missing.
+- `src/runtime/scene-loader.ts` — `runTarget` refactored: the
+  beat-grammar defense-in-depth check, the missing-beat callback
+  builder, and the in-flight-load builder are now extracted helpers
+  (`validateBeatGrammar`, `buildOnBeatMissing`, `buildLoad`).
+  Behavior is unchanged; the function reads as a linear pipeline of
+  `validate → resolve → mark-stage → build-load → await`. Reduces
+  cognitive complexity below SonarCloud's 15-token cap.
+
 ### Added
 
 - `src/runtime/composition-resolver.ts` — `headBeat?: string` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,93 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `src/runtime/composition-resolver.ts` — `headBeat?: string` and
+  `onBeatMissing?: () => void` fields on `ResolveCompositionOptions`,
+  paired with `beat?: string` and `onBeatMissing?: () => void` on
+  `SceneTimelineRunInput`. Implements PUL-F011's URL-beat forwarding
+  in line with ADR-015: when the caller supplies `headBeat`, the
+  resolver attaches `beat` (and the paired `onBeatMissing`) to the
+  FIRST plan step's run input only — subsequent scenes never receive
+  them, because ADR-015 scopes URL beat to the active head scene
+  (no search through later composition entries). Both fields are
+  omitted from the run input object when absent (the same `range` /
+  `behavior` precedent — `'beat' in input === false`), so the
+  runner's branching can rely on key presence. The resolver itself
+  does not interpret labels — that responsibility belongs to the
+  timeline runner per ADR-015.
+- `src/runtime/scene-navigation.ts` — `beat?: string` and
+  `onBeatMissing?: () => void` on `LoadSceneNavigationTargetOptions`.
+  The bridge forwards both to `resolveComposition` as `headBeat` /
+  `onBeatMissing`, omitting whichever the caller did not supply so
+  the resolver does not see spurious `undefined` keys.
+- `src/runtime/scene-loader.ts` — when the parsed `NavigationTarget`
+  carries `target.beat`, the loader extracts it, builds an
+  `onBeatMissing` closure that calls the existing `surfaceError(...)`
+  with `Error('beat positioning failed: beat "<beat>" does not exist
+  in scene "<head-scene-id>"')`, and forwards both to the bridge.
+  The closure does NOT short-circuit the lifecycle: missing-label
+  diagnostics write `data-pulsar-navigation-error` and invoke the
+  configured `onError` sink while the active scene stays mounted at
+  its initial timeline position (PUL-F011 clause 2's "remain at the
+  scene's first beat", per ADR-015's "do not reject through
+  `resolveComposition` for missing labels — that triggers cleanup
+  and unmounts the scene"). The error grammar uses the stable prefix
+  `beat positioning failed:` so callers can pattern-match on origin.
+- `src/main.ts` — placeholder timeline runner invokes
+  `input.onBeatMissing?.()` once when `input.beat !== undefined`.
+  The placeholder timeline returns `null` (no labels), so any URL
+  beat is a missing-label diagnostic by definition. The runner does
+  not throw — it surfaces the diagnostic via the loader's callback
+  and continues normally so the scene stays mounted. ADR-003's GSAP
+  runner replaces this stand-in with `timeline.labels[input.beat]`-
+  style seeking when the engine lands.
+- `docs/adrs/015-url-beat-positioning.md` — records ADR-015's
+  decisions: `beat` is timeline-runner state (not parser, dispatcher,
+  registry, or manifest state); URL beat targets the active head
+  scene only; an unknown beat is a non-fatal navigation-positioning
+  diagnostic surfaced through the existing
+  `data-pulsar-navigation-error` + `onError` surface; missing-label
+  rejection through `resolveComposition` is forbidden because it
+  triggers PUL-F006 cleanup and would unmount the scene; valid beat
+  seeking uses the timeline engine's label API (no parallel beat
+  schema in scene metadata, manifests, URL parsing, or registries).
+  Indexed in `docs/adrs/README.md`.
+- `tests/runtime/composition-resolver.test.ts` — new
+  `'URL beat positioning forwarding (PUL-F011)'` describe block (5
+  tests): `headBeat` reaches plan[0]'s run input only and subsequent
+  scenes get no `beat` key; `onBeatMissing` follows the same head-
+  scope semantics; absence of either option leaves the run input
+  free of `beat` / `onBeatMissing` keys; an `onBeatMissing` supplied
+  without `headBeat` is dropped (paired contract); a runner that
+  silently consumes `headBeat` does not cause the resolver to throw
+  or skip cleanup (resolver delegates label-existence to the runner).
+- `tests/runtime/scene-navigation.test.ts` — new
+  `'URL beat forwarding (PUL-F011)'` describe block (5 tests):
+  `beat` reaches the runner for a single-scene target; in a
+  `composition-index` slice, `beat` reaches the head scene only;
+  `onBeatMissing` follows the same head-only forwarding;
+  `onBeatMissing` supplied without `beat` is dropped (paired
+  contract); omitted `beat` produces no `beat` key on the run input.
+- `tests/runtime/scene-loader.test.ts` — new
+  `'beat positioning (PUL-F011)'` describe block (8 tests):
+  the loader extracts `target.beat` and forwards it to the runner;
+  a runner that invokes `onBeatMissing` writes
+  `data-pulsar-navigation-error='beat positioning failed: beat
+  "<beat>" does not exist in scene "<head-scene-id>"'` AND calls
+  `onError` while the scene stays mounted (proven via a pending
+  runner that holds the gate open: cleanup has NOT fired during
+  the diagnostic — only after the runner naturally exits); a
+  diagnostic surfaced after the load was disposed/aborted is
+  suppressed (parallel to `isPureAbort`); the diagnostic is
+  fired only once per navigation even if the runner calls
+  `onBeatMissing` repeatedly; a hand-built target with a
+  non-kebab `beat` value is rejected with the parser's grammar
+  message; a successful beat (runner does not invoke
+  `onBeatMissing`) leaves the error attribute absent; a
+  hand-built `composition`-only target with `beat` is rejected
+  with the parser's "beat requires a scene-like target" message
+  (defense-in-depth for ADR-013); targets without `beat` carry
+  no `beat` / `onBeatMissing` keys on the run input.
 - `tests/runtime/scene-loader.test.ts` — two PUL-F009 regression
   anchors in the "happy path" describe block: the canonical
   `?composition=full-talk` case (`kind: 'composition'` — head scene

--- a/docs/adrs/015-url-beat-positioning.md
+++ b/docs/adrs/015-url-beat-positioning.md
@@ -102,6 +102,33 @@ composition code.
 | `beat` in a composition is interpreted as "find this label anywhere in the remaining composition" | Scope `beat` to the active head scene only. Later scenes run normally. |
 | Composition `range` and URL `beat` get validated by different layers | Keep both concerns in the timeline runner, where the concrete timeline and per-entry overrides are already present. |
 
+## Current state (2026-05-05)
+
+PR #74 lands the runtime contract this ADR mandates: the parser
+emits `NavigationTarget.beat`; the dispatcher and resolver forward
+it to the head scene's run input; the scene loader supplies a
+non-fatal `onBeatMissing` callback that surfaces
+`data-pulsar-navigation-error` and the configured `onError` sink
+without unmounting the scene. Defense-in-depth at the loader
+re-validates kebab-case shape and the "beat requires a scene-like
+target" combination rule before any side effect.
+
+The contract is delivered. **PUL-F011 remains DRAFT** because the
+end-to-end seek path requires a real timeline engine — ADR-003's
+GSAP runner. The placeholder runner in `src/main.ts` honestly
+reports "every beat missing" against its `null` timeline, so the
+diagnostic path (PUL-F011 clause 2) is exercisable today, but the
+positioning path (PUL-F011 clause 1) is not testable until labels
+exist in real timelines.
+
+PUL-F023 ("Named timeline beats") is the requirement that delivers
+labelled timelines through the GSAP runner; PUL-F022 ("Timeline
+orchestration") is the broader composition / play / pause / seek
+spine. When those land, the GSAP runner replaces the placeholder
+in `src/main.ts` and PUL-F011 transitions to ACTIVE without further
+contract changes — the seek path is `if (timeline.labels[input.beat]
+=== undefined) input.onBeatMissing?.(); else timeline.seek(input.beat)`.
+
 ## Related ADRs
 
 - [ADR-003](003-gsap-timeline-engine.md) — labels and seeking are part

--- a/docs/adrs/015-url-beat-positioning.md
+++ b/docs/adrs/015-url-beat-positioning.md
@@ -1,0 +1,118 @@
+# ADR-015: URL Beat Positioning as Timeline-Runner State
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-05
+
+## Context
+
+PUL-F011 requires `beat=<label>` to position the active scene's
+timeline at the named timeline label. If the label does not exist, the
+runtime must surface an error and remain at the scene's first beat.
+
+The URL parser already accepts and validates `beat` as a kebab-case
+identifier (`src/runtime/navigation.ts`, PUL-F007 / ADR-013). The scene
+navigation dispatcher records the parsed target but deliberately does
+not consume `beat` (`src/runtime/scene-navigation.ts`, ADR-014). The
+composition resolver delegates timeline execution to
+`SceneTimelineRunner` (`src/runtime/composition-resolver.ts`, ADR-011)
+and treats a runner rejection as a lifecycle failure: it wraps the
+error, calls `cleanup(ctx)`, and aborts the composition.
+
+That resolver failure path is correct for real timeline failures, but
+it is the wrong shape for an unknown URL beat. PUL-F011 says the scene
+remains at its first beat. Throwing the missing-label error through the
+resolver would unmount the scene and violate the requirement.
+
+## Decision
+
+`beat` is timeline-runner state, not URL-parser, scene-registry,
+composition-manifest, or scene-loader dispatch state.
+
+Implementation that satisfies PUL-F011 must reuse the existing URL
+grammar and navigation target shape. `parseNavigationSearch` continues
+to validate only identifier form and legal parameter combinations. It
+must not inspect scene modules or timelines. `resolveSceneNavigation`
+continues to resolve only the active scene/composition slice. It must
+not inspect labels, build timelines, or duplicate timeline-runner
+logic.
+
+The concrete timeline runner is the first layer that has all required
+inputs in one place: the active scene module, the concrete
+`scene.timeline(ctx)` return value, the composition entry's `range` /
+`behavior` overrides, the cancellation signal, and the optional URL
+beat. Label existence and seeking therefore belong there.
+
+`beat` targets only the active scene at the head of the resolved
+navigation target. In a composition slice, it positions that first
+scene's timeline only; it is not a global search through later scenes
+and it does not rewrite the manifest slice.
+
+"Remain at the scene's first beat" means keep the active scene mounted
+at its initial timeline position. It does not require a new mandatory
+scene metadata field, a duplicated beat manifest, or a required
+`start` label on every timeline.
+
+An unknown beat is a non-fatal navigation-positioning diagnostic. The
+runtime must surface it through the existing workbench error surface
+(`data-pulsar-navigation-error` plus the loader's error sink) while
+allowing the active scene to stay mounted at the initial timeline
+position. Do not report an unknown beat by rejecting the resolver's
+`runTimeline` call, because that path exists for lifecycle failures and
+will run `cleanup(ctx)`.
+
+Valid beat seeking must use the timeline engine's label API. Do not
+create a second beat schema in scene metadata, composition manifests,
+URL parsing, or registries. Composition entry `range` remains a
+timeline-runner concern too; any future beat-vs-range interaction must
+be handled in the same runner boundary, not split across navigation and
+composition code.
+
+## Consequences
+
+### Positive
+
+- PUL-F011 reuses the existing grammar, dispatch, lifecycle, error
+  rendering, and stage observability boundaries.
+- Missing beat handling satisfies "surface an error and remain" without
+  weakening the resolver's mandatory-cleanup invariant for real
+  lifecycle failures.
+- Beat labels stay canonical in GSAP timelines; no duplicate manifest
+  or metadata source can drift.
+
+### Negative
+
+- The runner boundary needs a way to receive the optional URL beat and
+  surface a non-fatal positioning diagnostic. That is a small adapter
+  extension, but it must be explicit.
+- Tests must distinguish missing-label diagnostics from timeline
+  failures. Both mention timeline labels, but only one is fatal.
+
+### Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Unknown beat is thrown through `resolveComposition`, so cleanup unmounts the scene | Treat missing labels as non-fatal navigation-positioning diagnostics; runner rejection remains reserved for lifecycle failures. |
+| URL parsing starts resolving beat labels | Keep ADR-013's boundary: parser validates only shape and combinations, never runtime existence. |
+| Scene authors add a parallel `beats` metadata list | Labels in the returned timeline are the source of truth; metadata lists would drift and are rejected unless a future ADR supersedes this one. |
+| `beat` in a composition is interpreted as "find this label anywhere in the remaining composition" | Scope `beat` to the active head scene only. Later scenes run normally. |
+| Composition `range` and URL `beat` get validated by different layers | Keep both concerns in the timeline runner, where the concrete timeline and per-entry overrides are already present. |
+
+## Related ADRs
+
+- [ADR-003](003-gsap-timeline-engine.md) — labels and seeking are part
+  of the GSAP timeline contract.
+- [ADR-007](007-browser-workbench.md) — `beat` is part of the
+  workbench URL grammar.
+- [ADR-011](011-composition-resolver-orchestration.md) — the
+  composition resolver delegates timeline execution to an injected
+  runner and treats runner rejection as a lifecycle failure.
+- [ADR-013](013-url-navigation-grammar-boundary.md) — URL parsing is a
+  grammar boundary only.
+- [ADR-014](014-url-scene-target-selection.md) — scene navigation
+  resolves the active scene/composition slice and records `beat`
+  without consuming it.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -40,3 +40,4 @@ Each ADR includes:
 | [012](012-asset-preloader-fetch-and-drain.md) | Asset Preloader — Warm Bytes via Fetch + Drain; Decode-Complete is Future Work | Accepted |
 | [013](013-url-navigation-grammar-boundary.md) | URL Navigation Grammar Boundary | Accepted |
 | [014](014-url-scene-target-selection.md) | Loading the Addressed Scene as the Runtime Navigation Target | Accepted |
+| [015](015-url-beat-positioning.md) | URL Beat Positioning as Timeline-Runner State | Accepted |

--- a/src/main.ts
+++ b/src/main.ts
@@ -65,15 +65,34 @@ const createPreloader = (signal: AbortSignal): ReturnType<typeof createAssetPrel
 // navigation. ADR-003's GSAP runner replaces this slot when the
 // timeline engine lands; until then this stand-in honors the
 // "scene stays loaded between navigations" workbench expectation.
+//
+// PUL-F011 / ADR-015: when the URL carries `beat=<label>`, the runner
+// is responsible for label existence. The placeholder timeline returns
+// `null` (no labels), so EVERY URL beat is a missing-label diagnostic
+// by definition — `input.onBeatMissing?.()` is the correct response
+// here. The runner does NOT throw or reject; the loader's callback
+// writes `data-pulsar-navigation-error` and the scene stays mounted at
+// its initial timeline position. ADR-003's GSAP runner replaces this
+// stand-in with `timeline.labels[input.beat]`-style seeking when the
+// engine lands; until then the placeholder honestly reports "no
+// labels" rather than silently ignoring the URL.
+//
+// Abort ordering: the abort check runs BEFORE the missing-beat
+// diagnostic so a navigation that was superseded between
+// `scene.timeline(ctx)` resolution and the runner's first turn does
+// not surface a stale diagnostic for a disposed/aborted load.
 const runTimeline: SceneTimelineRunner = (input) =>
   new Promise<void>((resolve) => {
-    if (input.signal === undefined) {
-      // No abort path was wired (e.g. test harness without a
-      // signal); treat as a no-op so we don't wait forever.
+    if (input.signal?.aborted === true) {
       resolve();
       return;
     }
-    if (input.signal.aborted) {
+    if (input.beat !== undefined) {
+      input.onBeatMissing?.();
+    }
+    if (input.signal === undefined) {
+      // No abort path was wired (e.g. test harness without a
+      // signal); treat as a no-op so we don't wait forever.
       resolve();
       return;
     }

--- a/src/runtime/composition-resolver.ts
+++ b/src/runtime/composition-resolver.ts
@@ -101,6 +101,29 @@ export interface SceneTimelineRunInput {
    * when the caller did not pass a `signal`.
    */
   readonly signal?: AbortSignal;
+  /**
+   * URL beat label (PUL-F011) the runner SHOULD seek to before
+   * playing the timeline. Only present on the run input for the FIRST
+   * scene of the resolved composition slice — subsequent scenes never
+   * receive `beat` because ADR-015 scopes URL beat to the active head
+   * scene only. Absent when the navigation target had no `beat=`
+   * parameter. Label-existence checking is the runner's responsibility
+   * (the resolver does not parse the timeline value).
+   */
+  readonly beat?: string;
+  /**
+   * Non-fatal callback the runner SHOULD invoke when {@link beat} is
+   * supplied but the named label does not exist in the timeline
+   * (PUL-F011 / ADR-015). The runner MUST continue normally after
+   * invoking — playing the timeline from its initial position
+   * ("scene's first beat") — and MUST NOT throw or reject in response
+   * to a missing label, because the resolver treats runner rejection
+   * as a lifecycle failure and would unmount the scene via cleanup.
+   * Paired with {@link beat}: only present on the head scene's run
+   * input, and only when the caller supplied `onBeatMissing` on
+   * {@link ResolveCompositionOptions}.
+   */
+  readonly onBeatMissing?: () => void;
 }
 
 /**
@@ -148,6 +171,24 @@ export interface ResolveCompositionOptions {
    * forwarded signal.
    */
   readonly signal?: AbortSignal;
+  /**
+   * URL beat label (PUL-F011) to forward to the FIRST scene's run
+   * input as {@link SceneTimelineRunInput.beat}. Subsequent scenes
+   * never receive a beat — ADR-015 scopes URL beat to the active head
+   * scene only, so a composition slice does not search later scenes
+   * for the label. Absent when the navigation target had no `beat=`
+   * parameter.
+   */
+  readonly headBeat?: string;
+  /**
+   * Non-fatal callback paired with {@link headBeat}. Forwarded to the
+   * head scene's run input as {@link SceneTimelineRunInput.onBeatMissing}
+   * so the runner can report a missing label without rejecting (which
+   * would trigger PUL-F006 cleanup and unmount the scene, violating
+   * PUL-F011's "remain at the scene's first beat"). Absent when the
+   * caller did not opt into beat positioning.
+   */
+  readonly onBeatMissing?: () => void;
 }
 
 /**
@@ -209,14 +250,21 @@ function throwIfAborted(signal: AbortSignal | undefined, detail: string): void {
 
 /**
  * Build the {@link SceneTimelineRunInput} for one plan step. Omits
- * `range` / `behavior` from the output object when absent on the
- * source entry rather than emitting `range: undefined` keys, so the
- * runner's `range in input` checks behave intuitively.
+ * `range` / `behavior` / `beat` / `onBeatMissing` from the output
+ * object when absent on the source entry rather than emitting
+ * `field: undefined` keys, so the runner's `field in input` checks
+ * behave intuitively.
+ *
+ * `beat` and `onBeatMissing` are caller-supplied per-call (resolver
+ * passes them only for the head plan step); the rest are per-entry
+ * (resolver derives from the manifest snapshot).
  */
 function buildRunInput(
   step: PlanStep,
   timeline: unknown,
   signal: AbortSignal | undefined,
+  beat: string | undefined,
+  onBeatMissing: (() => void) | undefined,
 ): SceneTimelineRunInput {
   const input: { -readonly [K in keyof SceneTimelineRunInput]: SceneTimelineRunInput[K] } = {
     scene: step.scene,
@@ -225,6 +273,8 @@ function buildRunInput(
   if (step.range !== undefined) input.range = step.range;
   if (step.behavior !== undefined) input.behavior = step.behavior;
   if (signal !== undefined) input.signal = signal;
+  if (beat !== undefined) input.beat = beat;
+  if (onBeatMissing !== undefined) input.onBeatMissing = onBeatMissing;
   return input;
 }
 
@@ -281,7 +331,8 @@ function buildRunInput(
  * runner's job per ADR-011).
  */
 export async function resolveComposition(options: ResolveCompositionOptions): Promise<void> {
-  const { registry, manifest, ctx, preloadAssets, runTimeline, signal } = options;
+  const { registry, manifest, ctx, preloadAssets, runTimeline, signal, headBeat, onBeatMissing } =
+    options;
 
   assertCompositionManifest(manifest);
   const plan = buildPlan(manifest, registry);
@@ -299,8 +350,12 @@ export async function resolveComposition(options: ResolveCompositionOptions): Pr
   // No separate pre-loop check is needed because `assertCompositionManifest`
   // and `buildPlan` are synchronous — there is no yield point between
   // them and the loop's first iteration check.
+  //
+  // PUL-F011: `headBeat` / `onBeatMissing` (when supplied) are forwarded
+  // to the FIRST scene's run input only. Subsequent scenes do not
+  // receive them — ADR-015 scopes URL beat to the active head scene.
   let lastCompletedSceneId: string | undefined;
-  for (const step of plan) {
+  for (const [index, step] of plan.entries()) {
     throwIfAborted(
       signal,
       lastCompletedSceneId === undefined
@@ -312,7 +367,14 @@ export async function resolveComposition(options: ResolveCompositionOptions): Pr
       signal,
       `aborted after preloading ${quoteId(step.scene.id)}, before scene activation`,
     );
-    await runScene(step, ctx, runTimeline, signal);
+    const isHead = index === 0;
+    // `onBeatMissing` is paired with `headBeat` per ADR-015. Drop the
+    // callback when no beat is supplied — otherwise the runner would
+    // see `input.onBeatMissing` with no `input.beat` to trigger it
+    // against, an impossible state per the documented contract.
+    const stepBeat = isHead ? headBeat : undefined;
+    const stepOnBeatMissing = stepBeat === undefined ? undefined : onBeatMissing;
+    await runScene(step, ctx, runTimeline, signal, stepBeat, stepOnBeatMissing);
     lastCompletedSceneId = step.scene.id;
   }
 }
@@ -367,6 +429,8 @@ async function runScene(
   ctx: unknown,
   runTimeline: SceneTimelineRunner,
   signal: AbortSignal | undefined,
+  beat: string | undefined,
+  onBeatMissing: (() => void) | undefined,
 ): Promise<void> {
   // Track failure with explicit booleans so `throw undefined` /
   // `Promise.reject(undefined)` are still treated as failures. Using
@@ -384,7 +448,7 @@ async function runScene(
     // non-Promise value is identity, so synchronous timeline factories
     // are unaffected.
     const timeline = await scene.timeline(ctx);
-    await runTimeline(buildRunInput(step, timeline, signal));
+    await runTimeline(buildRunInput(step, timeline, signal, beat, onBeatMissing));
   } catch (err) {
     phaseFailed = true;
     phaseError = err;

--- a/src/runtime/composition-resolver.ts
+++ b/src/runtime/composition-resolver.ts
@@ -114,11 +114,19 @@ export interface SceneTimelineRunInput {
   /**
    * Non-fatal callback the runner SHOULD invoke when {@link beat} is
    * supplied but the named label does not exist in the timeline
-   * (PUL-F011 / ADR-015). The runner MUST continue normally after
-   * invoking — playing the timeline from its initial position
-   * ("scene's first beat") — and MUST NOT throw or reject in response
-   * to a missing label, because the resolver treats runner rejection
-   * as a lifecycle failure and would unmount the scene via cleanup.
+   * (PUL-F011 / ADR-015).
+   *
+   * On invocation, the runner MUST NOT throw, reject, or otherwise
+   * signal a lifecycle failure (the resolver would treat that as a
+   * fatal scene error and unmount via cleanup). The runner MUST also
+   * NOT seek to the requested label — there is no such label. The
+   * scene's playback position MUST be the timeline's start (PUL-F011's
+   * "scene's first beat"). Whether the runner then plays the timeline
+   * forward from that start, holds parked, or hands control to a
+   * presenter is the runner's contract with its callers — the
+   * requirement only mandates the position, not the post-position
+   * behavior.
+   *
    * Paired with {@link beat}: only present on the head scene's run
    * input, and only when the caller supplied `onBeatMissing` on
    * {@link ResolveCompositionOptions}.
@@ -185,8 +193,13 @@ export interface ResolveCompositionOptions {
    * head scene's run input as {@link SceneTimelineRunInput.onBeatMissing}
    * so the runner can report a missing label without rejecting (which
    * would trigger PUL-F006 cleanup and unmount the scene, violating
-   * PUL-F011's "remain at the scene's first beat"). Absent when the
-   * caller did not opt into beat positioning.
+   * PUL-F011's "remain at the scene's first beat").
+   *
+   * REQUIRED whenever {@link headBeat} is supplied: a beat without a
+   * diagnostic surface would silently lose the missing-label error
+   * the runner reports — the resolver throws when this invariant is
+   * violated rather than letting the diagnostic vanish. Absent when
+   * {@link headBeat} is also absent.
    */
   readonly onBeatMissing?: () => void;
 }
@@ -333,6 +346,17 @@ function buildRunInput(
 export async function resolveComposition(options: ResolveCompositionOptions): Promise<void> {
   const { registry, manifest, ctx, preloadAssets, runTimeline, signal, headBeat, onBeatMissing } =
     options;
+
+  // PUL-F011 / ADR-015: a `headBeat` without an `onBeatMissing` would
+  // silently lose the missing-label diagnostic the runner is contracted
+  // to surface (the runner MUST NOT throw on missing labels; the
+  // callback is its only error channel). Failing fast at the boundary
+  // is better than running a doomed lifecycle that reports nothing.
+  if (headBeat !== undefined && onBeatMissing === undefined) {
+    throw new Error(
+      'resolveComposition: `onBeatMissing` is required when `headBeat` is supplied — a beat without a diagnostic surface would silently lose missing-label errors',
+    );
+  }
 
   assertCompositionManifest(manifest);
   const plan = buildPlan(manifest, registry);

--- a/src/runtime/composition-resolver.ts
+++ b/src/runtime/composition-resolver.ts
@@ -352,9 +352,14 @@ export async function resolveComposition(options: ResolveCompositionOptions): Pr
   // to surface (the runner MUST NOT throw on missing labels; the
   // callback is its only error channel). Failing fast at the boundary
   // is better than running a doomed lifecycle that reports nothing.
+  // Routed through the resolver's `fail(...)` helper so the error
+  // carries the documented `composition resolution failed:` envelope
+  // — callers pattern-matching on origin get the same prefix as
+  // every other resolver-level failure.
   if (headBeat !== undefined && onBeatMissing === undefined) {
-    throw new Error(
-      'resolveComposition: `onBeatMissing` is required when `headBeat` is supplied — a beat without a diagnostic surface would silently lose missing-label errors',
+    throw fail(
+      '"onBeatMissing" is required when "headBeat" is supplied — a beat without a diagnostic surface would silently lose missing-label errors',
+      undefined,
     );
   }
 

--- a/src/runtime/scene-loader.ts
+++ b/src/runtime/scene-loader.ts
@@ -278,11 +278,25 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
     return (): void => {
       if (fired || signal.aborted || disposed) return;
       fired = true;
-      surfaceError(
-        new Error(
-          `beat positioning failed: beat "${beat}" does not exist in scene "${headSceneId}"`,
-        ),
-      );
+      // PUL-F011 / ADR-015: this path is non-fatal by contract — the
+      // runner is forbidden from throwing or rejecting on missing
+      // labels (the resolver would treat that as a lifecycle failure
+      // and unmount the scene). The injected `onError` sink is
+      // user-supplied, so an exception from it would propagate back
+      // through the runner's `onBeatMissing()` invocation, into the
+      // resolver's `await runTimeline(...)`, and trigger the
+      // cleanup-then-throw path. Swallow here so the diagnostic
+      // surface stays non-fatal even when the operator's logger
+      // throws.
+      try {
+        surfaceError(
+          new Error(
+            `beat positioning failed: beat "${beat}" does not exist in scene "${headSceneId}"`,
+          ),
+        );
+      } catch {
+        // Intentionally empty: see comment above.
+      }
     };
   };
 

--- a/src/runtime/scene-loader.ts
+++ b/src/runtime/scene-loader.ts
@@ -213,37 +213,127 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
     setStageAttr(ATTR_ERROR, describeError(err));
   };
 
+  /**
+   * Defense-in-depth for ADR-013's `beat` grammar rules.
+   * `parseNavigationSearch` enforces both on URL input, but
+   * `NavigationTarget` is an exported type that non-parser callers
+   * (event-detail unmarshaling, future test harnesses, programmatic
+   * navigation) can construct directly. Re-checking at the loader
+   * boundary stops a hand-built target with an invalid `beat`
+   * (wrong shape, or paired with a non-scene-like locator) from
+   * reaching the runner with a value the parser would have
+   * rejected. Returns an `Error` with the parser's exact grammar
+   * message when the target is invalid, or `null` when no further
+   * check is needed.
+   */
+  const validateBeatGrammar = (target: NavigationTarget): Error | null => {
+    if (target.beat === undefined) return null;
+    if (!isKebabIdentifier(target.beat)) {
+      return new Error(
+        `navigation grammar is invalid: "beat" must be a non-empty lowercase kebab-case string (${KEBAB_IDENTIFIER_FORM})`,
+      );
+    }
+    const k = target.locator.kind;
+    if (k !== 'scene' && k !== 'composition-scene' && k !== 'composition-index') {
+      return new Error(
+        'navigation grammar is invalid: "beat" requires a scene-like target ("scene", "composition" + "scene", or "composition" + "index")',
+      );
+    }
+    return null;
+  };
+
+  /**
+   * PUL-F011 / ADR-015: build the non-fatal callback the loader
+   * supplies to the timeline runner when the URL carries
+   * `beat=<label>`. The callback writes
+   * `data-pulsar-navigation-error` and calls `onError` without
+   * throwing, so a missing label does NOT cause the resolver to
+   * reject (which would unmount the scene via PUL-F006 cleanup —
+   * violating "remain at the scene's first beat"). Returns
+   * `undefined` when no beat was supplied.
+   *
+   * Three guards parallel the existing fatal-error suppression in
+   * the queue (`isPureAbort`, `inFlight.silent`, post-dispose
+   * no-op):
+   *  - `signal.aborted` — a stale runner that reports
+   *    `onBeatMissing` after the load was aborted (a new
+   *    navigation enqueued, popstate, etc.) MUST NOT write the
+   *    diagnostic for the superseded navigation. Mirrors
+   *    `isPureAbort`'s "the new event owns the visible state".
+   *  - `disposed` — post-`dispose()` runners must not surface
+   *    diagnostics; the workbench is shutting down.
+   *  - `fired` — a runner that calls the callback multiple
+   *    times (a buggy GSAP integration retrying on each label
+   *    miss, etc.) MUST NOT spam `onError` and the stage
+   *    attribute. Once-only matches the "single diagnostic per
+   *    navigation" semantics of every other surfaceError call.
+   */
+  const buildOnBeatMissing = (
+    beat: string | undefined,
+    headSceneId: string,
+    signal: AbortSignal,
+  ): (() => void) | undefined => {
+    if (beat === undefined) return undefined;
+    let fired = false;
+    return (): void => {
+      if (fired || signal.aborted || disposed) return;
+      fired = true;
+      surfaceError(
+        new Error(
+          `beat positioning failed: beat "${beat}" does not exist in scene "${headSceneId}"`,
+        ),
+      );
+    };
+  };
+
+  /**
+   * Build the in-flight load record: an `AbortController`, the
+   * preloader factory's per-load preloader (a synchronous failure
+   * is rolled back through `resetStageAttrs()` + `surfaceError`),
+   * and the bridge call that drives the lifecycle. Returns the
+   * record, or `null` when the preloader factory threw — in which
+   * case the caller has already been told via `surfaceError` and
+   * should bail. Hoisted out of `runTarget` so the latter stays
+   * within Sonar's cognitive-complexity budget.
+   */
+  const buildLoad = (
+    resolved: SceneNavigationTarget,
+    beat: string | undefined,
+  ): InFlightLoad | null => {
+    const controller = new AbortController();
+    let preloadAssets: AssetPreloader;
+    try {
+      preloadAssets = options.createPreloader(controller.signal);
+    } catch (err) {
+      // Roll back the success-state attrs we just wrote and surface
+      // the error so the stage doesn't lie about a half-loaded scene.
+      // `resetStageAttrs()` clears all three navigation attrs in
+      // lock-step with the success-path reset, so this rollback
+      // cannot drift if a fourth navigation attr is added later.
+      resetStageAttrs();
+      surfaceError(err);
+      return null;
+    }
+    const onBeatMissing = buildOnBeatMissing(beat, resolved.scene.id, controller.signal);
+    return {
+      controller,
+      settled: loadSceneNavigationTarget(resolved, {
+        ctx: options.ctx,
+        preloadAssets,
+        runTimeline: options.runTimeline,
+        signal: controller.signal,
+        ...(beat === undefined ? {} : { beat }),
+        ...(onBeatMissing === undefined ? {} : { onBeatMissing }),
+      }),
+      silent: false,
+    };
+  };
+
   const runTarget = async (target: NavigationTarget): Promise<void> => {
-    // Defense-in-depth for ADR-013's "beat requires a scene-like
-    // target" rule and the kebab-case identifier shape.
-    // `parseNavigationSearch` enforces both on URL input, but
-    // `NavigationTarget` is an exported type that non-parser callers
-    // (event-detail unmarshaling, future test harnesses, programmatic
-    // navigation) can construct directly. Re-checking at the loader
-    // boundary stops a hand-built target with an invalid `beat` (wrong
-    // shape, or paired with a non-scene-like locator) from reaching
-    // the runner with a value the parser would have rejected. Mirrors
-    // the parser's error grammar verbatim so a downstream caller
-    // pattern-matching on the message gets the same string regardless
-    // of which boundary rejected.
-    if (target.beat !== undefined) {
-      if (!isKebabIdentifier(target.beat)) {
-        surfaceError(
-          new Error(
-            `navigation grammar is invalid: "beat" must be a non-empty lowercase kebab-case string (${KEBAB_IDENTIFIER_FORM})`,
-          ),
-        );
-        return;
-      }
-      const k = target.locator.kind;
-      if (k !== 'scene' && k !== 'composition-scene' && k !== 'composition-index') {
-        surfaceError(
-          new Error(
-            'navigation grammar is invalid: "beat" requires a scene-like target ("scene", "composition" + "scene", or "composition" + "index")',
-          ),
-        );
-        return;
-      }
+    const beatErr = validateBeatGrammar(target);
+    if (beatErr !== null) {
+      surfaceError(beatErr);
+      return;
     }
 
     let resolved: SceneNavigationTarget | null;
@@ -264,82 +354,8 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
       setStageAttr(ATTR_COMPOSITION, resolved.composition.id);
     }
 
-    const controller = new AbortController();
-    let preloadAssets: AssetPreloader;
-    try {
-      // Build the preloader against this navigation's abort signal
-      // so its underlying `fetch` calls cancel when the user clicks
-      // back/forward mid-preload. A synchronous failure here (e.g.
-      // a misconfigured preloader factory) MUST flow through the
-      // documented error path — the same as a resolver failure —
-      // rather than escaping `runOnce` and leaving partial scene-
-      // target attributes on the stage with a rejected queue
-      // promise.
-      preloadAssets = options.createPreloader(controller.signal);
-    } catch (err) {
-      // Roll back the success-state attrs we just wrote and surface
-      // the error so the stage doesn't lie about a half-loaded scene.
-      // `resetStageAttrs()` clears all three navigation attrs in
-      // lock-step with the success-path reset, so this rollback
-      // cannot drift if a fourth navigation attr is added later.
-      resetStageAttrs();
-      surfaceError(err);
-      return;
-    }
-    // PUL-F011 / ADR-015: when the URL carries `beat=<label>`, the
-    // loader supplies a non-fatal callback that writes
-    // `data-pulsar-navigation-error` and calls `onError` without
-    // throwing, so a missing label does NOT cause the resolver to
-    // reject (which would unmount the scene via PUL-F006 cleanup —
-    // violating "remain at the scene's first beat"). The error
-    // message names both the beat and the head scene id so the
-    // operator can fix the URL or the timeline label. The closure
-    // captures `resolved.scene.id` (the head scene) at handle time;
-    // the bridge / resolver guarantees the callback only fires on
-    // the head scene's run input per ADR-015.
-    //
-    // Three guards parallel the existing fatal-error suppression in
-    // the queue (`isPureAbort`, `inFlight.silent`, post-dispose
-    // no-op):
-    //  - `controller.signal.aborted` — a stale runner that reports
-    //    `onBeatMissing` after the load was aborted (a new
-    //    navigation enqueued, popstate, etc.) MUST NOT write the
-    //    diagnostic for the superseded navigation. Mirrors
-    //    `isPureAbort`'s "the new event owns the visible state".
-    //  - `disposed` — post-`dispose()` runners must not surface
-    //    diagnostics; the workbench is shutting down.
-    //  - `beatDiagnosticFired` — a runner that calls the callback
-    //    multiple times (a buggy GSAP integration retrying on each
-    //    label miss, etc.) MUST NOT spam `onError` and the stage
-    //    attribute. Once-only matches the "single diagnostic per
-    //    navigation" semantics of every other surfaceError call.
-    const beat = target.beat;
-    let beatDiagnosticFired = false;
-    const onBeatMissing =
-      beat === undefined
-        ? undefined
-        : (): void => {
-            if (beatDiagnosticFired) return;
-            if (controller.signal.aborted || disposed) return;
-            beatDiagnosticFired = true;
-            surfaceError(
-              new Error(
-                `beat positioning failed: beat "${beat}" does not exist in scene "${resolved.scene.id}"`,
-              ),
-            );
-          };
-    const load: InFlightLoad = {
-      controller,
-      settled: loadSceneNavigationTarget(resolved, {
-        ctx: options.ctx,
-        preloadAssets,
-        runTimeline: options.runTimeline,
-        signal: controller.signal,
-        ...(beat === undefined ? {} : { beat }),
-        ...(onBeatMissing === undefined ? {} : { onBeatMissing }),
-      }),
-      silent: false,
-    };
+    const load = buildLoad(resolved, target.beat);
+    if (load === null) return;
     inFlight = load;
 
     try {

--- a/src/runtime/scene-loader.ts
+++ b/src/runtime/scene-loader.ts
@@ -32,6 +32,7 @@
 import type { CompositionRegistry } from './composition-registry';
 import type { AssetPreloader, SceneTimelineRunner } from './composition-resolver';
 import { describeError } from './error';
+import { KEBAB_IDENTIFIER_FORM, isKebabIdentifier } from './identifier';
 import type { NavigationTarget } from './navigation';
 import type { SceneRegistry } from './registry';
 import {
@@ -213,6 +214,38 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
   };
 
   const runTarget = async (target: NavigationTarget): Promise<void> => {
+    // Defense-in-depth for ADR-013's "beat requires a scene-like
+    // target" rule and the kebab-case identifier shape.
+    // `parseNavigationSearch` enforces both on URL input, but
+    // `NavigationTarget` is an exported type that non-parser callers
+    // (event-detail unmarshaling, future test harnesses, programmatic
+    // navigation) can construct directly. Re-checking at the loader
+    // boundary stops a hand-built target with an invalid `beat` (wrong
+    // shape, or paired with a non-scene-like locator) from reaching
+    // the runner with a value the parser would have rejected. Mirrors
+    // the parser's error grammar verbatim so a downstream caller
+    // pattern-matching on the message gets the same string regardless
+    // of which boundary rejected.
+    if (target.beat !== undefined) {
+      if (!isKebabIdentifier(target.beat)) {
+        surfaceError(
+          new Error(
+            `navigation grammar is invalid: "beat" must be a non-empty lowercase kebab-case string (${KEBAB_IDENTIFIER_FORM})`,
+          ),
+        );
+        return;
+      }
+      const k = target.locator.kind;
+      if (k !== 'scene' && k !== 'composition-scene' && k !== 'composition-index') {
+        surfaceError(
+          new Error(
+            'navigation grammar is invalid: "beat" requires a scene-like target ("scene", "composition" + "scene", or "composition" + "index")',
+          ),
+        );
+        return;
+      }
+    }
+
     let resolved: SceneNavigationTarget | null;
     try {
       resolved = resolveSceneNavigation(target, {
@@ -253,6 +286,48 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
       surfaceError(err);
       return;
     }
+    // PUL-F011 / ADR-015: when the URL carries `beat=<label>`, the
+    // loader supplies a non-fatal callback that writes
+    // `data-pulsar-navigation-error` and calls `onError` without
+    // throwing, so a missing label does NOT cause the resolver to
+    // reject (which would unmount the scene via PUL-F006 cleanup —
+    // violating "remain at the scene's first beat"). The error
+    // message names both the beat and the head scene id so the
+    // operator can fix the URL or the timeline label. The closure
+    // captures `resolved.scene.id` (the head scene) at handle time;
+    // the bridge / resolver guarantees the callback only fires on
+    // the head scene's run input per ADR-015.
+    //
+    // Three guards parallel the existing fatal-error suppression in
+    // the queue (`isPureAbort`, `inFlight.silent`, post-dispose
+    // no-op):
+    //  - `controller.signal.aborted` — a stale runner that reports
+    //    `onBeatMissing` after the load was aborted (a new
+    //    navigation enqueued, popstate, etc.) MUST NOT write the
+    //    diagnostic for the superseded navigation. Mirrors
+    //    `isPureAbort`'s "the new event owns the visible state".
+    //  - `disposed` — post-`dispose()` runners must not surface
+    //    diagnostics; the workbench is shutting down.
+    //  - `beatDiagnosticFired` — a runner that calls the callback
+    //    multiple times (a buggy GSAP integration retrying on each
+    //    label miss, etc.) MUST NOT spam `onError` and the stage
+    //    attribute. Once-only matches the "single diagnostic per
+    //    navigation" semantics of every other surfaceError call.
+    const beat = target.beat;
+    let beatDiagnosticFired = false;
+    const onBeatMissing =
+      beat === undefined
+        ? undefined
+        : (): void => {
+            if (beatDiagnosticFired) return;
+            if (controller.signal.aborted || disposed) return;
+            beatDiagnosticFired = true;
+            surfaceError(
+              new Error(
+                `beat positioning failed: beat "${beat}" does not exist in scene "${resolved.scene.id}"`,
+              ),
+            );
+          };
     const load: InFlightLoad = {
       controller,
       settled: loadSceneNavigationTarget(resolved, {
@@ -260,6 +335,8 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
         preloadAssets,
         runTimeline: options.runTimeline,
         signal: controller.signal,
+        ...(beat === undefined ? {} : { beat }),
+        ...(onBeatMissing === undefined ? {} : { onBeatMissing }),
       }),
       silent: false,
     };

--- a/src/runtime/scene-navigation.ts
+++ b/src/runtime/scene-navigation.ts
@@ -133,6 +133,11 @@ export interface LoadSceneNavigationTargetOptions {
    * to a missing label; the loader uses this hook to surface a
    * navigation-positioning diagnostic without unmounting the active
    * scene.
+   *
+   * REQUIRED whenever {@link beat} is supplied: a beat without a
+   * diagnostic surface would silently lose the missing-label error
+   * the runner reports — the bridge throws when this invariant is
+   * violated rather than letting the diagnostic vanish.
    */
   readonly onBeatMissing?: () => void;
 }
@@ -378,6 +383,17 @@ export async function loadSceneNavigationTarget(
   // because `snapshotSceneSlice` pulled both from the same scene
   // registry, so dedupe is identity-preserving.
   const uniqueScenes = Array.from(new Map(scenes.map((s) => [s.id, s])).values());
+
+  // PUL-F011 / ADR-015: a `beat` without an `onBeatMissing` would
+  // silently lose the missing-label diagnostic the runner is
+  // contracted to surface. Mirror the resolver's check at this
+  // boundary so the bridge's direct callers fail at construction
+  // time, not after the lifecycle started.
+  if (options.beat !== undefined && options.onBeatMissing === undefined) {
+    throw new Error(
+      'loadSceneNavigationTarget: `onBeatMissing` is required when `beat` is supplied — a beat without a diagnostic surface would silently lose missing-label errors',
+    );
+  }
 
   await resolveComposition({
     registry: createSceneRegistry(uniqueScenes),

--- a/src/runtime/scene-navigation.ts
+++ b/src/runtime/scene-navigation.ts
@@ -388,10 +388,14 @@ export async function loadSceneNavigationTarget(
   // silently lose the missing-label diagnostic the runner is
   // contracted to surface. Mirror the resolver's check at this
   // boundary so the bridge's direct callers fail at construction
-  // time, not after the lifecycle started.
+  // time, not after the lifecycle started. Routed through the
+  // module's `fail(...)` helper so the error carries the documented
+  // `scene navigation failed:` envelope — same prefix as every
+  // other navigation-level failure (unknown scene, out-of-range
+  // index, etc.).
   if (options.beat !== undefined && options.onBeatMissing === undefined) {
-    throw new Error(
-      'loadSceneNavigationTarget: `onBeatMissing` is required when `beat` is supplied — a beat without a diagnostic surface would silently lose missing-label errors',
+    fail(
+      '"onBeatMissing" is required when "beat" is supplied — a beat without a diagnostic surface would silently lose missing-label errors',
     );
   }
 

--- a/src/runtime/scene-navigation.ts
+++ b/src/runtime/scene-navigation.ts
@@ -117,6 +117,24 @@ export interface LoadSceneNavigationTargetOptions {
    * defined for composition-level abort.
    */
   readonly signal?: AbortSignal;
+  /**
+   * URL beat label (PUL-F011) the runner should seek to before
+   * playing the head scene's timeline. Forwarded to
+   * {@link resolveComposition} as `headBeat` — the resolver scopes
+   * delivery to the head scene's run input only, per ADR-015. Absent
+   * when the navigation target had no `beat=` URL parameter.
+   */
+  readonly beat?: string;
+  /**
+   * Non-fatal callback invoked by the runner when {@link beat} is
+   * supplied but the named timeline label does not exist (PUL-F011 /
+   * ADR-015). Forwarded to {@link resolveComposition} as
+   * `onBeatMissing`. The runner MUST NOT throw or reject in response
+   * to a missing label; the loader uses this hook to surface a
+   * navigation-positioning diagnostic without unmounting the active
+   * scene.
+   */
+  readonly onBeatMissing?: () => void;
 }
 
 const NAV_FAIL_PREFIX = 'scene navigation failed:';
@@ -368,5 +386,15 @@ export async function loadSceneNavigationTarget(
     preloadAssets: options.preloadAssets,
     runTimeline: options.runTimeline,
     ...(options.signal === undefined ? {} : { signal: options.signal }),
+    // `onBeatMissing` is paired with `beat` per ADR-015 — a callback
+    // without a label has no trigger condition, so dropping it when
+    // `beat` is absent prevents misuse-by-spread (e.g. a caller
+    // accidentally passing `onBeatMissing` with no `beat`).
+    ...(options.beat === undefined
+      ? {}
+      : {
+          headBeat: options.beat,
+          ...(options.onBeatMissing === undefined ? {} : { onBeatMissing: options.onBeatMissing }),
+        }),
   });
 }

--- a/tests/runtime/composition-resolver.test.ts
+++ b/tests/runtime/composition-resolver.test.ts
@@ -1229,7 +1229,7 @@ describe('URL beat positioning forwarding (PUL-F011)', () => {
         runCalls.push(input);
       },
     });
-    await resolveComposition({ ...options, headBeat: 'hook' });
+    await resolveComposition({ ...options, headBeat: 'hook', onBeatMissing: () => undefined });
     expect(runCalls).toHaveLength(2);
     expect(runCalls[0]?.scene.id).toBe('scene-a');
     expect(runCalls[0]?.beat).toBe('hook');
@@ -1290,6 +1290,21 @@ describe('URL beat positioning forwarding (PUL-F011)', () => {
     expect('onBeatMissing' in (runCalls[0] as object)).toBe(false);
   });
 
+  it('throws when `headBeat` is supplied without `onBeatMissing` (paired-required contract)', async () => {
+    // PUL-F011 / ADR-015: a `headBeat` without an `onBeatMissing`
+    // would silently lose the missing-label diagnostic the runner
+    // is contracted to surface. The resolver fails fast at the
+    // boundary rather than running a doomed lifecycle that reports
+    // nothing.
+    const { options } = buildHarness({
+      scenes: [{ id: 'scene-a' }],
+      manifest: ['scene-a'],
+    });
+    await expect(resolveComposition({ ...options, headBeat: 'hook' })).rejects.toThrow(
+      /^resolveComposition: `onBeatMissing` is required when `headBeat` is supplied/,
+    );
+  });
+
   it('does not interpret `headBeat` itself — a runner that silently consumes it does not error', async () => {
     // Resolver delegates label-existence checking to the runner per
     // ADR-015. A runner that receives `beat: 'unknown-label'` and
@@ -1309,7 +1324,11 @@ describe('URL beat positioning forwarding (PUL-F011)', () => {
       runTimeline: () => undefined,
     });
     await expect(
-      resolveComposition({ ...options, headBeat: 'never-defined' }),
+      resolveComposition({
+        ...options,
+        headBeat: 'never-defined',
+        onBeatMissing: () => undefined,
+      }),
     ).resolves.toBeUndefined();
     expect(cleanupCalls).toEqual(['scene-a']);
   });

--- a/tests/runtime/composition-resolver.test.ts
+++ b/tests/runtime/composition-resolver.test.ts
@@ -1209,3 +1209,108 @@ describe('per-scene cleanup invocation (PUL-F006)', () => {
     ]);
   });
 });
+
+describe('URL beat positioning forwarding (PUL-F011)', () => {
+  // PUL-F011: when `beat=<label>` is present, the runtime SHALL position
+  // the active scene's timeline at the named label; if the label does
+  // not exist, surface an error and remain at the scene's first beat.
+  // ADR-015 places label existence and seeking in the timeline-runner
+  // boundary. The resolver's job is forwarding URL beat state to the
+  // head scene's run input only; subsequent scenes in a composition
+  // slice do not receive `beat` (per ADR-015, `beat` targets the
+  // active head scene only).
+
+  it("forwards `headBeat` to plan[0]'s run input only — subsequent scenes get no beat", async () => {
+    const runCalls: SceneTimelineRunInput[] = [];
+    const { options } = buildHarness({
+      scenes: [{ id: 'scene-a' }, { id: 'scene-b' }],
+      manifest: ['scene-a', 'scene-b'],
+      runTimeline: (input) => {
+        runCalls.push(input);
+      },
+    });
+    await resolveComposition({ ...options, headBeat: 'hook' });
+    expect(runCalls).toHaveLength(2);
+    expect(runCalls[0]?.scene.id).toBe('scene-a');
+    expect(runCalls[0]?.beat).toBe('hook');
+    expect(runCalls[1]?.scene.id).toBe('scene-b');
+    expect(runCalls[1]?.beat).toBeUndefined();
+    // The `'beat' in input` check parallels how `range` / `behavior`
+    // are omitted when absent — the runner's branching can rely on key
+    // presence rather than checking for `undefined` separately.
+    expect('beat' in (runCalls[1] as object)).toBe(false);
+  });
+
+  it("forwards `onBeatMissing` to plan[0]'s run input only — subsequent scenes get no callback", async () => {
+    const callbacks: (SceneTimelineRunInput['onBeatMissing'] | undefined)[] = [];
+    const sentinel = (): void => undefined;
+    const { options } = buildHarness({
+      scenes: [{ id: 'scene-a' }, { id: 'scene-b' }],
+      manifest: ['scene-a', 'scene-b'],
+      runTimeline: (input) => {
+        callbacks.push(input.onBeatMissing);
+      },
+    });
+    await resolveComposition({ ...options, headBeat: 'hook', onBeatMissing: sentinel });
+    expect(callbacks[0]).toBe(sentinel);
+    expect(callbacks[1]).toBeUndefined();
+  });
+
+  it('does not attach `beat` or `onBeatMissing` keys when neither option is supplied', async () => {
+    const runCalls: SceneTimelineRunInput[] = [];
+    const { options } = buildHarness({
+      scenes: [{ id: 'scene-a' }],
+      manifest: ['scene-a'],
+      runTimeline: (input) => {
+        runCalls.push(input);
+      },
+    });
+    await resolveComposition(options);
+    expect(runCalls).toHaveLength(1);
+    expect('beat' in (runCalls[0] as object)).toBe(false);
+    expect('onBeatMissing' in (runCalls[0] as object)).toBe(false);
+  });
+
+  it('does not attach `onBeatMissing` when `headBeat` is absent (paired contract)', async () => {
+    // The callback is meaningless without a beat to trigger it. If a
+    // caller passes `onBeatMissing` alone, the resolver drops it so
+    // the runner never sees `input.onBeatMissing` with no
+    // `input.beat` (an impossible state per the documented contract).
+    const runCalls: SceneTimelineRunInput[] = [];
+    const { options } = buildHarness({
+      scenes: [{ id: 'scene-a' }],
+      manifest: ['scene-a'],
+      runTimeline: (input) => {
+        runCalls.push(input);
+      },
+    });
+    await resolveComposition({ ...options, onBeatMissing: () => undefined });
+    expect(runCalls).toHaveLength(1);
+    expect('beat' in (runCalls[0] as object)).toBe(false);
+    expect('onBeatMissing' in (runCalls[0] as object)).toBe(false);
+  });
+
+  it('does not interpret `headBeat` itself — a runner that silently consumes it does not error', async () => {
+    // Resolver delegates label-existence checking to the runner per
+    // ADR-015. A runner that receives `beat: 'unknown-label'` and
+    // returns void normally must NOT cause the resolver to throw or
+    // skip cleanup.
+    const cleanupCalls: string[] = [];
+    const { options } = buildHarness({
+      scenes: [
+        {
+          id: 'scene-a',
+          cleanup: () => {
+            cleanupCalls.push('scene-a');
+          },
+        },
+      ],
+      manifest: ['scene-a'],
+      runTimeline: () => undefined,
+    });
+    await expect(
+      resolveComposition({ ...options, headBeat: 'never-defined' }),
+    ).resolves.toBeUndefined();
+    expect(cleanupCalls).toEqual(['scene-a']);
+  });
+});

--- a/tests/runtime/composition-resolver.test.ts
+++ b/tests/runtime/composition-resolver.test.ts
@@ -1301,7 +1301,7 @@ describe('URL beat positioning forwarding (PUL-F011)', () => {
       manifest: ['scene-a'],
     });
     await expect(resolveComposition({ ...options, headBeat: 'hook' })).rejects.toThrow(
-      /^resolveComposition: `onBeatMissing` is required when `headBeat` is supplied/,
+      /^composition resolution failed: "onBeatMissing" is required when "headBeat" is supplied/,
     );
   });
 

--- a/tests/runtime/scene-loader.test.ts
+++ b/tests/runtime/scene-loader.test.ts
@@ -902,13 +902,86 @@ describe('createSceneLoader (PUL-F008)', () => {
       expect(lifecycleLog).toEqual(['create', 'cleanup']);
     });
 
-    it('suppresses a missing-beat diagnostic if the runner reports after the load was aborted (stale-load guard)', async () => {
+    it('suppresses a missing-beat diagnostic if the runner reports after the load was aborted by a superseding navigation (signal.aborted guard)', async () => {
       // Defense parallel to `isPureAbort` for fatal-error suppression:
-      // a runner that calls `onBeatMissing` after a navigation was
-      // superseded (e.g. popstate aborted the in-flight load) must
-      // NOT write a diagnostic for the dead navigation. Otherwise the
-      // stage would carry the previous URL's beat error after the new
-      // navigation completed.
+      // a runner that calls `onBeatMissing` AFTER its navigation was
+      // superseded (popstate / new handle() / dispose) must NOT write
+      // a diagnostic for the dead navigation. Otherwise the stage
+      // would carry the previous URL's beat error after the next
+      // navigation completed. This test specifically exercises the
+      // `signal.aborted` branch of the closure (NOT the `disposed`
+      // branch — that's covered by the dispose-then-fire variant).
+      const captured: unknown[] = [];
+      const intro = buildScene({ id: 'intro' });
+      const stage = buildStage();
+      let capturedOnBeatMissing: (() => void) | undefined;
+      let resolveFirstRunner: (() => void) | undefined;
+      const firstRunnerGate = new Promise<void>((res) => {
+        resolveFirstRunner = res;
+      });
+      let firstRunnerEntered: (() => void) | undefined;
+      const firstRunnerEnteredBarrier = new Promise<void>((res) => {
+        firstRunnerEntered = res;
+      });
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([intro]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        ctx: {},
+        createPreloader: () => () => undefined,
+        runTimeline: async (input) => {
+          if (input.beat !== undefined) {
+            // Capture the callback but do not fire it yet. The first
+            // navigation is held open via the gate, then aborted by
+            // the second handle() below; we'll fire the captured
+            // callback AFTER the abort so the closure sees
+            // `signal.aborted === true` (and `disposed === false`).
+            capturedOnBeatMissing = input.onBeatMissing;
+            firstRunnerEntered?.();
+            await firstRunnerGate;
+          }
+        },
+        onError: (err) => {
+          captured.push(err);
+        },
+      });
+
+      // Start the first navigation but do NOT await it — the runner
+      // is parked on `firstRunnerGate`.
+      const firstHandle = loader.handle(sceneTargetWithBeat('intro', 'unknown-label'));
+      await firstRunnerEnteredBarrier;
+
+      // Enqueue a second navigation. `enqueue()` aborts the in-flight
+      // load via `inFlight.controller.abort()` — that flips the first
+      // navigation's signal.aborted to true. The second navigation
+      // proceeds to wait for the first to settle (it won't, until we
+      // release the gate below).
+      const secondHandle = loader.handle(sceneTarget('intro'));
+
+      // The first runner's signal is now aborted. Fire its captured
+      // callback — the closure must observe `signal.aborted === true`
+      // and no-op (the loader is NOT disposed). Without the guard,
+      // this would write `data-pulsar-navigation-error` for a dead
+      // navigation.
+      capturedOnBeatMissing?.();
+
+      // Release the first runner's gate so the lifecycle drains and
+      // the second navigation can proceed.
+      resolveFirstRunner?.();
+      await firstHandle;
+      await secondHandle;
+
+      // Stage carries the second navigation's scene (`intro` with no
+      // beat) and no error attribute — the stale beat-missing was
+      // suppressed.
+      expect(captured).toEqual([]);
+      expect(stage.attrs.get('data-pulsar-scene-target')).toBe('intro');
+      expect(stage.attrs.has('data-pulsar-navigation-error')).toBe(false);
+    });
+
+    it('suppresses a missing-beat diagnostic if the runner reports after dispose (disposed guard)', async () => {
+      // Sibling of the signal.aborted test above — proves the
+      // `disposed` branch of the closure independently.
       const captured: unknown[] = [];
       const intro = buildScene({ id: 'intro' });
       const stage = buildStage();
@@ -920,11 +993,9 @@ describe('createSceneLoader (PUL-F008)', () => {
         ctx: {},
         createPreloader: () => () => undefined,
         runTimeline: (input) => {
-          // Capture the callback but DON'T call it yet — we simulate
-          // a runner that reports late, after the navigation was
-          // aborted by a follow-up dispose().
+          // Capture but don't fire; the runner exits immediately so
+          // the lifecycle settles. Then dispose; then fire.
           capturedOnBeatMissing = input.onBeatMissing;
-          // Resolve the runner immediately so the lifecycle settles.
         },
         onError: (err) => {
           captured.push(err);
@@ -932,14 +1003,11 @@ describe('createSceneLoader (PUL-F008)', () => {
       });
 
       await loader.handle(sceneTargetWithBeat('intro', 'unknown-label'));
-      // Drop the diagnostic that the runner DID surface during the
-      // original navigation — focus the test on a SECOND, late call
-      // that comes in after the load is dead.
+      // Drop the diagnostic the runner DID surface during the first
+      // navigation — focus the test on a SECOND, late call.
       stage.attrs.delete('data-pulsar-navigation-error');
       captured.length = 0;
 
-      // Now dispose the loader and have the captured callback fire.
-      // The closure must observe `disposed === true` and no-op.
       loader.dispose();
       capturedOnBeatMissing?.();
 

--- a/tests/runtime/scene-loader.test.ts
+++ b/tests/runtime/scene-loader.test.ts
@@ -782,4 +782,311 @@ describe('createSceneLoader (PUL-F008)', () => {
       expect(log).toEqual([]);
     });
   });
+
+  describe('beat positioning (PUL-F011)', () => {
+    // PUL-F011: when `beat=<label>` is present, the runtime SHALL
+    // position the active scene's timeline at the named label; if the
+    // label does not exist, surface an error and remain at the scene's
+    // first beat. ADR-015 places label existence + seeking in the
+    // timeline-runner boundary; the loader's job is to:
+    //   (a) extract `target.beat` and forward it to the runner;
+    //   (b) provide an `onBeatMissing` callback that writes the
+    //       `data-pulsar-navigation-error` attribute + calls `onError`
+    //       WITHOUT unmounting the scene (no rejection through the
+    //       resolver, which would trigger cleanup).
+
+    const sceneTargetWithBeat = (id: string, beat: string): NavigationTarget => ({
+      locator: { kind: 'scene', scene: id },
+      beat,
+    });
+
+    it('forwards `beat` from the parsed navigation target to the runner', async () => {
+      const seen: { beat?: string }[] = [];
+      const intro = buildScene({ id: 'intro' });
+      const stage = buildStage();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([intro]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        ctx: {},
+        createPreloader: () => () => undefined,
+        runTimeline: (input) => {
+          const captured: { beat?: string } = {};
+          if ('beat' in input) captured.beat = input.beat;
+          seen.push(captured);
+        },
+      });
+
+      await loader.handle(sceneTargetWithBeat('intro', 'hook'));
+
+      expect(seen).toEqual([{ beat: 'hook' }]);
+    });
+
+    it('keeps the scene mounted while the runner is still active after onBeatMissing (PUL-F011 "remain at the scene\'s first beat")', async () => {
+      // The substantive PUL-F011 invariant: a missing-label diagnostic
+      // MUST NOT cause the scene to be unmounted. Reading "create then
+      // cleanup" alone is insufficient evidence — that just describes
+      // any normal lifecycle. The test instead holds the runner pending
+      // (so the scene is "live"), observes the diagnostic surfaced AND
+      // the scene is still mounted (cleanup has NOT yet fired), then
+      // releases the runner and confirms cleanup ran on natural exit.
+      // This pins that the missing-beat path does NOT short-circuit the
+      // resolver into an early cleanup.
+      const captured: unknown[] = [];
+      const lifecycleLog: string[] = [];
+      let resolveRunner: (() => void) | undefined;
+      const runnerGate = new Promise<void>((res) => {
+        resolveRunner = res;
+      });
+      let runnerEntered: (() => void) | undefined;
+      const runnerEnteredBarrier = new Promise<void>((res) => {
+        runnerEntered = res;
+      });
+      const intro = buildScene({
+        id: 'intro',
+        create: () => {
+          lifecycleLog.push('create');
+        },
+        cleanup: () => {
+          lifecycleLog.push('cleanup');
+        },
+      });
+      const stage = buildStage();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([intro]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        ctx: {},
+        createPreloader: () => () => undefined,
+        runTimeline: async (input) => {
+          // Simulate an unknown timeline label: runner reports the
+          // diagnostic via `onBeatMissing`, signals the test that
+          // it has entered, and stays alive (await gate). The
+          // runner MUST NOT throw — that would trigger cleanup and
+          // unmount the scene per PUL-F006.
+          input.onBeatMissing?.();
+          runnerEntered?.();
+          await runnerGate;
+        },
+        onError: (err) => {
+          captured.push(err);
+        },
+      });
+
+      const handlePromise = loader.handle(sceneTargetWithBeat('intro', 'unknown-label'));
+
+      // Block until the runner has fired the diagnostic and is
+      // awaiting the gate. This synchronizes the assertions to a
+      // deterministic lifecycle point — independent of how many
+      // microtasks the queue / dispatcher / resolver chain costs.
+      await runnerEnteredBarrier;
+
+      // While the runner is still pending: scene IS mounted (create
+      // fired, cleanup has NOT), the diagnostic IS surfaced. This is
+      // the substantive "remain at the scene's first beat" assertion.
+      expect(lifecycleLog).toEqual(['create']);
+      expect(stage.attrs.get('data-pulsar-scene-target')).toBe('intro');
+      expect(stage.attrs.get('data-pulsar-navigation-error')).toBe(
+        'beat positioning failed: beat "unknown-label" does not exist in scene "intro"',
+      );
+      expect(captured).toHaveLength(1);
+      expect((captured[0] as Error).message).toBe(
+        'beat positioning failed: beat "unknown-label" does not exist in scene "intro"',
+      );
+
+      // Release the runner so the lifecycle completes naturally.
+      // Cleanup runs only now — proves the diagnostic did NOT
+      // short-circuit into an early unmount.
+      resolveRunner?.();
+      await handlePromise;
+      expect(lifecycleLog).toEqual(['create', 'cleanup']);
+    });
+
+    it('suppresses a missing-beat diagnostic if the runner reports after the load was aborted (stale-load guard)', async () => {
+      // Defense parallel to `isPureAbort` for fatal-error suppression:
+      // a runner that calls `onBeatMissing` after a navigation was
+      // superseded (e.g. popstate aborted the in-flight load) must
+      // NOT write a diagnostic for the dead navigation. Otherwise the
+      // stage would carry the previous URL's beat error after the new
+      // navigation completed.
+      const captured: unknown[] = [];
+      const intro = buildScene({ id: 'intro' });
+      const stage = buildStage();
+      let capturedOnBeatMissing: (() => void) | undefined;
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([intro]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        ctx: {},
+        createPreloader: () => () => undefined,
+        runTimeline: (input) => {
+          // Capture the callback but DON'T call it yet — we simulate
+          // a runner that reports late, after the navigation was
+          // aborted by a follow-up dispose().
+          capturedOnBeatMissing = input.onBeatMissing;
+          // Resolve the runner immediately so the lifecycle settles.
+        },
+        onError: (err) => {
+          captured.push(err);
+        },
+      });
+
+      await loader.handle(sceneTargetWithBeat('intro', 'unknown-label'));
+      // Drop the diagnostic that the runner DID surface during the
+      // original navigation — focus the test on a SECOND, late call
+      // that comes in after the load is dead.
+      stage.attrs.delete('data-pulsar-navigation-error');
+      captured.length = 0;
+
+      // Now dispose the loader and have the captured callback fire.
+      // The closure must observe `disposed === true` and no-op.
+      loader.dispose();
+      capturedOnBeatMissing?.();
+
+      expect(captured).toEqual([]);
+      expect(stage.attrs.has('data-pulsar-navigation-error')).toBe(false);
+    });
+
+    it('only fires the diagnostic once per navigation even if the runner calls onBeatMissing repeatedly', async () => {
+      // A buggy runner (or a future GSAP integration that retries on
+      // each beat-not-found) must not spam the error sink. Once-only
+      // gating matches every other surfaceError call in the loader.
+      const captured: unknown[] = [];
+      const intro = buildScene({ id: 'intro' });
+      const stage = buildStage();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([intro]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        ctx: {},
+        createPreloader: () => () => undefined,
+        runTimeline: (input) => {
+          input.onBeatMissing?.();
+          input.onBeatMissing?.();
+          input.onBeatMissing?.();
+        },
+        onError: (err) => {
+          captured.push(err);
+        },
+      });
+
+      await loader.handle(sceneTargetWithBeat('intro', 'unknown-label'));
+
+      expect(captured).toHaveLength(1);
+    });
+
+    it('rejects a constructed target whose `beat` value is not kebab-case (defense-in-depth for parser)', async () => {
+      // The parser validates `beat` shape; the loader re-validates so
+      // a hand-built `NavigationTarget` (event-detail unmarshaling,
+      // programmatic navigation) cannot bypass kebab-case enforcement.
+      const captured: unknown[] = [];
+      const intro = buildScene({ id: 'intro' });
+      const stage = buildStage();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([intro]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        ctx: {},
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+        onError: (err) => {
+          captured.push(err);
+        },
+      });
+
+      const malformed: NavigationTarget = {
+        locator: { kind: 'scene', scene: 'intro' },
+        // `Bad Label` has uppercase + space — invalid kebab.
+        // Cast to string is needed because the type annotation on
+        // `beat` is `string`, but parser enforcement makes any
+        // non-kebab beat unreachable in normal flow.
+        beat: 'Bad Label' as unknown as string,
+      };
+
+      await loader.handle(malformed);
+
+      expect(stage.attrs.has('data-pulsar-scene-target')).toBe(false);
+      expect(stage.attrs.get('data-pulsar-navigation-error')).toMatch(
+        /^navigation grammar is invalid: "beat" must be a non-empty lowercase kebab-case string/,
+      );
+      expect(captured).toHaveLength(1);
+    });
+
+    it('a successful beat (runner does NOT invoke onBeatMissing) leaves the error attribute absent', async () => {
+      const intro = buildScene({ id: 'intro' });
+      const stage = buildStage();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([intro]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        ctx: {},
+        createPreloader: () => () => undefined,
+        runTimeline: () => undefined, // simulates successful seek
+      });
+
+      await loader.handle(sceneTargetWithBeat('intro', 'hook'));
+
+      expect(stage.attrs.get('data-pulsar-scene-target')).toBe('intro');
+      expect(stage.attrs.has('data-pulsar-navigation-error')).toBe(false);
+    });
+
+    it('rejects a constructed `composition`-only target with `beat` (defense-in-depth for ADR-013)', async () => {
+      // `parseNavigationSearch` already rejects `composition=<id>&beat=<label>`,
+      // but `NavigationTarget` is an exported type and a non-parser
+      // caller could construct one directly. The loader re-enforces
+      // the rule before any side effect so a hand-built target does
+      // not bypass the grammar invariant the parser would have caught.
+      const captured: unknown[] = [];
+      const intro = buildScene({ id: 'intro' });
+      const stage = buildStage();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([intro]),
+        compositions: createCompositionRegistry([{ id: 'full-talk', manifest: ['intro'] }]),
+        stage: stage.element,
+        ctx: {},
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+        onError: (err) => {
+          captured.push(err);
+        },
+      });
+
+      const compositionOnlyWithBeat: NavigationTarget = {
+        locator: { kind: 'composition', composition: 'full-talk' },
+        beat: 'hook',
+      };
+
+      await loader.handle(compositionOnlyWithBeat);
+
+      expect(stage.attrs.has('data-pulsar-scene-target')).toBe(false);
+      expect(stage.attrs.has('data-pulsar-composition-target')).toBe(false);
+      expect(stage.attrs.get('data-pulsar-navigation-error')).toMatch(
+        /^navigation grammar is invalid: "beat" requires a scene-like target/,
+      );
+      expect(captured).toHaveLength(1);
+    });
+
+    it('targets without `beat` carry no `beat` or `onBeatMissing` on the run input', async () => {
+      const seen: { beatPresent: boolean; onBeatMissingPresent: boolean }[] = [];
+      const intro = buildScene({ id: 'intro' });
+      const stage = buildStage();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([intro]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        ctx: {},
+        createPreloader: () => () => undefined,
+        runTimeline: (input) => {
+          seen.push({
+            beatPresent: 'beat' in input,
+            onBeatMissingPresent: 'onBeatMissing' in input,
+          });
+        },
+      });
+
+      await loader.handle(sceneTarget('intro'));
+
+      expect(seen).toEqual([{ beatPresent: false, onBeatMissingPresent: false }]);
+    });
+  });
 });

--- a/tests/runtime/scene-loader.test.ts
+++ b/tests/runtime/scene-loader.test.ts
@@ -1015,6 +1015,53 @@ describe('createSceneLoader (PUL-F008)', () => {
       expect(stage.attrs.has('data-pulsar-navigation-error')).toBe(false);
     });
 
+    it('keeps the missing-beat path non-fatal when the injected onError sink throws', async () => {
+      // PUL-F011 / ADR-015: the diagnostic callback is contractually
+      // non-fatal — the runner is forbidden from throwing on missing
+      // labels. The injected `onError` sink is user-supplied, so an
+      // exception from it must NOT propagate back through
+      // `input.onBeatMissing()` into the resolver (which would treat
+      // it as a lifecycle failure and unmount the scene). Cleanup is
+      // therefore the natural lifecycle exit, NOT a phase-error
+      // wrap, when onError throws.
+      const lifecycleLog: string[] = [];
+      const intro = buildScene({
+        id: 'intro',
+        create: () => {
+          lifecycleLog.push('create');
+        },
+        cleanup: () => {
+          lifecycleLog.push('cleanup');
+        },
+      });
+      const stage = buildStage();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([intro]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        ctx: {},
+        createPreloader: () => () => undefined,
+        runTimeline: (input) => {
+          input.onBeatMissing?.();
+          // If onBeatMissing's surfaceError had thrown out, this
+          // line would not execute and the runner would surface a
+          // rejection — the assertion below would catch it.
+        },
+        onError: () => {
+          throw new Error('user-injected logger blew up');
+        },
+      });
+
+      await expect(
+        loader.handle(sceneTargetWithBeat('intro', 'unknown-label')),
+      ).resolves.toBeUndefined();
+
+      // Lifecycle ran end-to-end as expected for a successful
+      // missing-beat exit. cleanup fired naturally; no extra
+      // phase-error wrap, no AggregateError, no rejection.
+      expect(lifecycleLog).toEqual(['create', 'cleanup']);
+    });
+
     it('only fires the diagnostic once per navigation even if the runner calls onBeatMissing repeatedly', async () => {
       // A buggy runner (or a future GSAP integration that retries on
       // each beat-not-found) must not spam the error sink. Once-only

--- a/tests/runtime/scene-navigation.test.ts
+++ b/tests/runtime/scene-navigation.test.ts
@@ -863,7 +863,7 @@ describe('loadSceneNavigationTarget (PUL-F008 lifecycle bridge)', () => {
           beat: 'hook',
         }),
       ).rejects.toThrow(
-        /^loadSceneNavigationTarget: `onBeatMissing` is required when `beat` is supplied/,
+        /^scene navigation failed: "onBeatMissing" is required when "beat" is supplied/,
       );
     });
 

--- a/tests/runtime/scene-navigation.test.ts
+++ b/tests/runtime/scene-navigation.test.ts
@@ -749,6 +749,7 @@ describe('loadSceneNavigationTarget (PUL-F008 lifecycle bridge)', () => {
           seen.push(captured);
         },
         beat: 'hook',
+        onBeatMissing: () => undefined,
       });
 
       expect(seen).toEqual([{ beat: 'hook' }]);
@@ -783,6 +784,7 @@ describe('loadSceneNavigationTarget (PUL-F008 lifecycle bridge)', () => {
           seen.push(captured);
         },
         beat: 'hook',
+        onBeatMissing: () => undefined,
       });
 
       expect(seen).toEqual([{ id: 'intro', beat: 'hook' }, { id: 'middle' }]);
@@ -838,6 +840,31 @@ describe('loadSceneNavigationTarget (PUL-F008 lifecycle bridge)', () => {
       });
 
       expect(onBeatMissingPresence).toEqual([false]);
+    });
+
+    it('throws when `beat` is supplied without `onBeatMissing` (paired-required contract)', async () => {
+      // PUL-F011 / ADR-015: a `beat` without an `onBeatMissing` would
+      // silently lose the missing-label diagnostic the runner is
+      // contracted to surface. The bridge fails fast at the boundary,
+      // mirroring the resolver's check.
+      const intro = buildScene({ id: 'intro' });
+      const scenes = createSceneRegistry([intro]);
+      const compositions = createCompositionRegistry([]);
+      const target = resolveSceneNavigation(sceneTarget('intro'), {
+        scenes,
+        compositions,
+      }) as SceneNavigationTarget;
+
+      await expect(
+        loadSceneNavigationTarget(target, {
+          ctx: {},
+          preloadAssets: () => undefined,
+          runTimeline: () => undefined,
+          beat: 'hook',
+        }),
+      ).rejects.toThrow(
+        /^loadSceneNavigationTarget: `onBeatMissing` is required when `beat` is supplied/,
+      );
     });
 
     it('does not forward `beat` when the option is omitted', async () => {

--- a/tests/runtime/scene-navigation.test.ts
+++ b/tests/runtime/scene-navigation.test.ts
@@ -723,4 +723,145 @@ describe('loadSceneNavigationTarget (PUL-F008 lifecycle bridge)', () => {
 
     expect(seen).toEqual([ctx, ctx, ctx]);
   });
+
+  describe('URL beat forwarding (PUL-F011)', () => {
+    // ADR-015: URL beat is timeline-runner state. The bridge's only
+    // job is to forward `beat` and `onBeatMissing` from the loader to
+    // the resolver as `headBeat` / `onBeatMissing`. Label existence
+    // and seeking remain the runner's responsibility.
+
+    it('forwards `beat` to the runner for a single-scene target', async () => {
+      const seen: { beat?: string }[] = [];
+      const intro = buildScene({ id: 'intro' });
+      const scenes = createSceneRegistry([intro]);
+      const compositions = createCompositionRegistry([]);
+      const target = resolveSceneNavigation(sceneTarget('intro'), {
+        scenes,
+        compositions,
+      }) as SceneNavigationTarget;
+
+      await loadSceneNavigationTarget(target, {
+        ctx: {},
+        preloadAssets: () => undefined,
+        runTimeline: (input) => {
+          const captured: { beat?: string } = {};
+          if ('beat' in input) captured.beat = input.beat;
+          seen.push(captured);
+        },
+        beat: 'hook',
+      });
+
+      expect(seen).toEqual([{ beat: 'hook' }]);
+    });
+
+    it('forwards `beat` to the head scene only of a composition slice', async () => {
+      // Composition slice with two entries; the head must receive
+      // `beat`, the tail must not. ADR-015: URL beat targets the
+      // active head scene only — no search through later scenes.
+      // `composition-index` (per ADR-013) is the valid grammar for
+      // pairing composition with beat; `kind: 'composition'` alone
+      // would be rejected by the parser and the loader's defense-in-
+      // depth check.
+      const seen: { id: string; beat?: string }[] = [];
+      const intro = buildScene({ id: 'intro' });
+      const middle = buildScene({ id: 'middle' });
+      const scenes = createSceneRegistry([intro, middle]);
+      const compositions = createCompositionRegistry([
+        { id: 'full-talk', manifest: ['intro', 'middle'] },
+      ]);
+      const target = resolveSceneNavigation(compositionIndexTarget('full-talk', 0), {
+        scenes,
+        compositions,
+      }) as SceneNavigationTarget;
+
+      await loadSceneNavigationTarget(target, {
+        ctx: {},
+        preloadAssets: () => undefined,
+        runTimeline: (input) => {
+          const captured: { id: string; beat?: string } = { id: input.scene.id };
+          if ('beat' in input) captured.beat = input.beat;
+          seen.push(captured);
+        },
+        beat: 'hook',
+      });
+
+      expect(seen).toEqual([{ id: 'intro', beat: 'hook' }, { id: 'middle' }]);
+    });
+
+    it('forwards `onBeatMissing` to the head scene only', async () => {
+      const callbacks: (((() => void) | undefined) | 'absent')[] = [];
+      const sentinel = (): void => undefined;
+      const intro = buildScene({ id: 'intro' });
+      const middle = buildScene({ id: 'middle' });
+      const scenes = createSceneRegistry([intro, middle]);
+      const compositions = createCompositionRegistry([
+        { id: 'full-talk', manifest: ['intro', 'middle'] },
+      ]);
+      const target = resolveSceneNavigation(compositionIndexTarget('full-talk', 0), {
+        scenes,
+        compositions,
+      }) as SceneNavigationTarget;
+
+      await loadSceneNavigationTarget(target, {
+        ctx: {},
+        preloadAssets: () => undefined,
+        runTimeline: (input) => {
+          callbacks.push('onBeatMissing' in input ? input.onBeatMissing : 'absent');
+        },
+        beat: 'hook',
+        onBeatMissing: sentinel,
+      });
+
+      expect(callbacks).toEqual([sentinel, 'absent']);
+    });
+
+    it('does not forward `onBeatMissing` when `beat` is omitted (paired contract)', async () => {
+      // `onBeatMissing` is meaningless without a `beat` to trigger it.
+      // The bridge drops the callback when the caller forgot to supply
+      // a beat so the resolver / runner never see an impossible state.
+      const onBeatMissingPresence: boolean[] = [];
+      const intro = buildScene({ id: 'intro' });
+      const scenes = createSceneRegistry([intro]);
+      const compositions = createCompositionRegistry([]);
+      const target = resolveSceneNavigation(sceneTarget('intro'), {
+        scenes,
+        compositions,
+      }) as SceneNavigationTarget;
+
+      await loadSceneNavigationTarget(target, {
+        ctx: {},
+        preloadAssets: () => undefined,
+        runTimeline: (input) => {
+          onBeatMissingPresence.push('onBeatMissing' in input);
+        },
+        onBeatMissing: () => undefined,
+      });
+
+      expect(onBeatMissingPresence).toEqual([false]);
+    });
+
+    it('does not forward `beat` when the option is omitted', async () => {
+      const seen: SceneNavigationTarget['scene'][] = [];
+      const beatPresence: boolean[] = [];
+      const intro = buildScene({ id: 'intro' });
+      const scenes = createSceneRegistry([intro]);
+      const compositions = createCompositionRegistry([]);
+      const target = resolveSceneNavigation(sceneTarget('intro'), {
+        scenes,
+        compositions,
+      }) as SceneNavigationTarget;
+
+      await loadSceneNavigationTarget(target, {
+        ctx: {},
+        preloadAssets: () => undefined,
+        runTimeline: (input) => {
+          seen.push(input.scene);
+          beatPresence.push('beat' in input);
+        },
+      });
+
+      expect(seen).toHaveLength(1);
+      expect(beatPresence).toEqual([false]);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Implements PUL-F011's URL beat positioning end-to-end at the runtime
contract level: parser → dispatcher → resolver → timeline-runner adapter,
with a non-fatal callback for missing labels per ADR-015.

- **Data shape**: `SceneTimelineRunInput` carries optional `beat` and
  `onBeatMissing`; `ResolveCompositionOptions` and
  `LoadSceneNavigationTargetOptions` carry the matching forwarding
  fields. The resolver attaches both to plan[0]'s run input only —
  ADR-015 scopes URL beat to the active head scene (no search through
  composition tail). Both the bridge and the resolver enforce the
  paired contract (`onBeatMissing` is dropped when no `beat` is set).
- **Loader wiring**: extracts \`target.beat\`, builds a non-fatal
  \`onBeatMissing\` closure that writes
  \`data-pulsar-navigation-error\` and calls \`onError\` without
  rejecting the resolver. The closure is guarded for stale-load
  (signal aborted), post-dispose, and once-only invocations.
- **Defense-in-depth at the loader**: a hand-built \`NavigationTarget\`
  is re-validated for kebab-case \`beat\` shape AND the ADR-013
  "beat requires a scene-like target" combination rule.
- **Placeholder runner** (\`src/main.ts\`): invokes
  \`input.onBeatMissing?.()\` for any URL beat. The placeholder
  timeline returns \`null\` (no labels), so every beat is missing by
  definition. Abort signal is checked first to suppress stale
  diagnostics for superseded loads. ADR-003's GSAP runner replaces
  this with real \`timeline.labels[input.beat]\` seeking when the
  engine lands.
- **ADR-015** records the design: \`beat\` is timeline-runner state
  (not parser/dispatcher/registry/manifest state); missing-label
  diagnostic must NOT reject through \`resolveComposition\` (would
  trigger PUL-F006 cleanup and unmount the scene); valid label seeking
  belongs to the timeline engine's label API (no parallel beat schema
  in scene metadata).

## Test plan

- [x] \`pnpm lint\` — clean
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm test\` — 526 tests pass (resolver +5 PUL-F011 tests;
      bridge +5; loader +8 including a pending-runner pattern that
      proves the scene stays mounted DURING the diagnostic by holding
      the runner open via a barrier and asserting create has fired
      while cleanup has NOT)
- [x] \`pre-commit run --all-files\` — clean
- [x] \`gc_codex_review\` (pre-push, cycle 1) — 4 findings, all fixed
- [x] \`gc_codex_review\` (pre-push, cycle 2) — 6 findings, 5 fixed,
      1 escalated to user (see issue thread)

Closes #20