### PR TITLE
PUL-F012: URL parameter `mode`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `src/runtime/scene-loader.ts` — `SceneLoaderOptions.ctx: unknown`
+  replaced with `SceneLoaderOptions.buildCtx: (mode: NavigationMode)
+  => unknown`. The loader now derives the effective workbench mode
+  per navigation via `effectiveMode(target)` and calls `buildCtx` to
+  assemble the per-navigation scene context, so mode dispatch lives
+  at the runtime-core seam ADR-007 names (PUL-F012). `WorkbenchSceneCtx`
+  gained a `readonly mode: NavigationMode` field; the workbench's
+  `buildCtx` populates it. Constructing ctx per navigation is the
+  structural defense against ADR-007's "previous non-`present` mode
+  leaks into a `mode`-less URL" risk: there is no long-lived ctx slot
+  for mode to linger in. `buildCtx` is not invoked when the locator
+  is `kind: 'none'`, on parse-error events, or when scene resolution
+  fails — those paths run no lifecycle.
+- `src/main.ts` — workbench bootstrap now passes `buildCtx: (mode) =>
+  ({ stage, mode })` instead of a static ctx object. Type-checked
+  against the updated `WorkbenchSceneCtx` so a missing `mode` field
+  on a real ctx fails at compile time.
+- `docs/adrs/007-browser-workbench.md` — added the URL-only-source
+  invariant ("when `mode` is absent, the runtime selects the
+  effective mode `present`; it must not recover mode from
+  localStorage, sessionStorage, cookies, `history.state`, or prior
+  in-memory navigation state") and the matching risk-table row for
+  the leak case. PUL-F012 implementation expectation.
+- `docs/adrs/013-url-navigation-grammar-boundary.md` — added the
+  PUL-F012 paragraph spelling out the boundary contract: the parser
+  preserves absent `mode` as absent on `NavigationTarget`; the
+  runtime core derives effective `present` before dispatching mode
+  behavior or exposing `ctx.mode` to scenes. Corresponding risk-table
+  row added.
 - `src/runtime/composition-resolver.ts` / `src/runtime/scene-navigation.ts`
   — both now reject `headBeat` / `beat` supplied without a paired
   `onBeatMissing` callback. PUL-F011 / ADR-015 makes the callback the
@@ -27,6 +56,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `src/runtime/navigation.ts` — `effectiveMode(target?:
+  NavigationTarget): NavigationMode` pure helper that returns
+  `target?.mode ?? 'present'`. The single dispatch point for
+  PUL-F012's "URL parameter selects the mode; absent defaults to
+  `present`" rule. Pure function — depends only on its argument so
+  the ADR-007 invariant "URL is the only source of mode" is enforced
+  by construction (no `localStorage` / `sessionStorage` / cookie /
+  `history.state` access).
 - `src/runtime/composition-resolver.ts` — `headBeat?: string` and
   `onBeatMissing?: () => void` fields on `ResolveCompositionOptions`,
   paired with `beat?: string` and `onBeatMissing?: () => void` on

--- a/docs/adrs/007-browser-workbench.md
+++ b/docs/adrs/007-browser-workbench.md
@@ -95,6 +95,10 @@ presenter UI.
 ### Implementation expectations
 
 - The runtime parses URL parameters at startup and on `popstate`.
+- The URL is the only source of workbench mode selection. When
+  `mode` is absent, the runtime selects the effective mode `present`;
+  it must not recover mode from localStorage, sessionStorage, cookies,
+  `history.state`, or prior in-memory navigation state.
 - Mode is dispatched in the runtime core, not per scene. Scenes do not
   know which mode they are running in unless they need to (e.g.
   audio-suppressing when `mode=screenshot`).
@@ -132,6 +136,7 @@ presenter UI.
 | Modes accumulate scene-specific overrides until they aren't really modes | Hold the line: mode behavior is defined in the runtime core, not in individual scenes. Scene-specific behavior is rare and explicitly justified. |
 | `screenshot` mode is non-deterministic in subtle ways (fonts, async asset load, RNG) | Provide deterministic seeding and a preflight that resolves all promised assets before "ready"; the runtime's screenshot mode treats nondeterminism as a runtime bug, not an acceptance of reality. |
 | Agent reports URLs that depend on local state | URL parameters fully determine the targeted state; do not store inspection targets in localStorage or cookies. |
+| A previous non-`present` mode leaks into a URL without `mode` | Treat omitted `mode` as a fresh `present` selection on every startup and `popstate`; do not cache the last effective mode. |
 | Modes drift apart visually because each is touched independently | Audit each mode against `present` for the same target periodically; modes that diverge intentionally must say so in this ADR or its successor. |
 
 ## Related ADRs

--- a/docs/adrs/013-url-navigation-grammar-boundary.md
+++ b/docs/adrs/013-url-navigation-grammar-boundary.md
@@ -79,6 +79,14 @@ state must not redefine the target. A navigation change hands off to
 the existing runtime orchestration layer so `cleanup(ctx)` and
 composition-level cancellation semantics remain centralized.
 
+For PUL-F012, the parser preserves the difference between absent
+`mode` and an explicit `mode=present`: absent mode remains absent on
+the parsed `NavigationTarget`, while the runtime core selects
+effective mode `present` before dispatching mode behavior or exposing
+`ctx.mode` to scenes. This keeps URL grammar validation separate from
+workbench state selection and prevents the parser from becoming the
+mode dispatcher.
+
 ## Consequences
 
 ### Positive
@@ -105,6 +113,7 @@ composition-level cancellation semantics remain centralized.
 |------|------------|
 | Parser starts resolving scenes or manifests | Keep URL parsing as a pure boundary step; resolve through the registry/composition orchestration layers. |
 | URL mode handling leaks into individual scenes | Dispatch modes in the runtime core per ADR-007; expose only mode hints through context where needed. |
+| Parser defaults absent mode and hides URL intent | Preserve absent `mode` in `NavigationTarget`; derive the effective `present` mode in the runtime core handoff. |
 | Positional navigation becomes identity | Treat `index` as a composition-scoped compatibility locator; scene id remains content identity. |
 | Query values become resource paths or dynamic imports | Query values are identifiers only. Do not load modules, files, or network resources directly from URL parameter values. |
 | PUL-F010 handling forks from the existing composition path | Reuse the `composition-index` locator and dispatch through the same composition registry, scene registry, resolver, preloader, cleanup, and error-surfacing layers. |

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,6 +28,7 @@ import { createAssetPreloader } from './runtime/asset-preloader';
 import { createCompositionRegistry } from './runtime/composition-registry';
 import type { SceneTimelineRunner } from './runtime/composition-resolver';
 import {
+  type NavigationMode,
   type NavigationTarget,
   PULSAR_NAVIGATE_ERROR_EVENT_TYPE,
   PULSAR_NAVIGATE_EVENT_TYPE,
@@ -105,17 +106,22 @@ const runTimeline: SceneTimelineRunner = (input) =>
     );
   });
 
