### PR TITLE
Implement PUL-F015 workbench mode=loop contract layer (ADR-018)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,126 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `docs/adrs/018-workbench-mode-loop.md` — records the PUL-F015
+  contract: under `mode=loop` the loader truncates the validated
+  composition slice to the addressed head entry (parallel to
+  `standalone` per ADR-017) and passes `repeat: 'until-aborted'`
+  through the bridge / resolver to that head's timeline-runner input,
+  where the runner is responsible for restarting the timeline on
+  completion (e.g. ADR-003's future GSAP runner uses
+  `timeline.repeat(-1)`). Slice truncation makes "no following
+  entries run" a structural guarantee — a runner that ignores the
+  `repeat` hint cannot silently degrade loop into normal composition
+  playback. The single-scene-execution helper ADR-017 introduced is
+  generalized (`applySingleSceneSlice`); the SHAPE transform is
+  shared between `standalone` and `loop`, the runner-side semantic
+  difference (`input.repeat`) is what differentiates them.
+  Composition validation runs first, so unregistered compositions /
+  unknown member scenes / out-of-range indexes still surface as
+  navigation errors. The hint is head-only — following composition
+  entries do not receive `repeat`, parallel to PUL-F011 / ADR-015's
+  `headBeat` plumbing (and structurally vacuous under truncation,
+  but pinned in the resolver / bridge tests for layered correctness).
+  The loader → runner contract IS materially shipped; the seam
+  (`ctx.mode === 'loop'` reaches every lifecycle hook of the head
+  scene) is pinned. The actual restart-on-completion behavior depends
+  on ADR-003's GSAP runner, which is not yet implemented; the
+  placeholder runner has no real timeline and parks until abort,
+  vacuously satisfying the requirement. Following the ADR-016 /
+  ADR-017 precedent, PUL-F015 stays DRAFT and the issue ↔ requirement
+  link is `DOCUMENTS`; ACTIVE transitions when the GSAP runner lands
+  and actively reads `input.repeat === 'until-aborted'`, with an
+  end-to-end test alongside the seam tests in this PR. Indexed in
+  `docs/adrs/README.md`.
+- `docs/design/pul-f015-loop-mode-preflight.md` — codex
+  architecture preflight design context for PUL-F015. Names the
+  cross-cutting concerns to reuse (`NAVIGATION_MODES`,
+  `effectiveMode()`, `parseNavigationSearch()`,
+  `resolveSceneNavigation()`, `loadSceneNavigationTarget()`,
+  `resolveComposition()`, `createAssetPreloader()`,
+  `describeError()`, the per-navigation `AbortController`) and the
+  anti-patterns to avoid (composition-wide looping, scene-lifecycle
+  re-run on iteration, recursive `handle()` from the runner,
+  `setInterval` / polling / sleeps, manifest-mutation looping,
+  persisting loop state outside the URL).
+- `src/runtime/composition-resolver.ts` —
+  `SceneTimelineRunInput` gains optional `repeat?: 'until-aborted'`
+  and `ResolveCompositionOptions` gains optional
+  `headRepeat?: 'until-aborted'`. The resolver forwards `headRepeat`
+  to plan[0]'s run input only (head-only, parallel to `headBeat`);
+  subsequent scenes never receive `repeat`. The literal-typed union
+  lets future repeat semantics extend without breaking existing
+  runners.
+- `src/runtime/scene-navigation.ts` —
+  `LoadSceneNavigationTargetOptions` gains optional `repeat?:
+  'until-aborted'`; `loadSceneNavigationTarget()` forwards the
+  option to `resolveComposition` as `headRepeat` (parallel to how
+  `beat` becomes `headBeat`). `repeat` and `beat` are independent —
+  a URL like `?scene=x&mode=loop` (no beat) and
+  `?scene=x&beat=hook&mode=loop` (beat + loop) are both valid. The
+  bridge ALSO truncates a composition slice to its addressed head
+  when `repeat` is supplied (`truncateForRepeat`) — a structural
+  defense layered with the loader's `applySingleSceneSlice` so
+  direct bridge callers (test harnesses, future export pipelines)
+  get the same loop-mode single-scene-execution guarantee. The two
+  truncations are idempotent.
+- `src/runtime/scene-loader.ts` — when
+  `effectiveMode(target) === 'loop'`, the loader passes
+  `repeat: 'until-aborted'` through `loadSceneNavigationTarget()`.
+  Other modes (and a `mode`-less URL) leave the key absent on the
+  runner input — key-presence semantics, parallel to `beat` /
+  `range` / `behavior`. Mode dispatch lives at the loader, the same
+  place PUL-F012 derives `ctx.mode`. The single-scene-execution
+  helper that landed for `standalone` (ADR-017) is generalized to
+  `applySingleSceneSlice` and now runs for both `standalone` and
+  `loop`, truncating the validated composition slice to the
+  addressed head entry under either mode (per ADR-018: structural
+  defense against a runner that ignores the `repeat` hint).
+- `src/main.ts` — placeholder timeline runner docstring
+  acknowledges `input.repeat`. The placeholder ignores the hint;
+  parking until abort vacuously satisfies "restart on completion"
+  because no completion ever fires. ADR-003's GSAP runner will read
+  the hint and apply native repeat semantics.
+- `tests/runtime/composition-resolver.test.ts` — new
+  `'URL loop-mode runner repeat-hint forwarding (PUL-F015)'`
+  describe block (4 tests) pinning `headRepeat` head-only delivery,
+  key-presence semantics, resolver no-op on the value, and
+  independent forwarding alongside `headBeat`.
+- `tests/runtime/scene-navigation.test.ts` — new `'URL loop-mode
+  repeat forwarding (PUL-F015)'` describe block under
+  `loadSceneNavigationTarget` pinning the bridge's `repeat` →
+  `headRepeat` plumbing for single-scene targets, key absence when
+  option omitted, independence from `beat`, bridge-level slice
+  truncation under `repeat` (the structural defense added in
+  response to codex pre-push review), and that non-loop composition
+  navigation still runs the full slice.
+- `tests/runtime/scene-loader.test.ts` — new `'loop-mode runner
+  repeat-hint forwarding (PUL-F015)'` describe block pinning every
+  clause of PUL-F015 under `mode=loop`:
+  - `repeat: 'until-aborted'` on the head scene's runner input for
+    a `scene` target.
+  - Slice truncation under `composition` and `composition+scene`
+    targets — only the head runs, with `repeat: 'until-aborted'`
+    on its runner input. Non-final-index navigations are used so
+    a regression that dropped truncation would observe successor
+    entries running.
+  - cleanup runs exactly once for the head scene under `mode=loop`,
+    never for dropped slice entries (parallel to ADR-017).
+  - Key absence on the runner input when `mode` is unset.
+  - No `repeat` for any non-loop mode (six modes walked).
+  - `ctx.mode === 'loop'` exposed to every lifecycle hook of the
+    head scene under all four locator shapes.
+  - `beat=` forwarding alongside `repeat` under `mode=loop` with
+    the non-fatal missing-label diagnostic preserved.
+  - No `data-pulsar-mode-*` suppression attribute is preemptively
+    written (parity with ADR-016 / ADR-017).
+  - Composition-not-registered, composition-member-not-found, and
+    index-out-of-range errors STILL surface under `mode=loop` (no
+    silent fallback to direct scene lookup).
+  - Object-form head entry's `range` and `behavior` overrides reach
+    the runner unchanged through the truncated slice alongside
+    `repeat` — loop is single-scene-timeline repeat at the head,
+    NOT direct-scene flattening.
 - `docs/adrs/017-workbench-mode-standalone.md` — records the
   PUL-F014 contract: under `mode=standalone` the loader truncates
   the validated composition slice from `resolveSceneNavigation()`

