### PR TITLE
Implement PUL-F014: workbench mode `standalone`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `docs/adrs/017-workbench-mode-standalone.md` — records the
+  PUL-F014 contract: under `mode=standalone` the loader truncates
+  the validated composition slice from `resolveSceneNavigation()`
+  to a one-entry slice (the addressed head, preserved verbatim
+  including object-form `range` / `behavior` overrides) and runs
+  only the head scene's lifecycle. Composition validation still
+  runs first, so unregistered compositions / unknown member scenes
+  / out-of-range indexes still surface as navigation errors. Inter-scene transition suppression is
+  structural (no second scene to transition to). Surrounding chrome
+  and audio-bed suppression — the parts of PUL-F014's statement
+  that name surfaces not yet in the repo — are inherited by future
+  workbench-shell / audio-service requirements through `ctx.mode
+  === 'standalone'` at their own seam, the same hint they will
+  read for `mode=present`. Contrasts with ADR-016: PUL-F014 is
+  materially implementable today and transitions DRAFT → ACTIVE in
+  this PR. Indexed in `docs/adrs/README.md`.
+- `docs/design/pul-f014-standalone-mode-preflight.md` — codex
+  architecture preflight design context for PUL-F014. Names the
+  cross-cutting concerns to reuse (`NAVIGATION_MODES`,
+  `effectiveMode()`, `parseNavigationSearch()`,
+  `resolveSceneNavigation()`, `loadSceneNavigationTarget()`,
+  `resolveComposition()`, `createAssetPreloader()`,
+  `describeError()`, the per-navigation `AbortController`) and the
+  anti-patterns to avoid (second mode enum, `standalone` boolean,
+  manifest-mutation slicing, CSS-hide-after-the-fact, all-audio
+  suppression, persisting standalone state outside the URL).
+- `tests/runtime/scene-loader.test.ts` — new
+  `'standalone-mode single-scene execution (PUL-F014)'` describe
+  block (13 tests) pinning every clause of PUL-F014 under
+  `mode=standalone`:
+  - Single-scene execution at the addressed head scene for
+    `composition`, `composition+scene`, and `composition+index`
+    locators (no following composition entries fire).
+  - Direct `scene` target baseline parity (no slice to drop).
+  - `beat=` forwarding to the head scene's runner with the
+    non-fatal missing-label diagnostic preserved.
+  - `ctx.mode === 'standalone'` exposed to every lifecycle hook of
+    the head scene under all four locator shapes.
+  - Stage attributes communicate what the URL ADDRESSED:
+    `data-pulsar-scene-target` AND `data-pulsar-composition-target`
+    are both set when the URL named a composition under standalone.
+  - No `data-pulsar-mode-*` suppression attribute is preemptively
+    written (parity with ADR-016 invariant for `present`).
+  - Composition-not-registered, composition-member-not-found, and
+    index-out-of-range errors STILL surface under `mode=standalone`
+    (no silent fallback to direct scene lookup).
+  - Object-form head entry's `range` and `behavior` overrides reach
+    the runner unchanged — standalone is single-scene EXECUTION,
+    not direct-scene flattening.
+  - Cleanup runs exactly once for the head scene, never for dropped
+    slice entries.
 - `.github/workflows/ci.yml` — `osv-scan` blocking job. Installs
   the OSV-Scanner CLI binary directly (release `v2.3.8`, pinned by
   SHA256 against `osv-scanner_SHA256SUMS`), scans the root
@@ -28,6 +79,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `src/runtime/scene-loader.ts` — `runTarget` truncates the validated
+  composition slice to a single entry — the addressed head — when
+  `effectiveMode(target) === 'standalone'` AND
+  `resolved.composition !== undefined`. The truncation preserves the
+  head entry verbatim (object-form `{ id, range, behavior }` entries
+  stay object-form), so the runner receives `range` / `behavior`
+  overrides unchanged; following entries are dropped, so no
+  inter-scene transition runs and no later scene's lifecycle fires.
+  Validation still runs first via `resolveSceneNavigation()`, so a
+  malformed standalone target surfaces as a navigation error, not a
+  silent direct scene fallback. Stage attrs continue to record both
+  `data-pulsar-scene-target` and `data-pulsar-composition-target` to
+  preserve observability of what the URL addressed (PUL-F014 /
+  ADR-017).
 - `src/runtime/scene-loader.ts` — `SceneLoaderOptions.ctx: unknown`
   replaced with `SceneLoaderOptions.buildCtx: (mode: NavigationMode)
   => unknown`. The loader now derives the effective workbench mode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,15 +16,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   including object-form `range` / `behavior` overrides) and runs
   only the head scene's lifecycle. Composition validation still
   runs first, so unregistered compositions / unknown member scenes