-// Scene context carries the stage handle so scene lifecycle hooks
-// can mutate the DOM through an injected dependency rather than
-// reaching for the global `document` (ADR-008 #2 — explicit
-// dependencies over ambient globals).
-const ctx: WorkbenchSceneCtx = { stage };
+// Scene context carries the stage handle plus the per-navigation
+// effective workbench mode (PUL-F012 / ADR-007). The loader calls
+// this builder once per navigation that produces a runnable target,
+// passing the effective mode it derived from the URL via
+// `effectiveMode`. Constructing ctx per navigation enforces ADR-007's
+// "URL is the only source of mode" rule by construction — there is no
+// long-lived ctx slot for a previous mode to linger in. ADR-008 #2
+// (explicit dependencies over ambient globals) is satisfied as before
+// by passing `stage` through ctx rather than reaching for `document`.
+const buildCtx = (mode: NavigationMode): WorkbenchSceneCtx => ({ stage, mode });
 
 const loader = createSceneLoader({
   scenes: sceneRegistry,
   compositions: compositionRegistry,
   stage,
-  ctx,
+  buildCtx,
   createPreloader,
   runTimeline,
 });

--- a/src/runtime/navigation.ts
+++ b/src/runtime/navigation.ts
@@ -258,6 +258,29 @@ export function parseNavigationSearch(input: URLSearchParams | string): Navigati
 }
 
 /**
+ * Derive the effective workbench mode for the runtime/core dispatch
+ * boundary (PUL-F012). When `target.mode` is present, that mode is
+ * selected; when absent (or no target is supplied), the default
+ * `'present'` is selected.
+ *
+ * Per ADR-007 the URL is the **only** source of mode: this helper
+ * MUST NOT consult `localStorage`, `sessionStorage`, `document.cookie`,
+ * `history.state`, or any cached in-memory navigation state. Per
+ * ADR-013 the parser preserves absent `mode` as absent on the parsed
+ * `NavigationTarget`, so the dispatch boundary can distinguish "URL
+ * said `mode=present`" from "URL said nothing" if a future requirement
+ * needs that distinction; today both collapse to the same effective
+ * mode by design.
+ *
+ * Pure function — depends only on its argument. Adding a fallback that
+ * reads any other source would violate ADR-007's "fresh `present`
+ * selection on every startup and `popstate`" guarantee.
+ */
+export function effectiveMode(target?: NavigationTarget | undefined): NavigationMode {
+  return target?.mode ?? 'present';
+}
+
+/**
  * Minimal `Window`-like surface required by {@link subscribeNavigation}.
  * Defined as a narrow shape — rather than `Pick<Window, ...>` — so the
  * tests can inject a fake without standing up jsdom or pulling in DOM

--- a/src/runtime/scene-loader.ts
+++ b/src/runtime/scene-loader.ts
@@ -33,7 +33,12 @@ import type { CompositionRegistry } from './composition-registry';
 import type { AssetPreloader, SceneTimelineRunner } from './composition-resolver';
 import { describeError } from './error';
 import { KEBAB_IDENTIFIER_FORM, isKebabIdentifier } from './identifier';
-import type { NavigationTarget } from './navigation';
+import {
+  NAVIGATION_MODES,
+  type NavigationMode,
+  type NavigationTarget,
+  effectiveMode,
+} from './navigation';
 import type { SceneRegistry } from './registry';
 import {
   type SceneNavigationTarget,
@@ -56,14 +61,28 @@ export interface StageElement {
  * stage in `ctx` keeps scenes pure of `document` lookups and
  * Node-test-friendly without `typeof document === 'undefined'` guards.
  *
- * Future requirements (timeline engine, audio engine, mode dispatch)
- * extend this shape with `gsap`, `audio`, `mode`, etc. per ADR-003 /
- * ADR-004 / ADR-007. The runtime resolver itself never inspects
- * ctx — it is purely a scene-to-environment carrier.
+ * `mode` exposes the effective workbench mode the runtime selected
+ * for the current navigation (PUL-F012 / ADR-007). Scenes that need
+ * mode-aware behavior — `screenshot` audio suppression, `loop`
+ * indefinite repetition — read it here rather than re-implementing
+ * mode detection. Per ADR-007 the runtime core is the dispatch
+ * point; the field is set per navigation by {@link createSceneLoader}.
+ *
+ * Future requirements (timeline engine, audio engine) extend this
+ * shape with `gsap`, `audio`, etc. per ADR-003 / ADR-004. The runtime
+ * resolver itself never inspects ctx — it is purely a scene-to-
+ * environment carrier.
  */
 export interface WorkbenchSceneCtx {
   /** The workbench stage element, or `null` when the runtime has no stage. */
   readonly stage: StageElement | null;
+  /**
+   * The effective workbench mode for the current navigation per
+   * PUL-F012 / ADR-007. Set by the loader from
+   * {@link effectiveMode}; absent `mode` URL parameter resolves to
+   * `'present'`.
+   */
+  readonly mode: NavigationMode;
 }
 
 /**
@@ -77,8 +96,31 @@ export interface SceneLoaderOptions {
   readonly compositions: CompositionRegistry;
   /** May be `null` when the workbench has no stage (rare; e.g. Node tests). */
   readonly stage: StageElement | null;
-  /** Opaque scene context forwarded to every lifecycle hook. */
-  readonly ctx: unknown;
+  /**
+   * Per-navigation scene context builder. The loader calls this once
+   * per navigation that produces a runnable target, passing the
+   * effective workbench mode derived from the URL via
+   * {@link effectiveMode} (PUL-F012 / ADR-007). The returned value is
+   * forwarded opaquely to every lifecycle hook (`create` / `timeline`
+   * / `cleanup`); the resolver never inspects it.
+   *
+   * Returns {@link WorkbenchSceneCtx} so the production contract
+   * "scenes receive `ctx.mode`" is enforced at this boundary rather
+   * than relying on a single workbench bootstrap annotation. Mode
+   * dispatch lives at this seam per ADR-007 ("Mode is dispatched in
+   * the runtime core, not per scene"): the workbench supplies the
+   * stage and any other long-lived ctx members through a closure, the
+   * loader contributes the per-navigation `mode`, and the combined
+   * value is what scenes see as `ctx`. Constructing a fresh ctx per
+   * navigation also blocks any "previous mode leaks into a `mode`-less
+   * URL" regression — every navigation re-derives mode from its own
+   * target.
+   *
+   * Not invoked when the locator is `kind: 'none'` (no scene mounts)
+   * or when the navigation event is a parse-error event, because
+   * those paths run no lifecycle.
+   */
+  readonly buildCtx: (mode: NavigationMode) => WorkbenchSceneCtx;
   /**
    * Build a per-navigation asset preloader bound to that
    * navigation's abort signal. The loader calls this once per
@@ -243,6 +285,29 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
   };
 
   /**
+   * Defense-in-depth for ADR-007's mode allowlist (PUL-F012).
+   * `parseNavigationSearch` validates `mode` against
+   * `NAVIGATION_MODES` on URL input, but `NavigationTarget` is an
+   * exported type that non-parser callers (event-detail unmarshaling,
+   * future test harnesses, programmatic navigation) can construct
+   * directly. Re-checking at the loader boundary stops a hand-built
+   * target with a mode the parser would have rejected from reaching
+   * `effectiveMode` and `buildCtx`, where it would propagate to
+   * scenes as `ctx.mode`. Returns an `Error` with the parser's exact
+   * grammar message when the target is invalid, or `null` when no
+   * further check is needed.
+   */
+  const validateModeGrammar = (target: NavigationTarget): Error | null => {
+    if (target.mode === undefined) return null;
+    if (!(NAVIGATION_MODES as readonly string[]).includes(target.mode)) {
+      return new Error(
+        `navigation grammar is invalid: "mode" unknown mode "${target.mode}" — allowed: ${NAVIGATION_MODES.join(', ')}`,
+      );
+    }
+    return null;
+  };
+
+  /**
    * PUL-F011 / ADR-015: build the non-fatal callback the loader
    * supplies to the timeline runner when the URL carries
    * `beat=<label>`. The callback writes
@@ -312,7 +377,7 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
    */
   const buildLoad = (
     resolved: SceneNavigationTarget,
-    beat: string | undefined,
+    target: NavigationTarget,
   ): InFlightLoad | null => {
     const controller = new AbortController();
     let preloadAssets: AssetPreloader;
@@ -328,11 +393,40 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
       surfaceError(err);
       return null;
     }
