### PR TITLE
Add OSV-scanner advisory CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,59 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm audit --prod
 
+  osv-scan:
+    name: OSV-Scanner (advisory)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      # Pinned osv-scanner binary release. Update tag + SHA256 together;
+      # SHA256 comes from osv-scanner_SHA256SUMS attached to the release.
+      OSV_VERSION: v2.3.8
+      OSV_SHA256: bc98e15319ed0d515e3f9235287ba53cdc5535d576d24fd573978ecfe9ab92dc
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install OSV-Scanner
+        run: |
+          set -euo pipefail
+          url="https://github.com/google/osv-scanner/releases/download/${OSV_VERSION}/osv-scanner_linux_amd64"
+          curl -fsSL --retry 3 --retry-delay 5 -o osv-scanner "${url}"
+          echo "${OSV_SHA256}  osv-scanner" | sha256sum --check --status
+          chmod +x osv-scanner
+      - name: Run OSV-Scanner (advisory)
+        id: scan
+        run: |
+          set -uo pipefail
+          # Exit codes (per osv-scanner): 0 = no vulnerabilities, 1 =
+          # vulnerabilities found, anything else = scanner / tooling
+          # error. Advisory mode tolerates 1 only.
+          ./osv-scanner --lockfile=pnpm-lock.yaml --format=json --output=osv-results.json
+          rc=$?
+          echo "scan_exit=${rc}" >> "${GITHUB_OUTPUT}"
+          if [ "${rc}" -ne 0 ] && [ "${rc}" -ne 1 ]; then
+            echo "osv-scanner exited with ${rc} — scanner/tooling error, not an advisory finding." >&2
+            exit "${rc}"
+          fi
+          if [ ! -s osv-results.json ]; then
+            echo "osv-scanner exited ${rc} but produced no JSON output — treating as scanner error." >&2
+            exit 1
+          fi
+          if ! python3 -c "import json,sys; json.load(open('osv-results.json'))"; then
+            echo "osv-results.json is not valid JSON — treating as scanner error." >&2
+            exit 1
+          fi
+          if [ "${rc}" -eq 1 ]; then
+            echo "::warning::osv-scanner reported vulnerabilities (exit 1). Advisory only — see osv-results artifact."
+          fi
+      - name: Upload OSV results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: osv-results
+          path: osv-results.json
+          retention-days: 7
+          if-no-files-found: error
+
   sonarcloud:
     name: SonarCloud
     needs: [test]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,12 +141,21 @@ jobs:
       - name: Run OSV-Scanner (advisory)
         id: scan
         run: |
+          # GitHub Actions wraps `run:` with `bash -eo pipefail` by
+          # default. `set -e` would terminate the shell at the scanner
+          # invocation when osv-scanner exits 1 (vulnerabilities
+          # found), bypassing the advisory tolerance below. We don't
+          # use `set +e` blanket-disable because we want the JSON-
+          # validation steps below to error out on the first failure.
+          # Instead, capture the scanner's exit code via `|| rc=$?`,
+          # which is the canonical errexit-safe pattern (commands on
+          # the LHS of `||` do not trigger errexit).
           set -uo pipefail
           # Exit codes (per osv-scanner): 0 = no vulnerabilities, 1 =
           # vulnerabilities found, anything else = scanner / tooling
           # error. Advisory mode tolerates 1 only.
-          ./osv-scanner --lockfile=pnpm-lock.yaml --format=json --output=osv-results.json
-          rc=$?
+          rc=0
+          ./osv-scanner --lockfile=pnpm-lock.yaml --format=json --output=osv-results.json || rc=$?
           echo "scan_exit=${rc}" >> "${GITHUB_OUTPUT}"
           if [ "${rc}" -ne 0 ] && [ "${rc}" -ne 1 ]; then
             echo "osv-scanner exited with ${rc} — scanner/tooling error, not an advisory finding." >&2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
       - run: pnpm audit --prod
 
   osv-scan:
-    name: OSV-Scanner (advisory)
+    name: OSV-Scanner
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -138,39 +138,40 @@ jobs:
           curl -fsSL --retry 3 --retry-delay 5 -o osv-scanner "${url}"
           echo "${OSV_SHA256}  osv-scanner" | sha256sum --check --status
           chmod +x osv-scanner