-  / out-of-range indexes still surface as navigation errors. Inter-scene transition suppression is
-  structural (no second scene to transition to). Surrounding chrome
-  and audio-bed suppression — the parts of PUL-F014's statement
-  that name surfaces not yet in the repo — are inherited by future
-  workbench-shell / audio-service requirements through `ctx.mode
-  === 'standalone'` at their own seam, the same hint they will
-  read for `mode=present`. Contrasts with ADR-016: PUL-F014 is
-  materially implementable today and transitions DRAFT → ACTIVE in
-  this PR. Indexed in `docs/adrs/README.md`.
+  / out-of-range indexes still surface as navigation errors. The
+  single-scene execution mechanism is materially shipped; the seam
+  (`ctx.mode === 'standalone'` reaches every lifecycle hook of the
+  head scene) is pinned. Surrounding chrome, audio-bed, and
+  inter-scene-transition suppression — the three named surfaces
+  that don't exist in the repo today — are deferred to the future
+  workbench-shell / audio-service / GSAP runner requirements that
+  will land them. Following the ADR-016 precedent, PUL-F014 stays
+  DRAFT and the issue ↔ requirement link is `DOCUMENTS`; ACTIVE
+  transitions when each surface actively reads
+  `ctx.mode === 'standalone'` and suppresses, with end-to-end
+  tests alongside the seam tests in this PR. Indexed in
+  `docs/adrs/README.md`.
 - `docs/design/pul-f014-standalone-mode-preflight.md` — codex
   architecture preflight design context for PUL-F014. Names the
   cross-cutting concerns to reuse (`NAVIGATION_MODES`,

--- a/docs/adrs/017-workbench-mode-standalone.md
+++ b/docs/adrs/017-workbench-mode-standalone.md
@@ -1,0 +1,222 @@
+# ADR-017: Workbench Mode `standalone` — Single-Scene Execution at the Loader
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-09
+
+## Context
+
+ADR-007 names seven workbench modes: `present`, `standalone`, `loop`,
+`paused`, `scrub`, `screenshot`, `prompter`. ADR-013 fixes the URL
+grammar boundary that carries `mode=` to the runtime. ADR-014 fixes
+the scene navigation dispatch layer that turns a `NavigationTarget`
+into a runnable scene/slice. ADR-015 fixes URL beat positioning.
+ADR-016 establishes the pattern for landing a mode's contract while
+the dependent rendering surfaces are still pending: PUL-F013 stayed
+DRAFT because chrome / audio / GSAP runner / presenter input
+surfaces are not yet implemented.
+
+PUL-F014 specifies `mode=standalone`: in this mode the runtime
+SHALL render a single scene with surrounding chrome, inter-scene
+transitions, and audio bed suppressed; the scene SHALL run as if no
+surrounding composition existed.
+
+The non-trivial parts of that statement are operational *today* —
+unlike PUL-F013, which depends on subsystems that do not yet exist
+to render the suppressed facets.
+
+- "Render a single scene" — the loader can already drive a one-entry
+  manifest through the existing single-scene branch in
+  `loadSceneNavigationTarget`.
+- "Inter-scene transitions suppressed" — the runtime has no inter-
+  scene-transition rendering today (ADR-003 reserves the GSAP runner
+  for that). Under standalone there is no second scene in the
+  navigation queue, so no transition runs. The suppression is
+  *structural* — it follows from single-scene execution rather than
+  from a runner flag.
+- "Run as if no surrounding composition existed" — the loader drops
+  the validated composition slice and runs only the addressed head
+  scene's lifecycle.
+- "Surrounding chrome suppressed" / "audio bed suppressed" — neither
+  surface exists in this repo today. A future workbench-shell
+  requirement and a future audio-service requirement (per ADR-004)
+  will land them. They will read `ctx.mode` at their own seam to
+  decide whether to render. Today there is nothing to suppress.
+
+The question this ADR answers is: where does `mode=standalone`
+slice from a composition target down to a single-scene execution,
+and on what contract does PUL-F014 transition to ACTIVE?
+
+## Decision
+
+`mode=standalone` is dispatched at the loader (`src/runtime/scene-loader.ts`)
+as a slice transform on the already-validated `SceneNavigationTarget`
+produced by `resolveSceneNavigation()`. When `effectiveMode(target) ===
+'standalone'` and the resolved target carries a composition slice, the
+loader **truncates** the slice to a single entry — the addressed head —
+before constructing the in-flight load. The truncated slice preserves
+the original head entry verbatim (object-form `{ id, range, behavior }`
+entries stay object-form; bare-string entries stay bare strings) so the
+runner receives the head entry's `range` / `behavior` overrides
+unchanged. Following entries are dropped from the slice, so no
+inter-scene transition runs and no later scene's lifecycle fires.
+
+The slice is **truncated, not flattened.** Replacing the resolved
+target with `{ scene: resolved.scene }` (no composition) would lose
+the head entry's per-entry overrides, turning standalone into
+direct-scene flattening — which would contradict ADR-002 / ADR-011's
+"manifest entries carry overrides; the runner consumes them" contract
+and would silently break URLs whose head entry is object-form. The
+truncated `manifestSlice` (length 1) therefore continues through the
+composition branch in `loadSceneNavigationTarget()`, and the existing
+runner-input plumbing forwards `range` / `behavior` per ADR-011.
+
+PUL-F014 transitions DRAFT → ACTIVE in the PR that lands this ADR.
+The ACTIVE contract is single-scene execution at the addressed head
+scene under `mode=standalone`. Future chrome / audio / runner /
+presenter surfaces inherit `ctx.mode === 'standalone'` at *their*
+seam and decide their own suppression behavior — they extend
+PUL-F014's contract surface; they do not gate its ACTIVE transition.
+
+This is the deliberate contrast with ADR-016 / PUL-F013. PUL-F013's
+clauses (chrome / audio / inter-scene transitions / presenter input)
+each require a rendering or input surface that does not exist; the
+contract layer alone cannot render or respond, so the requirement
+stays DRAFT until those surfaces land. PUL-F014's clauses *all*
+collapse to "single-scene execution at the addressed head scene" or
+to facets whose suppression is structural under that contract — no
+absent rendering surface gates the transition.
+
+### Boundary
+
+The slice drop happens at the loader because:
+
+- The loader is the dispatch point that already derives `effectiveMode`
+  for `ctx.mode` (ADR-007 / PUL-F012). Adding the slice transform here
+  keeps mode-aware logic in one place.
+- The composition resolver MUST stay mode-opaque (ADR-011 — pure
+  orchestrator, no adapter knowledge). Slicing in the resolver would
+  give it knowledge of mode semantics it deliberately does not own.
+- `resolveSceneNavigation()` MUST run validation regardless of mode:
+  unregistered compositions, unknown member scenes, ambiguous
+  `composition+scene` locators, out-of-range indexes, and empty
+  compositions still surface as navigation errors under
+  `mode=standalone`. The slice drop runs *after* validation, so a
+  malformed standalone target does not silently fall back to a direct
+  scene lookup.
+- `loadSceneNavigationTarget()` already has a clean single-scene
+  branch. Reusing it removes the need for a "standalone-only" code
+  path through the lifecycle.
+
+### Stage attribute behavior
+
+`data-pulsar-scene-target` (head scene id) AND
+`data-pulsar-composition-target` (composition id) are both set on the
+stage when the URL named a composition under `mode=standalone`.
+The attrs communicate "what was addressed," not "what's running."
+Removing the composition attr would lose useful inspection signal for
+agents and screenshot tooling. No `data-pulsar-mode-*` suppression
+attribute is preemptively written under `standalone` (parity with
+ADR-016's invariant for `mode=present`); future chrome / audio
+adapters are free to use that namespace if they actually need a
+stage-level signal.
+
+### Beat semantics
+
+`beat=` under `mode=standalone` is forwarded to the head scene's
+runner unchanged. Missing-label diagnostics surface via the existing
+non-fatal `onBeatMissing` path (ADR-015), keeping single-scene
+authoring/inspection's primary use case — landing on a specific beat
+to inspect — fully supported.
+
+## Consequences
+
+### Positive
+
+- PUL-F014 transitions to ACTIVE on the same PR that lands the
+  contract: the requirement is materially implementable today, and
+  ADR-016's "DRAFT until rendering surfaces land" pattern would be
+  the wrong precedent here.
+- The slice transform is one branch in `runTarget` — about five lines
+  of code. The lifecycle path, resolver, registry, and beat plumbing
+  are unchanged. Surface area for regressions is small.
+- Future chrome / audio / runner adapters inherit `ctx.mode ===
+  'standalone'` for free — they read the same hint they already plan
+  to read for `present`, no new wiring required.
+- Composition validation is preserved: standalone is single-scene
+  *execution*, not single-scene *lookup*. A malformed composition
+  target fails the same way it does in any other mode.
+
+### Negative
+
+- The stage attrs say "this URL addressed composition X" while only
+  one scene runs. Agents inspecting the runtime see a coherent record
+  of the URL but must know `mode=standalone` to understand why the
+  rest of the composition did not execute. The mode parameter is in
+  the same URL the agent sees, so this is a small disambiguation cost
+  — but it is non-zero. The alternative (dropping the composition
+  attr) would lose more useful information than it would save.
+- `composition+scene` and `composition+index` look slightly
+  redundant under `mode=standalone`: both resolve to the same
+  single-scene execution as direct `scene=` would. They remain
+  accepted because they preserve composition context for the head
+  scene's lookup (range / behavior overrides on the head entry are
+  still respected) and because rejecting them would force authors to
+  rewrite URLs when toggling between modes.
+
+### Risks
+
+- A future requirement could mean to *also* suppress audio that the
+  addressed scene owns (today the statement only suppresses the
+  surrounding *audio bed*). When that requirement lands, audio surface
+  authors will read `ctx.mode === 'standalone'` at their own seam
+  rather than the loader gaining new logic. The seam is set; the
+  behavior is the future surface's contract.
+- A non-parser caller could construct a `NavigationTarget` whose
+  `mode` field is forged. The defense-in-depth check
+  `validateModeGrammar` already rejects unknown mode strings at the
+  loader boundary. Slice transforms only run when the mode passes
+  validation.
+- Inter-scene transition rendering does not exist yet. When ADR-003's
+  GSAP runner lands, the runner will see `ctx.mode === 'standalone'`
+  at the seam and know not to schedule a transition out of the head
+  scene — but until then, "no transition runs" is true because there
+  is no transition code anywhere. A regression that *added* transition
+  scheduling without consulting `ctx.mode` would re-introduce the
+  facet PUL-F014 forbids; the seam test
+  (`ctx.mode === 'standalone'` reaches every lifecycle hook of the
+  head scene) is the structural defense against that.
+
+## Related ADRs
+
+- [ADR-003](003-gsap-timeline-engine.md) — the timeline runner is the
+  seam through which inter-scene transition rendering will flow when
+  it lands; today the runner is a placeholder, so transition
+  suppression under standalone is structural.
+- [ADR-004](004-howler-audio-engine.md) — `ctx.audio` is the seam
+  through which audio rendering will flow; the surrounding-audio-bed
+  suppression clause maps onto a future audio surface reading
+  `ctx.mode === 'standalone'`.
+- [ADR-007](007-browser-workbench.md) — defines the seven workbench
+  modes and the URL-only-source invariant for mode selection.
+- [ADR-008](008-agent-native-authoring.md) — manifests-over-flow-
+  control underpins the slice-drop-not-manifest-mutation choice.
+- [ADR-011](011-composition-resolver-orchestration.md) — the resolver
+  is opaque to mode; the slice transform happens at the loader, not
+  inside the resolver.
+- [ADR-013](013-url-navigation-grammar-boundary.md) — the parser
+  preserves `mode` and forbids recovering it from any non-URL source.
+- [ADR-014](014-url-scene-target-selection.md) — scene navigation
+  dispatch is mode-blind; it resolves the active slice and hands off
+  to the loader for mode dispatch.
+- [ADR-015](015-url-beat-positioning.md) — beat semantics under
+  standalone are unchanged: head-scope only, runner-side label
+  resolution, non-fatal missing-label diagnostic.
+- [ADR-016](016-workbench-mode-present.md) — establishes the pattern
+  this ADR contrasts against: PUL-F013 stays DRAFT pending rendering
+  surfaces; PUL-F014 goes ACTIVE because its clauses are
+  materially implementable today.

--- a/docs/adrs/017-workbench-mode-standalone.md
+++ b/docs/adrs/017-workbench-mode-standalone.md
@@ -75,21 +75,45 @@ truncated `manifestSlice` (length 1) therefore continues through the
 composition branch in `loadSceneNavigationTarget()`, and the existing
 runner-input plumbing forwards `range` / `behavior` per ADR-011.
 
-PUL-F014 transitions DRAFT → ACTIVE in the PR that lands this ADR.
-The ACTIVE contract is single-scene execution at the addressed head
-scene under `mode=standalone`. Future chrome / audio / runner /
-presenter surfaces inherit `ctx.mode === 'standalone'` at *their*
-seam and decide their own suppression behavior — they extend
-PUL-F014's contract surface; they do not gate its ACTIVE transition.
+PUL-F014 stays DRAFT after this PR lands, mirroring the PUL-F013
+precedent in ADR-016. This PR ships:
 
-This is the deliberate contrast with ADR-016 / PUL-F013. PUL-F013's
-clauses (chrome / audio / inter-scene transitions / presenter input)
-each require a rendering or input surface that does not exist; the
-contract layer alone cannot render or respond, so the requirement
-stays DRAFT until those surfaces land. PUL-F014's clauses *all*
-collapse to "single-scene execution at the addressed head scene" or
-to facets whose suppression is structural under that contract — no
-absent rendering surface gates the transition.
+- The single-scene execution mechanism (slice truncation at the
+  loader) — the structural form of "the scene SHALL run as if no
+  surrounding composition existed," which IS materially implemented.
+- The seam — `ctx.mode === 'standalone'` reaches every lifecycle
+  hook of the head scene through the existing PUL-F012 plumbing.
+- Tests pinning the seam and the slice-truncation behavior.
+
+What it does NOT yet ship is the active *suppression* of the three
+named surfaces under standalone:
+
+- Surrounding chrome rendering does not exist anywhere in the repo.
+  When a future workbench-shell requirement lands chrome, it MUST
+  read `ctx.mode === 'standalone'` from the seam this PR pinned and
+  SUPPRESS. Today nothing renders chrome, so the suppression clause
+  is vacuously true — but vacuous truth is not enforcement.
+- Audio-bed playback does not exist (ADR-004's Howler audio service
+  is not implemented). When the future audio service lands, it MUST
+  read the seam and suppress the surrounding audio bed under
+  standalone. The "audio bed" qualifier is intentional: scene-owned
+  sound effects are a separate behavior the audio service decides at
+  its own contract.
+- Inter-scene transition rendering does not exist (ADR-003's GSAP
+  runner is a placeholder). Under standalone, single-scene execution
+  ensures no second scene runs, so no transition fires structurally
+  — but when the runner lands and starts scheduling transitions, it
+  MUST read the seam and suppress the leaving-transition out of the
+  head scene under standalone.
+
+Following the ADR-016 precedent, PUL-F014 transitions DRAFT → ACTIVE
+when each of the three rendering surfaces above lands AND its
+implementation explicitly reads `ctx.mode === 'standalone'` and
+suppresses the named facet, with an end-to-end test alongside the
+seam tests in this PR. Until then, the issue ↔ requirement link
+stays as `DOCUMENTS` and the status stays DRAFT — matching how
+ADR-016 / PUL-F013 records "land the contract layer; keep the
+requirement DRAFT until the dependent subsystems land."
 
 ### Boundary
 
@@ -137,16 +161,24 @@ to inspect — fully supported.
 
 ### Positive
 
-- PUL-F014 transitions to ACTIVE on the same PR that lands the
-  contract: the requirement is materially implementable today, and
-  ADR-016's "DRAFT until rendering surfaces land" pattern would be
-  the wrong precedent here.
-- The slice transform is one branch in `runTarget` — about five lines
-  of code. The lifecycle path, resolver, registry, and beat plumbing
-  are unchanged. Surface area for regressions is small.
+- The single-scene execution mechanism is materially shipped: the
+  loader truncates the validated composition slice to one entry,
+  preserving object-form `range` / `behavior` overrides. That
+  satisfies the "run as if no surrounding composition existed"
+  clause in code, not just in documentation.
+- Following ADR-016's precedent keeps the DRAFT → ACTIVE bar
+  consistent across mode requirements: ACTIVE means every facet the
+  statement names has a real surface that actively conforms.
+  Future authors reading the requirement set will see one rule, not
+  two.
+- The slice-truncation helper (`applyStandaloneSlice`) is one pure
+  function in `runTarget`. The lifecycle path, resolver, registry,
+  and beat plumbing are unchanged. Surface area for regressions is
+  small.
 - Future chrome / audio / runner adapters inherit `ctx.mode ===
   'standalone'` for free — they read the same hint they already plan
-  to read for `present`, no new wiring required.
+  to read for `present`, no new wiring required. When they conform,
+  PUL-F014 transitions to ACTIVE.
 - Composition validation is preserved: standalone is single-scene
   *execution*, not single-scene *lookup*. A malformed composition
   target fails the same way it does in any other mode.
@@ -216,7 +248,10 @@ to inspect — fully supported.
 - [ADR-015](015-url-beat-positioning.md) — beat semantics under
   standalone are unchanged: head-scope only, runner-side label
   resolution, non-fatal missing-label diagnostic.
-- [ADR-016](016-workbench-mode-present.md) — establishes the pattern
-  this ADR contrasts against: PUL-F013 stays DRAFT pending rendering
-  surfaces; PUL-F014 goes ACTIVE because its clauses are
-  materially implementable today.
+- [ADR-016](016-workbench-mode-present.md) — establishes the
+  precedent this ADR follows: land the contract layer plus seam
+  tests, keep the requirement DRAFT until each named facet has a
+  real rendering / input surface that actively conforms. PUL-F014's
+  ACTIVE transition is gated on chrome, audio-bed, and
+  inter-scene-transition surfaces all reading `ctx.mode ===
+  'standalone'` and suppressing.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -42,3 +42,4 @@ Each ADR includes:
 | [014](014-url-scene-target-selection.md) | Loading the Addressed Scene as the Runtime Navigation Target | Accepted |
 | [015](015-url-beat-positioning.md) | URL Beat Positioning as Timeline-Runner State | Accepted |
 | [016](016-workbench-mode-present.md) | Workbench Mode `present` — Contract Boundary and Adapter Seams | Accepted |
+| [017](017-workbench-mode-standalone.md) | Workbench Mode `standalone` — Single-Scene Execution at the Loader | Accepted |

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -8,6 +8,7 @@ Design context for Pulsar. Source material for the ADRs in `../adrs/`.
 | [issue-078-osv-scanner-preflight.md](issue-078-osv-scanner-preflight.md) | CI security-scanner boundary and guardrails for advisory OSV coverage. |
 | [positioning-and-landscape.md](positioning-and-landscape.md) | Category, adjacent OSS projects, differentiation, strategic risks. |
 | [pul-f013-present-mode-preflight.md](pul-f013-present-mode-preflight.md) | Guardrails for implementing default `mode=present` behavior. |
+| [pul-f014-standalone-mode-preflight.md](pul-f014-standalone-mode-preflight.md) | Guardrails for implementing isolated `mode=standalone` behavior. |
 
 Design docs are mutable. Decisions are captured as ADRs (immutable once
 accepted).

--- a/docs/design/pul-f014-standalone-mode-preflight.md
+++ b/docs/design/pul-f014-standalone-mode-preflight.md
@@ -1,0 +1,148 @@
+# PUL-F014 Standalone Mode Preflight
+
+PUL-F014 specifies `mode=standalone`: render one scene as an isolated
+authoring / inspection target, with surrounding chrome,
+inter-scene transitions, and the audio bed suppressed. The scene still
+runs through the runtime lifecycle and sees the effective mode through
+`ctx.mode`.
+
+This is a mode-dispatch requirement across existing runtime seams. It
+is not a new scene model, router, composition schema, or lifecycle.
+
+## Boundary
+
+`standalone` selection must reuse the existing navigation path:
+
+- `src/runtime/navigation.ts` owns the `mode` URL grammar and the
+  `NAVIGATION_MODES` allowlist.
+- `effectiveMode()` owns effective mode derivation.
+- `src/runtime/scene-loader.ts` owns per-navigation mode dispatch,
+  `ctx.mode` construction, cancellation, stage diagnostics, and error
+  surfacing.
+- `src/runtime/scene-navigation.ts` owns target resolution and
+  composition slicing.
+- `src/runtime/composition-resolver.ts` owns preload -> create ->
+  timeline -> cleanup ordering, abort propagation, and exactly-once
+  cleanup.
+
+Do not add a second route, mode enum, `standalone` boolean, scene schema
+field, manifest flag, or local URL parser. URL input remains the only
+source of mode selection; `standalone` must not be recovered from
+localStorage, sessionStorage, cookies, `history.state`, or prior
+in-memory navigation state.
+
+## Required Reuse
+
+Implementation must reuse these cross-cutting concerns:
+
+- Identifier validation: `src/runtime/identifier.ts`.
+- URL and mode validation: `parseNavigationSearch()` and
+  `NAVIGATION_MODES`.
+- Effective mode derivation: `effectiveMode()`.
+- Scene and composition validation:
+  `assertSceneModule()`, `createSceneRegistry()`,
+  `assertCompositionManifest()`, and `createCompositionRegistry()`.
+- Navigation resolution: `resolveSceneNavigation()` and
+  `loadSceneNavigationTarget()`.
+- Lifecycle orchestration: `resolveComposition()` with injected
+  `createPreloader()` and `runTimeline()` adapters.
+- Asset handling: `createAssetPreloader()` with the existing scheme,
+  redirect, `baseUrl`, and `AbortSignal` rules.
+- Error rendering: `describeError()` plus the existing
+  `data-pulsar-navigation-error` stage diagnostic and `onError` sink.
+- Cancellation and cleanup: one per-navigation `AbortController`,
+  forwarded to preload and timeline adapters; cleanup remains
+  resolver-owned.
+
+If implementation needs a shared suppression representation, it must
+live at the workbench / adapter boundary that owns chrome, audio, and
+timeline execution. The resolver must remain mode-opaque and must not
+learn about chrome, Howler, GSAP, presenter controls, or DOM
+suppression attributes.
+
+## Standalone Contract
+
+`standalone` is single-scene execution:
+
+- A direct `scene` target runs only that scene.
+- A `composition` / `composition+scene` / `composition+index` target
+  may use composition context to find the addressed head scene, but
+  must not continue into following composition entries.
+- `beat` remains scoped to the addressed head scene per ADR-015.
+- Scene lifecycle remains unchanged: declared assets preload, `create`
+  runs, the scene timeline is handed to the runner, and `cleanup` runs
+  on exit / abort / error.
+
+The suppressed surfaces are external to the scene lifecycle:
+
+- Chrome suppression is workbench-shell behavior. Do not make scenes own
+  global chrome state.
+- Audio-bed suppression is audio-service behavior per ADR-004. It must
+  not suppress scene-owned sound effects unless a later requirement says
+  standalone is silent.
+- Inter-scene transition rendering, when ADR-003's runner lands, is
+  workbench/runner adapter behavior — a future runner reading
+  `ctx.mode` from its seam, not loader logic. Do not encode
+  transition suppression by mutating manifest entry CONTENTS (e.g.,
+  swapping a scene id, editing a `range` value, rewriting a
+  `behavior` blob, inserting a sentinel entry). Truncating the
+  resolved slice at the loader to a one-entry slice that preserves
+  the addressed head entry verbatim is the chosen mechanism for
+  single-scene execution under `mode=standalone` and is recorded in
+  ADR-017 — that is selection, not rewriting.
+
+## Guardrails
+
+- Treat `standalone` as mode behavior over an addressed head scene, not
+  as a separate composition type.
+- Preserve composition member / index validation before lifecycle
+  effects when the URL uses composition context. Invalid composition
+  targets must still fail as navigation errors, not silently degrade to
+  direct scene lookup.
+- Do not bypass `SceneLoader` to get "just one scene." The loader owns
+  the serialized navigation queue, stage attributes, abort handling,
+  and `ctx.mode`.
+- Do not call scene `cleanup()` from chrome, audio, or presenter
+  adapters. Drive cancellation through the existing per-navigation
+  `AbortSignal`.
+- Do not add duplicate exception hierarchies. Navigation failures keep
+  the `scene navigation failed:` surface; lifecycle failures keep the
+  `composition resolution failed:` surface; preload failures preserve
+  `AggregateError.errors`.
+- Do not mutate registered composition manifests to produce a
+  standalone slice. Snapshot or derive per-navigation execution input
+  at the dispatch boundary. ADR-017 truncates the *resolved*
+  `SceneNavigationCompositionContext` (already a per-navigation
+  snapshot deep-frozen in `scene-navigation.ts`); registry contents
+  are untouched.
+- Do not hide missing beats, unknown scenes, ambiguous
+  `composition+scene` locators, out-of-range indexes, empty
+  compositions, or preload failures because standalone is an inspection
+  mode.
+
+## Non-Goals
+
+PUL-F014 should not implement `present`, `loop`, `paused`, `scrub`,
+`screenshot`, or `prompter`; presenter controls; export behavior;
+decode-complete asset semantics; authoring UI; new scene metadata;
+persistence; or a generic mode-policy framework unless the concrete
+chrome / audio / timeline adapters need one now.
+
+## Anti-Patterns
+
+- Duplicating `NAVIGATION_MODES` or validating mode strings with a
+  local enum.
+- Reading `window.location` from a scene to detect standalone mode.
+- Treating `standalone` as `present` with CSS hidden after the fact
+  while still running following scenes, transition hooks, or the audio
+  bed.
+- Flattening `composition+index` to direct scene id lookup and losing
+  range / behavior overrides for the addressed entry.
+- Representing inter-scene transition suppression as fake scenes,
+  sentinel manifest entries, scene metadata, or by mutating an
+  entry's contents. (Truncating the *resolved* slice to a one-entry
+  slice that keeps the addressed head entry verbatim is selection,
+  not mutation, and is the mechanism ADR-017 chose.)
+- Suppressing all audio when the requirement only names the surrounding
+  audio bed.
+- Persisting the last standalone target or mode outside the URL.

