### PR TITLE
Land PUL-F013 contract boundary and adapter seams (ADR-016)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,9 +64,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the repo today (chrome, audio, GSAP runner, presenter UI are all
   future deliverables). PUL-F013 today lands the contract layer plus
   test pinning of the seams those surfaces will plug into; ACTIVE
-  transition is gated on at least one rendering / input surface
-  landing and adding its own end-to-end test. Mirrors the ADR-015 /
-  PUL-F011 precedent. Indexed in `docs/adrs/README.md`.
+  transition is gated on every facet PUL-F013's statement names
+  landing as a real rendering / input surface AND adding its own
+  end-to-end test (chrome, audio, inter-scene transitions, presenter
+  input — all four). Mirrors the ADR-015 / PUL-F011 precedent.
+  Indexed in `docs/adrs/README.md`.
 - `docs/design/pul-f013-present-mode-preflight.md` — codex
   architecture preflight design context for PUL-F013. Names the
   cross-cutting concerns to reuse (`NAVIGATION_MODES`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `docs/adrs/016-workbench-mode-present.md` — records the PUL-F013
+  contract boundary and the seams future rendering / input surfaces
+  will plug into. None of the four facets PUL-F013 names — render
+  full chrome, audio, inter-scene transitions, and respond to
+  presenter input — has a corresponding rendering / input surface in
+  the repo today (chrome, audio, GSAP runner, presenter UI are all
+  future deliverables). PUL-F013 today lands the contract layer plus
+  test pinning of the seams those surfaces will plug into; ACTIVE
+  transition is gated on at least one rendering / input surface
+  landing and adding its own end-to-end test. Mirrors the ADR-015 /
+  PUL-F011 precedent. Indexed in `docs/adrs/README.md`.
+- `docs/design/pul-f013-present-mode-preflight.md` — codex
+  architecture preflight design context for PUL-F013. Names the
+  cross-cutting concerns to reuse (`NAVIGATION_MODES`,
+  `effectiveMode()`, `loadSceneNavigationTarget()`,
+  `createAssetPreloader()`, `describeError()`, the per-navigation
+  `AbortController`) and the anti-patterns to avoid (duplicate mode
+  enums, scene-owned chrome, transitions encoded as fake scenes,
+  presenter UI calling scene `cleanup()` directly, persisting
+  mode/target state outside the URL).
+- `tests/runtime/scene-loader.test.ts` — new
+  `'present-mode adapter seams (PUL-F013 boundary, NOT a PUL-F013
+  implementation)'` describe block (6 tests) pinning the adapter
+  seams the four future rendering / input surfaces will plug into:
+  - Multi-scene composition under `mode=present` runs every scene's
+    `create → timeline → cleanup` with cleanup-before-next-create
+    ordering — the lifecycle hook ADR-003's GSAP runner will hang
+    inter-scene transition rendering off (NOT transition rendering
+    itself).
+  - Identical multi-scene behavior when `mode` is absent — pins
+    "present is the default."
+  - Every lifecycle hook in two consecutive multi-scene navigations
+    sees `ctx.mode === 'present'` — pins the mode hint chrome /
+    audio surfaces will read.
+  - Per-scene `AbortSignal` reaches the runner's `input.signal`
+    under `mode=present` — pins the seam PUL-F020 will drive (NOT
+    presenter input itself).
+  - An in-flight abort under `mode=present` flips `signal.aborted`
+    and triggers `cleanup(ctx)` on the active scene — pins the
+    abort-to-cleanup connectedness end to end. The runner's
+    signal-presence assertion runs before parking on the abort gate
+    so a regression that drops signal forwarding fails fast with an
+    assertion rather than via the test-runner timeout.
+  - No `data-pulsar-mode-*` suppression attribute is preemptively
+    written under `mode=present`. Scoped to the
+    `data-pulsar-mode-*` namespace only so unrelated future
+    diagnostics / observability attributes do not break the test.
 - `src/runtime/navigation.ts` — `effectiveMode(target?:
   NavigationTarget): NavigationMode` pure helper that returns
   `target?.mode ?? 'present'`. The single dispatch point for

--- a/docs/adrs/016-workbench-mode-present.md
+++ b/docs/adrs/016-workbench-mode-present.md
@@ -1,0 +1,200 @@
+# ADR-016: Workbench Mode `present` — Contract Boundary and Adapter Seams
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-06
+
+## Context
+
+PUL-F013 specifies `mode=present` behavior:
+
+> In `mode=present`, the runtime SHALL render full chrome, audio, and
+> inter-scene transitions, and SHALL respond to presenter input.
+
+`present` is one of the seven workbench modes ADR-007 defines, and it
+is the default selected by `effectiveMode()` when the URL omits
+`mode=`. Other modes (`standalone`, `loop`, `paused`, `scrub`,
+`screenshot`, `prompter`) suppress some subset of the four facets
+PUL-F013 names — for example, `standalone` suppresses chrome,
+inter-scene transitions, and the audio bed (PUL-F014); `screenshot`
+suppresses audio and animation (PUL-F018).
+
+Each of the four facets PUL-F013 names depends on a surface that has
+not yet landed in this repo:
+
+| Facet | Surface that delivers it | Status |
+|-------|--------------------------|--------|
+| Render full chrome | Workbench-shell requirement (not yet drafted) | absent |
+| Render audio | Audio service per ADR-004 (Howler.js); a future PUL-F* requirement will deliver the service | absent |
+| Render inter-scene transitions | GSAP timeline runner per ADR-003; the runner's adapter slot exists in `composition-resolver.ts` but the GSAP implementation has not landed | absent (placeholder runner in `src/main.ts`) |
+| Respond to presenter input | Presenter controls per PUL-F020 (advance / hold / skip), PUL-F021 (pause / resume), PUL-F025 (master mute) | absent |
+
+PUL-F013's natural ACTIVE state — "all four facets are rendered /
+accepting input under `mode=present` end to end" — is therefore not
+currently testable. Three options exist:
+
+1. **Pre-land an abstraction** (e.g., a `ModePolicy` record on `ctx`)
+   so PUL-F013 has something to point at. Risk: the abstraction has
+   no second consumer until PUL-F014 (standalone) lands; it would
+   commit the runtime to a representation before any of the four
+   future surfaces has stated what shape it actually needs to read.
+2. **Defer PUL-F013 entirely** until at least one rendering surface
+   lands. Risk: the present-mode contract is not pinned anywhere; a
+   regression that disables a seam under `mode=present` (e.g., drops
+   AbortSignal forwarding for the `present` value, or short-circuits
+   the multi-scene lifecycle) would not be caught until a future
+   PR touched the surface that depends on the seam.
+3. **Land the contract layer + the seam tests now**, leave PUL-F013
+   DRAFT, transition to ACTIVE when a rendering surface arrives.
+   Mirrors ADR-015 / PUL-F011's precedent: the `beat` contract layer
+   and the diagnostic path landed; PUL-F011 stays DRAFT pending the
+   GSAP runner that will exercise label seeking end to end.
+
+## Decision
+
+Take option 3. PUL-F013 today delivers:
+
+1. **This ADR**, recording the present-mode contract boundary and
+   identifying which seams future surfaces will plug into.
+2. **Test pinning of the seams** under `mode=present` — see
+   `tests/runtime/scene-loader.test.ts` block
+   `'present-mode contract (PUL-F013)'`. The tests pin:
+   - The composition resolver's structural cleanup-before-next-create
+     ordering across multiple scenes — the lifecycle hook ADR-003's
+     GSAP runner will hang inter-scene transition rendering off.
+   - The per-navigation `AbortSignal` reaches the timeline runner's
+     `input.signal` for every scene under `mode=present` — the seam
+     PUL-F020 will drive when actual presenter input arrives.
+   - An in-flight abort under `mode=present` flips
+     `signal.aborted` and triggers `cleanup(ctx)` on the in-flight
+     scene — pins the abort-to-cleanup connectedness end to end.
+   - `ctx.mode === 'present'` reaches every lifecycle hook in
+     multi-scene navigations — the hint chrome and audio surfaces
+     will read.
+   - No `data-pulsar-mode-*` suppression attribute is preemptively
+     written under `mode=present`.
+
+PUL-F013 explicitly does **not** introduce a mode-suppression
+representation today. No `ModePolicy` record, no
+`data-pulsar-mode-*` stage attributes, no `ctx.suppressed` flag. The
+shape of mode suppression is deferred to the requirement that has a
+concrete second consumer demanding it (likely PUL-F014 standalone),
+at which point the representation can be informed by an actual second
+mode rather than guessed.
+
+PUL-F013 stays **DRAFT**. The requirement statement names FOUR
+facets under `mode=present` — chrome, audio, inter-scene transitions,
+and presenter input — and ACTIVE requires every one of them to be
+rendered / accepted end to end. The contract is "rendering /
+responding," not "no suppression in absentia." A regression-resistant
+seam under `mode=present` is necessary for ACTIVE; it is not by
+itself sufficient. This PR explicitly does **not** satisfy PUL-F013;
+it lands the boundary and the seams the four future surface PRs will
+plug into.
+
+## Consequences
+
+### Positive
+
+- No premature abstraction. `ModePolicy` lands when a second
+  consumer (PUL-F014 standalone) needs it, with shape informed by
+  an actual second mode rather than guessed.
+- The seams are pinned. A future regression that disables the
+  abort signal forwarding, collapses multi-scene lifecycles, or
+  preemptively writes a `data-pulsar-mode-*` suppression attribute
+  under `mode=present` is caught by the contract tests.
+- The integration boundary is explicit. Future workbench-shell,
+  audio, and presenter-UI requirements know that `mode=present` is
+  the rendering / accepting baseline and that mode suppression
+  lives at their adapter boundary, not in the runtime core.
+
+### Negative
+
+- PUL-F013 stays DRAFT until at least one rendering surface lands.
+  A reviewer reading the requirement in isolation may expect ACTIVE
+  on first delivery; the DRAFT-with-contract-and-seams state is
+  intentional and matches the PUL-F011 / ADR-015 precedent.
+- The seam tests are necessary but not sufficient: they prove the
+  hooks exist and behave correctly under `mode=present`, but they
+  do not prove that future rendering surfaces will plug in
+  correctly. Each surface PR is responsible for adding its own
+  end-to-end "X renders under `mode=present`" tests.
+- The "no-suppression" invariant is enforced narrowly (no
+  `data-pulsar-mode-*` attribute) rather than broadly. A
+  workbench-shell PR that adds a non-`data-pulsar-mode-*`
+  attribute is not constrained by this ADR; its own ADR / tests
+  must establish the present-mode contract for that attribute.
+
+### Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| A future PR adds a `ModePolicy` abstraction without a second consumer demanding it | Cross-cutting reviewer step (`gc_codex_review`) flags duplicate-mode-validation patterns. Future-mode requirement plans must justify the suppression representation against the actual surface they are gating. |
+| `present` mode acquires a hidden suppression vector under a different stage-attribute namespace when the workbench shell lands | The contract test in this PR is scoped to `data-pulsar-mode-*`; subsequent surface PRs must add their own present-mode contract assertions for any new namespace they introduce. |
+| PUL-F014–F019 each invent a different suppression representation | When the second mode (likely PUL-F014 standalone) lands, that PR creates the suppression representation. Subsequent modes reuse it. The decision is deferred to the requirement that has a concrete need, not made speculatively here. |
+| PUL-F013 lingers DRAFT forever because chrome / audio / GSAP runner / presenter UI keep slipping | DRAFT status is a feature here: it tells reviewers the present-mode contract is partly delivered (boundary + seams) and gates ACTIVE on actual rendering. Each surface PR that lands a facet is the natural trigger to revisit PUL-F013's status. |
+
+## Current state (2026-05-06)
+
+This PR delivers the contract boundary and seam-pinning layer:
+
+- `tests/runtime/scene-loader.test.ts` — `'present-mode contract
+  (PUL-F013)'` describe block pinning multi-scene lifecycle order,
+  AbortSignal forwarding, abort-to-cleanup connectedness,
+  `ctx.mode === 'present'` end-to-end propagation, and the
+  no-`data-pulsar-mode-*` invariant.
+- `docs/design/pul-f013-present-mode-preflight.md` — the codex
+  preflight design context naming the four facets and the
+  cross-cutting concerns to reuse.
+- This ADR.
+
+PUL-F013 remains DRAFT. Issue #22 links to PUL-F013 via `DOCUMENTS`.
+This PR is **not** an implementation of PUL-F013 — it lands the
+contract boundary and the seams. The ACTIVE transition is gated on
+**every** facet PUL-F013's statement names landing as a real
+rendering / input surface AND adding its own end-to-end
+"X renders / responds under `mode=present`" test alongside the seam
+tests in this PR. The four required deliverables are:
+
+- A workbench-shell requirement that lands chrome rendering (a
+  future PUL-F* requirement; not yet drafted).
+- An audio-service requirement that lands `ctx.audio` per ADR-004
+  (a future PUL-F* requirement; PUL-F030 audio-unlock interaction
+  is related but not the audio service itself).
+- ADR-003's GSAP runner replacing the placeholder in `src/main.ts`
+  with timeline-driven inter-scene transitions.
+- PUL-F020 / PUL-F021 / PUL-F025 wiring presenter UI (advance,
+  hold, skip, pause / resume, master mute) to the AbortSignal seam.
+
+When all four arrive, PUL-F013 transitions to ACTIVE and the issue
+↔ requirement link upgrades from `DOCUMENTS` to `IMPLEMENTS`. Until
+then, treating this PR as satisfying PUL-F013 would be a
+traceability/status mismatch.
+
+## Related ADRs
+
+- [ADR-003](003-gsap-timeline-engine.md) — the timeline runner is
+  the seam through which inter-scene transitions and presenter
+  input flow.
+- [ADR-004](004-howler-audio-engine.md) — `ctx.audio` is the seam
+  through which audio rendering will flow.
+- [ADR-007](007-browser-workbench.md) — defines the seven workbench
+  modes and the URL-only-source invariant for mode selection.
+- [ADR-008](008-agent-native-authoring.md) — manifests-over-flow-
+  control underpins the no-mode-suppression-in-resolver constraint.
+- [ADR-011](011-composition-resolver-orchestration.md) — the
+  resolver is opaque to mode; mode-derived behavior lives at the
+  adapters it forwards to.
+- [ADR-013](013-url-navigation-grammar-boundary.md) — the parser
+  preserves absent `mode` as absent so the dispatch boundary
+  (`effectiveMode()`) owns the default-to-`present` rule.
+- [ADR-014](014-url-scene-target-selection.md) — scene navigation
+  dispatch is mode-blind; it resolves the active slice and hands
+  off to the loader.
+- [ADR-015](015-url-beat-positioning.md) — precedent for "deliver
+  the contract layer; keep the requirement DRAFT until the
+  dependent subsystem lands."

--- a/docs/adrs/016-workbench-mode-present.md
+++ b/docs/adrs/016-workbench-mode-present.md
@@ -62,7 +62,7 @@ Take option 3. PUL-F013 today delivers:
    identifying which seams future surfaces will plug into.
 2. **Test pinning of the seams** under `mode=present` — see
    `tests/runtime/scene-loader.test.ts` block
-   `'present-mode contract (PUL-F013)'`. The tests pin:
+   `'present-mode adapter seams (PUL-F013 boundary, NOT a PUL-F013 implementation)'`. The tests pin:
    - The composition resolver's structural cleanup-before-next-create
      ordering across multiple scenes — the lifecycle hook ADR-003's
      GSAP runner will hang inter-scene transition rendering off.
@@ -114,7 +114,9 @@ plug into.
 
 ### Negative
 
-- PUL-F013 stays DRAFT until at least one rendering surface lands.
+- PUL-F013 stays DRAFT until every facet PUL-F013's statement names
+  (chrome, audio, inter-scene transitions, presenter input) lands as
+  a real rendering / input surface that adds its own end-to-end test.
   A reviewer reading the requirement in isolation may expect ACTIVE
   on first delivery; the DRAFT-with-contract-and-seams state is
   intentional and matches the PUL-F011 / ADR-015 precedent.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -41,3 +41,4 @@ Each ADR includes:
 | [013](013-url-navigation-grammar-boundary.md) | URL Navigation Grammar Boundary | Accepted |
 | [014](014-url-scene-target-selection.md) | Loading the Addressed Scene as the Runtime Navigation Target | Accepted |
 | [015](015-url-beat-positioning.md) | URL Beat Positioning as Timeline-Runner State | Accepted |
+| [016](016-workbench-mode-present.md) | Workbench Mode `present` — Contract Boundary and Adapter Seams | Accepted |

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -6,6 +6,7 @@ Design context for Pulsar. Source material for the ADRs in `../adrs/`.
 |----------|---------|
 | [architecture-recommendations.md](architecture-recommendations.md) | Stack choices, runtime layers, library notes, migration plan. |
 | [positioning-and-landscape.md](positioning-and-landscape.md) | Category, adjacent OSS projects, differentiation, strategic risks. |
+| [pul-f013-present-mode-preflight.md](pul-f013-present-mode-preflight.md) | Guardrails for implementing default `mode=present` behavior. |
 
 Design docs are mutable. Decisions are captured as ADRs (immutable once
 accepted).

--- a/docs/design/pul-f013-present-mode-preflight.md
+++ b/docs/design/pul-f013-present-mode-preflight.md
@@ -1,8 +1,14 @@
 # PUL-F013 Present Mode Preflight
 
-PUL-F013 implements the default workbench behavior for `mode=present`:
+PUL-F013 specifies the default workbench behavior for `mode=present`:
 full chrome, audio, inter-scene transitions, and presenter input. It is
-an integration requirement, not a new runtime model.
+an integration requirement across existing runtime seams, not a new
+runtime model. None of the four facets has a rendering / input surface
+in this repo yet (see ADR-016): chrome and audio surfaces have not
+landed, inter-scene transition rendering is reserved by ADR-003's GSAP
+runner, and presenter input is PUL-F020 / PUL-F021 / PUL-F025.
+PUL-F013 ACTIVE requires every facet to land. This preflight defines
+the boundary and required reuse for that future work.
 
 ## Boundary
 

--- a/docs/design/pul-f013-present-mode-preflight.md
+++ b/docs/design/pul-f013-present-mode-preflight.md
@@ -1,0 +1,95 @@
+# PUL-F013 Present Mode Preflight
+
+PUL-F013 implements the default workbench behavior for `mode=present`:
+full chrome, audio, inter-scene transitions, and presenter input. It is
+an integration requirement, not a new runtime model.
+
+## Boundary
+
+`present` mode must be selected only through the existing navigation
+boundary:
+
+- `src/runtime/navigation.ts` owns the `mode` URL grammar and the
+  `NAVIGATION_MODES` allowlist.
+- `effectiveMode()` owns the absent-mode default to `present`.
+- `src/runtime/scene-loader.ts` owns per-navigation mode dispatch and
+  `ctx.mode` construction.
+- `src/runtime/scene-navigation.ts` owns scene/composition target
+  resolution.
+- `src/runtime/composition-resolver.ts` owns lifecycle ordering,
+  abort propagation, and cleanup.
+
+Do not add a parallel `present` flag, route, controller, enum, or
+manifest field. `mode=present` and omitted `mode` converge only at the
+runtime dispatch seam; parsing must continue to preserve whether the
+URL explicitly supplied `mode`.
+
+## Required Reuse
+
+Implementation must reuse these cross-cutting concerns:
+
+- Identifier validation: `src/runtime/identifier.ts`.
+- URL validation and mode parsing: `parseNavigationSearch()` and
+  `NAVIGATION_MODES`.
+- Effective mode derivation: `effectiveMode()`.
+- Scene/composition schemas and validators:
+  `assertSceneModule()`, `createSceneRegistry()`,
+  `assertCompositionManifest()`, and `createCompositionRegistry()`.
+- Lifecycle orchestration: `loadSceneNavigationTarget()` and
+  `resolveComposition()`.
+- Asset handling: `createAssetPreloader()` with the existing scheme and
+  redirect validation rules.
+- Error rendering: `describeError()` plus existing stage diagnostics
+  (`data-pulsar-navigation-error`).
+- Abort and cleanup: one per-navigation `AbortController`, forwarded to
+  preload and timeline adapters; cleanup remains resolver-owned and
+  exactly-once per activated scene.
+
+Chrome, audio, transition, and presenter-control adapters should be
+injected through the workbench context or the timeline runner seam
+already reserved by ADR-003, ADR-004, and ADR-011. The resolver must
+remain opaque to DOM, GSAP, Howler, and presenter UI details.
+
+## Guardrails
+
+- Chrome is workbench-owned persistent UI, not scene metadata and not a
+  lifecycle hook. Scenes may render their content into `ctx.stage`;
+  they must not own global chrome state.
+- Audio is exposed through `ctx.audio` per ADR-004. Scenes must not
+  create raw `<audio>` elements or import Howler directly unless a
+  documented scene-specific exception also registers cleanup with the
+  runtime.
+- Inter-scene transitions belong in the timeline-runner / workbench
+  integration layer. Do not encode transitions as fake scenes or mutate
+  composition manifests to insert transition entries.
+- Presenter input owns cancellation and timeline operations. It should
+  drive the existing `AbortSignal` and runner controls rather than
+  adding a second skip/cleanup path.
+- Missing beats and navigation errors use the existing non-fatal or
+  fatal surfaces. Do not throw from a missing-beat callback or unmount
+  the scene to report a positioning diagnostic.
+- `present` must not read mode, target, mute, or navigation state from
+  localStorage, sessionStorage, cookies, `history.state`, or prior
+  in-memory navigation state.
+
+## Non-Goals
+
+PUL-F013 should not implement alternate workbench modes (`standalone`,
+`loop`, `paused`, `scrub`, `screenshot`, `prompter`), export behavior,
+decode-complete asset semantics, new scene schema fields, persistence,
+or authoring UI. It may add the minimum shared adapter surface needed
+for full present-mode playback, but only where the existing ADRs have
+already reserved that boundary.
+
+## Anti-Patterns
+
+- Duplicating `NAVIGATION_MODES` or re-validating mode strings with a
+  local enum.
+- Adding per-scene mode detection from `window.location`.
+- Building presenter controls that call scene `cleanup()` directly.
+- Creating a second exception hierarchy for presentation errors.
+- Swallowing `AggregateError.errors` from resolver or preloader
+  failures.
+- Treating `present` as a special-case route that bypasses
+  `SceneLoader`.
+- Persisting the last selected mode or composition target.

--- a/tests/runtime/scene-loader.test.ts
+++ b/tests/runtime/scene-loader.test.ts
@@ -1684,4 +1684,375 @@ describe('createSceneLoader (PUL-F008)', () => {
       expect(probe.modes).toEqual([]);
     });
   });