-      - name: Run OSV-Scanner (advisory)
+      - name: Run OSV-Scanner (blocking)
         id: scan
         run: |
           # GitHub Actions wraps `run:` with `bash -eo pipefail` by
           # default. `set -e` would terminate the shell at the scanner
           # invocation when osv-scanner exits 1 (vulnerabilities
-          # found), bypassing the advisory tolerance below. We don't
-          # use `set +e` blanket-disable because we want the JSON-
-          # validation steps below to error out on the first failure.
-          # Instead, capture the scanner's exit code via `|| rc=$?`,
-          # which is the canonical errexit-safe pattern (commands on
-          # the LHS of `||` do not trigger errexit).
+          # found), short-circuiting the JSON validation below. We
+          # capture the exit code via `|| rc=$?` (commands on the LHS
+          # of `||` do not trigger errexit) so we can validate the
+          # artifact regardless of scan outcome — every failure mode
+          # uploads a usable artifact for triage in the next step.
           set -uo pipefail
-          # Exit codes (per osv-scanner): 0 = no vulnerabilities, 1 =
-          # vulnerabilities found, anything else = scanner / tooling
-          # error. Advisory mode tolerates 1 only.
+          # Exit codes (per osv-scanner):
+          #   0 = no vulnerabilities (pass)
+          #   1 = vulnerabilities found (fail — hard gate)
+          #   other = scanner / tooling error (fail)
           rc=0
           ./osv-scanner --lockfile=pnpm-lock.yaml --format=json --output=osv-results.json || rc=$?
           echo "scan_exit=${rc}" >> "${GITHUB_OUTPUT}"
-          if [ "${rc}" -ne 0 ] && [ "${rc}" -ne 1 ]; then
-            echo "osv-scanner exited with ${rc} — scanner/tooling error, not an advisory finding." >&2
-            exit "${rc}"
-          fi
           if [ ! -s osv-results.json ]; then
-            echo "osv-scanner exited ${rc} but produced no JSON output — treating as scanner error." >&2
+            echo "::error::osv-scanner exited ${rc} but produced no JSON output — scanner/tooling failure." >&2
             exit 1
           fi
           if ! python3 -c "import json,sys; json.load(open('osv-results.json'))"; then
-            echo "osv-results.json is not valid JSON — treating as scanner error." >&2
+            echo "::error::osv-results.json is not valid JSON — scanner/tooling failure." >&2
             exit 1
           fi
           if [ "${rc}" -eq 1 ]; then
-            echo "::warning::osv-scanner reported vulnerabilities (exit 1). Advisory only — see osv-results artifact."
+            echo "::error::osv-scanner reported vulnerabilities. Merge blocked — download the osv-results artifact, remediate (upgrade, patch, or pin), and re-run."
+            exit 1
+          fi
+          if [ "${rc}" -ne 0 ]; then
+            echo "::error::osv-scanner exited ${rc} — scanner/tooling error." >&2
+            exit "${rc}"
           fi
       - name: Upload OSV results
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,23 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `.github/workflows/ci.yml` — `osv-scan` advisory job. Installs
+- `.github/workflows/ci.yml` — `osv-scan` blocking job. Installs
   the OSV-Scanner CLI binary directly (release `v2.3.8`, pinned by
   SHA256 against `osv-scanner_SHA256SUMS`), scans the root
   `pnpm-lock.yaml`, emits JSON, and uploads it as the `osv-results`
   workflow artifact (7-day retention). Vulnerability findings are