+    // PUL-F012 / ADR-007: mode dispatch lives at the runtime-core
+    // seam. The loader derives the effective mode from the parsed
+    // target via `effectiveMode` (URL-only — no localStorage,
+    // sessionStorage, cookies, history.state, or cached state) and
+    // hands the workbench's `buildCtx` that mode so the per-navigation
+    // ctx carries `mode`. Every navigation re-derives from its own
+    // target, so a previous non-`present` mode cannot leak into a
+    // subsequent `mode`-less URL.
+    //
+    // Built AFTER the preloader so a preloader-factory failure does
+    // not waste any builder-side allocations, and wrapped in the same
+    // rollback-then-surfaceError pattern so a throwing builder does
+    // not leave stale stage attrs or skip the queue's error sink.
+    let ctx: unknown;
+    try {
+      ctx = options.buildCtx(effectiveMode(target));
+    } catch (err) {
+      // Abort the freshly-created controller before bailing so any
+      // signal-tied resource the preloader factory may have wired
+      // (e.g. a fetch listener registered on `controller.signal`)
+      // observes cancellation and releases. Without this, the signal
+      // is GC'd in the never-aborted state and any abort-keyed
+      // listener runs at GC time (or never).
+      controller.abort();
+      resetStageAttrs();
+      surfaceError(err);
+      return null;
+    }
+    const beat = target.beat;
     const onBeatMissing = buildOnBeatMissing(beat, resolved.scene.id, controller.signal);
     return {
       controller,
       settled: loadSceneNavigationTarget(resolved, {
-        ctx: options.ctx,
+        ctx,
         preloadAssets,
         runTimeline: options.runTimeline,
         signal: controller.signal,
@@ -347,6 +441,11 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
     const beatErr = validateBeatGrammar(target);
     if (beatErr !== null) {
       surfaceError(beatErr);
+      return;
+    }
+    const modeErr = validateModeGrammar(target);
+    if (modeErr !== null) {
+      surfaceError(modeErr);
       return;
     }
 
@@ -368,7 +467,7 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
       setStageAttr(ATTR_COMPOSITION, resolved.composition.id);
     }
 
-    const load = buildLoad(resolved, target.beat);
+    const load = buildLoad(resolved, target);
     if (load === null) return;
     inFlight = load;
 

--- a/src/scenes/placeholder.ts
+++ b/src/scenes/placeholder.ts
@@ -24,13 +24,23 @@
 // composition context) and `trailerSafe: false` (it has nothing
 // trailer-worthy to show).
 
+import { NAVIGATION_MODES } from '../runtime/navigation';
 import type { SceneModule } from '../runtime/scene';
 import type { WorkbenchSceneCtx } from '../runtime/scene-loader';
 
 const LIFECYCLE_ATTR = 'data-pulsar-scene-lifecycle';
 
-const isWorkbenchCtx = (value: unknown): value is WorkbenchSceneCtx =>
-  typeof value === 'object' && value !== null && 'stage' in value;
+// PUL-F012: WorkbenchSceneCtx now requires `mode` alongside `stage`.
+// The predicate must check both so the type narrowing matches the
+// declared shape — a value that has only `stage` is NOT a valid
+// WorkbenchSceneCtx, and narrowing it would mislead future
+// mode-aware scene code into reading `undefined` from `ctx.mode`.
+const isWorkbenchCtx = (value: unknown): value is WorkbenchSceneCtx => {
+  if (typeof value !== 'object' || value === null) return false;
+  if (!('stage' in value) || !('mode' in value)) return false;
+  const mode = (value as { mode: unknown }).mode;
+  return typeof mode === 'string' && (NAVIGATION_MODES as readonly string[]).includes(mode);
+};
 
 const writeLifecycle = (ctx: unknown, phase: 'create' | 'timeline' | 'cleanup'): void => {
   if (!isWorkbenchCtx(ctx)) return;

--- a/src/scenes/placeholder.ts
+++ b/src/scenes/placeholder.ts
@@ -31,14 +31,27 @@ import type { WorkbenchSceneCtx } from '../runtime/scene-loader';
 const LIFECYCLE_ATTR = 'data-pulsar-scene-lifecycle';
 
 // PUL-F012: WorkbenchSceneCtx now requires `mode` alongside `stage`.
-// The predicate must check both so the type narrowing matches the
-// declared shape — a value that has only `stage` is NOT a valid
-// WorkbenchSceneCtx, and narrowing it would mislead future
-// mode-aware scene code into reading `undefined` from `ctx.mode`.
+// The predicate validates the full shape — `stage` must be `null` or
+// an object exposing `setAttribute` / `removeAttribute`, and `mode`
+// must be in `NAVIGATION_MODES`. Narrowing on a partial check would
+// pass a malformed `{ stage: {}, mode: 'present' }` that later
+// crashes inside `writeLifecycle` when it tries to call
+// `stage.setAttribute`, contradicting the no-op-on-malformed-ctx
+// contract these scene hooks document.
+const isStageShape = (stage: unknown): stage is WorkbenchSceneCtx['stage'] => {
+  if (stage === null) return true;
+  if (typeof stage !== 'object') return false;
+  const candidate = stage as Partial<Record<'setAttribute' | 'removeAttribute', unknown>>;
+  return (
+    typeof candidate.setAttribute === 'function' && typeof candidate.removeAttribute === 'function'
+  );
+};
+
 const isWorkbenchCtx = (value: unknown): value is WorkbenchSceneCtx => {
   if (typeof value !== 'object' || value === null) return false;
   if (!('stage' in value) || !('mode' in value)) return false;
-  const mode = (value as { mode: unknown }).mode;
+  const { stage, mode } = value as { stage: unknown; mode: unknown };
+  if (!isStageShape(stage)) return false;
   return typeof mode === 'string' && (NAVIGATION_MODES as readonly string[]).includes(mode);
 };
 

--- a/tests/runtime/navigation.test.ts
+++ b/tests/runtime/navigation.test.ts
@@ -8,6 +8,7 @@ import {
   PULSAR_NAVIGATE_ERROR_EVENT_TYPE,
   PULSAR_NAVIGATE_EVENT_TYPE,
   bootstrapNavigation,
+  effectiveMode,
   parseNavigationSearch,
   subscribeNavigation,
 } from '../../src/runtime/navigation';
@@ -363,6 +364,131 @@ describe('parseNavigationSearch — boundary discipline', () => {
     const target = parseNavigationSearch('composition=t&index=0&beat=hook&mode=loop');
     expect(Object.isFrozen(target)).toBe(true);
     expect(Object.isFrozen(target.locator)).toBe(true);
+  });
+});
+
+describe('effectiveMode — PUL-F012: derive workbench mode for runtime dispatch', () => {
+  // PUL-F012 / ADR-007 / ADR-013: the parser preserves absent `mode`
+  // on `NavigationTarget`; the runtime/core handoff (this helper)
+  // selects the effective mode. Absent → 'present'. Present → that
+  // mode value. The helper is the single dispatch point so the rule
+  // "URL is the only source of mode" cannot be violated by a caller
+  // sneaking a localStorage / sessionStorage / cookie / history.state
+  // read into the path.
+
+  it('returns "present" when no target is supplied (helper accepts undefined)', () => {
+    expect(effectiveMode(undefined)).toBe('present');
+  });
+
+  it('returns "present" when locator is "none" and mode is absent', () => {
+    expect(effectiveMode({ locator: { kind: 'none' } })).toBe('present');
+  });
+
+  it('returns "present" when locator is "scene" and mode is absent', () => {
+    expect(effectiveMode({ locator: { kind: 'scene', scene: 'intro' } })).toBe('present');
+  });
+
+  it.each(ALL_MODES)('returns the explicit mode "%s" when target carries it', (mode) => {
+    // Per-mode round-trip — every workbench mode in NAVIGATION_MODES
+    // is selectable via the URL parameter.
+    expect(effectiveMode({ locator: { kind: 'none' }, mode })).toBe(mode);
+  });
+
+  it('round-trips through parseNavigationSearch — explicit mode is selected', () => {
+    expect(effectiveMode(parseNavigationSearch('mode=screenshot'))).toBe('screenshot');
+  });
+
+  it('round-trips through parseNavigationSearch — empty URL defaults to "present"', () => {
+    expect(effectiveMode(parseNavigationSearch(''))).toBe('present');
+    expect(effectiveMode(parseNavigationSearch('?'))).toBe('present');
+    expect(effectiveMode(parseNavigationSearch('scene=intro'))).toBe('present');
+  });
+
+  it('round-trips an explicit "mode=present" identically to absent (both → "present")', () => {
+    // Per ADR-013: parser preserves absent mode as absent (test-only
+    // observation), but the dispatch boundary collapses both shapes to
+    // the same effective `present`. Two equivalent ways to get the
+    // default — both must work.
+    expect(effectiveMode(parseNavigationSearch('mode=present'))).toBe('present');
+    expect(effectiveMode(parseNavigationSearch(''))).toBe('present');
+  });
+
+  it('does not read browser-storage globals (URL is the only source)', () => {
+    // ADR-007 risk-table: "A previous non-`present` mode leaks into a
+    // URL without `mode`" — mitigation is "treat omitted mode as a
+    // fresh `present` selection on every startup and `popstate`; do
+    // not cache the last effective mode." A pure helper trivially
+    // satisfies this, but a future maintainer might add a fallback
+    // ("read from localStorage if the URL didn't say"). This test
+    // pins the contract by installing throwing getter spies on every
+    // forbidden source (`localStorage`, `sessionStorage`,
+    // `document.cookie`, `history.state`) before invoking the helper.
+    // Any read — even a benign existence check — fails the test.
+    type GlobalThisRecord = Record<string, unknown>;
+    const installSpy = (host: object, key: string, message: string): (() => void) => {
+      const original = Object.getOwnPropertyDescriptor(host, key);
+      const spy = vi.fn(() => {
+        throw new Error(message);
+      });
+      Object.defineProperty(host, key, { configurable: true, get: spy });
+      return () => {
+        if (original) {
+          Object.defineProperty(host, key, original);
+        } else {
+          Reflect.deleteProperty(host, key);
+        }
+      };
+    };
+
+    // `document` and `history` may or may not exist in the vitest
+    // node env. Install a fake host when absent so the cookie /
+    // history.state spy still gets a chance to fire if a regression
+    // walks `globalThis.document.cookie` etc.
+    const ensureHost = (key: 'document' | 'history'): (() => void) => {
+      const root = globalThis as GlobalThisRecord;
+      if (root[key] !== undefined) return () => undefined;
+      root[key] = {};
+      return () => {
+        Reflect.deleteProperty(root, key);
+      };
+    };
+
+    const restorers: (() => void)[] = [];
+    const restoreDocumentHost = ensureHost('document');
+    const restoreHistoryHost = ensureHost('history');
+    restorers.push(restoreDocumentHost, restoreHistoryHost);
+
+    restorers.push(installSpy(globalThis, 'localStorage', 'localStorage must not be read'));
+    restorers.push(installSpy(globalThis, 'sessionStorage', 'sessionStorage must not be read'));
+    restorers.push(
+      installSpy(
+        (globalThis as GlobalThisRecord).document as object,
+        'cookie',
+        'document.cookie must not be read',
+      ),
+    );
+    restorers.push(
+      installSpy(
+        (globalThis as GlobalThisRecord).history as object,
+        'state',
+        'history.state must not be read',
+      ),
+    );
+
+    try {
+      expect(effectiveMode(undefined)).toBe('present');
+      expect(
+        effectiveMode({ locator: { kind: 'scene', scene: 'intro' }, mode: 'screenshot' }),
+      ).toBe('screenshot');
+      expect(effectiveMode({ locator: { kind: 'none' } })).toBe('present');
+    } finally {
+      // Restore in reverse order so spy descriptors are removed
+      // before the host objects they're attached to.
+      while (restorers.length > 0) {
+        const restore = restorers.pop();
+        restore?.();
+      }
+    }
   });
 });
 

--- a/tests/runtime/scene-loader.test.ts
+++ b/tests/runtime/scene-loader.test.ts
@@ -10,13 +10,28 @@
 //  - ADR-014 — scene navigation dispatch + cleanup-before-handoff.
 //  - ADR-013 — URL grammar boundary; F007 supplies NavigationTarget.
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { createCompositionRegistry } from '../../src/runtime/composition-registry';
 import type { SceneTimelineRunner } from '../../src/runtime/composition-resolver';
-import type { NavigationTarget } from '../../src/runtime/navigation';
+import {
+  NAVIGATION_MODES,
+  type NavigationMode,
+  type NavigationTarget,
+} from '../../src/runtime/navigation';
 import { createSceneRegistry } from '../../src/runtime/registry';
 import type { SceneModule } from '../../src/runtime/scene';
-import { type StageElement, createSceneLoader } from '../../src/runtime/scene-loader';
+import {
+  type StageElement,
+  type WorkbenchSceneCtx,
+  createSceneLoader,
+} from '../../src/runtime/scene-loader';
+
+// Default ctx builder for tests that don't care about ctx contents:
+// produces a minimal WorkbenchSceneCtx with a null stage and the
+// effective mode the loader supplies. PUL-F012 tightened the loader's
+// `buildCtx` return type to `WorkbenchSceneCtx`, so a `() => ({})`
+// stub no longer satisfies the type.
+const stubCtx = (mode: NavigationMode): WorkbenchSceneCtx => ({ stage: null, mode });
 
 interface BuildSceneOpts {
   readonly id: string;
@@ -90,7 +105,7 @@ describe('createSceneLoader (PUL-F008)', () => {
         scenes: createSceneRegistry([intro]),
         compositions: createCompositionRegistry([]),
         stage: stage.element,
-        ctx: {},
+        buildCtx: stubCtx,
         createPreloader: () => () => undefined,
         runTimeline: noopRunner,
       });
@@ -112,7 +127,7 @@ describe('createSceneLoader (PUL-F008)', () => {
           { id: 'full-talk', manifest: ['intro', 'middle'] },
         ]),
         stage: stage.element,
-        ctx: {},
+        buildCtx: stubCtx,
         createPreloader: () => () => undefined,
         runTimeline: noopRunner,
       });