+
+  describe('present-mode adapter seams (PUL-F013 boundary, NOT a PUL-F013 implementation)', () => {
+    // PUL-F013 statement: in `mode=present`, the runtime SHALL render
+    // full chrome, audio, and inter-scene transitions, and SHALL respond
+    // to presenter input. NONE of the four facets has a corresponding
+    // rendering / input surface in this repo today — chrome is a future
+    // workbench-shell requirement, audio is reserved by ADR-004
+    // (Howler.js), inter-scene transition RENDERING is reserved by
+    // ADR-003 (GSAP timeline runner), and actual presenter input is
+    // PUL-F020 / PUL-F021 / PUL-F025. The tests below DO NOT pin
+    // PUL-F013's clauses end to end — they pin the underlying adapter
+    // seams those four future surfaces will plug into, asserted under
+    // `mode=present` so a future regression cannot quietly disable a
+    // seam for the present value.
+    //
+    // PUL-F013 stays DRAFT until every facet its statement names
+    // lands as a real rendering / input surface that adds its own
+    // end-to-end "X renders / responds under mode=present" test
+    // alongside these seam tests. ADR-016 records the boundary.
+    //
+    // The seams pinned here:
+    //
+    //   - The composition resolver's structural cleanup-before-next-
+    //     create ordering — the lifecycle hook the GSAP runner will
+    //     hang inter-scene transition rendering off (ADR-003 / ADR-011
+    //     / PUL-F004).
+    //   - The per-navigation `AbortSignal` forwarded to the runner —
+    //     the seam PUL-F020 / F021 / F025 will drive when actual
+    //     presenter input arrives (PUL-F006 / ADR-011).
+    //   - `ctx.mode === 'present'` carried into every lifecycle hook —
+    //     the hint chrome and audio surfaces will read when each lands
+    //     (PUL-F012 / ADR-007).
+    //   - Absence of any preemptive `data-pulsar-mode-*` suppression
+    //     attribute on the stage under `present`.
+
+    const presentTarget = (composition: string, index = 0): NavigationTarget => ({
+      locator: { kind: 'composition-index', composition, index },
+      mode: 'present',
+    });
+    const absentModeTarget = (composition: string, index = 0): NavigationTarget => ({
+      locator: { kind: 'composition-index', composition, index },
+    });
+
+    interface LifecycleProbe {
+      readonly log: string[];
+      readonly scenes: readonly SceneModule[];
+      readonly compositionId: string;
+    }
+
+    const buildLifecycleProbe = (compositionId = 'full-talk'): LifecycleProbe => {
+      const log: string[] = [];
+      const trace = (id: string): SceneModule =>
+        buildScene({
+          id,
+          create: () => {
+            log.push(`create:${id}`);
+          },
+          timeline: () => {
+            log.push(`timeline:${id}`);
+            return null;
+          },
+          cleanup: () => {
+            log.push(`cleanup:${id}`);
+          },
+        });
+      return {
+        log,
+        scenes: [trace('scene-a'), trace('scene-b'), trace('scene-c')],
+        compositionId,
+      };
+    };
+
+    it('runs every scene in a composition under `mode=present` with cleanup-before-next-create ordering (pins the inter-scene-transition seam, NOT transition rendering)', async () => {
+      // Inter-scene transition RENDERING is reserved by ADR-003's GSAP
+      // runner and not implemented in this repo yet. What this test
+      // pins is the lifecycle ordering the future runner will hang
+      // transition rendering off: under `mode=present` the resolver
+      // visits every entry in a composition slice in manifest order
+      // and runs cleanup before the next entry's create (ADR-011 /
+      // PUL-F004). A regression that collapsed `mode=present` to a
+      // single-scene load — or that re-ordered cleanup after the next
+      // create — would fail here and break every future inter-scene
+      // transition before it ships.
+      const probe = buildLifecycleProbe();
+      const stage = buildStage();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([...probe.scenes]),
+        compositions: createCompositionRegistry([
+          {
+            id: probe.compositionId,
+            manifest: probe.scenes.map((s) => s.id),
+          },
+        ]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+      });
+
+      await loader.handle(presentTarget(probe.compositionId));
+
+      expect(probe.log).toEqual([
+        'create:scene-a',
+        'timeline:scene-a',
+        'cleanup:scene-a',
+        'create:scene-b',
+        'timeline:scene-b',
+        'cleanup:scene-b',
+        'create:scene-c',
+        'timeline:scene-c',
+        'cleanup:scene-c',
+      ]);
+      expect(stage.attrs.get('data-pulsar-scene-target')).toBe('scene-a');
+      expect(stage.attrs.get('data-pulsar-composition-target')).toBe(probe.compositionId);
+    });
+
+    it('produces the same multi-scene lifecycle when `mode` is absent (clause: present is the default)', async () => {
+      // PUL-F013 is paired with PUL-F012's "absent mode defaults to
+      // present" contract: a URL with no `mode=` parameter selects the
+      // same behavior as an explicit `mode=present`. Pinning a separate
+      // run of the multi-scene flow without `mode` proves the runtime
+      // does not branch on "explicit vs default" present in any way that
+      // would let PUL-F013 drift between the two.
+      const probe = buildLifecycleProbe();
+      const stage = buildStage();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([...probe.scenes]),
+        compositions: createCompositionRegistry([
+          {
+            id: probe.compositionId,
+            manifest: probe.scenes.map((s) => s.id),
+          },
+        ]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+      });
+
+      await loader.handle(absentModeTarget(probe.compositionId));
+
+      expect(probe.log).toEqual([
+        'create:scene-a',
+        'timeline:scene-a',
+        'cleanup:scene-a',
+        'create:scene-b',
+        'timeline:scene-b',
+        'cleanup:scene-b',
+        'create:scene-c',
+        'timeline:scene-c',
+        'cleanup:scene-c',
+      ]);
+    });
+
+    it('exposes `ctx.mode === "present"` in every lifecycle hook for both explicit and absent mode (mode-hint contract clauses 1/2 will consume)', async () => {
+      // Chrome and audio rendering, when those subsystems land, will
+      // read `ctx.mode` to decide whether to render / play. Pinning that
+      // every lifecycle hook in a multi-scene flow under `mode=present`
+      // (and absent mode) sees `ctx.mode === 'present'` is the
+      // executable form of "the runtime exposes the present hint to
+      // every scene that runs under it" — a regression that built ctx
+      // once per loader (instead of once per navigation) would leak the
+      // wrong mode into later hooks here.
+      const seen: { phase: string; sceneId: string; mode: unknown }[] = [];
+      const recordMode =
+        (phase: string, sceneId: string) =>
+        (ctx: unknown): unknown => {
+          seen.push({ phase, sceneId, mode: (ctx as { mode?: NavigationMode }).mode });
+          return null;
+        };
+      const sceneA = buildScene({
+        id: 'scene-a',
+        create: recordMode('create', 'scene-a'),
+        timeline: recordMode('timeline', 'scene-a') as SceneModule['timeline'],
+        cleanup: recordMode('cleanup', 'scene-a'),
+      });
+      const sceneB = buildScene({
+        id: 'scene-b',
+        create: recordMode('create', 'scene-b'),
+        timeline: recordMode('timeline', 'scene-b') as SceneModule['timeline'],
+        cleanup: recordMode('cleanup', 'scene-b'),
+      });
+      const stage = buildStage();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA, sceneB]),
+        compositions: createCompositionRegistry([
+          { id: 'full-talk', manifest: ['scene-a', 'scene-b'] },
+        ]),
+        stage: stage.element,
+        buildCtx: (mode) => ({ stage: stage.element, mode }),
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+      });
+
+      await loader.handle(presentTarget('full-talk'));
+      await loader.handle(absentModeTarget('full-talk'));
+
+      // 6 hooks per navigation × 2 navigations = 12 entries; every
+      // single one carries `present`. The two-navigation shape also
+      // catches a regression where mode is captured into a closure once
+      // and reused across navigations.
+      expect(seen).toHaveLength(12);
+      for (const entry of seen) {
+        expect(entry.mode).toBe('present');
+      }
+    });
+
+    it('forwards a non-undefined `AbortSignal` to the runner under `mode=present` (pins the presenter-input seam, NOT presenter input itself)', async () => {
+      // Actual presenter input is PUL-F020's deliverable. What this
+      // test pins is the seam PUL-F020 will drive: the per-navigation
+      // `AbortSignal` (PUL-F006 / ADR-011) reaches the timeline
+      // runner's `input.signal` under `mode=present`. A regression
+      // that dropped the signal forwarding for present mode would
+      // disconnect the seam before PUL-F020 even lands.
+      const captured: { signalDefined: boolean; aborted: boolean }[] = [];
+      const sceneA = buildScene({ id: 'scene-a' });
+      const sceneB = buildScene({ id: 'scene-b' });
+      const stage = buildStage();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA, sceneB]),
+        compositions: createCompositionRegistry([
+          { id: 'full-talk', manifest: ['scene-a', 'scene-b'] },
+        ]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: (input) => {
+          captured.push({
+            signalDefined: input.signal !== undefined,
+            aborted: input.signal?.aborted === true,
+          });
+        },
+      });
+
+      await loader.handle(presentTarget('full-talk'));
+
+      // One entry per scene the runner saw. Both must show a defined,
+      // un-aborted signal at the moment the runner observed it.
+      expect(captured).toEqual([
+        { signalDefined: true, aborted: false },
+        { signalDefined: true, aborted: false },
+      ]);
+    });
+
+    it('an in-flight abort under `mode=present` flips `signal.aborted` and triggers cleanup (pins the abort-to-cleanup connectedness PUL-F020 will drive)', async () => {
+      // Actual presenter input is PUL-F020's deliverable; here we
+      // pin the connectedness of the abort seam end to end under
+      // `mode=present`: when the per-navigation `AbortController` is
+      // aborted (PUL-F020 will drive this from a presenter control;
+      // the loader drives it from a superseding handle() in this
+      // test), the runner observes `signal.aborted === true`, the
+      // runner's promise can resolve from that signal, and the
+      // resolver's mandatory-cleanup invariant runs `cleanup(ctx)`
+      // on the in-flight scene. Without this connectedness, every
+      // future presenter-driven abort would either leak the signal
+      // or skip cleanup.
+      //
+      // Determinism: the test asserts the runner observed a defined
+      // signal BEFORE parking on the abort gate, so a regression that
+      // dropped signal forwarding fails fast with an assertion rather
+      // than via the test-runner timeout.
+      const cleanupRan: string[] = [];
+      let runnerSignal: AbortSignal | undefined;
+      // First runner call holds open until aborted; subsequent calls
+      // (the superseding navigation's runner) resolve immediately so
+      // the test does not hang waiting for an interrupt that never
+      // arrives.
+      let runnerCalls = 0;
+      const runner: SceneTimelineRunner = (input) => {
+        runnerCalls += 1;
+        if (runnerCalls !== 1) return undefined;
+        // Capture and assert signal presence synchronously, before
+        // returning the gate promise. A missing signal fails the
+        // test deterministically with the assertion below — not via
+        // the 5s test timeout the abort-listener path would otherwise
+        // hit.
+        runnerSignal = input.signal;
+        if (runnerSignal === undefined) {
+          throw new Error('mode=present did not forward a signal to the runner');
+        }
+        const signal = runnerSignal;
+        return new Promise<void>((resolve) => {
+          signal.addEventListener('abort', () => resolve(), { once: true });
+        });
+      };
+      const sceneA = buildScene({
+        id: 'scene-a',
+        cleanup: () => {
+          cleanupRan.push('scene-a');
+        },
+      });
+      const sceneB = buildScene({
+        id: 'scene-b',
+        cleanup: () => {
+          cleanupRan.push('scene-b');
+        },
+      });
+      const stage = buildStage();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA, sceneB]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: runner,
+        onError: () => undefined,
+      });
+
+      // First navigation: scene-a starts and the runner parks waiting
+      // for abort. We do NOT await this handle — we want the runner
+      // sitting on the gate when the abort arrives.
+      const first = loader.handle({
+        locator: { kind: 'scene', scene: 'scene-a' },
+        mode: 'present',
+      });
+      while (runnerCalls === 0) {
+        await Promise.resolve();
+      }
+      // Signal MUST be present by the time the runner parked on it;
+      // assert before triggering the abort so a regression fails here
+      // rather than via timeout.
+      expect(runnerSignal).toBeDefined();
+      expect(runnerSignal?.aborted).toBe(false);
+
+      // Second navigation: simulates the presenter / popstate trigger
+      // that PUL-F020 will drive. The loader aborts the first load.
+      const second = loader.handle({
+        locator: { kind: 'scene', scene: 'scene-b' },
+        mode: 'present',
+      });
+
+      await first;
+      await second;
+
+      expect(runnerSignal?.aborted).toBe(true);
+      // scene-a's cleanup ran (mandatory cleanup on every scene exit
+      // — PUL-F006). scene-b's cleanup ran on its normal-advance exit
+      // because the second navigation also completed.
+      expect(cleanupRan).toContain('scene-a');
+      expect(cleanupRan).toContain('scene-b');
+    });
+
+    it('writes no `data-pulsar-mode-*` suppression attribute on the stage under `mode=present`', async () => {
+      // The PUL-F013 invariant is narrow: under `mode=present` the
+      // loader MUST NOT preemptively write a suppression-style stage
+      // attribute under the `data-pulsar-mode-` namespace (e.g.
+      // `data-pulsar-mode-suppress-chrome`, `data-pulsar-mode-mute`).
+      // Future modes that DO suppress facets are free to do so
+      // through this namespace; PUL-F013 forbids it for `present`.
+      // The assertion is scoped to that namespace only — adding
+      // unrelated diagnostics or observability attributes (e.g. a
+      // future `data-pulsar-state-*`) does not break this test.
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+      });
+
+      await loader.handle({ locator: { kind: 'scene', scene: 'scene-a' }, mode: 'present' });
+
+      const modeAttrs = Array.from(stage.attrs.keys()).filter((name) =>
+        name.startsWith('data-pulsar-mode-'),
+      );
+      expect(modeAttrs).toEqual([]);
+    });
+  });
 });