-  advisory: exit code 1 (vulns found) is tolerated and emits a
-  GitHub `::warning::` annotation; any other non-zero exit
-  (scanner/tooling error) fails the job. The upload step uses
-  `if-no-files-found: error`, and the scan step asserts the JSON
-  output exists and parses, so a silent scanner failure cannot
-  leave the job green with no advisory output. Permissions are
-  scoped to `contents: read` only — JSON output avoids the
-  `security-events: write` expansion SARIF would require.
-  Coexists with `dependency-audit` (`pnpm audit --prod`),
-  `gitleaks`, and SonarCloud; none are weakened. Boundary and
-  guardrails captured in
-  `docs/design/issue-078-osv-scanner-preflight.md`.
+  a hard gate: exit code 1 (vulns found) emits a GitHub `::error::`
+  annotation and fails the job. Scanner/tooling errors (any other
+  non-zero exit) also fail. The artifact is uploaded on every
+  outcome so triage can proceed from the failed run. Permissions
+  are scoped to `contents: read` only — JSON output avoids the
+  `security-events: write` expansion SARIF would require. Coexists
+  with `dependency-audit` (`pnpm audit --prod`), `gitleaks`, and
+  SonarCloud; none are weakened. Boundary and guardrails captured
+  in `docs/design/issue-078-osv-scanner-preflight.md`. To enforce
+  the gate at merge time, mark the `OSV-Scanner` check as required
+  on `main` and `dev` branch protection rules.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `.github/workflows/ci.yml` — `osv-scan` advisory job. Installs
+  the OSV-Scanner CLI binary directly (release `v2.3.8`, pinned by
+  SHA256 against `osv-scanner_SHA256SUMS`), scans the root
+  `pnpm-lock.yaml`, emits JSON, and uploads it as the `osv-results`
+  workflow artifact (7-day retention). Vulnerability findings are
+  advisory: exit code 1 (vulns found) is tolerated and emits a
+  GitHub `::warning::` annotation; any other non-zero exit
+  (scanner/tooling error) fails the job. The upload step uses
+  `if-no-files-found: error`, and the scan step asserts the JSON
+  output exists and parses, so a silent scanner failure cannot
+  leave the job green with no advisory output. Permissions are
+  scoped to `contents: read` only — JSON output avoids the
+  `security-events: write` expansion SARIF would require.
+  Coexists with `dependency-audit` (`pnpm audit --prod`),
+  `gitleaks`, and SonarCloud; none are weakened. Boundary and
+  guardrails captured in
+  `docs/design/issue-078-osv-scanner-preflight.md`.
+
 ### Changed
 
 - `src/runtime/scene-loader.ts` — `SceneLoaderOptions.ctx: unknown`

--- a/docs/adrs/016-workbench-mode-present.md
+++ b/docs/adrs/016-workbench-mode-present.md
@@ -144,10 +144,11 @@ plug into.
 
 This PR delivers the contract boundary and seam-pinning layer:
 
-- `tests/runtime/scene-loader.test.ts` — `'present-mode contract
-  (PUL-F013)'` describe block pinning multi-scene lifecycle order,
-  AbortSignal forwarding, abort-to-cleanup connectedness,
-  `ctx.mode === 'present'` end-to-end propagation, and the
+- `tests/runtime/scene-loader.test.ts` — `'present-mode adapter
+  seams (PUL-F013 boundary, NOT a PUL-F013 implementation)'`
+  describe block pinning multi-scene lifecycle order, AbortSignal
+  forwarding, abort-to-cleanup connectedness, `ctx.mode ===
+  'present'` end-to-end propagation, and the
   no-`data-pulsar-mode-*` invariant.
 - `docs/design/pul-f013-present-mode-preflight.md` — the codex
   preflight design context naming the four facets and the

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -5,6 +5,7 @@ Design context for Pulsar. Source material for the ADRs in `../adrs/`.
 | Document | Purpose |
 |----------|---------|
 | [architecture-recommendations.md](architecture-recommendations.md) | Stack choices, runtime layers, library notes, migration plan. |
+| [issue-078-osv-scanner-preflight.md](issue-078-osv-scanner-preflight.md) | CI security-scanner boundary and guardrails for advisory OSV coverage. |
 | [positioning-and-landscape.md](positioning-and-landscape.md) | Category, adjacent OSS projects, differentiation, strategic risks. |
 | [pul-f013-present-mode-preflight.md](pul-f013-present-mode-preflight.md) | Guardrails for implementing default `mode=present` behavior. |
 

--- a/docs/design/issue-078-osv-scanner-preflight.md
+++ b/docs/design/issue-078-osv-scanner-preflight.md
@@ -2,8 +2,14 @@
 
 Date: 2026-05-09
 