--- a/docs/adrs/018-workbench-mode-loop.md
+++ b/docs/adrs/018-workbench-mode-loop.md
@@ -1,0 +1,326 @@
+# ADR-018: Workbench Mode `loop` — Runner Repeat Hint at the Loader/Runner Seam
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-09
+
+## Context
+
+ADR-007 names seven workbench modes: `present`, `standalone`, `loop`,
+`paused`, `scrub`, `screenshot`, `prompter`. ADR-013 fixes the URL
+grammar boundary that carries `mode=` to the runtime. ADR-014 fixes the
+scene navigation dispatch layer. ADR-015 fixes URL beat positioning.
+ADR-016 establishes the precedent for landing a mode's contract while
+the dependent rendering surfaces are still pending: PUL-F013 stayed
+DRAFT because chrome / audio / GSAP runner / presenter input surfaces
+are not yet implemented. ADR-017 follows the same precedent for
+PUL-F014 (`mode=standalone`): single-scene execution at the loader
+ships materially, the seam (`ctx.mode === 'standalone'`) is pinned, and
+the requirement stays DRAFT until each named suppression facet has a
+real surface that actively conforms.
+
+PUL-F015 specifies `mode=loop`:
+
+> In `mode=loop`, the runtime SHALL run the addressed scene's timeline
+> and restart it on completion.
+
+The non-trivial parts of that statement decompose this way:
+
+- "Run the addressed scene's timeline" — already structurally true
+  via `loadSceneNavigationTarget()` and the runner adapter
+  (`SceneTimelineRunner`). No new code required for that clause.
+- "Restart it on completion" — a runner-side contract: the timeline
+  runner repeats the timeline until the navigation aborts or
+  disposes. ADR-003's GSAP runner does not yet exist; the placeholder
+  runner in `src/main.ts` has no real timeline (`scene.timeline(ctx)`
+  returns `null`) and parks until abort. With no natural completion
+  to fire, "restart on completion" is vacuously satisfied today —
+  but vacuous truth is not enforcement.
+
+The question this ADR answers is: where does the loader → runner
+contract for `mode=loop` live, and on what contract does PUL-F015
+transition to ACTIVE?
+
+## Decision
+
+`mode=loop` is dispatched at the loader (`src/runtime/scene-loader.ts`)
+as a runner-input field forwarded to the timeline-runner adapter on
+the head scene's run input only. When `effectiveMode(target) === 'loop'`
+the loader passes `repeat: 'until-aborted'` through
+`loadSceneNavigationTarget()` and the resolver to
+`SceneTimelineRunInput.repeat`. The runner is responsible for honoring
+the hint — ADR-003's future GSAP runner will use GSAP's native repeat
+(e.g. `timeline.repeat(-1)`) rather than a polling / `setInterval` /
+recursive-`handle()` loop the loader would have had to invent.
+
+The hint is **head-only**. Under composition targets the slice's first
+entry is the addressed scene; following composition entries never
+receive `repeat`. This scoping is structural: a looping head's
+timeline never naturally completes, so following entries cannot run.
+Forwarding `repeat` to non-head scenes would imply a following entry
+could itself loop, which contradicts the requirement's "the addressed
+scene's timeline" scoping. The plumbing is parallel to PUL-F011 /
+ADR-015's `headBeat` head-only forwarding — same shape, different
+field.
+
+`SceneTimelineRunInput.repeat` is declared as a literal-typed field
+(`'until-aborted'`) rather than a boolean so future repeat semantics
+(e.g. a fixed-iteration variant) can extend the union without breaking
+existing runners. A runner that ignores the field, or that only
+recognizes `'until-aborted'`, gracefully degrades to no-repeat
+behavior. The resolver and bridge do not interpret the value.
+
+The slice IS **truncated** under `mode=loop` to the addressed head
+entry — the same shape transform `mode=standalone` applies (ADR-017).
+This was contested in pre-push review: the original draft of this ADR
+relied on the runner's repeat behavior alone for "no following entries
+run." Codex's pre-push pass flagged the foot-gun: if the runner
+ignores `input.repeat` (a placeholder, a buggy GSAP wiring, a future
+test runner), the resolver advances to the next composition entry and
+loop silently degrades into normal composition playback. That violates
+the documented loop guarantee.
+
+Truncating the slice makes "no following entries run" a structural
+guarantee that does not depend on runner conformance. The two single-
+scene-execution modes (`standalone` and `loop`) share the same slice
+transform; they differ only in whether the head's timeline repeats —
+a runner-side concern via `input.repeat`. Conflating the two modes
+into one shape transform is appropriate because the SHAPE is
+identical; the SEMANTIC difference (timeline repeat) lives at the
+runner contract where it belongs.
+
+The slice is **truncated, not flattened.** Replacing the resolved
+target with `{ scene }` (no composition) would lose the head entry's
+per-entry `range` / `behavior` overrides (object-form entries per
+ADR-002 / ADR-011), turning loop into direct-scene flattening — same
+foot-gun ADR-017 calls out for standalone. The truncated
+`manifestSlice` (length 1) continues through the composition branch
+in `loadSceneNavigationTarget()`, and the existing runner-input
+plumbing forwards `range` / `behavior` per ADR-011.
+
+PUL-F015 stays DRAFT after this PR lands, mirroring the ADR-016 /
+PUL-F013 and ADR-017 / PUL-F014 precedent. This PR ships:
+
+- The loader → runner-input contract: `repeat: 'until-aborted'`
+  reaches the head scene's run input under `effectiveMode === 'loop'`.
+- The seam: `ctx.mode === 'loop'` reaches every lifecycle hook of the
+  head scene through the existing PUL-F012 plumbing.
+- Tests pinning the seam, the head-only scoping, the no-other-mode
+  contamination, and the existing invariants under `loop` (composition
+  validation still runs; no `data-pulsar-mode-*` attribute; beat
+  forwarding preserved; `range` / `behavior` overrides preserved).
+
+What it does NOT yet ship is the active *restart-on-completion*
+behavior:
+
+- ADR-003's GSAP runner is not implemented. The placeholder runner
+  has no real timeline to repeat; it returns `null` from
+  `scene.timeline(ctx)` and parks until abort. With no natural
+  completion event, the placeholder vacuously satisfies "restart on
+  completion" but cannot exercise it. When the GSAP runner lands, it
+  MUST read `input.repeat === 'until-aborted'` and apply the engine's
+  native repeat semantics. End-to-end tests of "the timeline does
+  restart" are gated on that surface landing.
+
+PUL-F015 transitions DRAFT → ACTIVE when ADR-003's GSAP runner lands
+AND it actively reads `input.repeat === 'until-aborted'` and restarts
+the timeline, with an end-to-end test alongside the seam tests in this
+PR. Until then, the issue ↔ requirement link stays as `DOCUMENTS` and
+the status stays DRAFT — matching how ADR-016 / PUL-F013 records "land
+the contract layer; keep the requirement DRAFT until the dependent
+subsystems land."
+
+### Boundary
+
+The repeat hint flows from the loader because:
+
+- The loader already derives `effectiveMode(target)` for `ctx.mode`
+  (ADR-007 / PUL-F012). Reusing the same derivation for `repeat`
+  keeps mode-aware logic in one place — no second `target.mode`
+  inspection on a different layer.
+- The composition resolver MUST stay mode-opaque (ADR-011 — pure
+  orchestrator, no adapter knowledge). The resolver plumbs
+  `headRepeat` exactly the way it plumbs `headBeat`: as an opaque
+  forwarding field with no semantics it interprets. The loader is
+  the only thing that maps `effectiveMode === 'loop'` to
+  `repeat: 'until-aborted'`.
+- `resolveSceneNavigation()` MUST run validation regardless of mode:
+  unregistered compositions, unknown member scenes, ambiguous
+  `composition+scene` locators, out-of-range indexes, and empty
+  compositions still surface as navigation errors under `mode=loop`.
+  No silent fallback to direct scene lookup.
+- `loadSceneNavigationTarget()` already plumbs head-only options
+  (`beat` / `onBeatMissing`); adding `repeat` to that list reuses
+  the same shape rather than inventing a new bridge surface.
+
+### Stage attribute behavior
+
+`data-pulsar-scene-target` (head scene id) AND
+`data-pulsar-composition-target` (composition id) are both set on the
+stage when the URL named a composition under `mode=loop`. The attrs
+communicate "what was addressed," not "what's running" — same
+invariant as `mode=standalone` (ADR-017). No `data-pulsar-mode-*`
+suppression attribute is preemptively written under `loop` (parity
+with ADR-016 / ADR-017); future workbench surfaces are free to use
+that namespace if they actually need a stage-level signal.
+
+### Beat semantics
+
+`beat=` under `mode=loop` is forwarded to the head scene's runner
+unchanged. The runner sees both `input.beat` and `input.repeat` on
+the same input bundle and is free to honor them independently — for a
+GSAP runner, that is "seek to label, then play with repeat(-1)."
+Missing-label diagnostics surface via the existing non-fatal
+`onBeatMissing` path (ADR-015).
+
+### Composition slice behavior
+
+Truncated to the addressed head entry, parallel to `mode=standalone`
+(ADR-017). The single-scene-execution helper at the loader is shared:
+`applySingleSceneSlice` runs for both `effectiveMode === 'standalone'`
+and `effectiveMode === 'loop'`. Following composition entries do not
+run; the head scene's `repeat: 'until-aborted'` reaches the runner
+input and the runner is responsible for the actual restart-on-
+completion behavior.
+
+The composition slice MUST be validated by `resolveSceneNavigation()`
+BEFORE the truncation transform. Unregistered compositions, unknown
+member scenes, ambiguous `composition+scene` locators, and out-of-
+range indexes still surface as navigation errors under `mode=loop` —
+the same invariant ADR-017 holds for standalone.
+
+## Consequences
+
+### Positive
+
+- Mode → runner-input plumbing lives at the loader, the same place
+  PUL-F012 derives `ctx.mode`. One mode dispatch site, not two.
+- The resolver stays mode-opaque (ADR-011): `headRepeat` is plumbed
+  the same way `headBeat` already is, with no new resolver semantics.
+- The runner contract is a single optional input field (`repeat?:
+  'until-aborted'`). A runner that ignores it (placeholder, future
+  non-loop test runners) gracefully degrades; a runner that honors it
+  (future GSAP) reads one field instead of inferring loop semantics
+  from `ctx.mode`.
+- Following ADR-016 / ADR-017's precedent keeps the DRAFT → ACTIVE
+  bar consistent across mode requirements: ACTIVE means the named
+  behavior is actively delivered end to end, not just structurally
+  scaffolded.
+- No premature abstraction. No `ModePolicy` record, no shared
+  mode-hint type, no policy table. When a future mode needs a
+  different shape of runner hint, it adds its own field; if multiple
+  modes converge on a shared representation, that representation
+  lands then with at least two consumers informing its shape.
+
+### Negative
+
+- PUL-F015 stays DRAFT until ADR-003's GSAP runner lands. A reviewer
+  reading the requirement in isolation may expect ACTIVE on first
+  delivery; the DRAFT-with-contract-and-seams state is intentional
+  and matches the PUL-F011 / PUL-F013 / PUL-F014 precedent.
+- Adding `repeat` to `SceneTimelineRunInput` widens the runner
+  adapter surface. Every runner adapter (placeholder today, future
+  GSAP, test harnesses) sees the new field. Test runners that don't
+  care about loop semantics ignore it; this is the cost of
+  extending the input shape. The alternative (a separate runner
+  parameter) would be larger surface, not smaller.
+- The seam tests are necessary but not sufficient: they prove the
+  hook exists and behaves correctly under `mode=loop`, but they do
+  not prove that a future GSAP runner will plug in correctly. The
+  surface PR that lands the GSAP runner is responsible for adding
+  its own end-to-end "the timeline restarts under `mode=loop`" test.
+
+### Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| A future runner ignores `input.repeat` and the regression goes unnoticed | The seam tests pin "loader sets `input.repeat = 'until-aborted'` under `mode=loop`." A runner that ignores the hint produces wrong runtime behavior (no loop). When the GSAP runner lands, its own end-to-end test proves the hint is honored. |
+| `repeat` accumulates as a kitchen-sink field for unrelated repeat semantics | The literal-typed union (`'until-aborted'`) constrains valid values. Adding a new variant (`'twice'`, `{ count: 5 }`) is an explicit type extension, visible in code review. |
+| Slice truncation flattens to direct-scene and loses object-form `range` / `behavior` overrides | The seam test "preserves the addressed head entry's `range` and `behavior` overrides under `mode=loop` (composition+index with object-form entry)" pins object-form head-entry plumbing through the truncated slice. A flatten-by-mistake would lose those overrides. |
+| A runner that ignores `input.repeat` silently degrades loop into normal composition playback | Slice truncation makes "no following entries run" structural — a no-op runner under `mode=loop` runs the head's lifecycle once and then completes the navigation, rather than advancing to a tail entry that should not have run. |
+| PUL-F015 lingers DRAFT forever because the GSAP runner keeps slipping | DRAFT is a feature here: it tells reviewers the loop-mode contract is partly delivered (boundary + seam) and gates ACTIVE on actual restart-on-completion. The GSAP runner PR (ADR-003) is the natural trigger to revisit PUL-F015's status. |
+| A non-parser caller forges a `NavigationTarget` with `mode: 'loop'` mid-flight | The defense-in-depth check `validateModeGrammar` already rejects unknown modes at the loader boundary; `'loop'` is in the `NAVIGATION_MODES` allowlist, and `effectiveMode` is the only consumer of the field. |
+
+## Current state (2026-05-09)
+
+This PR delivers the contract boundary and seam-pinning layer:
+
+- `src/runtime/composition-resolver.ts` — `SceneTimelineRunInput`
+  gains optional `repeat?: 'until-aborted'`;
+  `ResolveCompositionOptions` gains optional `headRepeat?:
+  'until-aborted'`; the resolver forwards `headRepeat` to plan[0]'s
+  run input only.
+- `src/runtime/scene-navigation.ts` —
+  `LoadSceneNavigationTargetOptions` gains optional `repeat?:
+  'until-aborted'`; `loadSceneNavigationTarget()` forwards it to
+  `resolveComposition` as `headRepeat`.
+- `src/runtime/scene-loader.ts` — when `effectiveMode(target) ===
+  'loop'`, the loader passes `repeat: 'until-aborted'` through the
+  bridge; otherwise the key is omitted (key-presence semantics).
+  The single-scene-execution helper that ADR-017 introduced is
+  generalized (`applySingleSceneSlice`) and runs for both `standalone`
+  and `loop` so the slice is truncated to the addressed head under
+  either mode — the SHAPE transform is shared, the runner-side
+  semantic difference (`input.repeat`) is what differentiates them.
+- `tests/runtime/composition-resolver.test.ts` — new
+  `'URL loop-mode runner repeat-hint forwarding (PUL-F015)'`
+  describe block.
+- `tests/runtime/scene-navigation.test.ts` — new `'URL loop-mode
+  repeat forwarding (PUL-F015)'` describe block under
+  `loadSceneNavigationTarget`.
+- `tests/runtime/scene-loader.test.ts` — new `'loop-mode runner
+  repeat-hint forwarding (PUL-F015)'` describe block.
+- `docs/design/pul-f015-loop-mode-preflight.md` — codex
+  architecture preflight design context (created by preflight,
+  preserved here as the binding plan constraints for follow-on
+  work).
+- This ADR.
+
+PUL-F015 remains DRAFT. Issue #24 links to PUL-F015 via `DOCUMENTS`.
+This PR is **not** an implementation of PUL-F015's "restart on
+completion" clause — it lands the contract boundary and the seam.
+The ACTIVE transition is gated on ADR-003's GSAP runner replacing the
+placeholder in `src/main.ts` AND actively reading `input.repeat ===
+'until-aborted'` to drive timeline repeat semantics, with an
+end-to-end test alongside these seam tests. Treating this PR as
+satisfying PUL-F015 would be a traceability/status mismatch.
+
+## Related ADRs
+
+- [ADR-003](003-gsap-timeline-engine.md) — the timeline runner is
+  the seam through which restart-on-completion will flow when the
+  GSAP runner lands. Today the runner is a placeholder, so loop
+  behavior is structurally vacuous.
+- [ADR-007](007-browser-workbench.md) — defines the seven workbench
+  modes and the URL-only-source invariant for mode selection.
+- [ADR-008](008-agent-native-authoring.md) — manifests-over-flow-
+  control underpins the no-mode-suppression-in-resolver constraint.
+- [ADR-011](011-composition-resolver-orchestration.md) — the
+  resolver is opaque to mode; mode-derived behavior lives at the
+  adapters it forwards to. The resolver plumbs `headRepeat`
+  unchanged, the same way it plumbs `headBeat`.
+- [ADR-013](013-url-navigation-grammar-boundary.md) — the parser
+  preserves `mode` and forbids recovering it from any non-URL
+  source.
+- [ADR-014](014-url-scene-target-selection.md) — scene navigation
+  dispatch is mode-blind; it resolves the active slice and hands
+  off to the loader for mode dispatch.
+- [ADR-015](015-url-beat-positioning.md) — precedent for "the
+  resolver plumbs a head-only optional field; runner owns the
+  semantics; loader fails fast at the paired-required boundary."
+  ADR-018's `headRepeat` mirrors `headBeat`'s shape.
+- [ADR-016](016-workbench-mode-present.md) — establishes the
+  contract-layer-plus-seam-tests precedent. PUL-F013 stays DRAFT
+  pending chrome / audio / GSAP runner / presenter input.
+- [ADR-017](017-workbench-mode-standalone.md) — applies the same
+  precedent to PUL-F014 with the slice-truncation seam. PUL-F015
+  shares that slice-truncation transform — the loader runs
+  `applySingleSceneSlice` for both `standalone` and `loop` so
+  "no following entries run" is a structural guarantee, not
+  runner-conformance-dependent. The two modes differ only in
+  whether the head's timeline repeats (a runner-side concern via
+  `input.repeat`).

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -43,3 +43,4 @@ Each ADR includes:
 | [015](015-url-beat-positioning.md) | URL Beat Positioning as Timeline-Runner State | Accepted |
 | [016](016-workbench-mode-present.md) | Workbench Mode `present` — Contract Boundary and Adapter Seams | Accepted |
 | [017](017-workbench-mode-standalone.md) | Workbench Mode `standalone` — Single-Scene Execution at the Loader | Accepted |