--- a/tests/runtime/scene-loader.test.ts
+++ b/tests/runtime/scene-loader.test.ts
@@ -1891,17 +1891,21 @@ describe('createSceneLoader (PUL-F008)', () => {
       }
     });
 
-    it('forwards a non-undefined `AbortSignal` to the runner under `mode=present` (pins the presenter-input seam, NOT presenter input itself)', async () => {
+    it('forwards a non-undefined `AbortSignal` to the runner under `mode=present` AND under absent `mode` (pins the presenter-input seam, NOT presenter input itself)', async () => {
       // Actual presenter input is PUL-F020's deliverable. What this
       // test pins is the seam PUL-F020 will drive: the per-navigation
       // `AbortSignal` (PUL-F006 / ADR-011) reaches the timeline
-      // runner's `input.signal` under `mode=present`. A regression
-      // that dropped the signal forwarding for present mode would
-      // disconnect the seam before PUL-F020 even lands.
-      const captured: { signalDefined: boolean; aborted: boolean }[] = [];
+      // runner's `input.signal` under `mode=present` AND under absent
+      // `mode` (the URL form that defaults to `present` per
+      // PUL-F012 / ADR-007). Asserting both forms catches a regression
+      // that dropped signal forwarding for one but not the other —
+      // e.g. an "if mode is explicitly present" branch that skipped
+      // the absent-mode default.
+      const captured: { mode: string; signalDefined: boolean; aborted: boolean }[] = [];
       const sceneA = buildScene({ id: 'scene-a' });
       const sceneB = buildScene({ id: 'scene-b' });
       const stage = buildStage();
+      let phase: 'explicit-present' | 'absent-mode' = 'explicit-present';
       const loader = createSceneLoader({
         scenes: createSceneRegistry([sceneA, sceneB]),
         compositions: createCompositionRegistry([
@@ -1912,6 +1916,7 @@ describe('createSceneLoader (PUL-F008)', () => {
         createPreloader: () => () => undefined,
         runTimeline: (input) => {
           captured.push({
+            mode: phase,
             signalDefined: input.signal !== undefined,
             aborted: input.signal?.aborted === true,
           });
@@ -1919,12 +1924,18 @@ describe('createSceneLoader (PUL-F008)', () => {
       });
 
       await loader.handle(presentTarget('full-talk'));
+      phase = 'absent-mode';
+      await loader.handle(absentModeTarget('full-talk'));
 
-      // One entry per scene the runner saw. Both must show a defined,
-      // un-aborted signal at the moment the runner observed it.
+      // 2 scenes per navigation × 2 navigations = 4 entries. Every
+      // single one must show a defined, un-aborted signal — proving
+      // the seam reaches the runner identically for both URL forms
+      // that select `present`.
       expect(captured).toEqual([
-        { signalDefined: true, aborted: false },
-        { signalDefined: true, aborted: false },
+        { mode: 'explicit-present', signalDefined: true, aborted: false },
+        { mode: 'explicit-present', signalDefined: true, aborted: false },
+        { mode: 'absent-mode', signalDefined: true, aborted: false },
+        { mode: 'absent-mode', signalDefined: true, aborted: false },
       ]);
     });
 

--- a/tests/runtime/scene-loader.test.ts
+++ b/tests/runtime/scene-loader.test.ts
@@ -1731,8 +1731,15 @@ describe('createSceneLoader (PUL-F008)', () => {
       readonly log: string[];
       readonly scenes: readonly SceneModule[];
       readonly compositionId: string;
+      readonly runner: SceneTimelineRunner;
     }
 
+    // Build a probe whose runner writes into the SAME log as the
+    // scene's create/timeline/cleanup hooks. This is what makes the
+    // transition-order test catch a regression that bypassed or
+    // re-ordered `runTimeline` under `mode=present` — without the
+    // runner observation, a "skip runTimeline for present" bug would
+    // still emit `create → timeline → cleanup` and pass.
     const buildLifecycleProbe = (compositionId = 'full-talk'): LifecycleProbe => {
       const log: string[] = [];
       const trace = (id: string): SceneModule =>
@@ -1749,24 +1756,29 @@ describe('createSceneLoader (PUL-F008)', () => {
             log.push(`cleanup:${id}`);
           },
         });
+      const runner: SceneTimelineRunner = (input) => {
+        log.push(`runTimeline:${input.scene.id}`);
+      };
       return {
         log,
         scenes: [trace('scene-a'), trace('scene-b'), trace('scene-c')],
         compositionId,
+        runner,
       };
     };
 
-    it('runs every scene in a composition under `mode=present` with cleanup-before-next-create ordering (pins the inter-scene-transition seam, NOT transition rendering)', async () => {
+    it('runs every scene in a composition under `mode=present` with cleanup-before-next-create ordering AND `runTimeline` between timeline-factory and cleanup (pins the inter-scene-transition seam, NOT transition rendering)', async () => {
       // Inter-scene transition RENDERING is reserved by ADR-003's GSAP
       // runner and not implemented in this repo yet. What this test
       // pins is the lifecycle ordering the future runner will hang
       // transition rendering off: under `mode=present` the resolver
-      // visits every entry in a composition slice in manifest order
+      // visits every entry in a composition slice in manifest order,
+      // calls `runTimeline` between the timeline factory and cleanup,
       // and runs cleanup before the next entry's create (ADR-011 /
-      // PUL-F004). A regression that collapsed `mode=present` to a
-      // single-scene load — or that re-ordered cleanup after the next
-      // create — would fail here and break every future inter-scene
-      // transition before it ships.
+      // PUL-F004). The runner's `runTimeline:<id>` log entry catches
+      // a regression that bypassed `runTimeline` under `mode=present`
+      // — without it, "skip runTimeline for present" would still emit
+      // create / timeline / cleanup and pass.
       const probe = buildLifecycleProbe();
       const stage = buildStage();
       const loader = createSceneLoader({
@@ -1780,7 +1792,7 @@ describe('createSceneLoader (PUL-F008)', () => {
         stage: stage.element,
         buildCtx: stubCtx,
         createPreloader: () => () => undefined,
-        runTimeline: noopRunner,
+        runTimeline: probe.runner,
       });
 
       await loader.handle(presentTarget(probe.compositionId));
@@ -1788,12 +1800,15 @@ describe('createSceneLoader (PUL-F008)', () => {
       expect(probe.log).toEqual([
         'create:scene-a',
         'timeline:scene-a',
+        'runTimeline:scene-a',
         'cleanup:scene-a',
         'create:scene-b',
         'timeline:scene-b',
+        'runTimeline:scene-b',
         'cleanup:scene-b',
         'create:scene-c',
         'timeline:scene-c',
+        'runTimeline:scene-c',
         'cleanup:scene-c',
       ]);
       expect(stage.attrs.get('data-pulsar-scene-target')).toBe('scene-a');
@@ -1820,7 +1835,7 @@ describe('createSceneLoader (PUL-F008)', () => {
         stage: stage.element,
         buildCtx: stubCtx,
         createPreloader: () => () => undefined,
-        runTimeline: noopRunner,
+        runTimeline: probe.runner,
       });
 
       await loader.handle(absentModeTarget(probe.compositionId));
@@ -1828,12 +1843,15 @@ describe('createSceneLoader (PUL-F008)', () => {
       expect(probe.log).toEqual([
         'create:scene-a',
         'timeline:scene-a',
+        'runTimeline:scene-a',
         'cleanup:scene-a',
         'create:scene-b',
         'timeline:scene-b',
+        'runTimeline:scene-b',
         'cleanup:scene-b',
         'create:scene-c',
         'timeline:scene-c',
+        'runTimeline:scene-c',
         'cleanup:scene-c',
       ]);
     });
@@ -1958,6 +1976,15 @@ describe('createSceneLoader (PUL-F008)', () => {
       // than via the test-runner timeout.
       const cleanupRan: string[] = [];
       let runnerSignal: AbortSignal | undefined;
+      // The runner resolves a deferred when its first call enters; the
+      // test awaits that deferred (or a 1s timeout) instead of an
+      // unbounded microtask spin so a regression that prevents the
+      // runner from starting fails with a deterministic assertion
+      // rather than hanging the test process.
+      let runnerEntered: () => void = () => undefined;
+      const runnerEnteredPromise = new Promise<void>((resolve) => {
+        runnerEntered = resolve;
+      });
       // First runner call holds open until aborted; subsequent calls
       // (the superseding navigation's runner) resolve immediately so
       // the test does not hang waiting for an interrupt that never
@@ -1968,10 +1995,11 @@ describe('createSceneLoader (PUL-F008)', () => {
         if (runnerCalls !== 1) return undefined;
         // Capture and assert signal presence synchronously, before
         // returning the gate promise. A missing signal fails the
-        // test deterministically with the assertion below — not via
-        // the 5s test timeout the abort-listener path would otherwise
+        // test deterministically with the throw below — not via the
+        // 5s test timeout the abort-listener path would otherwise
         // hit.
         runnerSignal = input.signal;
+        runnerEntered();
         if (runnerSignal === undefined) {
           throw new Error('mode=present did not forward a signal to the runner');
         }
@@ -2010,12 +2038,21 @@ describe('createSceneLoader (PUL-F008)', () => {
         locator: { kind: 'scene', scene: 'scene-a' },
         mode: 'present',
       });
-      while (runnerCalls === 0) {
-        await Promise.resolve();
-      }
+      // Bounded wait: race the deferred against a 1s timeout. A
+      // regression that prevents the runner from starting fails the
+      // assertion below with `runnerCalls === 0`, not via the 5s test
+      // timeout.
+      const guard = new Promise<'timeout'>((resolve) => {
+        setTimeout(() => resolve('timeout'), 1000);
+      });
+      const enteredOrTimeout = await Promise.race([
+        runnerEnteredPromise.then(() => 'entered' as const),
+        guard,
+      ]);
+      expect(enteredOrTimeout).toBe('entered');
+      expect(runnerCalls).toBe(1);
       // Signal MUST be present by the time the runner parked on it;
-      // assert before triggering the abort so a regression fails here
-      // rather than via timeout.
+      // assert before triggering the abort.
       expect(runnerSignal).toBeDefined();
       expect(runnerSignal?.aborted).toBe(false);
 


### PR DESCRIPTION
## Summary

Document the `mode=present` contract boundary in [ADR-016](docs/adrs/016-workbench-mode-present.md) and pin the six adapter seams future rendering / input surfaces will plug into.

**This PR does not implement PUL-F013.** PUL-F013's four facets (chrome, audio, inter-scene transition rendering, presenter input) all depend on surfaces that have not landed:

| Facet | Surface that delivers it | Status |
|---|---|---|
| Chrome | Workbench-shell requirement (not yet drafted) | absent |
| Audio | Audio service per ADR-004 (Howler.js) — future PUL-F* | absent |
| Inter-scene transitions | GSAP timeline runner per ADR-003 | absent (placeholder runner in `src/main.ts`) |
| Presenter input | PUL-F020 / PUL-F021 / PUL-F025 | absent |

PUL-F013 stays DRAFT; ACTIVE requires all four surfaces to land and add their own end-to-end tests on top of the seam tests in this PR. Mirrors the ADR-015 / PUL-F011 precedent.

## What's pinned

`tests/runtime/scene-loader.test.ts` — `'present-mode adapter seams (PUL-F013 boundary, NOT a PUL-F013 implementation)'` block (6 tests):
- Multi-scene composition under `mode=present` runs every scene's `create → timeline → cleanup` with cleanup-before-next-create — the hook the GSAP runner will hang transition rendering off.
- Identical multi-scene behavior when `mode` is absent.
- Every lifecycle hook in two consecutive multi-scene navigations sees `ctx.mode === 'present'`.
- Per-scene `AbortSignal` reaches the runner's `input.signal` under `mode=present`.
- An in-flight abort under `mode=present` flips `signal.aborted` and triggers `cleanup` on the active scene; signal-presence is asserted before parking on the abort gate so a regression fails fast rather than via timeout.
- No `data-pulsar-mode-*` suppression attribute is preemptively written under `mode=present`.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 574 passed
- [x] `pre-commit run --all-files`
- [x] `gc_codex_review` (pre-push, 2 cycles)

Closes #22