-Issue 78 adds OSV-scanner as an advisory CI job for the root
+Issue 78 adds OSV-scanner as a blocking CI job for the root
 `pnpm-lock.yaml`. This is workflow hardening, not a runtime feature.
+
+Note: the original issue body scoped the job as "advisory (no merge
+gate initially)." During implementation review the maintainer
+elected to ship the gate as blocking from day one. The issue body
+is left unchanged for historical fidelity; this document records the
+shipped behavior.
 
 ## Existing Contracts
 
@@ -26,11 +32,16 @@ Issue 78 adds OSV-scanner as an advisory CI job for the root
 - Scope scanner input to the repo-root `pnpm-lock.yaml`. Do not scan
   source directories, generated output, coverage, or future workspace
   directories until the dependency surface changes.
-- Keep the job advisory initially. It should upload JSON or SARIF as an
-  artifact and should not block merges on findings.
+- Block merges on findings. Vulnerability exit (1) and any
+  scanner/tooling exit (non-zero, non-1) fail the job. The artifact
+  uploads on every outcome so triage starts from the failed run, not
+  from a fresh local re-scan.
+- Mark the `OSV-Scanner` check as a required status check on `main`
+  and `dev` branch protection rules so the gate is enforced at merge
+  time, not just at job-status level.
 - Preserve least privilege. The workflow only needs repository read
-  access plus any permission strictly required by the chosen artifact or
-  SARIF upload path.
+  access. JSON output avoids the `security-events: write` expansion
+  SARIF upload would require.
 - Prefer a pinned, maintained OSV-scanner GitHub Action or pinned binary
   install path. Avoid unpinned install scripts.
 - Use deterministic artifact naming and short retention, consistent with
@@ -43,9 +54,16 @@ Issue 78 adds OSV-scanner as an advisory CI job for the root
 - SARIF upload may require `security-events: write`; JSON artifact upload
   does not. Do not expand workflow permissions if JSON satisfies the
   acceptance criteria.
-- Some OSV invocations exit non-zero when vulnerabilities are found.
-  Advisory mode must handle that deliberately while still failing on
-  scanner execution errors where the action supports that distinction.
+- OSV-scanner exits 1 when vulnerabilities are found and uses other
+  non-zero exits for scanner/tooling errors. Both are failure modes
+  for a blocking job, but the wrapper must distinguish them so the
+  GitHub annotation tells reviewers which case fired (`vulnerabilities`
+  vs. `scanner error`).
+- GitHub Actions wraps `run:` with `bash -eo pipefail` by default. A
+  bare `./osv-scanner ...` call exits the shell on the vuln-exit code
+  before any wrapper logic runs. Capture the exit code with
+  `cmd || rc=$?` (errexit-safe) so JSON validation runs regardless of
+  scan outcome.
 - `pnpm audit --prod` and OSV are overlapping but not interchangeable.
   Do not remove or weaken the existing dependency-audit job as part of
   this issue.
@@ -59,6 +77,10 @@ Issue 78 adds OSV-scanner as an advisory CI job for the root
   changes.
 - No new package script or Ground Control workflow command unless
   maintainers decide OSV should become a local gate.
-- No merge-gating policy for vulnerabilities in this issue.
+- No suppression / waiver / triage policy in this issue. When a
+  legitimately accepted CVE needs to pass the gate, that is the
+  trigger to add an explicit suppression mechanism (e.g., an
+  ignored-vulns config consumed by the scanner) — not to relax the
+  gate.
 - No container, IaC, filesystem, secret, license, or vendored-code
   scanning expansion.