@@ -154,7 +169,7 @@ describe('createSceneLoader (PUL-F008)', () => {
           { id: 'full-talk', manifest: ['intro', 'middle', 'outro'] },
         ]),
         stage: stage.element,
-        ctx: {},
+        buildCtx: stubCtx,
         createPreloader: () => () => undefined,
         runTimeline: noopRunner,
       });
@@ -203,7 +218,7 @@ describe('createSceneLoader (PUL-F008)', () => {
           { id: 'full-talk', manifest: ['intro', 'middle', 'outro'] },
         ]),
         stage: stage.element,
-        ctx: {},
+        buildCtx: stubCtx,
         createPreloader: () => () => undefined,
         runTimeline: noopRunner,
       });
@@ -256,7 +271,7 @@ describe('createSceneLoader (PUL-F008)', () => {
             { id: 'trailer', manifest: ['scene-a', 'scene-b', 'scene-c', 'scene-d'] },
           ]),
           stage: stage.element,
-          ctx: {},
+          buildCtx: stubCtx,
           createPreloader: () => () => undefined,
           runTimeline: noopRunner,
         });
@@ -297,7 +312,7 @@ describe('createSceneLoader (PUL-F008)', () => {
             { id: 'full-talk', manifest: ['scene-a', 'scene-b', 'scene-c'] },
           ]),
           stage: stage.element,