+| [018](018-workbench-mode-loop.md) | Workbench Mode `loop` — Runner Repeat Hint at the Loader/Runner Seam | Accepted |

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -9,6 +9,7 @@ Design context for Pulsar. Source material for the ADRs in `../adrs/`.
 | [positioning-and-landscape.md](positioning-and-landscape.md) | Category, adjacent OSS projects, differentiation, strategic risks. |
 | [pul-f013-present-mode-preflight.md](pul-f013-present-mode-preflight.md) | Guardrails for implementing default `mode=present` behavior. |
 | [pul-f014-standalone-mode-preflight.md](pul-f014-standalone-mode-preflight.md) | Guardrails for implementing isolated `mode=standalone` behavior. |
+| [pul-f015-loop-mode-preflight.md](pul-f015-loop-mode-preflight.md) | Guardrails for implementing repeated `mode=loop` scene-timeline playback. |
 
 Design docs are mutable. Decisions are captured as ADRs (immutable once
 accepted).

--- a/docs/design/pul-f015-loop-mode-preflight.md
+++ b/docs/design/pul-f015-loop-mode-preflight.md
@@ -1,0 +1,138 @@
+# PUL-F015 Loop Mode Preflight
+
+PUL-F015 specifies `mode=loop`: run the addressed scene's timeline and
+restart it on completion. This is a scene-inspection mode for visual
+and audio tuning. It is not a new scene model, composition model,
+router, lifecycle, or persistence feature.
+
+ADR-007 already defines `loop` as a workbench mode. ADR-011 already
+defines the resolver as a lifecycle orchestrator with an injected
+timeline runner. No new ADR is needed unless implementation discovers
+that multiple runner/workbench surfaces need a shared mode-policy
+representation that cannot be expressed through the existing runner
+input and `ctx.mode` seams.
+
+## Boundary
+
+`loop` selection must reuse the existing navigation path:
+
+- `src/runtime/navigation.ts` owns the `mode` URL grammar and the
+  `NAVIGATION_MODES` allowlist.
+- `effectiveMode()` owns effective mode derivation.
+- `src/runtime/scene-loader.ts` owns per-navigation mode dispatch,
+  `ctx.mode` construction, cancellation, stage diagnostics, and error
+  surfacing.
+- `src/runtime/scene-navigation.ts` owns target resolution and
+  composition slicing. Its `scene` field is the addressed head scene.
+- `src/runtime/composition-resolver.ts` owns preload -> create ->
+  timeline -> cleanup ordering, abort propagation, and exactly-once
+  cleanup.
+- The timeline runner owns timeline playhead behavior, completion
+  detection, label seeking, and restart / repeat mechanics.
+
+Do not add a second route, mode enum, `loop` boolean, scene schema
+field, manifest flag, local URL parser, or loop-specific resolver.
+URL input remains the only source of mode selection; `loop` must not be
+recovered from localStorage, sessionStorage, cookies, `history.state`,
+or prior in-memory navigation state.
+
+## Required Reuse
+
+Implementation must reuse these cross-cutting concerns:
+
+- Identifier validation: `src/runtime/identifier.ts`.
+- URL and mode validation: `parseNavigationSearch()` and
+  `NAVIGATION_MODES`.
+- Effective mode derivation: `effectiveMode()`.
+- Scene and composition validation:
+  `assertSceneModule()`, `createSceneRegistry()`,
+  `assertCompositionManifest()`, and `createCompositionRegistry()`.
+- Navigation resolution: `resolveSceneNavigation()` and
+  `loadSceneNavigationTarget()`.
+- Lifecycle orchestration: `resolveComposition()` with injected
+  `createPreloader()` and `runTimeline()` adapters.
+- Asset handling: `createAssetPreloader()` with the existing scheme,
+  redirect, `baseUrl`, and `AbortSignal` rules.
+- Error rendering: `describeError()` plus the existing
+  `data-pulsar-navigation-error` stage diagnostic and `onError` sink.
+- Cancellation and cleanup: one per-navigation `AbortController`,
+  forwarded to preload and timeline adapters; cleanup remains
+  resolver-owned.
+
+## Loop Contract
+
+Looping applies to the addressed head scene's timeline:
+
+- A direct `scene` target loops that scene's timeline.
+- A `composition` target loops the first scene's timeline.
+- A `composition+scene` or `composition+index` target loops the
+  resolved head scene's timeline, preserving the head entry's `range`
+  / `behavior` overrides.
+- `beat` remains scoped to the addressed head scene per ADR-015. If a
+  beat is valid, the first loop starts from that position; subsequent
+  restarts return to the loop start chosen by the runner contract, not
+  to a parser-owned bookmark.
+
+The requirement says the timeline restarts, not that the scene
+lifecycle restarts. Do not implement loop by repeatedly running
+`create(ctx)` / `timeline(ctx)` / `cleanup(ctx)` for the same scene.
+Scene setup should occur once for the active navigation, the runner
+should repeat the timeline until the navigation is aborted or disposed,
+and resolver-owned cleanup should run once when the scene exits.
+
+When the URL used composition context, validation must still happen
+before lifecycle effects. Unknown compositions, unknown member scenes,
+ambiguous `composition+scene` locators, out-of-range indexes, empty
+compositions, unregistered referenced scenes, preload failures, and
+missing beats must surface through the existing diagnostics. Loop mode
+must not silently degrade to direct scene lookup.
+
+## Guardrails
+
+- Keep `loop` mode behavior at the loader / runner seam. The resolver
+  must remain mode-opaque and must not learn about repeat semantics.
+- Prefer the runner's native repeat / restart controls once ADR-003's
+  GSAP runner lands. Do not build timing loops with `setInterval`,
+  polling, sleeps, or recursive `handle()` calls.
+- Preserve runner input semantics: `range`, `behavior`, `beat`,
+  `onBeatMissing`, and `signal` keep their existing meanings. If loop
+  needs an additional runner hint, extend the runner input deliberately
+  rather than smuggling behavior through manifest metadata or scene
+  fields.
+- Honor `AbortSignal` promptly. A loop that ignores abort will block
+  navigation handoff and delay resolver-owned cleanup.
+- Do not call scene `cleanup()` from runner, chrome, audio, or
+  workbench controls. Drive exit through the existing navigation abort
+  path.
+- Do not add duplicate exception hierarchies. Navigation failures keep
+  the `scene navigation failed:` surface; lifecycle failures keep the
+  `composition resolution failed:` surface; missing beats keep the
+  non-fatal `beat positioning failed:` diagnostic.
+- Do not preemptively write `data-pulsar-mode-*` attributes unless a
+  concrete workbench surface needs them. Stage diagnostics should keep
+  describing the addressed scene / composition and navigation errors.
+
+## Non-Goals
+
+PUL-F015 should not implement `present`, `standalone`, `paused`,
+`scrub`, `screenshot`, or `prompter`; presenter controls; authoring UI;
+export behavior; decode-complete asset semantics; new scene metadata;
+new composition metadata; persistence; or a generic mode-policy
+framework. It should not make loop imply chrome suppression, audio
+suppression, deterministic rendering, or visible scrub controls.
+
+## Anti-Patterns
+
+- Duplicating `NAVIGATION_MODES` or validating mode strings with a
+  local enum.
+- Reading `window.location` from a scene to detect loop mode.
+- Looping an entire composition when the requirement names the
+  addressed scene's timeline.
+- Re-running scene lifecycle hooks on each iteration.
+- Calling `loader.handle(target)` from inside the runner to restart
+  playback.
+- Flattening a composition target to direct scene lookup and losing
+  range / behavior overrides for the addressed entry.
+- Encoding loop behavior in scene metadata, composition entries,
+  sentinel scenes, fake transitions, or mutable manifest rewrites.
+- Persisting the last loop target, loop state, or mode outside the URL.