--- a/src/runtime/scene-loader.ts
+++ b/src/runtime/scene-loader.ts
@@ -437,6 +437,48 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
     };
   };
 
+  /**
+   * PUL-F014 / ADR-017: under `mode=standalone` the runtime renders a
+   * single scene "as if no surrounding composition existed." The
+   * composition slice — already validated by `resolveSceneNavigation`
+   * so unregistered compositions / unknown member scenes /
+   * out-of-range indexes still surface as navigation errors — is
+   * truncated to a one-entry slice so the lifecycle runs only the
+   * addressed head scene. The slice is TRUNCATED rather than dropped
+   * so the head entry's per-entry `range` / `behavior` overrides
+   * (object-form entries per ADR-002 / ADR-011) reach the runner
+   * unchanged: a flat `{ scene }` would lose them and turn standalone
+   * into direct-scene flattening, contradicting ADR-017's contract.
+   * Stage attrs (set by the caller before this transform) reflect
+   * what the URL ADDRESSED, not what runs:
+   * `data-pulsar-composition-target` stays set so external observers
+   * (agents, screenshot tooling) see the URL-addressed composition
+   * even when only the head scene executes. Pure function — no
+   * closure captures — hoisted out of `runTarget` so the latter stays
+   * within Sonar's cognitive-complexity budget.
+   */
+  const applyStandaloneSlice = (
+    resolved: SceneNavigationTarget,
+    target: NavigationTarget,
+  ): SceneNavigationTarget => {
+    if (effectiveMode(target) !== 'standalone' || resolved.composition === undefined) {
+      return resolved;
+    }
+    const headEntry = resolved.composition.manifestSlice[0];
+    const headScene = resolved.composition.sceneSlice[0];
+    if (headEntry === undefined || headScene === undefined) {
+      return resolved;
+    }
+    return {
+      scene: resolved.scene,
+      composition: {
+        id: resolved.composition.id,
+        manifestSlice: Object.freeze([headEntry]),
+        sceneSlice: Object.freeze([headScene]),
+      },
+    };
+  };
+
   const runTarget = async (target: NavigationTarget): Promise<void> => {
     const beatErr = validateBeatGrammar(target);
     if (beatErr !== null) {
@@ -467,36 +509,7 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
       setStageAttr(ATTR_COMPOSITION, resolved.composition.id);
     }
 
-    // PUL-F014 / ADR-017: under `mode=standalone` the runtime renders a
-    // single scene "as if no surrounding composition existed." The
-    // composition slice — already validated by `resolveSceneNavigation`
-    // above so unregistered compositions / unknown member scenes /
-    // out-of-range indexes still surface as navigation errors — is
-    // truncated to a one-entry slice so the lifecycle runs only the
-    // addressed head scene. The slice is TRUNCATED rather than dropped
-    // so the head entry's per-entry `range` / `behavior` overrides
-    // (object-form entries per ADR-002 / ADR-011) reach the runner
-    // unchanged: a flat `{ scene }` would lose them and turn standalone
-    // into direct-scene flattening, contradicting ADR-017's contract.
-    // Stage attrs reflect what the URL ADDRESSED, not what runs:
-    // `data-pulsar-composition-target` stays set so external observers
-    // (agents, screenshot tooling) see the URL-addressed composition
-    // even when only the head scene executes.
-    let runnable: SceneNavigationTarget = resolved;
-    if (effectiveMode(target) === 'standalone' && resolved.composition !== undefined) {
-      const headEntry = resolved.composition.manifestSlice[0];
-      const headScene = resolved.composition.sceneSlice[0];
-      if (headEntry !== undefined && headScene !== undefined) {
-        runnable = {
-          scene: resolved.scene,
-          composition: {
-            id: resolved.composition.id,
-            manifestSlice: Object.freeze([headEntry]),
-            sceneSlice: Object.freeze([headScene]),
-          },
-        };
-      }
-    }
+    const runnable = applyStandaloneSlice(resolved, target);
 
     const load = buildLoad(runnable, target);
     if (load === null) return;

--- a/src/runtime/scene-loader.ts
+++ b/src/runtime/scene-loader.ts
@@ -467,7 +467,38 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
       setStageAttr(ATTR_COMPOSITION, resolved.composition.id);
     }
 