-          ctx: {},
+          buildCtx: stubCtx,
           createPreloader: () => () => undefined,
           runTimeline: noopRunner,
         });
@@ -318,7 +333,7 @@ describe('createSceneLoader (PUL-F008)', () => {
         scenes: createSceneRegistry([buildScene({ id: 'intro' })]),
         compositions: createCompositionRegistry([]),
         stage: stage.element,
-        ctx: {},
+        buildCtx: stubCtx,
         createPreloader: () => () => undefined,
         runTimeline: noopRunner,
       });
@@ -340,7 +355,7 @@ describe('createSceneLoader (PUL-F008)', () => {
         scenes: createSceneRegistry([intro]),
         compositions: createCompositionRegistry([]),
         stage: stage.element,
-        ctx: {},
+        buildCtx: stubCtx,
         createPreloader: () => () => undefined,
         runTimeline: noopRunner,
       });
@@ -361,7 +376,7 @@ describe('createSceneLoader (PUL-F008)', () => {
         scenes: createSceneRegistry([buildScene({ id: 'intro' })]),
         compositions: createCompositionRegistry([]),
         stage: stage.element,
-        ctx: {},
+        buildCtx: stubCtx,
         createPreloader: () => () => undefined,
         runTimeline: noopRunner,
         onError: (err) => {
@@ -386,7 +401,7 @@ describe('createSceneLoader (PUL-F008)', () => {
         scenes: createSceneRegistry([buildScene({ id: 'intro' })]),
         compositions: createCompositionRegistry([]),
         stage: stage.element,
-        ctx: {},
+        buildCtx: stubCtx,
         createPreloader: () => () => undefined,
         runTimeline: noopRunner,
         onError: () => undefined,
@@ -412,7 +427,7 @@ describe('createSceneLoader (PUL-F008)', () => {
         scenes: createSceneRegistry([broken]),
         compositions: createCompositionRegistry([]),
         stage: stage.element,
-        ctx: {},
+        buildCtx: stubCtx,
         createPreloader: () => () => undefined,
         runTimeline: noopRunner,
         onError: () => undefined,
@@ -435,7 +450,7 @@ describe('createSceneLoader (PUL-F008)', () => {
         scenes: createSceneRegistry([buildScene({ id: 'intro' })]),
         compositions: createCompositionRegistry([]),
         stage: stage.element,
-        ctx: {},
+        buildCtx: stubCtx,
         createPreloader: () => () => undefined,
         runTimeline: noopRunner,
         onError: (err) => {
@@ -500,7 +515,7 @@ describe('createSceneLoader (PUL-F008)', () => {
         scenes: createSceneRegistry([intro, middle]),
         compositions: createCompositionRegistry([]),
         stage: stage.element,
-        ctx: {},
+        buildCtx: stubCtx,
         createPreloader: () => () => undefined,
         runTimeline: blockingRunner,
       });
@@ -543,7 +558,7 @@ describe('createSceneLoader (PUL-F008)', () => {
         scenes: createSceneRegistry([intro]),
         compositions: createCompositionRegistry([]),
         stage: stage.element,
-        ctx: {},
+        buildCtx: stubCtx,
         createPreloader: () => () => undefined,
         runTimeline: blockingRunner,
         onError: (err) => {
@@ -603,7 +618,7 @@ describe('createSceneLoader (PUL-F008)', () => {
         scenes: createSceneRegistry([a, b, c]),
         compositions: createCompositionRegistry([]),
         stage: stage.element,
-        ctx: {},
+        buildCtx: stubCtx,
         createPreloader: () => () => undefined,
         runTimeline: blockingRunner,
       });
@@ -653,7 +668,7 @@ describe('createSceneLoader (PUL-F008)', () => {
         scenes: createSceneRegistry([intro]),
         compositions: createCompositionRegistry([]),
         stage: stage.element,
-        ctx: {},
+        buildCtx: stubCtx,
         createPreloader: () => () => undefined,
         runTimeline: blockingRunner,
         onError: (err) => {
@@ -713,7 +728,7 @@ describe('createSceneLoader (PUL-F008)', () => {
         scenes: createSceneRegistry([intro, middle]),
         compositions: createCompositionRegistry([]),
         stage: stage.element,
-        ctx: {},
+        buildCtx: stubCtx,
         createPreloader: () => () => undefined,
         runTimeline: blockingRunner,
         onError: () => undefined,
@@ -749,7 +764,7 @@ describe('createSceneLoader (PUL-F008)', () => {
         scenes: createSceneRegistry([intro, middle]),
         compositions: createCompositionRegistry([]),
         stage: stage.element,
-        ctx: {},
+        buildCtx: stubCtx,
         createPreloader: (signal) => {
           observedSignals.push(signal);
           return () => undefined;
@@ -799,7 +814,7 @@ describe('createSceneLoader (PUL-F008)', () => {
         scenes: createSceneRegistry([broken, buildScene({ id: 'next' })]),
         compositions: createCompositionRegistry([]),
         stage: stage.element,
-        ctx: {},
+        buildCtx: stubCtx,
         createPreloader: () => () => undefined,
         runTimeline: blockingRunner,
         onError: (err) => {
@@ -834,7 +849,7 @@ describe('createSceneLoader (PUL-F008)', () => {
         scenes: createSceneRegistry([buildScene({ id: 'intro' })]),
         compositions: createCompositionRegistry([]),
         stage: stage.element,
-        ctx: {},
+        buildCtx: stubCtx,
         createPreloader: () => {
           throw new Error('preloader factory blew up');
         },
@@ -867,7 +882,7 @@ describe('createSceneLoader (PUL-F008)', () => {
         scenes: createSceneRegistry([intro]),
         compositions: createCompositionRegistry([]),
         stage: buildStage().element,
-        ctx: {},
+        buildCtx: stubCtx,
         createPreloader: () => () => undefined,
         runTimeline: noopRunner,
       });
@@ -904,7 +919,7 @@ describe('createSceneLoader (PUL-F008)', () => {
         scenes: createSceneRegistry([intro]),
         compositions: createCompositionRegistry([]),
         stage: stage.element,
-        ctx: {},
+        buildCtx: stubCtx,
         createPreloader: () => () => undefined,
         runTimeline: (input) => {
           const captured: { beat?: string } = {};
@@ -952,7 +967,7 @@ describe('createSceneLoader (PUL-F008)', () => {
         scenes: createSceneRegistry([intro]),
         compositions: createCompositionRegistry([]),
         stage: stage.element,
-        ctx: {},
+        buildCtx: stubCtx,
         createPreloader: () => () => undefined,
         runTimeline: async (input) => {
           // Simulate an unknown timeline label: runner reports the
@@ -1023,7 +1038,7 @@ describe('createSceneLoader (PUL-F008)', () => {
         scenes: createSceneRegistry([intro]),
         compositions: createCompositionRegistry([]),
         stage: stage.element,
-        ctx: {},
+        buildCtx: stubCtx,
         createPreloader: () => () => undefined,
         runTimeline: async (input) => {
           if (input.beat !== undefined) {
@@ -1086,7 +1101,7 @@ describe('createSceneLoader (PUL-F008)', () => {
         scenes: createSceneRegistry([intro]),
         compositions: createCompositionRegistry([]),
         stage: stage.element,
-        ctx: {},
+        buildCtx: stubCtx,
         createPreloader: () => () => undefined,
         runTimeline: (input) => {
           // Capture but don't fire; the runner exits immediately so
@@ -1135,7 +1150,7 @@ describe('createSceneLoader (PUL-F008)', () => {
         scenes: createSceneRegistry([intro]),
         compositions: createCompositionRegistry([]),
         stage: stage.element,
-        ctx: {},
+        buildCtx: stubCtx,
         createPreloader: () => () => undefined,
         runTimeline: (input) => {
           input.onBeatMissing?.();
@@ -1169,7 +1184,7 @@ describe('createSceneLoader (PUL-F008)', () => {
         scenes: createSceneRegistry([intro]),
         compositions: createCompositionRegistry([]),
         stage: stage.element,
-        ctx: {},
+        buildCtx: stubCtx,
         createPreloader: () => () => undefined,
         runTimeline: (input) => {
           input.onBeatMissing?.();
@@ -1197,7 +1212,7 @@ describe('createSceneLoader (PUL-F008)', () => {
         scenes: createSceneRegistry([intro]),
         compositions: createCompositionRegistry([]),
         stage: stage.element,
-        ctx: {},
+        buildCtx: stubCtx,
         createPreloader: () => () => undefined,
         runTimeline: noopRunner,
         onError: (err) => {
@@ -1230,7 +1245,7 @@ describe('createSceneLoader (PUL-F008)', () => {
         scenes: createSceneRegistry([intro]),
         compositions: createCompositionRegistry([]),
         stage: stage.element,
-        ctx: {},
+        buildCtx: stubCtx,
         createPreloader: () => () => undefined,
         runTimeline: () => undefined, // simulates successful seek
       });
@@ -1254,7 +1269,7 @@ describe('createSceneLoader (PUL-F008)', () => {
         scenes: createSceneRegistry([intro]),
         compositions: createCompositionRegistry([{ id: 'full-talk', manifest: ['intro'] }]),
         stage: stage.element,
-        ctx: {},
+        buildCtx: stubCtx,
         createPreloader: () => () => undefined,
         runTimeline: noopRunner,
         onError: (err) => {
@@ -1285,7 +1300,7 @@ describe('createSceneLoader (PUL-F008)', () => {
         scenes: createSceneRegistry([intro]),
         compositions: createCompositionRegistry([]),
         stage: stage.element,
-        ctx: {},
+        buildCtx: stubCtx,
         createPreloader: () => () => undefined,
         runTimeline: (input) => {
           seen.push({
@@ -1298,6 +1313,375 @@ describe('createSceneLoader (PUL-F008)', () => {
       await loader.handle(sceneTarget('intro'));
 
       expect(seen).toEqual([{ beatPresent: false, onBeatMissingPresent: false }]);
+    });
+  });
+
+  describe('mode dispatch (PUL-F012)', () => {
+    // PUL-F012 / ADR-007: when the parsed `NavigationTarget` carries
+    // `mode`, the loader selects the corresponding workbench mode.
+    // Absent `mode` defaults to `'present'`. Mode dispatch lives in
+    // the runtime core (this loader), not in scenes — the loader
+    // calls `options.buildCtx(effectiveMode)` once per navigation,
+    // and the returned ctx (carrying `mode`) is what scenes see.
+    //
+    // The "URL is the only source" rule (no localStorage,
+    // sessionStorage, cookies, history.state, cached state) is pinned
+    // by the across-navigation no-leak test below: a navigation that
+    // sets a non-`present` mode must not influence a subsequent
+    // `mode`-less navigation's effective mode.
+
+    interface ModeProbe {
+      readonly modes: NavigationMode[];
+      readonly buildCtx: (mode: NavigationMode) => WorkbenchSceneCtx;
+    }
+
+    const buildModeProbe = (): ModeProbe => {
+      const modes: NavigationMode[] = [];
+      return {
+        modes,
+        buildCtx: vi.fn((mode: NavigationMode): WorkbenchSceneCtx => {
+          modes.push(mode);
+          return { stage: null, mode };
+        }),
+      };
+    };
+
+    it.each(NAVIGATION_MODES)(
+      'invokes buildCtx with %s when target.mode is %s (clause 1: explicit mode is selected)',
+      async (mode) => {
+        const intro = buildScene({ id: 'intro' });
+        const stage = buildStage();
+        const probe = buildModeProbe();
+        const loader = createSceneLoader({
+          scenes: createSceneRegistry([intro]),
+          compositions: createCompositionRegistry([]),
+          stage: stage.element,
+          buildCtx: probe.buildCtx,
+          createPreloader: () => () => undefined,
+          runTimeline: noopRunner,
+        });
+
+        await loader.handle({ locator: { kind: 'scene', scene: 'intro' }, mode });
+
+        expect(probe.modes).toEqual([mode]);
+      },
+    );
+
+    it('invokes buildCtx with "present" when target.mode is absent (clause 2: default is present)', async () => {
+      const intro = buildScene({ id: 'intro' });
+      const stage = buildStage();
+      const probe = buildModeProbe();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([intro]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: probe.buildCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+      });
+
+      await loader.handle(sceneTarget('intro'));
+
+      expect(probe.modes).toEqual(['present']);
+    });
+
+    it('the ctx threaded into the lifecycle carries the effective mode', async () => {
+      // The ctx the loader hands the lifecycle MUST carry the mode
+      // value returned by buildCtx — proves the per-navigation ctx
+      // (not a stale cached one) is what scenes receive on every
+      // hook (`create` / `timeline` / `cleanup`).
+      const seen: { phase: string; mode: unknown }[] = [];
+      const recordMode = (phase: string) => (ctx: unknown) => {
+        seen.push({
+          phase,
+          mode: (ctx as { mode?: NavigationMode }).mode,
+        });
+      };
+      const intro = buildScene({
+        id: 'intro',
+        create: recordMode('create'),
+        timeline: ((ctx: unknown) => {
+          recordMode('timeline')(ctx);
+        }) as SceneModule['timeline'],
+        cleanup: recordMode('cleanup'),
+      });
+      const stage = buildStage();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([intro]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: (mode) => ({ stage: stage.element, mode }),
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+      });
+
+      await loader.handle({ locator: { kind: 'scene', scene: 'intro' }, mode: 'screenshot' });
+
+      expect(seen).toEqual([
+        { phase: 'create', mode: 'screenshot' },
+        { phase: 'timeline', mode: 'screenshot' },
+        { phase: 'cleanup', mode: 'screenshot' },
+      ]);
+    });
+
+    it('a previous non-present mode does not leak into a later mode-less navigation (ADR-007 risk-table)', async () => {
+      // ADR-007 risk-table: "A previous non-`present` mode leaks into
+      // a URL without `mode`" — mitigation: "Treat omitted `mode` as a
+      // fresh `present` selection on every startup and `popstate`; do
+      // not cache the last effective mode." This is the canonical
+      // regression test: load with mode=screenshot, then load with no
+      // mode, and verify the second navigation's ctx carries `present`,
+      // NOT `screenshot`.
+      //
+      // Two assertions in one test: (a) the probe's `buildCtx` was
+      // called with the right effective mode at each step, AND (b) the
+      // ctx that actually reaches the second scene's lifecycle hooks
+      // carries `mode: 'present'`. The second assertion guards against
+      // a regression that calls `buildCtx('present')` correctly but
+      // accidentally reuses the previously-built `{ mode: 'screenshot' }`
+      // ctx — that bug would pass the input-only assertion but leak the
+      // stale mode to the runner / scene.
+      const seen: { sceneId: string; mode: unknown }[] = [];
+      const recordCreate =
+        (sceneId: string) =>
+        (ctx: unknown): void => {
+          seen.push({ sceneId, mode: (ctx as { mode?: NavigationMode }).mode });
+        };
+      const intro = buildScene({ id: 'intro', create: recordCreate('intro') });
+      const outro = buildScene({ id: 'outro', create: recordCreate('outro') });
+      const stage = buildStage();
+      const probe = buildModeProbe();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([intro, outro]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: probe.buildCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+      });
+
+      await loader.handle({ locator: { kind: 'scene', scene: 'intro' }, mode: 'screenshot' });
+      await loader.handle({ locator: { kind: 'scene', scene: 'outro' } });
+
+      expect(probe.modes).toEqual(['screenshot', 'present']);
+      expect(seen).toEqual([
+        { sceneId: 'intro', mode: 'screenshot' },
+        { sceneId: 'outro', mode: 'present' },
+      ]);
+    });
+
+    it('does not invoke buildCtx when the locator is `kind: "none"` (no scene mounts)', async () => {
+      // The runtime does not mount any scene for `?` (no explicit
+      // target), so the per-navigation ctx is never assembled — there
+      // is nothing to hand it to. Without this contract, an "always
+      // build ctx" loader would invoke the workbench's `buildCtx` for
+      // every popstate even when no lifecycle ran, which makes
+      // ctx-build cost (e.g. async stage allocation) charge the no-op
+      // path.
+      const intro = buildScene({ id: 'intro' });
+      const stage = buildStage();
+      const probe = buildModeProbe();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([intro]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: probe.buildCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+      });
+
+      await loader.handle(noneTarget);
+
+      expect(probe.modes).toEqual([]);
+    });
+
+    it('does not invoke buildCtx on parse-error events (handleError path)', async () => {
+      // The error path writes the navigation-error attribute and runs
+      // `onError`; no lifecycle runs, so no ctx is needed. Asserting
+      // `buildCtx` was not invoked stops a regression that
+      // pre-emptively built ctx on the error path (wasted allocation
+      // and a misleading "fresh navigation" signal to mode listeners).
+      const stage = buildStage();
+      const probe = buildModeProbe();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: probe.buildCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+        onError: () => undefined,
+      });
+
+      loader.handleError(new Error('navigation grammar is invalid: parse failure'));
+      await loader.idle();
+
+      expect(probe.modes).toEqual([]);
+    });
+
+    it('rejects a constructed target with an unknown mode (defense-in-depth for ADR-007)', async () => {
+      // `parseNavigationSearch` already rejects unknown modes, but
+      // `NavigationTarget` is an exported type and a non-parser caller
+      // could construct one directly. The loader re-enforces the
+      // ADR-007 mode allowlist before any side effect so a hand-built
+      // target does not bypass the grammar invariant the parser would
+      // have caught — same defense-in-depth pattern used for `beat`.
+      const captured: unknown[] = [];
+      const intro = buildScene({ id: 'intro' });
+      const stage = buildStage();
+      const probe = buildModeProbe();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([intro]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: probe.buildCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+        onError: (err) => {
+          captured.push(err);
+        },
+      });
+
+      const malformedMode: NavigationTarget = {
+        locator: { kind: 'scene', scene: 'intro' },
+        mode: 'shouty-mode' as unknown as NavigationMode,
+      };
+
+      await loader.handle(malformedMode);
+
+      expect(probe.modes).toEqual([]);
+      expect(stage.attrs.has('data-pulsar-scene-target')).toBe(false);
+      expect(stage.attrs.get('data-pulsar-navigation-error')).toMatch(
+        /^navigation grammar is invalid: "mode"/,
+      );
+      expect(captured).toHaveLength(1);
+    });
+
+    it('surfaces a buildCtx exception via onError and resets stage attrs (no stale targets)', async () => {
+      // A throwing builder must NOT leave stale `data-pulsar-scene-target`
+      // / `data-pulsar-composition-target` attrs on the stage, must
+      // surface the error through the configured `onError` sink, and
+      // must keep the navigation queue healthy (subsequent handle()
+      // calls succeed). Without this contract, a workbench with a
+      // crashing ctx-builder would lie to the operator about a
+      // half-loaded scene and reject every queued navigation.
+      const captured: unknown[] = [];
+      const intro = buildScene({ id: 'intro' });
+      const outro = buildScene({ id: 'outro' });
+      const stage = buildStage();
+      let ctxCalls = 0;
+      const buildCtx = (mode: NavigationMode): WorkbenchSceneCtx => {
+        ctxCalls += 1;
+        if (ctxCalls === 1) {
+          throw new Error('builder bug');
+        }
+        return { stage: null, mode };
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([intro, outro]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+        onError: (err) => {
+          captured.push(err);
+        },
+      });
+
+      await loader.handle(sceneTarget('intro'));
+
+      expect(stage.attrs.has('data-pulsar-scene-target')).toBe(false);
+      expect(stage.attrs.has('data-pulsar-composition-target')).toBe(false);
+      expect(stage.attrs.get('data-pulsar-navigation-error')).toMatch(/builder bug/);
+      expect(captured).toHaveLength(1);
+      expect((captured[0] as Error).message).toBe('builder bug');
+
+      // The queue is still healthy: a subsequent navigation runs
+      // through the lifecycle normally.
+      await loader.handle(sceneTarget('outro'));
+      expect(stage.attrs.get('data-pulsar-scene-target')).toBe('outro');
+    });
+
+    it('aborts the per-load AbortController when buildCtx throws (no signal-tied resource leak)', async () => {
+      // The preloader factory has already received the controller's
+      // signal before buildCtx runs. If buildCtx then throws, the
+      // controller would otherwise be GC'd in the never-aborted state
+      // and any abort-keyed listener registered against the signal
+      // (e.g. a fetch listener) would never see cancellation. Pin
+      // that the loader explicitly aborts on the buildCtx-throw path.
+      let capturedSignal: AbortSignal | undefined;
+      const intro = buildScene({ id: 'intro' });
+      const stage = buildStage();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([intro]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: () => {
+          throw new Error('builder bug');
+        },
+        createPreloader: (signal) => {
+          capturedSignal = signal;
+          return () => undefined;
+        },
+        runTimeline: noopRunner,
+        onError: () => undefined,
+      });
+
+      await loader.handle(sceneTarget('intro'));
+
+      expect(capturedSignal).toBeDefined();
+      expect(capturedSignal?.aborted).toBe(true);
+    });
+
+    it('does not invoke buildCtx when the preloader factory throws (no wasted builder allocation)', async () => {
+      // ADR-007 / PUL-F012 ordering: the loader builds the preloader
+      // FIRST. If the preloader factory throws, no lifecycle runs and
+      // no cleanup will consume any ctx. Asserting `buildCtx` was not
+      // invoked stops a regression that pre-emptively ran the builder
+      // (wasted side effects, plus a misleading "fresh navigation"
+      // signal to mode listeners).
+      const intro = buildScene({ id: 'intro' });
+      const stage = buildStage();
+      const probe = buildModeProbe();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([intro]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: probe.buildCtx,
+        createPreloader: () => {
+          throw new Error('preloader factory bug');
+        },
+        runTimeline: noopRunner,
+        onError: () => undefined,
+      });
+
+      await loader.handle(sceneTarget('intro'));
+
+      expect(probe.modes).toEqual([]);
+    });
+
+    it('does not invoke buildCtx when scene resolution fails (no lifecycle, no ctx)', async () => {
+      // A target that names an unregistered scene fails resolution
+      // before the lifecycle starts. There is no ctx-handoff to do
+      // because nothing is mounted; charging buildCtx in this path
+      // would be wasted work and could leak mode-aware listeners on
+      // failed navigations.
+      const stage = buildStage();
+      const probe = buildModeProbe();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: probe.buildCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+        onError: () => undefined,
+      });
+
+      await loader.handle(sceneTarget('does-not-exist'));
+
+      expect(probe.modes).toEqual([]);
     });
   });
 });

--- a/tests/scenes/placeholder.test.ts
+++ b/tests/scenes/placeholder.test.ts
@@ -78,6 +78,17 @@ describe('placeholderScene', () => {
     ['object with `stage` but no `mode`', { stage: {} }],
     ['object with unknown `mode`', { stage: {}, mode: 'shouty-mode' }],
     ['object with `mode: null`', { stage: {}, mode: null }],
+    [
+      'object with `stage` lacking setAttribute/removeAttribute (would crash writeLifecycle)',
+      { stage: {}, mode: 'present' },
+    ],
+    [
+      'object with `stage.setAttribute` non-function',
+      {
+        stage: { setAttribute: 'not-a-function', removeAttribute: () => undefined },
+        mode: 'present',
+      },
+    ],
   ])('is a no-op when ctx is %s', (_label, ctx) => {
     it('does not throw and does not mutate any concurrently-existing stage', () => {
       const sentinel = buildStage();

--- a/tests/scenes/placeholder.test.ts
+++ b/tests/scenes/placeholder.test.ts
@@ -36,21 +36,21 @@ describe('placeholderScene', () => {
 
   it('writes the lifecycle attribute on `create` against the ctx stage', () => {
     const stage = buildStage();
-    placeholderScene.create({ stage: stage.element });
+    placeholderScene.create({ stage: stage.element, mode: 'present' });
     expect(stage.attrs.get('data-pulsar-scene-lifecycle')).toBe('create');
   });
 
   it('overwrites the lifecycle attribute on `timeline`', () => {
     const stage = buildStage();
-    placeholderScene.create({ stage: stage.element });
-    placeholderScene.timeline({ stage: stage.element });
+    placeholderScene.create({ stage: stage.element, mode: 'present' });
+    placeholderScene.timeline({ stage: stage.element, mode: 'present' });
     expect(stage.attrs.get('data-pulsar-scene-lifecycle')).toBe('timeline');
   });
 
   it('removes the lifecycle attribute on `cleanup`', () => {
     const stage = buildStage();
-    placeholderScene.create({ stage: stage.element });
-    placeholderScene.cleanup({ stage: stage.element });
+    placeholderScene.create({ stage: stage.element, mode: 'present' });
+    placeholderScene.cleanup({ stage: stage.element, mode: 'present' });
     expect(stage.attrs.has('data-pulsar-scene-lifecycle')).toBe(false);
   });
 
@@ -63,6 +63,11 @@ describe('placeholderScene', () => {
   // a malformed ctx and the implementation accidentally reaches for
   // a different stage handle (or the global `document`) — a no-throw-
   // only assertion would miss that.
+  //
+  // PUL-F012: WorkbenchSceneCtx now also requires `mode`. Ctx values
+  // that have `stage` but no `mode` (or with a non-allowlisted mode)
+  // are treated as malformed and ignored — narrowing them would let
+  // future mode-aware scene code read `undefined` from `ctx.mode`.
   describe.each<[label: string, ctx: unknown]>([
     ['null', null],
     ['undefined', undefined],
@@ -70,6 +75,9 @@ describe('placeholderScene', () => {
     ['string primitive', 'ctx'],
     ['object without `stage` key', {}],
     ['object with `stage: null`', { stage: null }],
+    ['object with `stage` but no `mode`', { stage: {} }],
+    ['object with unknown `mode`', { stage: {}, mode: 'shouty-mode' }],
+    ['object with `mode: null`', { stage: {}, mode: null }],
   ])('is a no-op when ctx is %s', (_label, ctx) => {
     it('does not throw and does not mutate any concurrently-existing stage', () => {
       const sentinel = buildStage();


### PR DESCRIPTION
## Summary

- Implements PUL-F012: when the `mode` URL parameter is present the runtime selects the corresponding workbench mode; absent `mode` defaults to `present`.
- Mode dispatch lives at the runtime-core seam (`SceneLoader`), not in scenes. `WorkbenchSceneCtx` gains a required `mode` field; `SceneLoaderOptions.ctx` becomes `buildCtx: (mode) => WorkbenchSceneCtx`, called once per navigation. URL is the only source of mode by construction (no `localStorage` / `sessionStorage` / cookies / `history.state` / cached state).
- Loader-boundary defense-in-depth (`validateModeGrammar`) catches hand-built `NavigationTarget`s with non-allowlisted modes; `buildCtx` failures are surfaced via `onError`, the per-load `AbortController` is aborted, stage attrs are reset, and the queue stays healthy.
- ADR-007 + ADR-013 updated by codex preflight to record the URL-only-source rule and the parser-vs-runtime-core boundary for PUL-F012. Pre-push codex review ran cycles 1 and 2 (8 findings, all addressed; security review clean both cycles). Cycle history: https://github.com/KeplerOps/pulsar/issues/21#issuecomment-4382661708.

## Test plan

- [x] `pnpm lint && pnpm typecheck && pnpm test` — 566 tests pass.
- [x] `pre-commit run --all-files` — clean.
- [x] New tests cover all 7 modes, default-to-`present` for absent mode, no-leak across navigations (asserted both at `buildCtx` input and via the second scene's `create`-hook ctx), URL-only-source spies on `localStorage` / `sessionStorage` / `document.cookie` / `history.state`, mode-validator defense-in-depth, `buildCtx`-throw error path, AbortController abort on `buildCtx` throw, no-buildCtx-call paths (parse-error, `kind: 'none'`, resolve failure, preloader-factory throw).

Closes #21