--- a/src/main.ts
+++ b/src/main.ts
@@ -78,6 +78,14 @@ const createPreloader = (signal: AbortSignal): ReturnType<typeof createAssetPrel
 // engine lands; until then the placeholder honestly reports "no
 // labels" rather than silently ignoring the URL.
 //
+// PUL-F015 / ADR-018: when the URL carries `mode=loop` the loader
+// sets `input.repeat = 'until-aborted'`. The placeholder ignores the
+// hint — it has no real timeline to restart, and parking until abort
+// vacuously satisfies "restart on completion" because no completion
+// ever fires. The future GSAP runner (ADR-003) reads the hint and
+// uses GSAP's native repeat (e.g. `timeline.repeat(-1)`); the
+// placeholder's no-op is the correct stand-in until then.
+//
 // Abort ordering: the abort check runs BEFORE the missing-beat
 // diagnostic so a navigation that was superseded between
 // `scene.timeline(ctx)` resolution and the runner's first turn does

--- a/src/runtime/composition-resolver.ts
+++ b/src/runtime/composition-resolver.ts
@@ -132,6 +132,25 @@ export interface SceneTimelineRunInput {
    * {@link ResolveCompositionOptions}.
    */
   readonly onBeatMissing?: () => void;
+  /**
+   * Repeat hint for the head scene's timeline (PUL-F015 / ADR-018).
+   * When `'until-aborted'`, the runner SHOULD restart the timeline on
+   * completion and continue restarting until the navigation aborts or
+   * disposes (e.g. a future GSAP runner uses `timeline.repeat(-1)`).
+   *
+   * Only present on the run input for the FIRST scene of the resolved
+   * composition slice — subsequent scenes never receive `repeat`
+   * because a head whose timeline never naturally completes cannot
+   * advance to following entries. Absent when the navigation target
+   * had no `mode=loop` parameter.
+   *
+   * Discriminated by literal type so future repeat semantics (e.g. a
+   * fixed-iteration variant) can extend the union without breaking
+   * existing runners — a runner that ignores the field, or that only
+   * recognizes `'until-aborted'`, gracefully degrades to no-repeat
+   * behavior. The resolver does not interpret the value.
+   */
+  readonly repeat?: 'until-aborted';
 }
 
 /**
@@ -202,6 +221,21 @@ export interface ResolveCompositionOptions {
    * {@link headBeat} is also absent.
    */
   readonly onBeatMissing?: () => void;
+  /**
+   * URL loop-mode repeat hint (PUL-F015 / ADR-018) to forward to the
+   * FIRST scene's run input as {@link SceneTimelineRunInput.repeat}.
+   * Subsequent scenes never receive a repeat hint — under
+   * `mode=loop` the head's timeline never naturally completes, so
+   * following composition entries cannot run. Absent when the
+   * navigation target had no `mode=loop` parameter.
+   *
+   * The resolver does not interpret the value — honoring "restart on
+   * completion" is the runner's contract per ADR-018. A runner that
+   * ignores the field gracefully degrades to no-repeat (a regression
+   * the seam tests in `scene-loader.test.ts` pin against the loader
+   * boundary, where mode dispatch lives).
+   */
+  readonly headRepeat?: 'until-aborted';
 }
 
 /**
@@ -278,6 +312,7 @@ function buildRunInput(
   signal: AbortSignal | undefined,
   beat: string | undefined,
   onBeatMissing: (() => void) | undefined,
+  repeat: 'until-aborted' | undefined,
 ): SceneTimelineRunInput {
   const input: { -readonly [K in keyof SceneTimelineRunInput]: SceneTimelineRunInput[K] } = {
     scene: step.scene,
@@ -288,6 +323,7 @@ function buildRunInput(
   if (signal !== undefined) input.signal = signal;
   if (beat !== undefined) input.beat = beat;
   if (onBeatMissing !== undefined) input.onBeatMissing = onBeatMissing;
+  if (repeat !== undefined) input.repeat = repeat;
   return input;
 }
 
@@ -344,8 +380,17 @@ function buildRunInput(
  * runner's job per ADR-011).
  */
 export async function resolveComposition(options: ResolveCompositionOptions): Promise<void> {
-  const { registry, manifest, ctx, preloadAssets, runTimeline, signal, headBeat, onBeatMissing } =
-    options;
+  const {
+    registry,
+    manifest,
+    ctx,
+    preloadAssets,
+    runTimeline,
+    signal,
+    headBeat,
+    onBeatMissing,
+    headRepeat,
+  } = options;
 
   // PUL-F011 / ADR-015: a `headBeat` without an `onBeatMissing` would
   // silently lose the missing-label diagnostic the runner is contracted
@@ -403,7 +448,13 @@ export async function resolveComposition(options: ResolveCompositionOptions): Pr
     // against, an impossible state per the documented contract.
     const stepBeat = isHead ? headBeat : undefined;
     const stepOnBeatMissing = stepBeat === undefined ? undefined : onBeatMissing;
-    await runScene(step, ctx, runTimeline, signal, stepBeat, stepOnBeatMissing);
+    // `headRepeat` is head-only per ADR-018: under `mode=loop` the
+    // head's timeline never naturally completes, so subsequent scenes
+    // cannot run. Forwarding repeat to non-head scenes would imply a
+    // following entry could itself loop, which contradicts the
+    // requirement's "the addressed scene's timeline" scoping.
+    const stepRepeat = isHead ? headRepeat : undefined;
+    await runScene(step, ctx, runTimeline, signal, stepBeat, stepOnBeatMissing, stepRepeat);
     lastCompletedSceneId = step.scene.id;
   }
 }
@@ -460,6 +511,7 @@ async function runScene(
   signal: AbortSignal | undefined,
   beat: string | undefined,
   onBeatMissing: (() => void) | undefined,
+  repeat: 'until-aborted' | undefined,
 ): Promise<void> {
   // Track failure with explicit booleans so `throw undefined` /
   // `Promise.reject(undefined)` are still treated as failures. Using
@@ -477,7 +529,7 @@ async function runScene(
     // non-Promise value is identity, so synchronous timeline factories
     // are unaffected.
     const timeline = await scene.timeline(ctx);
-    await runTimeline(buildRunInput(step, timeline, signal, beat, onBeatMissing));
+    await runTimeline(buildRunInput(step, timeline, signal, beat, onBeatMissing, repeat));
   } catch (err) {
     phaseFailed = true;
     phaseError = err;

--- a/src/runtime/scene-loader.ts
+++ b/src/runtime/scene-loader.ts
@@ -423,6 +423,18 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
     }
     const beat = target.beat;
     const onBeatMissing = buildOnBeatMissing(beat, resolved.scene.id, controller.signal);
+    // PUL-F015 / ADR-018: under `mode=loop` the runner restarts the
+    // addressed scene's timeline on completion. The loader is the
+    // dispatch point for mode → runner-input plumbing (parallel to
+    // PUL-F012's `ctx.mode` derivation): when `effectiveMode === 'loop'`,
+    // pass `repeat: 'until-aborted'` through the bridge. The bridge
+    // and resolver scope delivery to the head scene only — following
+    // composition entries do not see `repeat`, because a looping
+    // head's timeline never naturally completes. Use a literal
+    // `undefined` sentinel so the spread below cleanly omits the key
+    // for non-loop modes (parity with the `beat` plumbing).
+    const repeat: 'until-aborted' | undefined =
+      effectiveMode(target) === 'loop' ? 'until-aborted' : undefined;
     return {
       controller,
       settled: loadSceneNavigationTarget(resolved, {
@@ -432,36 +444,56 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
         signal: controller.signal,
         ...(beat === undefined ? {} : { beat }),
         ...(onBeatMissing === undefined ? {} : { onBeatMissing }),
+        ...(repeat === undefined ? {} : { repeat }),
       }),
       silent: false,
     };
   };
 
   /**
-   * PUL-F014 / ADR-017: under `mode=standalone` the runtime renders a
-   * single scene "as if no surrounding composition existed." The
-   * composition slice — already validated by `resolveSceneNavigation`
-   * so unregistered compositions / unknown member scenes /
-   * out-of-range indexes still surface as navigation errors — is
-   * truncated to a one-entry slice so the lifecycle runs only the
-   * addressed head scene. The slice is TRUNCATED rather than dropped
-   * so the head entry's per-entry `range` / `behavior` overrides
-   * (object-form entries per ADR-002 / ADR-011) reach the runner
-   * unchanged: a flat `{ scene }` would lose them and turn standalone
-   * into direct-scene flattening, contradicting ADR-017's contract.
+   * Truncate the validated composition slice to its addressed head
+   * entry under modes that mean "run only the addressed scene."
+   *
+   * PUL-F014 / ADR-017 (`standalone`): the runtime renders a single
+   * scene "as if no surrounding composition existed."
+   *
+   * PUL-F015 / ADR-018 (`loop`): the runtime runs the addressed
+   * scene's timeline and restarts on completion. Truncating the
+   * slice makes "no following entries run" a structural guarantee
+   * even if the runner ignores the `repeat: 'until-aborted'` hint
+   * (codex review): a runner bug or no-op runner under `mode=loop`
+   * MUST NOT silently degrade into normal composition playback.
+   *
+   * Both modes share the same slice-shape transform — they differ
+   * only in whether the head's timeline repeats (a runner-side
+   * concern via `input.repeat`).
+   *
+   * The composition slice — already validated by
+   * `resolveSceneNavigation` so unregistered compositions /
+   * unknown member scenes / out-of-range indexes still surface as
+   * navigation errors — is truncated to a one-entry slice so the
+   * lifecycle runs only the addressed head scene. The slice is
+   * TRUNCATED rather than dropped so the head entry's per-entry
+   * `range` / `behavior` overrides (object-form entries per ADR-002
+   * / ADR-011) reach the runner unchanged: a flat `{ scene }` would
+   * lose them and turn the mode into direct-scene flattening,
+   * contradicting ADR-017 / ADR-018's "preserve head-entry
+   * overrides" contract.
+   *
    * Stage attrs (set by the caller before this transform) reflect
    * what the URL ADDRESSED, not what runs:
-   * `data-pulsar-composition-target` stays set so external observers
-   * (agents, screenshot tooling) see the URL-addressed composition
-   * even when only the head scene executes. Pure function — no
-   * closure captures — hoisted out of `runTarget` so the latter stays
-   * within Sonar's cognitive-complexity budget.
+   * `data-pulsar-composition-target` stays set so external
+   * observers (agents, screenshot tooling) see the URL-addressed
+   * composition even when only the head scene executes. Pure
+   * function — no closure captures — hoisted out of `runTarget` so
+   * the latter stays within Sonar's cognitive-complexity budget.
    */