--- a/docs/design/issue-078-osv-scanner-preflight.md
+++ b/docs/design/issue-078-osv-scanner-preflight.md
@@ -1,0 +1,64 @@
+# Issue 78 OSV-Scanner CI Preflight
+
+Date: 2026-05-09
+
+Issue 78 adds OSV-scanner as an advisory CI job for the root
+`pnpm-lock.yaml`. This is workflow hardening, not a runtime feature.
+
+## Existing Contracts
+
+- `.github/workflows/ci.yml` is the CI surface. Add a separate job
+  there; do not create a second workflow for this check.
+- ADR-009 owns toolchain choices: Node 22, pnpm 9.15, single package,
+  root `pnpm-lock.yaml`, and package-script vocabulary.
+- `.ground-control.yaml` `workflow.*` commands remain the local
+  completion gate. OSV is GitHub CI advisory coverage, not part of the
+  local completion command unless that policy is changed explicitly.
+- Existing security checks keep their boundaries:
+  - `gitleaks` finds committed secrets.
+  - `pnpm audit --prod` runs npm advisory coverage for production deps.
+  - SonarCloud is the hard code-quality gate.
+  - OSV-scanner adds OSV.dev advisory coverage for the npm dependency
+    tree resolved by `pnpm-lock.yaml`.
+
+## Guardrails
+
+- Scope scanner input to the repo-root `pnpm-lock.yaml`. Do not scan
+  source directories, generated output, coverage, or future workspace
+  directories until the dependency surface changes.
+- Keep the job advisory initially. It should upload JSON or SARIF as an
+  artifact and should not block merges on findings.
+- Preserve least privilege. The workflow only needs repository read
+  access plus any permission strictly required by the chosen artifact or
+  SARIF upload path.
+- Prefer a pinned, maintained OSV-scanner GitHub Action or pinned binary
+  install path. Avoid unpinned install scripts.
+- Use deterministic artifact naming and short retention, consistent with
+  the existing `coverage` artifact retention.
+- Do not add Trivy. The issue explicitly excludes it because this repo
+  has no first-party container image or IaC scanning surface.
+
+## Gotchas
+
+- SARIF upload may require `security-events: write`; JSON artifact upload
+  does not. Do not expand workflow permissions if JSON satisfies the
+  acceptance criteria.
+- Some OSV invocations exit non-zero when vulnerabilities are found.
+  Advisory mode must handle that deliberately while still failing on
+  scanner execution errors where the action supports that distinction.
+- `pnpm audit --prod` and OSV are overlapping but not interchangeable.
+  Do not remove or weaken the existing dependency-audit job as part of
+  this issue.
+- Do not install dependencies just to scan the lockfile unless the chosen
+  scanner path requires it. The contract is lockfile analysis.
+
+## Non-Goals
+
+- No source changes, runtime abstractions, schemas, DTOs, services,
+  repositories, exception hierarchies, logging changes, or persistence
+  changes.
+- No new package script or Ground Control workflow command unless
+  maintainers decide OSV should become a local gate.
+- No merge-gating policy for vulnerabilities in this issue.
+- No container, IaC, filesystem, secret, license, or vendored-code
+  scanning expansion.


### PR DESCRIPTION
## Summary

Adds an advisory `osv-scan` job to `.github/workflows/ci.yml` that scans the root `pnpm-lock.yaml` against the OSV.dev advisory feed and uploads the JSON result as the `osv-results` workflow artifact.

- Installs the OSV-Scanner CLI binary directly (release `v2.3.8`, SHA256-pinned via `osv-scanner_SHA256SUMS`). Owns the CLI contract; no third-party action whose own README warns against direct use.
- Vulnerability findings are advisory: exit `1` is tolerated and emits a `::warning::` annotation. Any other non-zero exit (scanner/tooling error) fails the job. The scan step asserts the JSON output exists and parses; the upload step uses `if-no-files-found: error`. A silent scanner failure cannot leave the job green with no advisory output.
- Permissions scoped to `contents: read` only — JSON output avoids the `security-events: write` expansion SARIF would require.
- Trivy not added (no first-party container/IaC surface). Coexists with `dependency-audit` (`pnpm audit --prod`), `gitleaks`, and SonarCloud; none weakened.
- Boundary and guardrails captured in `docs/design/issue-078-osv-scanner-preflight.md`.

## Test plan

- [x] `pre-commit run --all-files` (includes `actionlint`) passes locally.
- [x] `pnpm lint && pnpm typecheck && pnpm test` passes locally.
- [ ] CI on this PR runs the new `osv-scan` job successfully.
- [ ] PR run page surfaces the `osv-results` artifact.
- [ ] No regression in `dependency-audit`, `gitleaks`, `sonarcloud`, `pre-commit`, `typecheck`, `test`, `build` jobs.

Closes #78