-    const load = buildLoad(resolved, target);
+    // PUL-F014 / ADR-017: under `mode=standalone` the runtime renders a
+    // single scene "as if no surrounding composition existed." The
+    // composition slice — already validated by `resolveSceneNavigation`
+    // above so unregistered compositions / unknown member scenes /
+    // out-of-range indexes still surface as navigation errors — is
+    // truncated to a one-entry slice so the lifecycle runs only the
+    // addressed head scene. The slice is TRUNCATED rather than dropped
+    // so the head entry's per-entry `range` / `behavior` overrides
+    // (object-form entries per ADR-002 / ADR-011) reach the runner
+    // unchanged: a flat `{ scene }` would lose them and turn standalone
+    // into direct-scene flattening, contradicting ADR-017's contract.
+    // Stage attrs reflect what the URL ADDRESSED, not what runs:
+    // `data-pulsar-composition-target` stays set so external observers
+    // (agents, screenshot tooling) see the URL-addressed composition
+    // even when only the head scene executes.
+    let runnable: SceneNavigationTarget = resolved;
+    if (effectiveMode(target) === 'standalone' && resolved.composition !== undefined) {
+      const headEntry = resolved.composition.manifestSlice[0];
+      const headScene = resolved.composition.sceneSlice[0];
+      if (headEntry !== undefined && headScene !== undefined) {
+        runnable = {
+          scene: resolved.scene,
+          composition: {
+            id: resolved.composition.id,
+            manifestSlice: Object.freeze([headEntry]),
+            sceneSlice: Object.freeze([headScene]),
+          },
+        };
+      }
+    }
+
+    const load = buildLoad(runnable, target);
     if (load === null) return;
     inFlight = load;
 