-  const applyStandaloneSlice = (
+  const applySingleSceneSlice = (
     resolved: SceneNavigationTarget,
     target: NavigationTarget,
   ): SceneNavigationTarget => {
-    if (effectiveMode(target) !== 'standalone' || resolved.composition === undefined) {
+    const mode = effectiveMode(target);
+    if ((mode !== 'standalone' && mode !== 'loop') || resolved.composition === undefined) {
       return resolved;
     }
     const headEntry = resolved.composition.manifestSlice[0];
@@ -509,7 +541,7 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
       setStageAttr(ATTR_COMPOSITION, resolved.composition.id);
     }
 
-    const runnable = applyStandaloneSlice(resolved, target);
+    const runnable = applySingleSceneSlice(resolved, target);
 
     const load = buildLoad(runnable, target);
     if (load === null) return;

--- a/src/runtime/scene-navigation.ts
+++ b/src/runtime/scene-navigation.ts
@@ -140,6 +140,15 @@ export interface LoadSceneNavigationTargetOptions {
    * violated rather than letting the diagnostic vanish.
    */
   readonly onBeatMissing?: () => void;
+  /**
+   * URL loop-mode repeat hint (PUL-F015 / ADR-018) the runner uses to
+   * decide whether to restart the addressed scene's timeline on
+   * completion. Forwarded to {@link resolveComposition} as `headRepeat`
+   * — the resolver scopes delivery to the head scene's run input only,
+   * so following composition entries never receive `repeat`. Absent
+   * when the navigation target had no `mode=loop` parameter.
+   */
+  readonly repeat?: 'until-aborted';
 }
 
 const NAV_FAIL_PREFIX = 'scene navigation failed:';
@@ -275,6 +284,46 @@ function resolveCompositionAndIndex(
 }
 
 /**
+ * PUL-F015 / ADR-018 bridge-level structural defense for loop-mode.
+ * When a caller supplies `repeat` alongside a composition slice, the
+ * head's timeline restarts on completion — by definition the head's
+ * timeline never naturally completes, so following composition entries
+ * cannot run. Truncating the slice at the bridge guarantees that
+ * structural promise without depending on the runner's adapter
+ * conformance to `input.repeat`. A direct bridge caller (test harness,
+ * future export pipeline, etc.) gets the same guarantee the loader's
+ * `applySingleSceneSlice` provides on the loader→bridge path; the two
+ * truncations are idempotent (truncating a single-entry slice is a
+ * no-op).
+ *
+ * Pure function — no closure captures. Returns the input unchanged
+ * when `repeat` is absent, when there is no composition slice, or
+ * when the slice is already empty (the bridge would surface that as
+ * a navigation error elsewhere).
+ */
+function truncateForRepeat(
+  target: SceneNavigationTarget,
+  repeat: 'until-aborted' | undefined,
+): SceneNavigationTarget {
+  if (repeat === undefined || target.composition === undefined) {
+    return target;
+  }
+  const headEntry = target.composition.manifestSlice[0];
+  const headScene = target.composition.sceneSlice[0];
+  if (headEntry === undefined || headScene === undefined) {
+    return target;
+  }
+  return {
+    scene: target.scene,
+    composition: {
+      id: target.composition.id,
+      manifestSlice: Object.freeze([headEntry]),
+      sceneSlice: Object.freeze([headScene]),
+    },
+  };
+}
+
+/**
  * Resolves a {@link NavigationTarget} (from PUL-F007's parser) against
  * the runtime registries and returns a {@link SceneNavigationTarget}
  * the bridge can run, or `null` when the locator is `kind: 'none'`
@@ -362,15 +411,29 @@ export async function loadSceneNavigationTarget(
   target: SceneNavigationTarget,
   options: LoadSceneNavigationTargetOptions,
 ): Promise<void> {
-  const composition = target.composition;
+  // PUL-F015 / ADR-018: under `repeat: 'until-aborted'` the addressed
+  // scene's timeline restarts on completion — by definition the head's
+  // timeline never naturally completes, so following composition
+  // entries cannot run. Truncating the slice at the bridge layer makes
+  // "no following entries run" a structural guarantee that does not
+  // depend on the runner honoring `input.repeat` (codex pre-push
+  // review): a runner bug or no-op runner under `repeat` MUST NOT
+  // silently degrade into normal composition playback. The truncation
+  // is layered with the loader's `applySingleSceneSlice` (which already
+  // truncates for `mode=standalone` and `mode=loop`) so direct bridge
+  // callers — outside the loader path — still benefit from the
+  // structural guarantee. Truncating an already-single-entry slice is
+  // a no-op, so the layering is idempotent.
+  const effectiveTarget = truncateForRepeat(target, options.repeat);
+  const composition = effectiveTarget.composition;
   // Collapse the single-scene vs composition-slice paths into one
   // assignment so the two values cannot drift (e.g. picking
   // composition manifest with single-scene registry, or vice versa).
   let scenes: readonly SceneModule[];
   let manifest: CompositionManifest;
   if (composition === undefined) {
-    scenes = [target.scene];
-    manifest = [target.scene.id];
+    scenes = [effectiveTarget.scene];
+    manifest = [effectiveTarget.scene.id];
   } else {
     scenes = composition.sceneSlice;
     manifest = composition.manifestSlice;
@@ -416,5 +479,11 @@ export async function loadSceneNavigationTarget(
           headBeat: options.beat,
           ...(options.onBeatMissing === undefined ? {} : { onBeatMissing: options.onBeatMissing }),
         }),
+    // `repeat` is independent of `beat` per ADR-018: a URL like
+    // `?scene=x&mode=loop` (no beat) and `?scene=x&beat=hook&mode=loop`
+    // (beat + loop) are both valid. Spread `headRepeat` only when the
+    // caller supplied it so a runner that branches on `'repeat' in
+    // input` sees an absent key rather than `undefined`.
+    ...(options.repeat === undefined ? {} : { headRepeat: options.repeat }),
   });
 }

--- a/tests/runtime/composition-resolver.test.ts
+++ b/tests/runtime/composition-resolver.test.ts
@@ -1333,3 +1333,104 @@ describe('URL beat positioning forwarding (PUL-F011)', () => {
     expect(cleanupCalls).toEqual(['scene-a']);
   });
 });
+
+describe('URL loop-mode runner repeat-hint forwarding (PUL-F015)', () => {
+  // PUL-F015: in `mode=loop`, the runtime SHALL run the addressed
+  // scene's timeline and restart it on completion. ADR-018 places
+  // mode dispatch at the loader and the repeat semantics at the
+  // timeline-runner adapter. The resolver's job is forwarding the
+  // URL-derived `headRepeat` hint to the head scene's run input only;
+  // subsequent scenes in a composition slice do not receive `repeat`
+  // because the head's looping timeline never naturally completes —
+  // following entries cannot run. The resolver does NOT interpret
+  // `headRepeat` itself; honoring "restart on completion" is the
+  // runner's contract.
+
+  it("forwards `headRepeat` to plan[0]'s run input only — subsequent scenes get no repeat", async () => {
+    const runCalls: SceneTimelineRunInput[] = [];
+    const { options } = buildHarness({
+      scenes: [{ id: 'scene-a' }, { id: 'scene-b' }],
+      manifest: ['scene-a', 'scene-b'],
+      runTimeline: (input) => {
+        runCalls.push(input);
+      },
+    });
+    await resolveComposition({ ...options, headRepeat: 'until-aborted' });
+    expect(runCalls).toHaveLength(2);
+    expect(runCalls[0]?.scene.id).toBe('scene-a');
+    expect(runCalls[0]?.repeat).toBe('until-aborted');
+    expect(runCalls[1]?.scene.id).toBe('scene-b');
+    expect(runCalls[1]?.repeat).toBeUndefined();
+    // Parallel to `beat` / `range` / `behavior`: the key is OMITTED
+    // from the input object when absent, not set to `undefined`. The
+    // runner can branch on `'repeat' in input` rather than checking
+    // for `undefined`.
+    expect('repeat' in (runCalls[1] as object)).toBe(false);
+  });
+
+  it('does not attach `repeat` when `headRepeat` is absent', async () => {
+    const runCalls: SceneTimelineRunInput[] = [];
+    const { options } = buildHarness({
+      scenes: [{ id: 'scene-a' }],
+      manifest: ['scene-a'],
+      runTimeline: (input) => {
+        runCalls.push(input);
+      },
+    });
+    await resolveComposition(options);
+    expect(runCalls).toHaveLength(1);
+    expect('repeat' in (runCalls[0] as object)).toBe(false);
+  });
+
+  it('does not interpret `headRepeat` itself — a runner that ignores the hint and returns normally does not error', async () => {
+    // Resolver delegates restart-on-completion to the runner per
+    // ADR-018. A runner that receives `repeat: 'until-aborted'` and
+    // returns void normally (e.g. the placeholder runner that has no
+    // real timeline to repeat) must NOT cause the resolver to throw
+    // or skip cleanup.
+    const cleanupCalls: string[] = [];
+    const { options } = buildHarness({
+      scenes: [
+        {
+          id: 'scene-a',
+          cleanup: () => {
+            cleanupCalls.push('scene-a');
+          },
+        },
+      ],
+      manifest: ['scene-a'],
+      runTimeline: () => undefined,
+    });
+    await expect(
+      resolveComposition({
+        ...options,
+        headRepeat: 'until-aborted',
+      }),
+    ).resolves.toBeUndefined();
+    expect(cleanupCalls).toEqual(['scene-a']);
+  });
+
+  it('forwards `headRepeat` alongside `headBeat` independently — both reach plan[0] without coupling', async () => {
+    // `headRepeat` and `headBeat` are two independent head-only
+    // forwardings (PUL-F011 and PUL-F015). A regression that paired
+    // them — e.g. requiring `headBeat` whenever `headRepeat` is set,
+    // or vice versa — would break URLs like `?scene=x&beat=hook&mode=loop`.
+    const runCalls: SceneTimelineRunInput[] = [];
+    const { options } = buildHarness({
+      scenes: [{ id: 'scene-a' }],
+      manifest: ['scene-a'],
+      runTimeline: (input) => {
+        runCalls.push(input);
+      },
+    });
+    await resolveComposition({
+      ...options,
+      headBeat: 'hook',
+      onBeatMissing: () => undefined,
+      headRepeat: 'until-aborted',
+    });
+    expect(runCalls).toHaveLength(1);
+    expect(runCalls[0]?.beat).toBe('hook');
+    expect(runCalls[0]?.repeat).toBe('until-aborted');
+  });
+});

--- a/tests/runtime/scene-loader.test.ts
+++ b/tests/runtime/scene-loader.test.ts
@@ -2606,4 +2606,513 @@ describe('createSceneLoader (PUL-F008)', () => {
       expect(cleaned).toEqual(['scene-a']);
     });
   });
+
+  describe('loop-mode runner repeat-hint forwarding (PUL-F015)', () => {
+    // PUL-F015 statement: in `mode=loop`, the runtime SHALL run the
+    // addressed scene's timeline and restart it on completion.
+    //
+    // Materially-implementable parts of the statement that this block
+    // pins (ADR-018 records the contract boundary):
+    //   - The loader passes `repeat: 'until-aborted'` to the timeline
+    //     runner adapter when `effectiveMode(target) === 'loop'`. The
+    //     runner is responsible for honoring the hint (e.g. ADR-003's
+    //     future GSAP runner uses `timeline.repeat(-1)`).
+    //   - The hint is HEAD-ONLY: under composition targets the head
+    //     scene's runner input carries `repeat`; following entries do
+    //     not. (Following entries do not run anyway because a looping
+    //     head's timeline never naturally completes — the head-only
+    //     scoping is what keeps the contract honest if a future
+    //     runner exposes a non-`'until-aborted'` repeat semantics.)
+    //   - `ctx.mode === 'loop'` reaches every lifecycle hook of the
+    //     head scene — the seam future runner / chrome / audio
+    //     surfaces will read.
+    //   - Other modes (`present`, `standalone`, `paused`, `scrub`,
+    //     `screenshot`, `prompter`) and a `mode`-less URL DO NOT set
+    //     `repeat`. A regression that broadcast `repeat` under any
+    //     mode would break URLs that depend on no-repeat semantics
+    //     (e.g. screenshot determinism).
+    //   - No `data-pulsar-mode-*` suppression attribute is preemptively
+    //     written under `loop` (parity with ADR-016 / ADR-017).
+    //   - Composition validation (unregistered composition, unknown
+    //     member scene, out-of-range index) STILL surfaces as a
+    //     navigation error under `mode=loop` — no silent fallback to
+    //     direct scene lookup.
+    //   - Beat semantics under `mode=loop` are unchanged from PUL-F011:
+    //     the head scene's runner sees `input.beat`; missing-label
+    //     diagnostics surface via `data-pulsar-navigation-error` /
+    //     `onError` without unmounting.
+    //   - Object-form head entry's `range` / `behavior` overrides
+    //     reach the runner unchanged. Loop is single-scene-timeline
+    //     repeat at the head, NOT direct-scene flattening.
+    //
+    // PUL-F015 stays DRAFT after this PR (ADR-018 records the
+    // boundary; following the ADR-016 / ADR-017 / PUL-F013 / PUL-F014
+    // precedent). The seam — the loader passes `repeat: 'until-aborted'`
+    // and `ctx.mode === 'loop'` — IS materially shipped. The actual
+    // restart-on-completion behavior is the runner's contract:
+    // ADR-003's GSAP runner reads `input.repeat` when it lands.
+    // Until then, the placeholder runner has no real timeline (returns
+    // `null`) and parks until abort — vacuously satisfying "restart
+    // on completion" because no completion ever fires. ACTIVE
+    // transitions when the GSAP runner actively reads
+    // `input.repeat === 'until-aborted'` and restarts the timeline,
+    // with an end-to-end test alongside these seam tests.
+
+    const loopSceneTarget = (id: string): NavigationTarget => ({
+      locator: { kind: 'scene', scene: id },
+      mode: 'loop',
+    });
+    const loopCompositionTarget = (composition: string): NavigationTarget => ({
+      locator: { kind: 'composition', composition },
+      mode: 'loop',
+    });
+    const loopCompositionSceneTarget = (composition: string, scene: string): NavigationTarget => ({
+      locator: { kind: 'composition-scene', composition, scene },
+      mode: 'loop',
+    });
+    const loopCompositionIndexTarget = (composition: string, index: number): NavigationTarget => ({
+      locator: { kind: 'composition-index', composition, index },
+      mode: 'loop',
+    });
+
+    it('passes `repeat: "until-aborted"` to the runner for a `scene` target under `mode=loop`', async () => {
+      // Direct-scene navigation is the simplest loop path: the
+      // addressed scene IS the head, no slice resolution. A regression
+      // that gated `repeat` on `target.composition` being defined
+      // would silently drop the hint here.
+      const captured: { sceneId: string; repeat: 'until-aborted' | undefined }[] = [];
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      const runner: SceneTimelineRunner = (input) => {
+        captured.push({ sceneId: input.scene.id, repeat: input.repeat });
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: runner,
+      });
+
+      await loader.handle(loopSceneTarget('scene-a'));
+
+      expect(captured).toEqual([{ sceneId: 'scene-a', repeat: 'until-aborted' }]);
+    });
+
+    it('runs only the head scene of a `composition` target under `mode=loop` (slice truncation; runner sees `repeat: "until-aborted"` for the head)', async () => {
+      // PUL-F015 / ADR-018: loop truncates the validated composition
+      // slice to the addressed head, parallel to standalone (ADR-017).
+      // Truncation makes "no following entries run" a structural
+      // guarantee — a runner bug or no-op runner under `mode=loop`
+      // MUST NOT silently degrade into normal composition playback
+      // (codex pre-push review). Use a non-final-index navigation so
+      // the slice has successors that would be observable if
+      // truncation were missing — last-index would slice to one
+      // entry anyway and fail to discriminate.
+      const captured: { sceneId: string; repeat: 'until-aborted' | undefined }[] = [];
+      const sceneA = buildScene({ id: 'scene-a' });
+      const sceneB = buildScene({ id: 'scene-b' });
+      const sceneC = buildScene({ id: 'scene-c' });
+      const stage = buildStage();
+      const runner: SceneTimelineRunner = (input) => {
+        captured.push({ sceneId: input.scene.id, repeat: input.repeat });
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA, sceneB, sceneC]),
+        compositions: createCompositionRegistry([
+          { id: 'full-talk', manifest: ['scene-a', 'scene-b', 'scene-c'] },
+        ]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: runner,
+      });
+
+      await loader.handle(loopCompositionIndexTarget('full-talk', 0));
+
+      expect(captured).toEqual([{ sceneId: 'scene-a', repeat: 'until-aborted' }]);
+    });
+
+    it('runs only the addressed scene of a `composition+scene` target under `mode=loop`', async () => {
+      // composition+scene targeting a non-final entry exercises the
+      // slice transform from a different locator shape; pins parity
+      // with the composition-target case above.
+      const captured: { sceneId: string; repeat: 'until-aborted' | undefined }[] = [];
+      const sceneA = buildScene({ id: 'scene-a' });
+      const sceneB = buildScene({ id: 'scene-b' });
+      const sceneC = buildScene({ id: 'scene-c' });
+      const stage = buildStage();
+      const runner: SceneTimelineRunner = (input) => {
+        captured.push({ sceneId: input.scene.id, repeat: input.repeat });
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA, sceneB, sceneC]),
+        compositions: createCompositionRegistry([
+          { id: 'full-talk', manifest: ['scene-a', 'scene-b', 'scene-c'] },
+        ]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: runner,
+      });
+
+      await loader.handle(loopCompositionSceneTarget('full-talk', 'scene-b'));
+
+      expect(captured).toEqual([{ sceneId: 'scene-b', repeat: 'until-aborted' }]);
+    });
+
+    it('runs cleanup exactly once for the head scene under `mode=loop`, never for dropped slice entries', async () => {
+      // Same invariant as PUL-F014 (ADR-017) under standalone: a
+      // regression that dropped the slice for execution but left
+      // following scenes wired through the synthesized registry could
+      // double-clean or skip-clean. Pin exactly-once cleanup on the
+      // head and zero cleanup for the dropped entries.
+      const cleaned: string[] = [];
+      const trace = (id: string): SceneModule =>
+        buildScene({
+          id,
+          cleanup: () => {
+            cleaned.push(id);
+          },
+        });
+      const scenes = [trace('scene-a'), trace('scene-b'), trace('scene-c')];
+      const stage = buildStage();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry(scenes),
+        compositions: createCompositionRegistry([
+          { id: 'full-talk', manifest: scenes.map((s) => s.id) },
+        ]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+      });
+
+      await loader.handle(loopCompositionTarget('full-talk'));
+
+      expect(cleaned).toEqual(['scene-a']);
+    });
+
+    it('omits the `repeat` key on the runner input when `mode=loop` is absent (key-presence semantics)', async () => {
+      // The runner input uses key-presence semantics for optional
+      // fields (parallel to `beat` / `range` / `behavior`): a runner
+      // can branch on `'repeat' in input` rather than `=== undefined`.
+      // A regression that always set `input.repeat = undefined` (or
+      // any non-`'until-aborted'` value) under non-loop modes would
+      // break that contract.
+      const captured: { hasRepeat: boolean; repeat: unknown }[] = [];
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      const runner: SceneTimelineRunner = (input) => {
+        captured.push({ hasRepeat: 'repeat' in input, repeat: input.repeat });
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: runner,
+      });
+
+      // No mode at all (defaults to `present`).
+      await loader.handle(sceneTarget('scene-a'));
+
+      expect(captured).toEqual([{ hasRepeat: false, repeat: undefined }]);
+    });
+
+    it('does not set `repeat` for any non-loop mode', async () => {
+      // Walk the seven-mode allowlist (minus `loop`) and confirm that
+      // none of them produce `repeat` on the runner input. Catching
+      // every non-loop mode discriminates against an over-broad fix
+      // that gated `repeat` on `mode !== undefined` rather than
+      // `mode === 'loop'`.
+      const nonLoopModes = NAVIGATION_MODES.filter((m) => m !== 'loop');
+      const captured: { mode: NavigationMode; hasRepeat: boolean }[] = [];
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      const runner: SceneTimelineRunner = (input) => {
+        const ctx = (input as { scene: { id: string } }).scene;
+        const mode = (
+          captured.length < nonLoopModes.length ? nonLoopModes[captured.length] : 'present'
+        ) as NavigationMode;
+        captured.push({ mode, hasRepeat: 'repeat' in input });
+        void ctx;
+      };
+      for (const mode of nonLoopModes) {
+        const loader = createSceneLoader({
+          scenes: createSceneRegistry([sceneA]),
+          compositions: createCompositionRegistry([]),
+          stage: stage.element,
+          buildCtx: stubCtx,
+          createPreloader: () => () => undefined,
+          runTimeline: runner,
+        });
+        await loader.handle({ locator: { kind: 'scene', scene: 'scene-a' }, mode });
+      }
+
+      expect(captured).toHaveLength(nonLoopModes.length);
+      for (const entry of captured) {
+        expect(entry.hasRepeat).toBe(false);
+      }
+    });
+
+    it('exposes `ctx.mode === "loop"` to every lifecycle hook of the head scene under all locator shapes', async () => {
+      // Parallel to the PUL-F014 standalone seam test. Future runner /
+      // chrome / audio surfaces read `ctx.mode` to decide their own
+      // repeat / suppression behavior; this test pins the seam end to
+      // end across all four locator shapes that can appear under
+      // `mode=loop`.
+      const seen: { phase: string; locatorKind: string; mode: unknown }[] = [];
+      const recordMode =
+        (phase: string, locatorKind: string) =>
+        (ctx: unknown): unknown => {
+          seen.push({ phase, locatorKind, mode: (ctx as { mode?: NavigationMode }).mode });
+          return null;
+        };
+      const makeScene = (locatorKind: string): SceneModule =>
+        buildScene({
+          id: 'scene-a',
+          create: recordMode('create', locatorKind),
+          timeline: recordMode('timeline', locatorKind) as SceneModule['timeline'],
+          cleanup: recordMode('cleanup', locatorKind),
+        });
+      const stage = buildStage();
+      const buildLoader = (sceneId: string, locatorKind: string) =>
+        createSceneLoader({
+          scenes: createSceneRegistry([makeScene(locatorKind)]),
+          compositions: createCompositionRegistry([{ id: 'full-talk', manifest: [sceneId] }]),
+          stage: stage.element,
+          buildCtx: (mode) => ({ stage: stage.element, mode }),
+          createPreloader: () => () => undefined,
+          runTimeline: noopRunner,
+        });
+
+      await buildLoader('scene-a', 'scene').handle(loopSceneTarget('scene-a'));
+      await buildLoader('scene-a', 'composition').handle(loopCompositionTarget('full-talk'));
+      await buildLoader('scene-a', 'composition-scene').handle(
+        loopCompositionSceneTarget('full-talk', 'scene-a'),
+      );
+      await buildLoader('scene-a', 'composition-index').handle(
+        loopCompositionIndexTarget('full-talk', 0),
+      );
+
+      // 3 hooks per navigation × 4 locator shapes = 12 entries; every
+      // single one must carry `loop`.
+      expect(seen).toHaveLength(12);
+      for (const entry of seen) {
+        expect(entry.mode).toBe('loop');
+      }
+    });
+
+    it('forwards `beat` to the head scene runner alongside `repeat` under `mode=loop`, and surfaces missing-beat as a non-fatal diagnostic', async () => {
+      // PUL-F011 / PUL-F015 are independent: a URL like
+      // `?scene=x&beat=hook&mode=loop` must deliver both `beat` and
+      // `repeat` to the runner. A regression that paired them — e.g.
+      // dropping `repeat` when `beat` is supplied — would silently
+      // break loop-mode navigation when a beat is also requested.
+      const captured: {
+        sceneId: string;
+        beat: string | undefined;
+        repeat: 'until-aborted' | undefined;
+      }[] = [];
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      const errors: unknown[] = [];
+      const runner: SceneTimelineRunner = (input) => {
+        captured.push({
+          sceneId: input.scene.id,
+          beat: input.beat,
+          repeat: input.repeat,
+        });
+        if (input.beat !== undefined && input.onBeatMissing !== undefined) {
+          input.onBeatMissing();
+        }
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: runner,
+        onError: (err) => {
+          errors.push(err);
+        },
+      });
+
+      await loader.handle({
+        locator: { kind: 'scene', scene: 'scene-a' },
+        mode: 'loop',
+        beat: 'midpoint',
+      });
+
+      expect(captured).toEqual([{ sceneId: 'scene-a', beat: 'midpoint', repeat: 'until-aborted' }]);
+      expect(errors).toHaveLength(1);
+      expect((errors[0] as Error).message).toContain('beat positioning failed');
+      expect((errors[0] as Error).message).toContain('"midpoint"');
+      expect(stage.attrs.get('data-pulsar-navigation-error')).toBeDefined();
+    });
+
+    it('writes no `data-pulsar-mode-*` suppression attribute on the stage under `mode=loop`', async () => {
+      // Mirrors ADR-016 / ADR-017 invariant. PUL-F015 forbids the
+      // loader from preemptively writing a stage attribute for loop
+      // mode; runner-side or future-surface-side signaling lives at
+      // those surfaces, not at the loader.
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+      });
+
+      await loader.handle(loopSceneTarget('scene-a'));
+
+      const modeAttrs = Array.from(stage.attrs.keys()).filter((name) =>
+        name.startsWith('data-pulsar-mode-'),
+      );
+      expect(modeAttrs).toEqual([]);
+    });
+
+    it('surfaces composition-not-registered as a navigation error under `mode=loop` (no silent fallback)', async () => {
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      const errors: unknown[] = [];
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+        onError: (err) => {
+          errors.push(err);
+        },
+      });
+
+      await loader.handle(loopCompositionTarget('not-registered'));
+
+      expect(errors).toHaveLength(1);
+      expect((errors[0] as Error).message).toContain(
+        'composition "not-registered" is not registered',
+      );
+      expect(stage.attrs.get('data-pulsar-navigation-error')).toBeDefined();
+    });
+
+    it('surfaces composition-member error under `mode=loop` for an unknown scene in `composition+scene`', async () => {
+      const sceneA = buildScene({ id: 'scene-a' });
+      const sceneZ = buildScene({ id: 'scene-z' });
+      const stage = buildStage();
+      const errors: unknown[] = [];
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA, sceneZ]),
+        compositions: createCompositionRegistry([{ id: 'full-talk', manifest: ['scene-a'] }]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+        onError: (err) => {
+          errors.push(err);
+        },
+      });
+
+      await loader.handle(loopCompositionSceneTarget('full-talk', 'scene-z'));
+
+      expect(errors).toHaveLength(1);
+      expect((errors[0] as Error).message).toContain(
+        'scene "scene-z" is not a member of composition "full-talk"',
+      );
+    });
+
+    it('surfaces index-out-of-range under `mode=loop`', async () => {
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      const errors: unknown[] = [];
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([{ id: 'full-talk', manifest: ['scene-a'] }]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+        onError: (err) => {
+          errors.push(err);
+        },
+      });
+
+      await loader.handle(loopCompositionIndexTarget('full-talk', 5));
+
+      expect(errors).toHaveLength(1);
+      expect((errors[0] as Error).message).toContain('index 5 is out of range');
+    });
+
+    it("preserves the addressed head entry's `range` and `behavior` overrides on the runner input under `mode=loop` (composition+index with object-form entry)", async () => {
+      // PUL-F015 / ADR-018: loop truncates the validated composition
+      // slice to the addressed head and forwards `repeat` to that
+      // head's runner input. The slice is TRUNCATED rather than
+      // flattened — a flat `{ scene }` would lose object-form
+      // `range` / `behavior` overrides on the head entry, turning
+      // loop into direct-scene flattening (parity with ADR-017's
+      // standalone invariant). This pins all three slots — `range`,
+      // `behavior`, and `repeat` — through to the head runner, plus
+      // the truncation itself (the runner runs exactly once).
+      const sceneA = buildScene({ id: 'scene-a' });
+      const sceneB = buildScene({ id: 'scene-b' });
+      const sceneC = buildScene({ id: 'scene-c' });
+      const stage = buildStage();
+      const captured: {
+        sceneId: string;
+        range: unknown;
+        behavior: unknown;
+        repeat: unknown;
+      }[] = [];
+      const runner: SceneTimelineRunner = (input) => {
+        captured.push({
+          sceneId: input.scene.id,
+          range: input.range,
+          behavior: input.behavior,
+          repeat: input.repeat,
+        });
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA, sceneB, sceneC]),
+        compositions: createCompositionRegistry([
+          {
+            id: 'full-talk',
+            manifest: [
+              'scene-a',
+              { id: 'scene-b', range: 'hook', behavior: { hold: true } },
+              'scene-c',
+            ],
+          },
+        ]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: runner,
+      });
+
+      await loader.handle(loopCompositionIndexTarget('full-talk', 1));
+
+      // Single runner invocation (truncation), with overrides AND
+      // `repeat` reaching the head's runner input together. A
+      // regression that flattened to direct-scene would show
+      // `range: undefined, behavior: undefined`; a regression that
+      // dropped truncation would show a second invocation for
+      // scene-c.
+      expect(captured).toEqual([
+        {
+          sceneId: 'scene-b',
+          range: 'hook',
+          behavior: { hold: true },
+          repeat: 'until-aborted',
+        },
+      ]);
+    });
+  });
 });

--- a/tests/runtime/scene-loader.test.ts
+++ b/tests/runtime/scene-loader.test.ts
@@ -2827,20 +2827,17 @@ describe('createSceneLoader (PUL-F008)', () => {
       // none of them produce `repeat` on the runner input. Catching
       // every non-loop mode discriminates against an over-broad fix
       // that gated `repeat` on `mode !== undefined` rather than
-      // `mode === 'loop'`.
+      // `mode === 'loop'`. Capturing the per-iteration mode alongside
+      // the `'repeat' in input` flag means the assertion failure
+      // identifies WHICH mode regressed, not just "some mode did."
       const nonLoopModes = NAVIGATION_MODES.filter((m) => m !== 'loop');
       const captured: { mode: NavigationMode; hasRepeat: boolean }[] = [];
       const sceneA = buildScene({ id: 'scene-a' });
       const stage = buildStage();
-      const runner: SceneTimelineRunner = (input) => {
-        const ctx = (input as { scene: { id: string } }).scene;
-        const mode = (
-          captured.length < nonLoopModes.length ? nonLoopModes[captured.length] : 'present'
-        ) as NavigationMode;
-        captured.push({ mode, hasRepeat: 'repeat' in input });
-        void ctx;
-      };
       for (const mode of nonLoopModes) {
+        const runner: SceneTimelineRunner = (input) => {
+          captured.push({ mode, hasRepeat: 'repeat' in input });
+        };
         const loader = createSceneLoader({
           scenes: createSceneRegistry([sceneA]),
           compositions: createCompositionRegistry([]),
@@ -2852,10 +2849,10 @@ describe('createSceneLoader (PUL-F008)', () => {
         await loader.handle({ locator: { kind: 'scene', scene: 'scene-a' }, mode });
       }
 
-      expect(captured).toHaveLength(nonLoopModes.length);
-      for (const entry of captured) {
-        expect(entry.hasRepeat).toBe(false);
-      }
+      // One entry per non-loop mode, each must have `hasRepeat: false`.
+      // Building the expected array from `nonLoopModes` keeps the
+      // assertion in sync if the mode allowlist ever changes.
+      expect(captured).toEqual(nonLoopModes.map((mode) => ({ mode, hasRepeat: false })));
     });
 
     it('exposes `ctx.mode === "loop"` to every lifecycle hook of the head scene under all locator shapes', async () => {

--- a/tests/runtime/scene-navigation.test.ts
+++ b/tests/runtime/scene-navigation.test.ts
@@ -891,4 +891,155 @@ describe('loadSceneNavigationTarget (PUL-F008 lifecycle bridge)', () => {
       expect(beatPresence).toEqual([false]);
     });
   });
+
+  describe('URL loop-mode repeat forwarding (PUL-F015)', () => {
+    // ADR-018: under `mode=loop` the runner restarts the addressed
+    // scene's timeline on completion. The bridge's only job is to
+    // forward the `repeat` option from the loader to the resolver as
+    // `headRepeat`. The resolver scopes delivery to the head scene's
+    // run input only — restart-on-completion is the runner's contract.
+
+    it('forwards `repeat` to the runner for a single-scene target', async () => {
+      const seen: { repeat?: 'until-aborted' }[] = [];
+      const intro = buildScene({ id: 'intro' });
+      const scenes = createSceneRegistry([intro]);
+      const compositions = createCompositionRegistry([]);
+      const target = resolveSceneNavigation(sceneTarget('intro'), {
+        scenes,
+        compositions,
+      }) as SceneNavigationTarget;
+
+      await loadSceneNavigationTarget(target, {
+        ctx: {},
+        preloadAssets: () => undefined,
+        runTimeline: (input) => {
+          const captured: { repeat?: 'until-aborted' } = {};
+          if ('repeat' in input) captured.repeat = input.repeat;
+          seen.push(captured);
+        },
+        repeat: 'until-aborted',
+      });
+
+      expect(seen).toEqual([{ repeat: 'until-aborted' }]);
+    });
+
+    it('truncates a composition slice to the addressed head when `repeat` is supplied — structural defense against runner non-conformance', async () => {
+      // PUL-F015 / ADR-018: under `repeat: 'until-aborted'` the head's
+      // timeline restarts forever — following composition entries
+      // cannot run by the requirement's definition. The bridge
+      // truncates the slice to a single entry as a structural defense
+      // so a runner that ignores `input.repeat` (or returns
+      // synchronously by mistake) cannot silently degrade loop-mode
+      // navigation into normal composition playback. This is layered
+      // with the loader's `applySingleSceneSlice` so direct bridge
+      // callers — outside the loader path — get the same guarantee.
+      const seen: { id: string; repeat: 'until-aborted' | undefined }[] = [];
+      const intro = buildScene({ id: 'intro' });
+      const middle = buildScene({ id: 'middle' });
+      const scenes = createSceneRegistry([intro, middle]);
+      const compositions = createCompositionRegistry([
+        { id: 'full-talk', manifest: ['intro', 'middle'] },
+      ]);
+      const target = resolveSceneNavigation(compositionIndexTarget('full-talk', 0), {
+        scenes,
+        compositions,
+      }) as SceneNavigationTarget;
+
+      await loadSceneNavigationTarget(target, {
+        ctx: {},
+        preloadAssets: () => undefined,
+        runTimeline: (input) => {
+          seen.push({ id: input.scene.id, repeat: input.repeat });
+        },
+        repeat: 'until-aborted',
+      });
+
+      // Only the head ran; the tail (`middle`) was structurally
+      // dropped. A regression that omitted bridge-level truncation
+      // would observe `middle` as a second runner entry here.
+      expect(seen).toEqual([{ id: 'intro', repeat: 'until-aborted' }]);
+    });
+
+    it('does not truncate a composition slice when `repeat` is absent — non-loop navigations run the full slice', async () => {
+      // The structural defense fires only under `repeat`. Composition
+      // navigation under any non-loop mode must still run every entry
+      // — a regression that always truncated would silently break
+      // normal composition playback (and standalone slice handling
+      // belongs to the loader, not the bridge).
+      const seen: string[] = [];
+      const intro = buildScene({ id: 'intro' });
+      const middle = buildScene({ id: 'middle' });
+      const scenes = createSceneRegistry([intro, middle]);
+      const compositions = createCompositionRegistry([
+        { id: 'full-talk', manifest: ['intro', 'middle'] },
+      ]);
+      const target = resolveSceneNavigation(compositionIndexTarget('full-talk', 0), {
+        scenes,
+        compositions,
+      }) as SceneNavigationTarget;
+
+      await loadSceneNavigationTarget(target, {
+        ctx: {},
+        preloadAssets: () => undefined,
+        runTimeline: (input) => {
+          seen.push(input.scene.id);
+        },
+      });
+
+      expect(seen).toEqual(['intro', 'middle']);
+    });
+
+    it('does not forward `repeat` when the option is omitted', async () => {
+      const repeatPresence: boolean[] = [];
+      const intro = buildScene({ id: 'intro' });
+      const scenes = createSceneRegistry([intro]);
+      const compositions = createCompositionRegistry([]);
+      const target = resolveSceneNavigation(sceneTarget('intro'), {
+        scenes,
+        compositions,
+      }) as SceneNavigationTarget;
+
+      await loadSceneNavigationTarget(target, {
+        ctx: {},
+        preloadAssets: () => undefined,
+        runTimeline: (input) => {
+          repeatPresence.push('repeat' in input);
+        },
+      });
+
+      expect(repeatPresence).toEqual([false]);
+    });
+
+    it('forwards `repeat` and `beat` independently — both reach the head without coupling', async () => {
+      // The bridge plumbs two independent head-only forwardings. A
+      // regression that paired them — e.g. dropping `repeat` when
+      // `beat` is absent, or vice versa — would break valid URLs
+      // like `?scene=x&mode=loop` (no beat) and `?scene=x&beat=hook`
+      // (no loop).
+      const seen: { beat?: string; repeat?: 'until-aborted' }[] = [];
+      const intro = buildScene({ id: 'intro' });
+      const scenes = createSceneRegistry([intro]);
+      const compositions = createCompositionRegistry([]);
+      const target = resolveSceneNavigation(sceneTarget('intro'), {
+        scenes,
+        compositions,
+      }) as SceneNavigationTarget;
+
+      await loadSceneNavigationTarget(target, {
+        ctx: {},
+        preloadAssets: () => undefined,
+        runTimeline: (input) => {
+          const captured: { beat?: string; repeat?: 'until-aborted' } = {};
+          if ('beat' in input) captured.beat = input.beat;
+          if ('repeat' in input) captured.repeat = input.repeat;
+          seen.push(captured);
+        },
+        beat: 'hook',
+        onBeatMissing: () => undefined,
+        repeat: 'until-aborted',
+      });
+
+      expect(seen).toEqual([{ beat: 'hook', repeat: 'until-aborted' }]);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Lands the loader → runner repeat-hint plumbing for `mode=loop` (PUL-F015 / ADR-018): loader passes `repeat: 'until-aborted'` through the bridge / resolver to the head scene's runner input under `effectiveMode === 'loop'`, where the runner is responsible for actually restarting the timeline on completion (ADR-003's future GSAP runner uses `timeline.repeat(-1)`).
- Layers slice truncation at the loader (`applySingleSceneSlice` for both `standalone` and `loop`) and the bridge (`truncateForRepeat` under `repeat`) so following composition entries cannot run regardless of runner conformance — added in response to codex pre-push review.
- Pins the seam: `ctx.mode === 'loop'` reaches every lifecycle hook of the head scene; head-only `repeat` delivery; key-presence semantics on the runner input; composition validation still surfaces under loop; no `data-pulsar-mode-*` suppression attribute; object-form head-entry `range` / `behavior` overrides preserved through truncation.

## Status disposition

PUL-F015 stays **DRAFT** following the ADR-016 (PUL-F013 / present) and ADR-017 (PUL-F014 / standalone) precedent. The placeholder runner has no real timeline and parks until abort, vacuously satisfying "restart on completion" but not exercising it. ACTIVE transitions when ADR-003's GSAP runner replaces the placeholder and actively reads `input.repeat === 'until-aborted'`, with an end-to-end test alongside the seam tests in this PR.

The issue ↔ requirement link is `DOCUMENTS`, not `IMPLEMENTS`.

## Test plan

- [ ] CI passes: `pnpm lint && pnpm typecheck && pnpm test`
- [ ] SonarCloud quality gate green
- [ ] Tests: `'loop-mode runner repeat-hint forwarding (PUL-F015)'` describe block in `tests/runtime/scene-loader.test.ts`; `'URL loop-mode repeat forwarding (PUL-F015)'` block in `tests/runtime/scene-navigation.test.ts`; `'URL loop-mode runner repeat-hint forwarding (PUL-F015)'` block in `tests/runtime/composition-resolver.test.ts`
- [ ] Manual: bridge-level truncation test demonstrates structural defense — direct bridge caller with `(repeat, multi-entry slice)` runs only the head

Codex pre-push review run twice (cap reached). Findings 2-2 (bridge slice-shape) and 2-3 (ADR self-contradiction) fixed. Finding 1 (no end-to-end loop) marked `not-applicable` per ADR-018-documented design — rationale recorded on the issue thread.

Closes #24