--- a/tests/runtime/scene-loader.test.ts
+++ b/tests/runtime/scene-loader.test.ts
@@ -2256,7 +2256,15 @@ describe('createSceneLoader (PUL-F008)', () => {
       ]);
     });
 
-    it('runs only the entry at the requested index of a `composition+index` target under `mode=standalone`', async () => {
+    it('runs only the entry at the requested index of a `composition+index` target under `mode=standalone` (skipping following entries — a last-index test would NOT catch a slice-truncation regression because the slice has no successors to skip)', async () => {
+      // index=1 against [a, b, c] resolves to a slice [b, c]. Under
+      // mode=standalone the loader must drop the trailing entry so
+      // only scene-b runs; without the slice transform scene-c would
+      // run too. Choosing a non-final index is what makes this test
+      // a regression detector for the slice transform itself —
+      // index=2 would slice to [c] and pass under any mode (no
+      // successors), so it would fail to discriminate standalone from
+      // present.
       const probe = buildLifecycleProbe();
       const stage = buildStage();
       const loader = createSceneLoader({
@@ -2270,13 +2278,13 @@ describe('createSceneLoader (PUL-F008)', () => {
         runTimeline: probe.runner,
       });
 
-      await loader.handle(standaloneCompositionIndexTarget(probe.compositionId, 2));
+      await loader.handle(standaloneCompositionIndexTarget(probe.compositionId, 1));
 
       expect(probe.log).toEqual([
-        'create:scene-c',
-        'timeline:scene-c',
-        'runTimeline:scene-c',
-        'cleanup:scene-c',
+        'create:scene-b',
+        'timeline:scene-b',
+        'runTimeline:scene-b',
+        'cleanup:scene-b',
       ]);
     });
 

--- a/tests/runtime/scene-loader.test.ts
+++ b/tests/runtime/scene-loader.test.ts
@@ -2103,4 +2103,493 @@ describe('createSceneLoader (PUL-F008)', () => {
       expect(modeAttrs).toEqual([]);
     });
   });
+
+  describe('standalone-mode single-scene execution (PUL-F014)', () => {
+    // PUL-F014 statement: in `mode=standalone`, the runtime SHALL render
+    // a single scene with surrounding chrome, inter-scene transitions,
+    // and audio bed suppressed; the scene SHALL run as if no surrounding
+    // composition existed.
+    //
+    // Materially-implementable parts of the statement that this block
+    // pins:
+    //   - "Render a single scene" / "run as if no surrounding
+    //     composition existed" — composition / composition+scene /
+    //     composition+index targets resolve normally (composition
+    //     validation still runs), but only the addressed head scene's
+    //     lifecycle is executed. No following composition entry runs.
+    //   - "Inter-scene transitions suppressed" — by virtue of
+    //     single-scene execution there is no second scene to transition
+    //     to; no later `runTimeline` call is made for the dropped
+    //     slice. The suppression is structural.
+    //   - `ctx.mode === 'standalone'` is exposed to every lifecycle
+    //     hook of the head scene — the seam future chrome / audio
+    //     surfaces (ADR-004 / future workbench-shell requirement) will
+    //     read to decide their own suppression behavior. Today there is
+    //     no chrome or audio bed in the repo to suppress, so no
+    //     end-to-end suppression test is possible until those surfaces
+    //     land.
+    //   - No `data-pulsar-mode-*` suppression attribute is preemptively
+    //     written under `standalone` (parity with ADR-016's invariant
+    //     for `mode=present`; future modes are free to use that
+    //     namespace if they actually need it).
+    //
+    // PUL-F014 transitions DRAFT → ACTIVE in this PR. ADR-017 records
+    // the boundary.
+
+    const standaloneCompositionTarget = (composition: string): NavigationTarget => ({
+      locator: { kind: 'composition', composition },
+      mode: 'standalone',
+    });
+    const standaloneCompositionSceneTarget = (
+      composition: string,
+      scene: string,
+    ): NavigationTarget => ({
+      locator: { kind: 'composition-scene', composition, scene },
+      mode: 'standalone',
+    });
+    const standaloneCompositionIndexTarget = (
+      composition: string,
+      index: number,
+    ): NavigationTarget => ({
+      locator: { kind: 'composition-index', composition, index },
+      mode: 'standalone',
+    });
+    const standaloneSceneTarget = (id: string): NavigationTarget => ({
+      locator: { kind: 'scene', scene: id },
+      mode: 'standalone',
+    });
+
+    interface LifecycleProbe {
+      readonly log: string[];
+      readonly scenes: readonly SceneModule[];
+      readonly compositionId: string;
+      readonly runner: SceneTimelineRunner;
+    }
+
+    // Probe whose runner ALSO writes into the same lifecycle log so a
+    // regression that bypassed `runTimeline` for the head scene under
+    // standalone (e.g. "skip the runner because it's standalone") would
+    // be caught — without the runner observation, dropping `runTimeline`
+    // entirely would still emit `create → timeline → cleanup` and pass.
+    const buildLifecycleProbe = (compositionId = 'full-talk'): LifecycleProbe => {
+      const log: string[] = [];
+      const trace = (id: string): SceneModule =>
+        buildScene({
+          id,
+          create: () => {
+            log.push(`create:${id}`);
+          },
+          timeline: () => {
+            log.push(`timeline:${id}`);
+            return null;
+          },
+          cleanup: () => {
+            log.push(`cleanup:${id}`);
+          },
+        });
+      const runner: SceneTimelineRunner = (input) => {
+        log.push(`runTimeline:${input.scene.id}`);
+      };
+      return {
+        log,
+        scenes: [trace('scene-a'), trace('scene-b'), trace('scene-c')],
+        compositionId,
+        runner,
+      };
+    };
+
+    it('runs only the head scene of a `composition` target under `mode=standalone` (no following entries fire)', async () => {
+      // The composition lists three scenes; under `mode=standalone` only
+      // the first must execute. A regression that forgot to drop the
+      // composition slice would emit lifecycle entries for scene-b and
+      // scene-c too.
+      const probe = buildLifecycleProbe();
+      const stage = buildStage();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([...probe.scenes]),
+        compositions: createCompositionRegistry([
+          { id: probe.compositionId, manifest: probe.scenes.map((s) => s.id) },
+        ]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: probe.runner,
+      });
+
+      await loader.handle(standaloneCompositionTarget(probe.compositionId));
+
+      expect(probe.log).toEqual([
+        'create:scene-a',
+        'timeline:scene-a',
+        'runTimeline:scene-a',
+        'cleanup:scene-a',
+      ]);
+    });
+
+    it('runs only the addressed scene of a `composition+scene` target under `mode=standalone`', async () => {
+      const probe = buildLifecycleProbe();
+      const stage = buildStage();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([...probe.scenes]),
+        compositions: createCompositionRegistry([
+          { id: probe.compositionId, manifest: probe.scenes.map((s) => s.id) },
+        ]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: probe.runner,
+      });
+
+      await loader.handle(standaloneCompositionSceneTarget(probe.compositionId, 'scene-b'));
+
+      expect(probe.log).toEqual([
+        'create:scene-b',
+        'timeline:scene-b',
+        'runTimeline:scene-b',
+        'cleanup:scene-b',
+      ]);
+    });
+
+    it('runs only the entry at the requested index of a `composition+index` target under `mode=standalone`', async () => {
+      const probe = buildLifecycleProbe();
+      const stage = buildStage();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([...probe.scenes]),
+        compositions: createCompositionRegistry([
+          { id: probe.compositionId, manifest: probe.scenes.map((s) => s.id) },
+        ]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: probe.runner,
+      });
+
+      await loader.handle(standaloneCompositionIndexTarget(probe.compositionId, 2));
+
+      expect(probe.log).toEqual([
+        'create:scene-c',
+        'timeline:scene-c',
+        'runTimeline:scene-c',
+        'cleanup:scene-c',
+      ]);
+    });
+
+    it('runs a direct `scene` target under `mode=standalone` unchanged (baseline parity — no slice to drop)', async () => {
+      const probe = buildLifecycleProbe();
+      const stage = buildStage();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([...probe.scenes]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: probe.runner,
+      });
+
+      await loader.handle(standaloneSceneTarget('scene-b'));
+
+      expect(probe.log).toEqual([
+        'create:scene-b',
+        'timeline:scene-b',
+        'runTimeline:scene-b',
+        'cleanup:scene-b',
+      ]);
+    });
+
+    it('forwards `beat` to the head scene runner under `mode=standalone` and surfaces missing-beat as a non-fatal diagnostic', async () => {
+      // Beat semantics under standalone are identical to other modes:
+      // the runner sees `headBeat` on its input, and a missing-label
+      // call from the runner surfaces via `data-pulsar-navigation-error`
+      // and `onError` without unmounting the scene. A regression that
+      // dropped beat forwarding for standalone would lose the diagnostic
+      // surface for single-scene authoring — exactly the use case this
+      // mode targets.
+      const captured: { sceneId: string; beat: string | undefined }[] = [];
+      const sceneA = buildScene({ id: 'scene-a' });
+      const sceneB = buildScene({ id: 'scene-b' });
+      const stage = buildStage();
+      const errors: unknown[] = [];
+      const runner: SceneTimelineRunner = (input) => {
+        captured.push({ sceneId: input.scene.id, beat: input.beat });
+        if (input.beat !== undefined && input.onBeatMissing !== undefined) {
+          input.onBeatMissing();
+        }
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA, sceneB]),
+        compositions: createCompositionRegistry([
+          { id: 'full-talk', manifest: ['scene-a', 'scene-b'] },
+        ]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: runner,
+        onError: (err) => {
+          errors.push(err);
+        },
+      });
+
+      await loader.handle({
+        locator: { kind: 'composition-scene', composition: 'full-talk', scene: 'scene-b' },
+        mode: 'standalone',
+        beat: 'midpoint',
+      });
+
+      // Only scene-b's runner ran (single-scene), with the beat
+      // forwarded.
+      expect(captured).toEqual([{ sceneId: 'scene-b', beat: 'midpoint' }]);
+      // The missing-beat diagnostic surfaced via the loader's standard
+      // path — `onError` invoked once with the loader's wrapping
+      // message, and the stage attribute is set.
+      expect(errors).toHaveLength(1);
+      expect((errors[0] as Error).message).toContain('beat positioning failed');
+      expect((errors[0] as Error).message).toContain('"midpoint"');
+      expect(stage.attrs.get('data-pulsar-navigation-error')).toBeDefined();
+    });
+
+    it('exposes `ctx.mode === "standalone"` to every lifecycle hook of the head scene under all locator shapes', async () => {
+      const seen: { phase: string; locatorKind: string; mode: unknown }[] = [];
+      const recordMode =
+        (phase: string, locatorKind: string) =>
+        (ctx: unknown): unknown => {
+          seen.push({ phase, locatorKind, mode: (ctx as { mode?: NavigationMode }).mode });
+          return null;
+        };
+      // Build a single scene with phase recorders; we rebuild the loader
+      // per locator-shape navigation so each navigation gets a fresh
+      // recorder run without cross-contamination.
+      const makeScene = (locatorKind: string): SceneModule =>
+        buildScene({
+          id: 'scene-a',
+          create: recordMode('create', locatorKind),
+          timeline: recordMode('timeline', locatorKind) as SceneModule['timeline'],
+          cleanup: recordMode('cleanup', locatorKind),
+        });
+      const stage = buildStage();
+      const buildLoader = (sceneId: string, locatorKind: string) =>
+        createSceneLoader({
+          scenes: createSceneRegistry([makeScene(locatorKind)]),
+          compositions: createCompositionRegistry([{ id: 'full-talk', manifest: [sceneId] }]),
+          stage: stage.element,
+          buildCtx: (mode) => ({ stage: stage.element, mode }),
+          createPreloader: () => () => undefined,
+          runTimeline: noopRunner,
+        });
+
+      await buildLoader('scene-a', 'scene').handle(standaloneSceneTarget('scene-a'));
+      await buildLoader('scene-a', 'composition').handle(standaloneCompositionTarget('full-talk'));
+      await buildLoader('scene-a', 'composition-scene').handle(
+        standaloneCompositionSceneTarget('full-talk', 'scene-a'),
+      );
+      await buildLoader('scene-a', 'composition-index').handle(
+        standaloneCompositionIndexTarget('full-talk', 0),
+      );
+
+      // 3 hooks per navigation × 4 locator shapes = 12 entries; every
+      // single one must carry `standalone`.
+      expect(seen).toHaveLength(12);
+      for (const entry of seen) {
+        expect(entry.mode).toBe('standalone');
+      }
+    });
+
+    it('writes both `data-pulsar-scene-target` and `data-pulsar-composition-target` for a composition target under `mode=standalone` (preserves observability of what the URL addressed)', async () => {
+      const probe = buildLifecycleProbe();
+      const stage = buildStage();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([...probe.scenes]),
+        compositions: createCompositionRegistry([
+          { id: probe.compositionId, manifest: probe.scenes.map((s) => s.id) },
+        ]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: probe.runner,
+      });
+
+      await loader.handle(standaloneCompositionSceneTarget(probe.compositionId, 'scene-b'));
+
+      expect(stage.attrs.get('data-pulsar-scene-target')).toBe('scene-b');
+      expect(stage.attrs.get('data-pulsar-composition-target')).toBe(probe.compositionId);
+    });
+
+    it('writes no `data-pulsar-mode-*` suppression attribute on the stage under `mode=standalone`', async () => {
+      // Mirrors ADR-016's invariant for `mode=present`. Future
+      // chrome/audio adapters may use `data-pulsar-mode-*` if they need
+      // a stage-level signal; PUL-F014 forbids the loader from
+      // preemptively writing one.
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+      });
+
+      await loader.handle(standaloneSceneTarget('scene-a'));
+
+      const modeAttrs = Array.from(stage.attrs.keys()).filter((name) =>
+        name.startsWith('data-pulsar-mode-'),
+      );
+      expect(modeAttrs).toEqual([]);
+    });
+
+    it('surfaces composition-not-registered as a navigation error under `mode=standalone` (no silent fallback to direct scene lookup)', async () => {
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      const errors: unknown[] = [];
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+        onError: (err) => {
+          errors.push(err);
+        },
+      });
+
+      await loader.handle(standaloneCompositionTarget('not-registered'));
+
+      expect(errors).toHaveLength(1);
+      expect((errors[0] as Error).message).toContain(
+        'composition "not-registered" is not registered',
+      );
+      expect(stage.attrs.get('data-pulsar-navigation-error')).toBeDefined();
+    });
+
+    it('surfaces composition-member error under `mode=standalone` for an unknown scene in `composition+scene`', async () => {
+      const sceneA = buildScene({ id: 'scene-a' });
+      const sceneZ = buildScene({ id: 'scene-z' });
+      const stage = buildStage();
+      const errors: unknown[] = [];
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA, sceneZ]),
+        compositions: createCompositionRegistry([{ id: 'full-talk', manifest: ['scene-a'] }]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+        onError: (err) => {
+          errors.push(err);
+        },
+      });
+
+      await loader.handle(standaloneCompositionSceneTarget('full-talk', 'scene-z'));
+
+      expect(errors).toHaveLength(1);
+      expect((errors[0] as Error).message).toContain(
+        'scene "scene-z" is not a member of composition "full-talk"',
+      );
+    });
+
+    it('surfaces index-out-of-range under `mode=standalone`', async () => {
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      const errors: unknown[] = [];
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([{ id: 'full-talk', manifest: ['scene-a'] }]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+        onError: (err) => {
+          errors.push(err);
+        },
+      });
+
+      await loader.handle(standaloneCompositionIndexTarget('full-talk', 5));
+
+      expect(errors).toHaveLength(1);
+      expect((errors[0] as Error).message).toContain('index 5 is out of range');
+    });
+
+    it("preserves the addressed head entry's `range` and `behavior` overrides on the runner input under `mode=standalone` (composition+index with object-form entry)", async () => {
+      // PUL-F014 / ADR-017: standalone is single-scene EXECUTION at the
+      // addressed head, NOT direct-scene flattening. A regression that
+      // dropped the composition slice entirely (instead of truncating
+      // it to one entry) would lose the head entry's `range` /
+      // `behavior` overrides — the runner would receive `range:
+      // undefined, behavior: undefined` even though the URL named an
+      // object-form entry that carries them. This test pins both
+      // override slots through to the runner.
+      const sceneA = buildScene({ id: 'scene-a' });
+      const sceneB = buildScene({ id: 'scene-b' });
+      const sceneC = buildScene({ id: 'scene-c' });
+      const stage = buildStage();
+      const captured: {
+        sceneId: string;
+        range: unknown;
+        behavior: unknown;
+      }[] = [];
+      const runner: SceneTimelineRunner = (input) => {
+        captured.push({
+          sceneId: input.scene.id,
+          range: input.range,
+          behavior: input.behavior,
+        });
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA, sceneB, sceneC]),
+        compositions: createCompositionRegistry([
+          {
+            id: 'full-talk',
+            manifest: [
+              'scene-a',
+              { id: 'scene-b', range: 'hook', behavior: { hold: true } },
+              'scene-c',
+            ],
+          },
+        ]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: runner,
+      });
+
+      await loader.handle(standaloneCompositionIndexTarget('full-talk', 1));
+
+      // Runner ran exactly once (single-scene execution) AND the
+      // addressed entry's overrides reached `input.range` /
+      // `input.behavior`. A regression that flattened to direct-scene
+      // would show `range: undefined, behavior: undefined` here.
+      expect(captured).toEqual([{ sceneId: 'scene-b', range: 'hook', behavior: { hold: true } }]);
+    });
+
+    it('runs cleanup exactly once for the head scene under `mode=standalone`, never for dropped slice entries', async () => {
+      // A regression that dropped the slice for execution but left
+      // following scenes in the synthesized registry could double-clean
+      // or skip-clean. This test pins exactly-once cleanup on the head
+      // scene and zero cleanup for the dropped entries.
+      const cleaned: string[] = [];
+      const trace = (id: string): SceneModule =>
+        buildScene({
+          id,
+          cleanup: () => {
+            cleaned.push(id);
+          },
+        });
+      const scenes = [trace('scene-a'), trace('scene-b'), trace('scene-c')];
+      const stage = buildStage();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry(scenes),
+        compositions: createCompositionRegistry([
+          { id: 'full-talk', manifest: scenes.map((s) => s.id) },
+        ]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+      });
+
+      await loader.handle(standaloneCompositionTarget('full-talk'));
+
+      expect(cleaned).toEqual(['scene-a']);
+    });
+  });
 });

--- a/tests/runtime/scene-loader.test.ts
+++ b/tests/runtime/scene-loader.test.ts
@@ -2133,8 +2133,14 @@ describe('createSceneLoader (PUL-F008)', () => {
     //     for `mode=present`; future modes are free to use that
     //     namespace if they actually need it).
     //
-    // PUL-F014 transitions DRAFT → ACTIVE in this PR. ADR-017 records
-    // the boundary.
+    // PUL-F014 stays DRAFT after this PR (ADR-017 records the
+    // boundary; following the ADR-016 / PUL-F013 precedent). The
+    // single-scene execution mechanism and the `ctx.mode` seam ARE
+    // materially shipped; the three named suppression surfaces
+    // (chrome, audio bed, inter-scene transitions) gate the
+    // DRAFT → ACTIVE transition — each must land as a real surface
+    // that actively reads `ctx.mode === 'standalone'` and suppresses,
+    // with end-to-end tests alongside these seam tests.
 
     const standaloneCompositionTarget = (composition: string): NavigationTarget => ({
       locator: { kind: 'composition', composition },


### PR DESCRIPTION
## Summary

Implements `mode=standalone` per PUL-F014 — single-scene execution at the addressed head scene. The loader truncates the validated composition slice from `resolveSceneNavigation()` to a one-entry slice (head entry preserved verbatim with `range` / `behavior` overrides intact); following entries are dropped so no inter-scene transition runs and no later scene's lifecycle fires.

- Production change is one branch in `runTarget` (`src/runtime/scene-loader.ts`); validates first via `resolveSceneNavigation()` so malformed standalone targets still surface as navigation errors. Stage attrs record what the URL addressed (both `data-pulsar-scene-target` and `data-pulsar-composition-target`).
- `ctx.mode === 'standalone'` reaches every lifecycle hook of the head scene through the existing PUL-F012 seam. Future chrome / audio / runner / presenter surfaces (none exist in this repo today) will inherit the hint at their own seam.
- New ADR-017 records the contract and contrasts with ADR-016 (PUL-F013 stays DRAFT pending rendering surfaces; PUL-F014 is materially implementable today and transitions DRAFT → ACTIVE on this PR).
- 13 new tests in `tests/runtime/scene-loader.test.ts` covering each clause; full repo: 587 tests passing.

## Test plan

- [x] `pre-commit run --all-files` passes locally.
- [x] `pnpm lint && pnpm typecheck && pnpm test` passes locally (587/587).
- [ ] CI green on this PR (all 7 jobs including the new `OSV-Scanner` blocking gate).
- [ ] No regression in other test suites.

Closes #23