### PR TITLE
PUL-F016: workbench mode=paused contract layer (ADR-019)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,168 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `docs/adrs/019-workbench-mode-paused.md` — records the PUL-F016
+  contract: under `mode=paused` the loader truncates the validated
+  composition slice to the addressed head entry (parallel to
+  `standalone` per ADR-017 and `loop` per ADR-018) and passes
+  `hold: 'first-frame'` through the bridge / resolver to that head's
+  timeline-runner input, where the runner is responsible for
+  pinning the timeline at time 0 (e.g. ADR-003's future GSAP runner
+  uses `timeline.seek(0)` + `timeline.pause()`). Slice truncation
+  makes "no following entries run" a structural guarantee — a
+  runner that ignores the `hold` hint cannot silently degrade
+  paused into normal composition playback. The single-scene-execution
+  helper ADR-017 introduced and ADR-018 extended is widened again
+  (`applySingleSceneSlice`) to fire under `paused`; the SHAPE
+  transform is shared between `standalone`, `loop`, and `paused`,
+  the runner-side semantic differences (`input.repeat` vs
+  `input.hold` vs neither) are what differentiate them. Composition
+  validation runs first, so unregistered compositions / unknown
+  member scenes / out-of-range indexes still surface as navigation
+  errors. The hint is head-only — following composition entries do
+  not receive `hold`, parallel to PUL-F011 / ADR-015's `headBeat`
+  and PUL-F015 / ADR-018's `headRepeat`. ADR-019 also records the
+  runner-side policy that `hold` wins over `beat` when both are
+  set under `mode=paused` (paused is layout/styling inspection;
+  `mode=scrub` is the appropriate mode for beat-targeted timeline
+  inspection); the loader does NOT strip `beat` when `mode=paused`
+  is set — the policy is a runner contract, not a loader-side
+  filter. The loader → runner contract IS materially shipped; the
+  seam (`ctx.mode === 'paused'` reaches every lifecycle hook of the
+  head scene) is pinned. The actual hold-at-first-frame behavior
+  depends on ADR-003's GSAP runner, which is not yet implemented;
+  the placeholder runner has no real timeline and parks until
+  abort, vacuously satisfying the requirement. Following the
+  ADR-016 / ADR-017 / ADR-018 precedent, PUL-F016 stays DRAFT and
+  the issue ↔ requirement link is `DOCUMENTS`; ACTIVE transitions
+  when the GSAP runner lands and actively reads `input.hold ===
+  'first-frame'`, with an end-to-end test alongside the seam tests
+  in this PR. Indexed in `docs/adrs/README.md`.
+- `docs/design/pul-f016-paused-mode-preflight.md` — codex
+  architecture preflight design context for PUL-F016. Names the
+  cross-cutting concerns to reuse (`NAVIGATION_MODES`,
+  `effectiveMode()`, `parseNavigationSearch()`,
+  `resolveSceneNavigation()`, `loadSceneNavigationTarget()`,
+  `resolveComposition()`, `createAssetPreloader()`,
+  `describeError()`, the per-navigation `AbortController`, and the
+  shared `applySingleSceneSlice` / `truncateToHead` helpers) and
+  the anti-patterns to avoid (per-scene `if (mode === 'paused')`
+  branches, raw `setTimeout` / `requestAnimationFrame` /
+  CSS-keyframe / canvas-loop / autoplay-audio in `create(ctx)`
+  that bypass runtime pause control, lifecycle short-circuits that
+  skip `create(ctx)` or `timeline(ctx)`, conflating paused with
+  screenshot or scrub, persisting paused state outside the URL,
+  stripping `beat=` at the loader when `mode=paused` is set). The
+  document records that codex's sandbox was unable to write design
+  files during preflight (`bwrap: loopback: Failed RTM_NEWADDR`),
+  so the guardrails are preserved verbatim from the preflight
+  tool's returned summary.
+- `src/runtime/composition-resolver.ts` —
+  `SceneTimelineRunInput` gains optional `hold?: 'first-frame'` and
+  `ResolveCompositionOptions` gains optional `headHold?:
+  'first-frame'`. The resolver forwards `headHold` to plan[0]'s
+  run input only (head-only, parallel to `headBeat` and
+  `headRepeat`); subsequent scenes never receive `hold`. The
+  literal-typed union lets future hold semantics extend without
+  breaking existing runners.
+- `src/runtime/scene-navigation.ts` —
+  `LoadSceneNavigationTargetOptions` gains optional `hold?:
+  'first-frame'`; `loadSceneNavigationTarget()` forwards the
+  option to `resolveComposition` as `headHold` (parallel to how
+  `repeat` becomes `headRepeat`). `hold`, `repeat`, and `beat` are
+  independent — a programmatic caller can supply any combination,
+  and the runner's policy decides which wins when more than one
+  reaches its input. The bridge ALSO truncates a composition slice
+  to its addressed head when `hold` is supplied (the previous
+  `truncateForRepeat` helper is renamed to a shared `truncateToHead`
+  predicate that fires when EITHER `repeat` or `hold` is supplied)
+  — a structural defense layered with the loader's
+  `applySingleSceneSlice` so direct bridge callers (test harnesses,
+  future export pipelines) get the same paused-mode single-scene-
+  execution guarantee. The two truncations are idempotent.
+- `src/runtime/scene-loader.ts` — when
+  `effectiveMode(target) === 'paused'`, the loader passes
+  `hold: 'first-frame'` through `loadSceneNavigationTarget()`.
+  Other modes (and a `mode`-less URL) leave the key absent on the
+  runner input — key-presence semantics, parallel to `beat` /
+  `repeat` / `range` / `behavior`. Mode dispatch lives at the
+  loader, the same place PUL-F012 derives `ctx.mode` and PUL-F015
+  derives `repeat`. The single-scene-execution helper that landed
+  for `standalone` (ADR-017) and `loop` (ADR-018) is widened to
+  also include `paused`, truncating the validated composition
+  slice to the addressed head entry under any of the three modes
+  (per ADR-019: structural defense against a runner that ignores
+  the `hold` hint).
+- `src/main.ts` — placeholder timeline runner docstring
+  acknowledges `input.hold`. The placeholder ignores the hint;
+  parking until abort vacuously satisfies "hold at first frame
+  without advancing" because no frame ever advances. ADR-003's
+  GSAP runner will read the hint and call `timeline.pause()`.
+- `tests/runtime/composition-resolver.test.ts` — new
+  `'URL paused-mode runner hold-hint forwarding (PUL-F016)'`
+  describe block (4 tests) pinning `headHold` head-only delivery,
+  key-presence semantics, resolver no-op on the value, and
+  independent forwarding alongside `headBeat` and `headRepeat`.
+- `tests/runtime/scene-navigation.test.ts` — new `'URL paused-mode
+  hold forwarding (PUL-F016)'` describe block under
+  `loadSceneNavigationTarget` (5 tests) pinning the bridge's
+  `hold` → `headHold` plumbing for single-scene targets, key
+  absence when option omitted, independence from `beat` and
+  `repeat`, bridge-level slice truncation under `hold` (the
+  structural defense added in response to the same codex pre-push
+  review reasoning ADR-018 records for `repeat`), and that
+  non-paused composition navigation still runs the full slice.
+- `tests/runtime/scene-loader.test.ts` — new `'paused-mode runner
+  hold-hint forwarding (PUL-F016)'` describe block pinning every
+  clause of PUL-F016 under `mode=paused`:
+  - `hold: 'first-frame'` on the head scene's runner input for a
+    `scene` target.
+  - Slice truncation under `composition` and `composition+scene`
+    targets — only the head runs, with `hold: 'first-frame'`
+    on its runner input. Non-final-index navigations are used so
+    a regression that dropped truncation would observe successor
+    entries running.
+  - cleanup runs exactly once for the head scene under
+    `mode=paused`, never for dropped slice entries (parallel to
+    ADR-017 / ADR-018).
+  - Key absence on the runner input when `mode` is unset.
+  - No `hold` for any non-paused mode (six modes walked from
+    `NAVIGATION_MODES`).
+  - `ctx.mode === 'paused'` exposed to every lifecycle hook of the
+    head scene under all four locator shapes.
+  - `beat=` forwarding alongside `hold` under `mode=paused` with
+    the non-fatal missing-label diagnostic preserved (the loader
+    forwards both; the runner's "first frame wins" policy decides
+    which wins at the runner contract).
+  - No `data-pulsar-mode-*` suppression attribute is preemptively
+    written (parity with ADR-016 / ADR-017 / ADR-018).
+  - Stage attrs `data-pulsar-scene-target` AND
+    `data-pulsar-composition-target` both set when URL named a
+    composition under paused (preserves observability of what the
+    URL addressed).
+  - Composition-not-registered, composition-member-not-found, and
+    index-out-of-range errors STILL surface under `mode=paused`
+    (no silent fallback to direct scene lookup).
+  - Object-form head entry's `range` and `behavior` overrides reach
+    the runner unchanged through the truncated slice alongside
+    `hold` — paused is single-scene-mount with held timeline at
+    the head, NOT direct-scene flattening.
+  - A hold-until-abort runner under `mode=paused` keeps the head
+    scene mounted until a new navigation supersedes it; cleanup
+    fires only on abort, not on `hold` arrival. Pins the
+    runner-side pending-until-abort contract through the
+    loader+resolver+navigation flow so a regression that made the
+    resolver bypass `runTimeline` under `hold`, or that dropped
+    signal forwarding to the runner under paused, would fail
+    here. Codex pre-push review (cycle 2) flagged that the
+    cleanup-once test alone — using a synchronous `noopRunner` —
+    would not catch a runner that resolved immediately after
+    `seek(0) + pause()` and unmounted the scene one turn after
+    mount; this test is the structural defense for that bug
+    class. ADR-019's two-part runner contract (freeze the
+    timeline at time 0 AND keep the runner promise pending until
+    abort) is what the future GSAP runner PR will additionally
+    pin end-to-end against a real timeline.
 - `docs/adrs/018-workbench-mode-loop.md` — records the PUL-F015
   contract: under `mode=loop` the loader truncates the validated
   composition slice to the addressed head entry (parallel to

--- a/docs/adrs/019-workbench-mode-paused.md
+++ b/docs/adrs/019-workbench-mode-paused.md
@@ -1,0 +1,423 @@
+# ADR-019: Workbench Mode `paused` — Runner Hold-at-First-Frame Hint at the Loader/Runner Seam
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-09
+
+## Context
+
+ADR-007 names seven workbench modes: `present`, `standalone`, `loop`,
+`paused`, `scrub`, `screenshot`, `prompter`. ADR-013 fixes the URL
+grammar boundary that carries `mode=` to the runtime. ADR-014 fixes
+the scene navigation dispatch layer. ADR-015 fixes URL beat
+positioning. ADR-016 (`mode=present`), ADR-017 (`mode=standalone`),
+and ADR-018 (`mode=loop`) establish the precedent for landing a
+mode's contract layer plus seam tests while the dependent rendering
+surfaces are still pending: PUL-F013, PUL-F014, and PUL-F015 all
+stayed DRAFT after their respective contract PRs because chrome /
+audio / GSAP runner / presenter input surfaces are not yet
+implemented.
+
+PUL-F016 specifies `mode=paused`:
+
+> In `mode=paused`, the runtime SHALL mount the addressed scene and
+> hold it at its first frame without advancing the timeline.
+
+The non-trivial parts of that statement decompose this way:
+
+- "Mount the addressed scene" — already structurally true via
+  `loadSceneNavigationTarget()` and the existing scene-loader path.
+  `scene.create(ctx)` runs normally; preload runs normally;
+  `scene.timeline(ctx)` resolves to whatever the scene returns. No
+  new code required for that clause.
+- "Hold it at its first frame without advancing the timeline" — a
+  runner-side contract: under `paused`, the timeline runner MUST
+  render frame 0 and not advance. ADR-003's GSAP runner does not yet
+  exist; the placeholder runner in `src/main.ts` has no real
+  timeline (`scene.timeline(ctx)` returns `null`) and parks until
+  abort. With no real timeline to advance, "hold at first frame
+  without advancing" is vacuously satisfied today — but vacuous truth
+  is not enforcement.
+
+The question this ADR answers is: where does the loader → runner
+contract for `mode=paused` live, and on what contract does PUL-F016
+transition to ACTIVE?
+
+## Decision
+
+`mode=paused` is dispatched at the loader (`src/runtime/scene-loader.ts`)
+as a runner-input field forwarded to the timeline-runner adapter on
+the head scene's run input only. When `effectiveMode(target) === 'paused'`
+the loader passes `hold: 'first-frame'` through
+`loadSceneNavigationTarget()` and the resolver to
+`SceneTimelineRunInput.hold`. The runner is responsible for honoring
+the hint — ADR-003's future GSAP runner will seek to time 0 and call
+`timeline.pause()` rather than allowing the timeline to advance, AND
+will keep its returned promise pending until the per-navigation
+`AbortSignal` fires.
+
+The pending-until-abort part of the runner contract is structurally
+load-bearing. `resolveComposition()` awaits `runTimeline()` and then
+runs `cleanup(ctx)` (PUL-F006 / ADR-011 mandatory cleanup). A runner
+that observes `input.hold === 'first-frame'`, calls
+`timeline.seek(0)` + `timeline.pause()`, and resolves the promise
+synchronously would cause the resolver to advance to cleanup one
+turn after the scene mounted — the scene would unmount immediately,
+contradicting the requirement's "hold." The placeholder runner
+today already parks until abort (it has no timeline to advance and
+no completion event to fire), so the placeholder's shape is the
+correct stand-in. The GSAP runner's hold contract is therefore a
+two-part rule: (1) under `hold === 'first-frame'`, freeze the
+timeline at time 0 via the engine's native API, and (2) keep the
+runner's promise pending until the navigation aborts (parallel to
+how the placeholder treats every navigation today). End-to-end tests
+in the GSAP runner PR will pin both clauses.
+
+The hint is **head-only**. Under composition targets the slice's
+first entry is the addressed scene; following composition entries
+never receive `hold`. This scoping is structural: a paused head's
+timeline never advances, so following entries cannot run. Forwarding
+`hold` to non-head scenes would imply a following entry could itself
+be held at frame 0, which contradicts the requirement's "the
+addressed scene" scoping. The plumbing is parallel to PUL-F011 /
+ADR-015's `headBeat` and PUL-F015 / ADR-018's `headRepeat` head-only
+forwarding — same shape, different field.
+
+`SceneTimelineRunInput.hold` is declared as a literal-typed field
+(`'first-frame'`) rather than a boolean so future hold semantics
+(e.g. `'final-frame'` for end-of-scene inspection, or a
+deterministic-frame variant for screenshot mode) can extend the
+union without breaking existing runners. A runner that ignores the
+field, or that only recognizes `'first-frame'`, gracefully degrades
+to no-hold behavior. The resolver and bridge do not interpret the
+value.
+
+The slice IS **truncated** under `mode=paused` to the addressed head
+entry — the same shape transform `mode=standalone` (ADR-017) and
+`mode=loop` (ADR-018) apply. Without truncation, a runner that
+ignores `input.hold` (a placeholder, a buggy GSAP wiring, a future
+test runner) would let the resolver advance to the next composition
+entry and paused-mode would silently degrade into normal composition
+playback. That violates the documented paused guarantee.
+
+Truncating the slice makes "no following entries run" a structural
+guarantee that does not depend on runner conformance. The three
+single-scene-execution modes (`standalone`, `loop`, and `paused`)
+share the same slice transform; they differ only in the head's
+runner-side semantic — standalone plays normally, loop sets
+`input.repeat = 'until-aborted'`, paused sets
+`input.hold = 'first-frame'`. The shape transform is shared because
+the structural promise ("no following entries run") is identical;
+the runner-side behaviors live where they belong.
+
+The slice is **truncated, not flattened.** Replacing the resolved
+target with `{ scene }` (no composition) would lose the head entry's
+per-entry `range` / `behavior` overrides (object-form entries per
+ADR-002 / ADR-011), turning paused into direct-scene flattening —
+same foot-gun ADR-017 / ADR-018 call out. The truncated
+`manifestSlice` (length 1) continues through the composition branch
+in `loadSceneNavigationTarget()`, and the existing runner-input
+plumbing forwards `range` / `behavior` per ADR-011.
+
+PUL-F016 stays DRAFT after this PR lands, mirroring the ADR-016 /
+PUL-F013, ADR-017 / PUL-F014, and ADR-018 / PUL-F015 precedent. This
+PR ships:
+
+- The loader → runner-input contract: `hold: 'first-frame'` reaches
+  the head scene's run input under `effectiveMode === 'paused'`.
+- The seam: `ctx.mode === 'paused'` reaches every lifecycle hook of
+  the head scene through the existing PUL-F012 plumbing.
+- Tests pinning the seam, the head-only scoping, the
+  no-other-mode contamination, and the existing invariants under
+  `paused` (composition validation still runs; no
+  `data-pulsar-mode-*` attribute; beat forwarding preserved;
+  `range` / `behavior` overrides preserved).
+
+What it does NOT yet ship is the active *hold-at-first-frame*
+behavior:
+
+- ADR-003's GSAP runner is not implemented. The placeholder runner
+  has no real timeline to hold; it returns `null` from
+  `scene.timeline(ctx)` and parks until abort. With no frame ever
+  rendered, the placeholder vacuously satisfies "hold at first frame
+  without advancing" but cannot exercise it. When the GSAP runner
+  lands, it MUST read `input.hold === 'first-frame'` and seek to
+  time 0 + pause the timeline (or equivalent native API).
+  End-to-end tests of "the timeline does not advance" are gated on
+  that surface landing.
+
+PUL-F016 transitions DRAFT → ACTIVE when ADR-003's GSAP runner lands
+AND it actively reads `input.hold === 'first-frame'` and pins the
+timeline at time 0, with an end-to-end test alongside the seam tests
+in this PR. Until then, the issue ↔ requirement link stays as
+`DOCUMENTS` and the status stays DRAFT — matching how ADR-016 /
+PUL-F013, ADR-017 / PUL-F014, and ADR-018 / PUL-F015 record "land
+the contract layer; keep the requirement DRAFT until the dependent
+subsystems land."
+
+### Boundary
+
+The hold hint flows from the loader because:
+
+- The loader already derives `effectiveMode(target)` for `ctx.mode`
+  (ADR-007 / PUL-F012). Reusing the same derivation for `hold`
+  keeps mode-aware logic in one place — no second `target.mode`
+  inspection on a different layer.
+- The composition resolver MUST stay mode-opaque (ADR-011 — pure
+  orchestrator, no adapter knowledge). The resolver plumbs
+  `headHold` exactly the way it plumbs `headBeat` and `headRepeat`:
+  as an opaque forwarding field with no semantics it interprets.
+  The loader is the only thing that maps `effectiveMode === 'paused'`
+  to `hold: 'first-frame'`.
+- `resolveSceneNavigation()` MUST run validation regardless of mode:
+  unregistered compositions, unknown member scenes, ambiguous
+  `composition+scene` locators, out-of-range indexes, and empty
+  compositions still surface as navigation errors under
+  `mode=paused`. No silent fallback to direct scene lookup.
+- `loadSceneNavigationTarget()` already plumbs head-only options
+  (`beat` / `onBeatMissing` / `repeat`); adding `hold` to that list
+  reuses the same shape rather than inventing a new bridge surface.
+
+### Stage attribute behavior
+
+`data-pulsar-scene-target` (head scene id) AND
+`data-pulsar-composition-target` (composition id) are both set on
+the stage when the URL named a composition under `mode=paused`. The
+attrs communicate "what was addressed," not "what's running" — same
+invariant as `mode=standalone` (ADR-017) and `mode=loop` (ADR-018).
+No `data-pulsar-mode-*` suppression attribute is preemptively
+written under `paused` (parity with ADR-016 / ADR-017 / ADR-018);
+future workbench surfaces are free to use that namespace if they
+actually need a stage-level signal.
+
+### Beat semantics
+
+There are two contracts here, owned by two layers:
+
+**Loader contract.** `beat=` under `mode=paused` is forwarded to the
+head scene's runner unchanged. The loader does NOT strip `beat`
+when `mode=paused` is set — coupling those two URL parameters at
+the loader would prevent a scene-author tool from reusing the same
+beat parameter across `present` (full playback), `paused` (layout
+review), and `scrub` (beat-targeted hold) without rewriting the
+URL between modes. The runner sees both `input.beat` and
+`input.hold` on the same input bundle.
+
+**Runner contract.** ADR-019's runner-side policy is **first frame
+wins**: when both `hold === 'first-frame'` and `beat` are present,
+the runner SHOULD hold the timeline at frame 0 and SHOULD NOT seek
+to the named label. Paused is a layout/styling-inspection mode,
+not a beat-targeting mode. For beat-targeted timeline inspection,
+`mode=scrub` is the appropriate mode; for deterministic frame
+output for visual regression, `mode=screenshot` is the appropriate
+mode. A hold-first runner therefore does not attempt label
+resolution under paused, and consequently does NOT invoke
+`onBeatMissing` even for an unknown beat — there is no
+"missing-label" event because no seek was attempted. This means a
+URL like `?scene=x&beat=does-not-exist&mode=paused` produces no
+beat diagnostic from a conformant GSAP runner, by design. ADR-015's
+"missing-label diagnostics surface non-fatally" applies to runners
+that DO attempt label resolution; a runner that legitimately
+chooses hold-over-seek does not have a missing-label event to
+report.
+
+Today's placeholder runner has no real timeline at all and does
+invoke `onBeatMissing` for any supplied beat (because every label
+is "missing" in a no-label timeline). That is honest within the
+placeholder's no-real-timeline world but is not the contract the
+GSAP runner will follow: when the GSAP runner lands, it will read
+`hold` first and skip beat resolution under paused. Tests under
+this PR forward `beat` and `hold` together to prove the loader
+forwards both unchanged; they do not pin the runner-side
+hold-wins policy because the placeholder runner does not implement
+it. The GSAP runner PR will add tests for the runner-side policy
+alongside its end-to-end paused tests.
+
+### Composition slice behavior
+
+Truncated to the addressed head entry, parallel to `mode=standalone`
+(ADR-017) and `mode=loop` (ADR-018). The single-scene-execution
+helper at the loader is shared: `applySingleSceneSlice` runs for
+all three modes (`standalone`, `loop`, `paused`). Following
+composition entries do not run; the head scene's
+`hold: 'first-frame'` reaches the runner input and the runner is
+responsible for the actual hold-at-first-frame behavior.
+
+The composition slice MUST be validated by `resolveSceneNavigation()`
+BEFORE the truncation transform. Unregistered compositions, unknown
+member scenes, ambiguous `composition+scene` locators, and
+out-of-range indexes still surface as navigation errors under
+`mode=paused` — the same invariant ADR-017 / ADR-018 hold for
+standalone and loop.
+
+The bridge ALSO truncates a composition slice when `hold` is
+supplied (`truncateToHead` shared with the `repeat` path) — a
+structural defense layered with the loader's `applySingleSceneSlice`
+so direct bridge callers (test harnesses, future export pipelines)
+get the same paused-mode single-scene-execution guarantee. The two
+truncations are idempotent.
+
+## Consequences
+
+### Positive
+
+- Mode → runner-input plumbing lives at the loader, the same place
+  PUL-F012 derives `ctx.mode` and PUL-F015 derives `repeat`. One
+  mode dispatch site, not three.
+- The resolver stays mode-opaque (ADR-011): `headHold` is plumbed
+  the same way `headBeat` and `headRepeat` already are, with no new
+  resolver semantics.
+- The runner contract is a single optional input field
+  (`hold?: 'first-frame'`). A runner that ignores it (placeholder,
+  future non-paused test runners) gracefully degrades; a runner that
+  honors it (future GSAP) reads one field instead of inferring
+  paused semantics from `ctx.mode`.
+- Following ADR-016 / ADR-017 / ADR-018's precedent keeps the DRAFT
+  → ACTIVE bar consistent across mode requirements: ACTIVE means the
+  named behavior is actively delivered end to end, not just
+  structurally scaffolded.
+- No premature abstraction. No `ModePolicy` record, no shared
+  mode-hint type, no policy table. When a future mode needs a
+  different shape of runner hint, it adds its own field; if multiple
+  modes converge on a shared representation, that representation
+  lands then with at least two consumers informing its shape. The
+  three single-scene-execution modes (standalone, loop, paused)
+  share `applySingleSceneSlice` because they share a structural
+  invariant, but they do NOT share a runner-input field — each owns
+  its own (`repeat`, `hold`, none).
+
+### Negative
+
+- PUL-F016 stays DRAFT until ADR-003's GSAP runner lands. A
+  reviewer reading the requirement in isolation may expect ACTIVE on
+  first delivery; the DRAFT-with-contract-and-seams state is
+  intentional and matches the PUL-F011 / PUL-F013 / PUL-F014 /
+  PUL-F015 precedent.
+- Adding `hold` to `SceneTimelineRunInput` widens the runner adapter
+  surface. Every runner adapter (placeholder today, future GSAP,
+  test harnesses) sees the new field. Test runners that don't care
+  about paused semantics ignore it; this is the cost of extending
+  the input shape. The alternative (a separate runner parameter)
+  would be larger surface, not smaller.
+- The seam tests are necessary but not sufficient: they prove the
+  hook exists and behaves correctly under `mode=paused`, but they
+  do not prove that a future GSAP runner will plug in correctly.
+  The surface PR that lands the GSAP runner is responsible for
+  adding its own end-to-end "the timeline does not advance under
+  `mode=paused`" test.
+- The documented "first frame wins" runner-side policy for
+  `beat` × `hold` combinations is not exercised by any test in this
+  PR — the placeholder runner has no real timeline and no real beat
+  resolution, so the policy is an ADR-level contract that the
+  future GSAP runner PR will pin with its own tests.
+
+### Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| A future runner ignores `input.hold` and the regression goes unnoticed | The seam tests pin "loader sets `input.hold = 'first-frame'` under `mode=paused`." A runner that ignores the hint produces wrong runtime behavior (timeline advances). When the GSAP runner lands, its own end-to-end test proves the hint is honored. |
+| `hold` accumulates as a kitchen-sink field for unrelated hold semantics | The literal-typed union (`'first-frame'`) constrains valid values. Adding a new variant (`'final-frame'`, `{ frame: N }`) is an explicit type extension, visible in code review. |
+| Slice truncation flattens to direct-scene and loses object-form `range` / `behavior` overrides | The seam test "preserves the addressed head entry's `range` and `behavior` overrides under `mode=paused` (composition+index with object-form entry)" pins object-form head-entry plumbing through the truncated slice. A flatten-by-mistake would lose those overrides. |
+| A runner that ignores `input.hold` silently degrades paused into normal composition playback | Slice truncation makes "no following entries run" structural — a no-op runner under `mode=paused` runs the head's lifecycle once and then completes the navigation, rather than advancing to a tail entry that should not have run. |
+| PUL-F016 lingers DRAFT forever because the GSAP runner keeps slipping | DRAFT is a feature here: it tells reviewers the paused-mode contract is partly delivered (boundary + seam) and gates ACTIVE on actual hold-at-first-frame. The GSAP runner PR (ADR-003) is the natural trigger to revisit PUL-F016's status. |
+| A non-parser caller forges a `NavigationTarget` with `mode: 'paused'` mid-flight | The defense-in-depth check `validateModeGrammar` already rejects unknown modes at the loader boundary; `'paused'` is in the `NAVIGATION_MODES` allowlist, and `effectiveMode` is the only consumer of the field. |
+| `paused` and `screenshot` get conflated as "freeze the timeline" modes | ADR-019's beat-semantics section records the boundary: paused is layout/styling inspection (frame 0); screenshot is deterministic regression output (a specific frame chosen for determinism); scrub is beat-targeted timeline inspection. Each mode owns its own runner-input field and its own ADR. |
+
+## Current state (2026-05-09)
+
+This PR delivers the contract boundary and seam-pinning layer:
+
+- `src/runtime/composition-resolver.ts` — `SceneTimelineRunInput`
+  gains optional `hold?: 'first-frame'`;
+  `ResolveCompositionOptions` gains optional `headHold?:
+  'first-frame'`; the resolver forwards `headHold` to plan[0]'s
+  run input only.
+- `src/runtime/scene-navigation.ts` —
+  `LoadSceneNavigationTargetOptions` gains optional `hold?:
+  'first-frame'`; `loadSceneNavigationTarget()` forwards it to
+  `resolveComposition` as `headHold`. The previous
+  `truncateForRepeat` helper is renamed to a shared
+  `truncateToHead` predicate that fires when EITHER `repeat` or
+  `hold` is supplied — the shape transform is the same; the
+  predicate is wider.
+- `src/runtime/scene-loader.ts` — when `effectiveMode(target) ===
+  'paused'`, the loader passes `hold: 'first-frame'` through the
+  bridge; otherwise the key is omitted (key-presence semantics).
+  The `applySingleSceneSlice` helper that ADR-017 introduced and
+  ADR-018 extended is widened again to include `paused` so the
+  slice is truncated to the addressed head under any of the three
+  single-scene-execution modes — the SHAPE transform is shared, the
+  runner-side semantic differences (`input.repeat` vs `input.hold`
+  vs neither) are what differentiate them.
+- `src/main.ts` — placeholder timeline runner docstring
+  acknowledges `input.hold`. The placeholder ignores the hint;
+  parking until abort vacuously satisfies "hold at first frame
+  without advancing" because no frame ever advances. ADR-003's
+  GSAP runner will read the hint and call `timeline.pause()`.
+- `tests/runtime/composition-resolver.test.ts` — new
+  `'URL paused-mode runner hold-hint forwarding (PUL-F016)'`
+  describe block.
+- `tests/runtime/scene-navigation.test.ts` — new `'URL paused-mode
+  hold forwarding (PUL-F016)'` describe block under
+  `loadSceneNavigationTarget`.
+- `tests/runtime/scene-loader.test.ts` — new `'paused-mode runner
+  hold-hint forwarding (PUL-F016)'` describe block.
+- `docs/design/pul-f016-paused-mode-preflight.md` — codex
+  architecture preflight design context (preserved here as the
+  binding plan constraints for follow-on work).
+- This ADR.
+
+PUL-F016 remains DRAFT. Issue #25 links to PUL-F016 via `DOCUMENTS`.
+This PR is **not** an implementation of PUL-F016's "hold at first
+frame without advancing" clause — it lands the contract boundary
+and the seam. The ACTIVE transition is gated on ADR-003's GSAP
+runner replacing the placeholder in `src/main.ts` AND actively
+reading `input.hold === 'first-frame'` to pin the timeline at time
+0, with an end-to-end test alongside these seam tests. Treating
+this PR as satisfying PUL-F016 would be a traceability/status
+mismatch.
+
+## Related ADRs
+
+- [ADR-003](003-gsap-timeline-engine.md) — the timeline runner is
+  the seam through which hold-at-first-frame will flow when the
+  GSAP runner lands. Today the runner is a placeholder, so paused
+  behavior is structurally vacuous.
+- [ADR-007](007-browser-workbench.md) — defines the seven workbench
+  modes and the URL-only-source invariant for mode selection.
+- [ADR-008](008-agent-native-authoring.md) — manifests-over-flow-
+  control underpins the no-mode-suppression-in-resolver constraint.
+- [ADR-011](011-composition-resolver-orchestration.md) — the
+  resolver is opaque to mode; mode-derived behavior lives at the
+  adapters it forwards to. The resolver plumbs `headHold`
+  unchanged, the same way it plumbs `headBeat` and `headRepeat`.
+- [ADR-013](013-url-navigation-grammar-boundary.md) — the parser
+  preserves `mode` and forbids recovering it from any non-URL
+  source.
+- [ADR-014](014-url-scene-target-selection.md) — scene navigation
+  dispatch is mode-blind; it resolves the active slice and hands
+  off to the loader for mode dispatch.
+- [ADR-015](015-url-beat-positioning.md) — precedent for "the
+  resolver plumbs a head-only optional field; runner owns the
+  semantics; loader fails fast at the paired-required boundary."
+  ADR-019's `headHold` mirrors `headBeat`'s shape. ADR-019 also
+  records the runner-side policy that `hold` wins over `beat` when
+  both are supplied under `mode=paused`.
+- [ADR-016](016-workbench-mode-present.md) — establishes the
+  contract-layer-plus-seam-tests precedent. PUL-F013 stays DRAFT
+  pending chrome / audio / GSAP runner / presenter input.
+- [ADR-017](017-workbench-mode-standalone.md) — applies the same
+  precedent to PUL-F014 with the slice-truncation seam. ADR-019
+  shares that slice-truncation transform — the loader runs
+  `applySingleSceneSlice` for all three of `standalone`, `loop`,
+  and `paused` so "no following entries run" is a structural
+  guarantee, not runner-conformance-dependent.
+- [ADR-018](018-workbench-mode-loop.md) — applies the same
+  precedent to PUL-F015 with the `repeat` runner-input hint and
+  bridge-level slice truncation. ADR-019's `headHold` and the
+  shared `truncateToHead` helper are direct extensions of the
+  loop-mode contract.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -44,3 +44,4 @@ Each ADR includes:
 | [016](016-workbench-mode-present.md) | Workbench Mode `present` — Contract Boundary and Adapter Seams | Accepted |
 | [017](017-workbench-mode-standalone.md) | Workbench Mode `standalone` — Single-Scene Execution at the Loader | Accepted |
 | [018](018-workbench-mode-loop.md) | Workbench Mode `loop` — Runner Repeat Hint at the Loader/Runner Seam | Accepted |
+| [019](019-workbench-mode-paused.md) | Workbench Mode `paused` — Runner Hold-at-First-Frame Hint at the Loader/Runner Seam | Accepted |

--- a/docs/design/pul-f016-paused-mode-preflight.md
+++ b/docs/design/pul-f016-paused-mode-preflight.md
@@ -1,0 +1,204 @@
+# PUL-F016 Paused Mode Preflight
+
+PUL-F016 specifies `mode=paused`: mount the addressed scene and hold
+it at its first frame without advancing the timeline. This is a
+layout/styling-inspection mode for visual review without motion. It
+is not a presenter transport state, a scrub UI, a deterministic
+visual-regression mode, or a new scene model.
+
+ADR-007 already defines `paused` as a workbench mode. ADR-011
+already defines the resolver as a lifecycle orchestrator with an
+injected timeline runner. The runner-input shape introduced by
+ADR-018 (`repeat`) is the precedent for adding a new head-only
+optional field; ADR-019 records the analogous `hold` field for
+paused.
+
+## Boundary
+
+`paused` selection must reuse the existing navigation path:
+
+- `src/runtime/navigation.ts` owns the `mode` URL grammar and the
+  `NAVIGATION_MODES` allowlist.
+- `effectiveMode()` owns effective mode derivation.
+- `src/runtime/scene-loader.ts` owns per-navigation mode dispatch,
+  `ctx.mode` construction, cancellation, stage diagnostics, and
+  error surfacing. It is also the dispatch point that maps
+  `effectiveMode === 'paused'` to `hold: 'first-frame'`.
+- `src/runtime/scene-navigation.ts` owns target resolution and
+  composition slicing. Its `scene` field is the addressed head
+  scene.
+- `src/runtime/composition-resolver.ts` owns preload → create →
+  timeline → cleanup ordering, abort propagation, and exactly-once
+  cleanup. It must remain mode-opaque; `headHold` is plumbed the
+  same way `headBeat` and `headRepeat` are.
+- The timeline runner owns timeline playhead behavior. Under
+  `mode=paused` the runner reads `input.hold === 'first-frame'`
+  and pins the timeline at time 0 (or equivalent native API call).
+
+Do not add a second route, mode enum, `paused` boolean, scene
+schema field, manifest flag, local URL parser, or paused-specific
+resolver. URL input remains the only source of mode selection;
+`paused` must not be recovered from localStorage, sessionStorage,
+cookies, `history.state`, or prior in-memory navigation state.
+
+## Required Reuse
+
+Implementation must reuse these cross-cutting concerns:
+
+- Identifier validation: `src/runtime/identifier.ts`.
+- URL and mode validation: `parseNavigationSearch()` and
+  `NAVIGATION_MODES`.
+- Effective mode derivation: `effectiveMode()`.
+- Scene and composition validation:
+  `assertSceneModule()`, `createSceneRegistry()`,
+  `assertCompositionManifest()`, and `createCompositionRegistry()`.
+- Navigation resolution: `resolveSceneNavigation()` and
+  `loadSceneNavigationTarget()`.
+- Lifecycle orchestration: `resolveComposition()` with injected
+  `createPreloader()` and `runTimeline()` adapters.
+- Asset handling: `createAssetPreloader()` with the existing
+  scheme, redirect, `baseUrl`, and `AbortSignal` rules. Paused mode
+  does not change preload semantics — the addressed scene's assets
+  must still be loaded before `create(ctx)` runs.
+- Error rendering: `describeError()` plus the existing
+  `data-pulsar-navigation-error` stage diagnostic and `onError`
+  sink.
+- Cancellation and cleanup: one per-navigation `AbortController`,
+  forwarded to preload and timeline adapters; cleanup remains
+  resolver-owned.
+- Slice-truncation helper: the `applySingleSceneSlice` loader-side
+  helper and the `truncateToHead` bridge-level helper introduced
+  for `standalone` (ADR-017) and extended for `loop` (ADR-018) are
+  extended again to fire under `paused`. The shape transform is
+  shared; the predicate widens.
+
+## Paused Contract
+
+Paused mode means: resolve the addressed scene through the existing
+URL/registry/composition path, preload declared assets, run normal
+`create(ctx)` and `timeline(ctx)`, render the timeline at time `0`,
+then hold it there. It is not a resumable presenter transport
+state.
+
+- A direct `scene` target holds that scene's timeline at frame 0.
+- A `composition` target holds the first scene's timeline at frame
+  0; following composition entries do not run.
+- A `composition+scene` or `composition+index` target holds the
+  resolved head scene's timeline at frame 0, preserving the head
+  entry's `range` / `behavior` overrides; following composition
+  entries do not run.
+- `beat=<label>` must not redefine paused mode. For `mode=paused`,
+  first frame wins. The runner SHOULD ignore `input.beat` when
+  `input.hold === 'first-frame'`. Use `mode=scrub` for
+  beat/timeline inspection and `mode=screenshot` for deterministic
+  visual regression.
+
+The requirement says the addressed scene mounts and the timeline
+holds at first frame. Do not implement paused by skipping
+`create(ctx)`, by skipping `timeline(ctx)`, or by short-circuiting
+the lifecycle. Scene setup runs normally; only the timeline's
+playhead is pinned.
+
+When the URL used composition context, validation must still happen
+before lifecycle effects. Unknown compositions, unknown member
+scenes, ambiguous `composition+scene` locators, out-of-range
+indexes, empty compositions, unregistered referenced scenes, and
+preload failures must surface through the existing diagnostics.
+Paused mode must not silently degrade to direct scene lookup.
+
+Missing-beat diagnostics are different under paused. ADR-019's
+runner-side "first frame wins" policy means a conformant
+hold-first runner does NOT seek to a supplied `beat` label and
+therefore does NOT call `input.onBeatMissing` even when the label
+is missing — there is no missing-label event because no seek was
+attempted. The loader still forwards `beat` and `onBeatMissing` to
+the runner unchanged (the loader does not couple `beat` and `mode`
+at its layer); whether a missing-label diagnostic surfaces under
+paused is the runner's policy. The placeholder runner today does
+invoke `onBeatMissing` because it has no real timeline at all,
+which is honest within the placeholder world but not the contract
+the GSAP runner will follow.
+
+## Guardrails
+
+- Keep `paused` mode behavior at the loader / runner seam. The
+  resolver must remain mode-opaque and must not learn about
+  hold-at-first-frame semantics.
+- Prefer the runner's native pause controls once ADR-003's GSAP
+  runner lands (`timeline.pause()`, `timeline.seek(0)`). Do not
+  build hold loops with `setTimeout`,
+  `requestAnimationFrame` checks that gate themselves on a paused
+  flag, CSS / keyframe animation suppression layers, canvas loops
+  guarded by `if (paused)`, or per-scene `if (mode === 'paused')`
+  branches in `create(ctx)`.
+- Preserve runner input semantics: `range`, `behavior`, `beat`,
+  `onBeatMissing`, `repeat`, and `signal` keep their existing
+  meanings. The new `hold` field is optional and discriminated by
+  literal type so future variants can extend the union without
+  breaking existing runners.
+- Honor `AbortSignal` promptly. A held timeline that ignores abort
+  will block navigation handoff and delay resolver-owned cleanup.
+- Do not call scene `cleanup()` from runner, chrome, audio, or
+  workbench controls. Drive exit through the existing navigation
+  abort path.
+- Do not add duplicate exception hierarchies. Navigation failures
+  keep the `scene navigation failed:` surface; lifecycle failures
+  keep the `composition resolution failed:` surface; missing beats
+  keep the non-fatal `beat positioning failed:` diagnostic.
+- Do not preemptively write `data-pulsar-mode-*` attributes unless
+  a concrete workbench surface needs them. Stage diagnostics should
+  keep describing the addressed scene / composition and navigation
+  errors.
+- Paused mode should not trigger autoplay audio or scene-local raw
+  `<audio>` behavior. Audio suppression under paused is a future
+  audio-service-surface concern (ADR-004) — when the audio service
+  lands it will read `ctx.mode === 'paused'` at its own seam and
+  suppress the audio bed; today there is no audio service to
+  suppress.
+
+## Non-Goals
+
+PUL-F016 should not implement `present`, `standalone`, `loop`,
+`scrub`, `screenshot`, or `prompter`; presenter controls
+(advance / hold / skip / pause / resume / mute); authoring UI;
+export behavior; decode-complete asset semantics; new scene
+metadata; new composition metadata; persistence; or a generic
+mode-policy framework. It should not make paused imply chrome
+suppression, audio suppression, deterministic rendering, or
+visible scrub controls. It should not implement transport
+controls, scrub UI, screenshot determinism, or presenter resume
+behavior.
+
+PUL-F016 should not transition to ACTIVE until implementation
+includes tests proving first-frame mount without timeline
+advancement against a real timeline runner. The placeholder runner
+in `src/main.ts` has no real timeline, so PUL-F016 stays DRAFT
+after the contract-layer PR; the GSAP runner (ADR-003) is the
+natural trigger to revisit the status.
+
+## Anti-Patterns
+
+- Duplicating `NAVIGATION_MODES` or validating mode strings with a
+  local enum.
+- Reading `window.location` from a scene to detect paused mode.
+- Per-scene `if (mode === 'paused')` branches that skip work the
+  scene's `create(ctx)` would otherwise do.
+- Raw `setTimeout`, `requestAnimationFrame`, CSS / keyframe
+  animation, canvas loops, or autoplay audio inside `create(ctx)`
+  that bypass runtime pause control.
+- Calling `loader.handle(target)` from inside the runner to
+  re-render the held frame.
+- Flattening a composition target to direct scene lookup and losing
+  range / behavior overrides for the addressed entry.
+- Conflating `paused` with `screenshot`: paused is layout/styling
+  inspection at frame 0; screenshot is deterministic regression
+  output at a chosen frame; scrub is beat-targeted timeline
+  inspection.
+- Encoding paused behavior in scene metadata, composition entries,
+  sentinel scenes, fake transitions, or mutable manifest rewrites.
+- Persisting the last paused target, paused state, or mode outside
+  the URL.
+- Stripping `beat=` at the loader when `mode=paused` is set —
+  paused vs beat preference is the runner's policy contract, not a
+  loader-side filter; coupling them at the loader prevents authors
+  from reusing the same beat parameter across modes.

--- a/src/main.ts
+++ b/src/main.ts
@@ -86,6 +86,25 @@ const createPreloader = (signal: AbortSignal): ReturnType<typeof createAssetPrel
 // uses GSAP's native repeat (e.g. `timeline.repeat(-1)`); the
 // placeholder's no-op is the correct stand-in until then.
 //
+// PUL-F016 / ADR-019: when the URL carries `mode=paused` the loader
+// sets `input.hold = 'first-frame'`. The placeholder ignores the
+// hint — it has no real timeline to advance, and parking until abort
+// vacuously satisfies "hold at first frame without advancing"
+// because no frame ever advances. The future GSAP runner (ADR-003)
+// reads the hint, seeks to time 0, calls `timeline.pause()`, AND
+// keeps its returned promise pending until the per-navigation
+// `AbortSignal` fires. The pending-until-abort part is structurally
+// load-bearing: `resolveComposition()` awaits `runTimeline()` and
+// then runs `cleanup(ctx)`, so a runner that does `seek(0)` +
+// `pause()` and returns synchronously would unmount the scene one
+// turn after mount, contradicting the requirement's "hold." The
+// placeholder already parks until abort, so it models the correct
+// shape; the GSAP runner's contract is to keep doing so under
+// `hold` even after issuing the pause. ADR-019 records the
+// runner-side policy that `hold` wins over `beat` and `repeat`
+// when multiple are set on the same input — paused is a
+// layout/styling-inspection mode, not a transport state.
+//
 // Abort ordering: the abort check runs BEFORE the missing-beat
 // diagnostic so a navigation that was superseded between
 // `scene.timeline(ctx)` resolution and the runner's first turn does

--- a/src/runtime/composition-resolver.ts
+++ b/src/runtime/composition-resolver.ts
@@ -151,6 +151,36 @@ export interface SceneTimelineRunInput {
    * behavior. The resolver does not interpret the value.
    */
   readonly repeat?: 'until-aborted';
+  /**
+   * Hold hint for the head scene's timeline (PUL-F016 / ADR-019). When
+   * `'first-frame'`, the runner SHOULD render the addressed scene's
+   * timeline at time `0` and hold it there without advancing (e.g. a
+   * future GSAP runner calls `timeline.pause()` after seeking to time
+   * 0). The mount/preload/`create(ctx)`/`timeline(ctx)` flow runs
+   * normally; only timeline progression is suppressed.
+   *
+   * Only present on the run input for the FIRST scene of the resolved
+   * composition slice — subsequent scenes never receive `hold`
+   * because a head whose timeline never advances cannot reach the
+   * following entries. Absent when the navigation target had no
+   * `mode=paused` parameter.
+   *
+   * Discriminated by literal type so future hold semantics (e.g. a
+   * specific-frame variant for screenshot determinism) can extend
+   * the union without breaking existing runners — a runner that
+   * ignores the field, or that only recognizes `'first-frame'`,
+   * gracefully degrades to no-hold behavior. The resolver does not
+   * interpret the value.
+   *
+   * `hold` and `repeat` are independent fields on the runner input;
+   * the URL grammar makes their parent modes (`paused` and `loop`)
+   * mutually exclusive (mode is a single field), but a programmatic
+   * caller could supply both, and the runner's policy decides which
+   * wins. ADR-019 records the runner-side preference: `hold` wins
+   * over `repeat` when both are set, because a paused timeline never
+   * completes for the repeat to fire on.
+   */
+  readonly hold?: 'first-frame';
 }
 
 /**
@@ -236,6 +266,21 @@ export interface ResolveCompositionOptions {
    * boundary, where mode dispatch lives).
    */
   readonly headRepeat?: 'until-aborted';
+  /**
+   * URL paused-mode hold hint (PUL-F016 / ADR-019) to forward to the
+   * FIRST scene's run input as {@link SceneTimelineRunInput.hold}.
+   * Subsequent scenes never receive a hold hint — under `mode=paused`
+   * the head's timeline never advances, so following composition
+   * entries cannot run. Absent when the navigation target had no
+   * `mode=paused` parameter.
+   *
+   * The resolver does not interpret the value — honoring
+   * "hold at first frame" is the runner's contract per ADR-019. A
+   * runner that ignores the field gracefully degrades to no-hold (a
+   * regression the seam tests in `scene-loader.test.ts` pin against
+   * the loader boundary, where mode dispatch lives).
+   */
+  readonly headHold?: 'first-frame';
 }
 
 /**
@@ -313,6 +358,7 @@ function buildRunInput(
   beat: string | undefined,
   onBeatMissing: (() => void) | undefined,
   repeat: 'until-aborted' | undefined,
+  hold: 'first-frame' | undefined,
 ): SceneTimelineRunInput {
   const input: { -readonly [K in keyof SceneTimelineRunInput]: SceneTimelineRunInput[K] } = {
     scene: step.scene,
@@ -324,6 +370,7 @@ function buildRunInput(
   if (beat !== undefined) input.beat = beat;
   if (onBeatMissing !== undefined) input.onBeatMissing = onBeatMissing;
   if (repeat !== undefined) input.repeat = repeat;
+  if (hold !== undefined) input.hold = hold;
   return input;
 }
 
@@ -390,6 +437,7 @@ export async function resolveComposition(options: ResolveCompositionOptions): Pr
     headBeat,
     onBeatMissing,
     headRepeat,
+    headHold,
   } = options;
 
   // PUL-F011 / ADR-015: a `headBeat` without an `onBeatMissing` would
@@ -454,7 +502,22 @@ export async function resolveComposition(options: ResolveCompositionOptions): Pr
     // following entry could itself loop, which contradicts the
     // requirement's "the addressed scene's timeline" scoping.
     const stepRepeat = isHead ? headRepeat : undefined;
-    await runScene(step, ctx, runTimeline, signal, stepBeat, stepOnBeatMissing, stepRepeat);
+    // `headHold` is head-only per ADR-019: under `mode=paused` the
+    // head's timeline never advances, so subsequent scenes cannot
+    // run. Forwarding hold to non-head scenes would imply a
+    // following entry could itself be held at frame 0, which
+    // contradicts the requirement's "the addressed scene" scoping.
+    const stepHold = isHead ? headHold : undefined;
+    await runScene(
+      step,
+      ctx,
+      runTimeline,
+      signal,
+      stepBeat,
+      stepOnBeatMissing,
+      stepRepeat,
+      stepHold,
+    );
     lastCompletedSceneId = step.scene.id;
   }
 }
@@ -512,6 +575,7 @@ async function runScene(
   beat: string | undefined,
   onBeatMissing: (() => void) | undefined,
   repeat: 'until-aborted' | undefined,
+  hold: 'first-frame' | undefined,
 ): Promise<void> {
   // Track failure with explicit booleans so `throw undefined` /
   // `Promise.reject(undefined)` are still treated as failures. Using
@@ -529,7 +593,7 @@ async function runScene(
     // non-Promise value is identity, so synchronous timeline factories
     // are unaffected.
     const timeline = await scene.timeline(ctx);
-    await runTimeline(buildRunInput(step, timeline, signal, beat, onBeatMissing, repeat));
+    await runTimeline(buildRunInput(step, timeline, signal, beat, onBeatMissing, repeat, hold));
   } catch (err) {
     phaseFailed = true;
     phaseError = err;

--- a/src/runtime/scene-loader.ts
+++ b/src/runtime/scene-loader.ts
@@ -433,8 +433,19 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
     // head's timeline never naturally completes. Use a literal
     // `undefined` sentinel so the spread below cleanly omits the key
     // for non-loop modes (parity with the `beat` plumbing).
-    const repeat: 'until-aborted' | undefined =
-      effectiveMode(target) === 'loop' ? 'until-aborted' : undefined;
+    const mode = effectiveMode(target);
+    const repeat: 'until-aborted' | undefined = mode === 'loop' ? 'until-aborted' : undefined;
+    // PUL-F016 / ADR-019: under `mode=paused` the runner mounts the
+    // addressed scene and holds its timeline at the first frame.
+    // Same dispatch-point pattern as `repeat`: when
+    // `effectiveMode === 'paused'`, pass `hold: 'first-frame'`
+    // through the bridge. The bridge and resolver scope delivery to
+    // the head scene only — following composition entries do not see
+    // `hold`, because a paused head's timeline never advances.
+    // `mode=paused` and `mode=loop` are mutually exclusive at the URL
+    // boundary (mode is a single field), so at most one of `repeat` /
+    // `hold` is non-undefined here.
+    const hold: 'first-frame' | undefined = mode === 'paused' ? 'first-frame' : undefined;
     return {
       controller,
       settled: loadSceneNavigationTarget(resolved, {
@@ -445,6 +456,7 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
         ...(beat === undefined ? {} : { beat }),
         ...(onBeatMissing === undefined ? {} : { onBeatMissing }),
         ...(repeat === undefined ? {} : { repeat }),
+        ...(hold === undefined ? {} : { hold }),
       }),
       silent: false,
     };
@@ -464,9 +476,20 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
    * (codex review): a runner bug or no-op runner under `mode=loop`
    * MUST NOT silently degrade into normal composition playback.
    *
-   * Both modes share the same slice-shape transform — they differ
-   * only in whether the head's timeline repeats (a runner-side
-   * concern via `input.repeat`).
+   * PUL-F016 / ADR-019 (`paused`): the runtime mounts the addressed
+   * scene and holds it at its first frame without advancing the
+   * timeline. Truncating the slice makes "no following entries run"
+   * a structural guarantee even if the runner ignores the
+   * `hold: 'first-frame'` hint — a runner bug or no-op runner under
+   * `mode=paused` MUST NOT silently degrade into normal composition
+   * playback (parallel to the ADR-018 codex-review argument).
+   *
+   * All three modes share the same slice-shape transform — they
+   * differ only in the head's runner-side semantic: standalone
+   * plays normally, loop sets `input.repeat = 'until-aborted'`,
+   * paused sets `input.hold = 'first-frame'`. The shape transform
+   * is shared because the structural promise ("no following entries
+   * run") is identical.
    *
    * The composition slice — already validated by
    * `resolveSceneNavigation` so unregistered compositions /
@@ -477,7 +500,7 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
    * `range` / `behavior` overrides (object-form entries per ADR-002
    * / ADR-011) reach the runner unchanged: a flat `{ scene }` would
    * lose them and turn the mode into direct-scene flattening,
-   * contradicting ADR-017 / ADR-018's "preserve head-entry
+   * contradicting ADR-017 / ADR-018 / ADR-019's "preserve head-entry
    * overrides" contract.
    *
    * Stage attrs (set by the caller before this transform) reflect
@@ -493,7 +516,10 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
     target: NavigationTarget,
   ): SceneNavigationTarget => {
     const mode = effectiveMode(target);
-    if ((mode !== 'standalone' && mode !== 'loop') || resolved.composition === undefined) {
+    if (
+      (mode !== 'standalone' && mode !== 'loop' && mode !== 'paused') ||
+      resolved.composition === undefined
+    ) {
       return resolved;
     }
     const headEntry = resolved.composition.manifestSlice[0];

--- a/src/runtime/scene-navigation.ts
+++ b/src/runtime/scene-navigation.ts
@@ -149,6 +149,16 @@ export interface LoadSceneNavigationTargetOptions {
    * when the navigation target had no `mode=loop` parameter.
    */
   readonly repeat?: 'until-aborted';
+  /**
+   * URL paused-mode hold hint (PUL-F016 / ADR-019) the runner uses to
+   * decide whether to hold the addressed scene's timeline at its
+   * first frame. Forwarded to {@link resolveComposition} as
+   * `headHold` — the resolver scopes delivery to the head scene's
+   * run input only, so following composition entries never receive
+   * `hold`. Absent when the navigation target had no `mode=paused`
+   * parameter.
+   */
+  readonly hold?: 'first-frame';
 }
 
 const NAV_FAIL_PREFIX = 'scene navigation failed:';
@@ -284,28 +294,32 @@ function resolveCompositionAndIndex(
 }
 
 /**
- * PUL-F015 / ADR-018 bridge-level structural defense for loop-mode.
- * When a caller supplies `repeat` alongside a composition slice, the
- * head's timeline restarts on completion — by definition the head's
- * timeline never naturally completes, so following composition entries
- * cannot run. Truncating the slice at the bridge guarantees that
- * structural promise without depending on the runner's adapter
- * conformance to `input.repeat`. A direct bridge caller (test harness,
- * future export pipeline, etc.) gets the same guarantee the loader's
- * `applySingleSceneSlice` provides on the loader→bridge path; the two
- * truncations are idempotent (truncating a single-entry slice is a
- * no-op).
+ * Bridge-level structural defense for modes whose head-scene
+ * timeline does not naturally advance to completion:
+ *
+ * - PUL-F015 / ADR-018 (`mode=loop`, `repeat: 'until-aborted'`): the
+ *   head's timeline restarts on completion — by definition it never
+ *   naturally completes, so following composition entries cannot
+ *   run.
+ * - PUL-F016 / ADR-019 (`mode=paused`, `hold: 'first-frame'`): the
+ *   head's timeline holds at frame 0 and never advances, so
+ *   following composition entries cannot run.
+ *
+ * Truncating the slice at the bridge guarantees that structural
+ * promise without depending on the runner's adapter conformance to
+ * `input.repeat` / `input.hold`. A direct bridge caller (test
+ * harness, future export pipeline, etc.) gets the same guarantee
+ * the loader's `applySingleSceneSlice` provides on the loader→bridge
+ * path; the two truncations are idempotent (truncating a
+ * single-entry slice is a no-op).
  *
  * Pure function — no closure captures. Returns the input unchanged
- * when `repeat` is absent, when there is no composition slice, or
+ * when `headOnly` is `false`, when there is no composition slice, or
  * when the slice is already empty (the bridge would surface that as
  * a navigation error elsewhere).
  */
-function truncateForRepeat(
-  target: SceneNavigationTarget,
-  repeat: 'until-aborted' | undefined,
-): SceneNavigationTarget {
-  if (repeat === undefined || target.composition === undefined) {
+function truncateToHead(target: SceneNavigationTarget, headOnly: boolean): SceneNavigationTarget {
+  if (!headOnly || target.composition === undefined) {
     return target;
   }
   const headEntry = target.composition.manifestSlice[0];
@@ -411,20 +425,26 @@ export async function loadSceneNavigationTarget(
   target: SceneNavigationTarget,
   options: LoadSceneNavigationTargetOptions,
 ): Promise<void> {
-  // PUL-F015 / ADR-018: under `repeat: 'until-aborted'` the addressed
-  // scene's timeline restarts on completion — by definition the head's
-  // timeline never naturally completes, so following composition
-  // entries cannot run. Truncating the slice at the bridge layer makes
-  // "no following entries run" a structural guarantee that does not
-  // depend on the runner honoring `input.repeat` (codex pre-push
-  // review): a runner bug or no-op runner under `repeat` MUST NOT
-  // silently degrade into normal composition playback. The truncation
-  // is layered with the loader's `applySingleSceneSlice` (which already
-  // truncates for `mode=standalone` and `mode=loop`) so direct bridge
-  // callers — outside the loader path — still benefit from the
-  // structural guarantee. Truncating an already-single-entry slice is
-  // a no-op, so the layering is idempotent.
-  const effectiveTarget = truncateForRepeat(target, options.repeat);
+  // PUL-F015 / ADR-018 + PUL-F016 / ADR-019: under
+  // `repeat: 'until-aborted'` the head's timeline restarts on
+  // completion (loop), and under `hold: 'first-frame'` the head's
+  // timeline never advances (paused). Both modes share the same
+  // structural promise: following composition entries cannot run.
+  // Truncating the slice at the bridge layer makes "no following
+  // entries run" a structural guarantee that does not depend on the
+  // runner honoring `input.repeat` / `input.hold` (codex pre-push
+  // review): a runner bug or no-op runner under either mode MUST NOT
+  // silently degrade into normal composition playback. The
+  // truncation is layered with the loader's `applySingleSceneSlice`
+  // (which already truncates for `mode=standalone`, `mode=loop`, and
+  // `mode=paused`) so direct bridge callers — outside the loader
+  // path — still benefit from the structural guarantee. Truncating
+  // an already-single-entry slice is a no-op, so the layering is
+  // idempotent.
+  const effectiveTarget = truncateToHead(
+    target,
+    options.repeat !== undefined || options.hold !== undefined,
+  );
   const composition = effectiveTarget.composition;
   // Collapse the single-scene vs composition-slice paths into one
   // assignment so the two values cannot drift (e.g. picking
@@ -485,5 +505,13 @@ export async function loadSceneNavigationTarget(
     // caller supplied it so a runner that branches on `'repeat' in
     // input` sees an absent key rather than `undefined`.
     ...(options.repeat === undefined ? {} : { headRepeat: options.repeat }),
+    // `hold` is independent of `beat` and `repeat` per ADR-019: a URL
+    // like `?scene=x&mode=paused` (no beat, no loop) is valid, and so
+    // is `?scene=x&beat=hook&mode=paused` (the runner's policy
+    // decides which wins — ADR-019 records that `hold` wins over
+    // `beat` for paused mode). Spread `headHold` only when the
+    // caller supplied it so a runner that branches on `'hold' in
+    // input` sees an absent key rather than `undefined`.
+    ...(options.hold === undefined ? {} : { headHold: options.hold }),
   });
 }

--- a/tests/runtime/composition-resolver.test.ts
+++ b/tests/runtime/composition-resolver.test.ts
@@ -1434,3 +1434,107 @@ describe('URL loop-mode runner repeat-hint forwarding (PUL-F015)', () => {
     expect(runCalls[0]?.repeat).toBe('until-aborted');
   });
 });
+
+describe('URL paused-mode runner hold-hint forwarding (PUL-F016)', () => {
+  // PUL-F016: in `mode=paused`, the runtime SHALL mount the addressed
+  // scene and hold it at its first frame without advancing the
+  // timeline. ADR-019 places mode dispatch at the loader and the
+  // hold-at-first-frame semantics at the timeline-runner adapter. The
+  // resolver's job is forwarding the URL-derived `headHold` hint to
+  // the head scene's run input only; subsequent scenes in a
+  // composition slice do not receive `hold` because the head's
+  // timeline never advances under paused — following entries cannot
+  // run. The resolver does NOT interpret `headHold` itself; honoring
+  // hold-at-first-frame is the runner's contract.
+
+  it("forwards `headHold` to plan[0]'s run input only — subsequent scenes get no hold", async () => {
+    const runCalls: SceneTimelineRunInput[] = [];
+    const { options } = buildHarness({
+      scenes: [{ id: 'scene-a' }, { id: 'scene-b' }],
+      manifest: ['scene-a', 'scene-b'],
+      runTimeline: (input) => {
+        runCalls.push(input);
+      },
+    });
+    await resolveComposition({ ...options, headHold: 'first-frame' });
+    expect(runCalls).toHaveLength(2);
+    expect(runCalls[0]?.scene.id).toBe('scene-a');
+    expect(runCalls[0]?.hold).toBe('first-frame');
+    expect(runCalls[1]?.scene.id).toBe('scene-b');
+    expect(runCalls[1]?.hold).toBeUndefined();
+    // Parallel to `beat` / `repeat` / `range` / `behavior`: the key is
+    // OMITTED from the input object when absent, not set to
+    // `undefined`. The runner can branch on `'hold' in input` rather
+    // than checking for `undefined`.
+    expect('hold' in (runCalls[1] as object)).toBe(false);
+  });
+
+  it('does not attach `hold` when `headHold` is absent', async () => {
+    const runCalls: SceneTimelineRunInput[] = [];
+    const { options } = buildHarness({
+      scenes: [{ id: 'scene-a' }],
+      manifest: ['scene-a'],
+      runTimeline: (input) => {
+        runCalls.push(input);
+      },
+    });
+    await resolveComposition(options);
+    expect(runCalls).toHaveLength(1);
+    expect('hold' in (runCalls[0] as object)).toBe(false);
+  });
+
+  it('does not interpret `headHold` itself — a runner that ignores the hint and returns normally does not error', async () => {
+    // Resolver delegates hold-at-first-frame to the runner per
+    // ADR-019. A runner that receives `hold: 'first-frame'` and
+    // returns void normally (e.g. the placeholder runner that has no
+    // real timeline to pause) must NOT cause the resolver to throw or
+    // skip cleanup.
+    const cleanupCalls: string[] = [];
+    const { options } = buildHarness({
+      scenes: [
+        {
+          id: 'scene-a',
+          cleanup: () => {
+            cleanupCalls.push('scene-a');
+          },
+        },
+      ],
+      manifest: ['scene-a'],
+      runTimeline: () => undefined,
+    });
+    await expect(
+      resolveComposition({
+        ...options,
+        headHold: 'first-frame',
+      }),
+    ).resolves.toBeUndefined();
+    expect(cleanupCalls).toEqual(['scene-a']);
+  });
+
+  it('forwards `headHold` alongside `headBeat` and `headRepeat` independently — all three reach plan[0] without coupling', async () => {
+    // `headHold`, `headBeat`, and `headRepeat` are three independent
+    // head-only forwardings (PUL-F016, PUL-F011, PUL-F015). A
+    // regression that paired them — e.g. requiring `headBeat` or
+    // `headRepeat` whenever `headHold` is set — would break URLs like
+    // `?scene=x&beat=hook&mode=paused` and
+    // `?scene=x&mode=paused` (paused alone, no beat).
+    const runCalls: SceneTimelineRunInput[] = [];
+    const { options } = buildHarness({
+      scenes: [{ id: 'scene-a' }],
+      manifest: ['scene-a'],
+      runTimeline: (input) => {
+        runCalls.push(input);
+      },
+    });
+    await resolveComposition({
+      ...options,
+      headBeat: 'hook',
+      onBeatMissing: () => undefined,
+      headHold: 'first-frame',
+    });
+    expect(runCalls).toHaveLength(1);
+    expect(runCalls[0]?.beat).toBe('hook');
+    expect(runCalls[0]?.hold).toBe('first-frame');
+    expect(runCalls[0]?.repeat).toBeUndefined();
+  });
+});

--- a/tests/runtime/scene-loader.test.ts
+++ b/tests/runtime/scene-loader.test.ts
@@ -3112,4 +3112,730 @@ describe('createSceneLoader (PUL-F008)', () => {
       ]);
     });
   });
+
+  describe('paused-mode runner hold-hint forwarding (PUL-F016)', () => {
+    // PUL-F016 statement: in `mode=paused`, the runtime SHALL mount
+    // the addressed scene and hold it at its first frame without
+    // advancing the timeline.
+    //
+    // Materially-implementable parts of the statement that this
+    // block pins (ADR-019 records the contract boundary):
+    //   - The loader passes `hold: 'first-frame'` to the timeline
+    //     runner adapter when `effectiveMode(target) === 'paused'`.
+    //     The runner is responsible for honoring the hint (e.g.
+    //     ADR-003's future GSAP runner uses `timeline.pause()` at
+    //     time 0).
+    //   - The hint is HEAD-ONLY: under composition targets the head
+    //     scene's runner input carries `hold`; following entries do
+    //     not. Following entries do not run at all because the slice
+    //     is truncated to the addressed head — same structural
+    //     defense ADR-018 records for `mode=loop`.
+    //   - `ctx.mode === 'paused'` reaches every lifecycle hook of
+    //     the head scene — the seam future runner / chrome / audio
+    //     surfaces will read.
+    //   - Other modes (`present`, `standalone`, `loop`, `scrub`,
+    //     `screenshot`, `prompter`) and a `mode`-less URL DO NOT
+    //     set `hold`. A regression that broadcast `hold` under any
+    //     mode would break URLs that depend on no-hold semantics
+    //     (e.g. normal playback under `present`).
+    //   - No `data-pulsar-mode-*` suppression attribute is preempt-
+    //     ively written under `paused` (parity with ADR-016/017/018).
+    //   - Composition validation (unregistered composition, unknown
+    //     member scene, out-of-range index) STILL surfaces as a
+    //     navigation error under `mode=paused` — no silent fallback
+    //     to direct scene lookup.
+    //   - Beat semantics under `mode=paused` are unchanged from
+    //     PUL-F011 at the loader: the head scene's runner sees
+    //     `input.beat`; missing-label diagnostics surface via
+    //     `data-pulsar-navigation-error` / `onError` without
+    //     unmounting. ADR-019 records the runner-side policy that
+    //     `hold='first-frame'` wins over `beat` when both are
+    //     present, but that is a runner-side semantic, not a
+    //     loader-side filter — the loader forwards both.
+    //   - Object-form head entry's `range` / `behavior` overrides
+    //     reach the runner unchanged. Paused is single-scene-mount
+    //     with held timeline at the head, NOT direct-scene
+    //     flattening.
+    //
+    // PUL-F016 stays DRAFT after this PR (ADR-019 records the
+    // boundary; following the ADR-016 / ADR-017 / ADR-018 / PUL-F013
+    // / PUL-F014 / PUL-F015 precedent). The seam — the loader passes
+    // `hold: 'first-frame'` and `ctx.mode === 'paused'` — IS
+    // materially shipped. The actual hold-at-first-frame behavior is
+    // the runner's contract: ADR-003's GSAP runner reads
+    // `input.hold` when it lands. Until then, the placeholder runner
+    // has no real timeline (returns `null`) and parks until abort —
+    // vacuously satisfying "hold it at its first frame without
+    // advancing" because no frame ever advances. ACTIVE transitions
+    // when the GSAP runner actively reads `input.hold ===
+    // 'first-frame'` and pauses the timeline at time 0, with an
+    // end-to-end test alongside these seam tests.
+
+    const pausedSceneTarget = (id: string): NavigationTarget => ({
+      locator: { kind: 'scene', scene: id },
+      mode: 'paused',
+    });
+    const pausedCompositionTarget = (composition: string): NavigationTarget => ({
+      locator: { kind: 'composition', composition },
+      mode: 'paused',
+    });
+    const pausedCompositionSceneTarget = (
+      composition: string,
+      scene: string,
+    ): NavigationTarget => ({
+      locator: { kind: 'composition-scene', composition, scene },
+      mode: 'paused',
+    });
+    const pausedCompositionIndexTarget = (
+      composition: string,
+      index: number,
+    ): NavigationTarget => ({
+      locator: { kind: 'composition-index', composition, index },
+      mode: 'paused',
+    });
+
+    it('passes `hold: "first-frame"` to the runner for a `scene` target under `mode=paused`', async () => {
+      // Direct-scene navigation is the simplest paused path: the
+      // addressed scene IS the head, no slice resolution. A
+      // regression that gated `hold` on `target.composition` being
+      // defined would silently drop the hint here.
+      const captured: { sceneId: string; hold: 'first-frame' | undefined }[] = [];
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      const runner: SceneTimelineRunner = (input) => {
+        captured.push({ sceneId: input.scene.id, hold: input.hold });
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: runner,
+      });
+
+      await loader.handle(pausedSceneTarget('scene-a'));
+
+      expect(captured).toEqual([{ sceneId: 'scene-a', hold: 'first-frame' }]);
+    });
+
+    it('runs only the head scene of a `composition` target under `mode=paused` (slice truncation; runner sees `hold: "first-frame"` for the head)', async () => {
+      // PUL-F016 / ADR-019: paused truncates the validated
+      // composition slice to the addressed head, parallel to
+      // standalone (ADR-017) and loop (ADR-018). Truncation makes
+      // "no following entries run" a structural guarantee — a
+      // runner bug or no-op runner under `mode=paused` MUST NOT
+      // silently degrade into normal composition playback. Use a
+      // non-final-index navigation so the slice has successors that
+      // would be observable if truncation were missing.
+      const captured: { sceneId: string; hold: 'first-frame' | undefined }[] = [];
+      const sceneA = buildScene({ id: 'scene-a' });
+      const sceneB = buildScene({ id: 'scene-b' });
+      const sceneC = buildScene({ id: 'scene-c' });
+      const stage = buildStage();
+      const runner: SceneTimelineRunner = (input) => {
+        captured.push({ sceneId: input.scene.id, hold: input.hold });
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA, sceneB, sceneC]),
+        compositions: createCompositionRegistry([
+          { id: 'full-talk', manifest: ['scene-a', 'scene-b', 'scene-c'] },
+        ]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: runner,
+      });
+
+      await loader.handle(pausedCompositionIndexTarget('full-talk', 0));
+
+      expect(captured).toEqual([{ sceneId: 'scene-a', hold: 'first-frame' }]);
+    });
+
+    it('runs only the addressed scene of a `composition+scene` target under `mode=paused`', async () => {
+      // composition+scene targeting a non-final entry exercises the
+      // slice transform from a different locator shape; pins parity
+      // with the composition-target case above.
+      const captured: { sceneId: string; hold: 'first-frame' | undefined }[] = [];
+      const sceneA = buildScene({ id: 'scene-a' });
+      const sceneB = buildScene({ id: 'scene-b' });
+      const sceneC = buildScene({ id: 'scene-c' });
+      const stage = buildStage();
+      const runner: SceneTimelineRunner = (input) => {
+        captured.push({ sceneId: input.scene.id, hold: input.hold });
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA, sceneB, sceneC]),
+        compositions: createCompositionRegistry([
+          { id: 'full-talk', manifest: ['scene-a', 'scene-b', 'scene-c'] },
+        ]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: runner,
+      });
+
+      await loader.handle(pausedCompositionSceneTarget('full-talk', 'scene-b'));
+
+      expect(captured).toEqual([{ sceneId: 'scene-b', hold: 'first-frame' }]);
+    });
+
+    it('runs cleanup exactly once for the head scene under `mode=paused`, never for dropped slice entries', async () => {
+      // Same invariant as PUL-F014 (ADR-017) under standalone and
+      // PUL-F015 (ADR-018) under loop: a regression that dropped
+      // the slice for execution but left following scenes wired
+      // through the synthesized registry could double-clean or
+      // skip-clean. Pin exactly-once cleanup on the head and zero
+      // cleanup for the dropped entries.
+      const cleaned: string[] = [];
+      const trace = (id: string): SceneModule =>
+        buildScene({
+          id,
+          cleanup: () => {
+            cleaned.push(id);
+          },
+        });
+      const scenes = [trace('scene-a'), trace('scene-b'), trace('scene-c')];
+      const stage = buildStage();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry(scenes),
+        compositions: createCompositionRegistry([
+          { id: 'full-talk', manifest: scenes.map((s) => s.id) },
+        ]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+      });
+
+      await loader.handle(pausedCompositionTarget('full-talk'));
+
+      expect(cleaned).toEqual(['scene-a']);
+    });
+
+    it('a hold-until-abort runner under `mode=paused` keeps the head scene mounted until a new navigation supersedes it; cleanup fires only on abort, not on `hold` arrival (pins the runner-side pending-until-abort contract through the loader+resolver+navigation flow)', async () => {
+      // ADR-019 makes pending-until-abort a structural part of the
+      // hold contract: `resolveComposition()` awaits `runTimeline()`
+      // and then runs `cleanup(ctx)`. A runner that observes
+      // `input.hold === 'first-frame'`, calls `seek(0)` + `pause()`,
+      // and resolves synchronously would let the resolver advance
+      // to cleanup one turn after mount — the scene would unmount
+      // immediately, contradicting "hold." This test models the
+      // correct runner contract (pend until `input.signal.aborted`)
+      // and pins the loader+resolver+navigation flow so a
+      // regression that, for instance, made the resolver bypass
+      // `runTimeline` under `hold`, or that dropped signal
+      // forwarding to the runner under paused, would fail here.
+      //
+      // The placeholder runner in `src/main.ts` already follows
+      // this shape (parks until abort with no real timeline);
+      // ADR-003's GSAP runner must continue to follow it under
+      // `hold`. The runner-side scene-author guarantee — "the
+      // timeline does not advance" — is what the GSAP runner PR
+      // additionally pins; this test pins the structural
+      // mount-then-hold-then-abort-then-cleanup ordering, which is
+      // a necessary precondition for the scene-author guarantee.
+      const events: string[] = [];
+      // Per-scene "runner entered" gates so the test can deterministic-
+      // ally wait for the head scene's runner to reach the held state
+      // without relying on a fragile microtask count. The lifecycle is
+      // many-awaits-deep (queue → abortAndAwait → runOnce → runTarget
+      // → loadSceneNavigationTarget → resolveComposition → runScene →
+      // await create → await timeline → await runTimeline), so a fixed
+      // `await Promise.resolve()` count is brittle.
+      const enteredGates = new Map<string, Promise<void>>();
+      const enteredResolvers = new Map<string, () => void>();
+      const enteredGate = (id: string): Promise<void> => {
+        const existing = enteredGates.get(id);
+        if (existing !== undefined) return existing;
+        let resolver: () => void = () => undefined;
+        const promise = new Promise<void>((resolve) => {
+          resolver = resolve;
+        });
+        enteredGates.set(id, promise);
+        enteredResolvers.set(id, resolver);
+        return promise;
+      };
+      // Pre-create the head's gate so the test code below can `await
+      // enteredGate('scene-a')` even before the runner has run.
+      enteredGate('scene-a');
+      enteredGate('scene-b');
+      const sceneA = buildScene({
+        id: 'scene-a',
+        create: () => {
+          events.push('create:scene-a');
+        },
+        timeline: () => {
+          events.push('timeline:scene-a');
+          return null;
+        },
+        cleanup: () => {
+          events.push('cleanup:scene-a');
+        },
+      });
+      const sceneB = buildScene({
+        id: 'scene-b',
+        create: () => {
+          events.push('create:scene-b');
+        },
+        timeline: () => {
+          events.push('timeline:scene-b');
+          return null;
+        },
+        cleanup: () => {
+          events.push('cleanup:scene-b');
+        },
+      });
+      const stage = buildStage();
+      const runnerObservations: { sceneId: string; hold: unknown; hasSignal: boolean }[] = [];
+      const heldRunner: SceneTimelineRunner = (input) =>
+        new Promise<void>((resolve) => {
+          runnerObservations.push({
+            sceneId: input.scene.id,
+            hold: input.hold,
+            hasSignal: input.signal !== undefined,
+          });
+          events.push(`runTimeline-enter:${input.scene.id}`);
+          enteredResolvers.get(input.scene.id)?.();
+          // Pend until the per-navigation signal aborts. This is the
+          // shape the placeholder runner uses today and the shape
+          // ADR-019 requires of the future GSAP runner under `hold`.
+          // Without `input.signal`, the test misuses the contract.
+          if (input.signal === undefined) {
+            // Defensive: assert the seam exists. A regression that
+            // dropped signal forwarding under paused would surface
+            // here rather than via the test-runner timeout.
+            throw new Error('expected `input.signal` to be forwarded under `mode=paused`');
+          }
+          input.signal.addEventListener(
+            'abort',
+            () => {
+              events.push(`runTimeline-aborted:${input.scene.id}`);
+              resolve();
+            },
+            { once: true },
+          );
+        });
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA, sceneB]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: heldRunner,
+      });
+
+      // Launch the paused navigation but do NOT await — the runner
+      // is designed to pend, so awaiting here would hang. Instead,
+      // drive a second navigation that aborts the first.
+      const firstSettled = loader.handle(pausedSceneTarget('scene-a'));
+
+      // Wait deterministically for the runner to enter. The gate
+      // resolves the moment the runner observes its scene.
+      await enteredGate('scene-a');
+
+      // The held state: scene-a mounted, runner entered and
+      // pending, NO cleanup yet. A regression that let cleanup run
+      // immediately under `hold` would show `cleanup:scene-a` here.
+      expect(events).toEqual(['create:scene-a', 'timeline:scene-a', 'runTimeline-enter:scene-a']);
+      expect(runnerObservations).toEqual([
+        { sceneId: 'scene-a', hold: 'first-frame', hasSignal: true },
+      ]);
+
+      // Now navigate elsewhere. The loader aborts the in-flight
+      // load, the runner's signal listener fires, and cleanup runs
+      // for scene-a before scene-b's lifecycle starts. The second
+      // navigation is to a non-paused target so its runner sees
+      // `'hold' in input === false`; we still use the heldRunner so
+      // we can verify the lifecycle ordering before disposing.
+      const secondSettled = loader.handle(sceneTarget('scene-b'));
+      await enteredGate('scene-b');
+
+      // Expected ordering up to scene-b entering its runner:
+      // paused mount → held runner → abort → cleanup of scene-a →
+      // mount of scene-b → held runner for scene-b.
+      expect(events).toEqual([
+        'create:scene-a',
+        'timeline:scene-a',
+        'runTimeline-enter:scene-a',
+        'runTimeline-aborted:scene-a',
+        'cleanup:scene-a',
+        'create:scene-b',
+        'timeline:scene-b',
+        'runTimeline-enter:scene-b',
+      ]);
+
+      // Dispose to release scene-b's runner gate so the test does
+      // not leak a pending promise. Cleanup for scene-b fires after
+      // dispose-triggered abort.
+      loader.dispose();
+      await firstSettled;
+      await secondSettled;
+      await loader.idle();
+
+      expect(events).toEqual([
+        'create:scene-a',
+        'timeline:scene-a',
+        'runTimeline-enter:scene-a',
+        'runTimeline-aborted:scene-a',
+        'cleanup:scene-a',
+        'create:scene-b',
+        'timeline:scene-b',
+        'runTimeline-enter:scene-b',
+        'runTimeline-aborted:scene-b',
+        'cleanup:scene-b',
+      ]);
+    });
+
+    it('omits the `hold` key on the runner input when `mode=paused` is absent (key-presence semantics)', async () => {
+      // The runner input uses key-presence semantics for optional
+      // fields (parallel to `beat` / `repeat` / `range` /
+      // `behavior`): a runner can branch on `'hold' in input`
+      // rather than `=== undefined`. A regression that always set
+      // `input.hold = undefined` (or any non-`'first-frame'` value)
+      // under non-paused modes would break that contract.
+      const captured: { hasHold: boolean; hold: unknown }[] = [];
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      const runner: SceneTimelineRunner = (input) => {
+        captured.push({ hasHold: 'hold' in input, hold: input.hold });
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: runner,
+      });
+
+      // No mode at all (defaults to `present`).
+      await loader.handle(sceneTarget('scene-a'));
+
+      expect(captured).toEqual([{ hasHold: false, hold: undefined }]);
+    });
+
+    it('does not set `hold` for any non-paused mode', async () => {
+      // Walk the seven-mode allowlist (minus `paused`) and confirm
+      // that none of them produce `hold` on the runner input.
+      // Catching every non-paused mode discriminates against an
+      // over-broad fix that gated `hold` on `mode !== undefined`
+      // rather than `mode === 'paused'`. Capturing the per-iteration
+      // mode alongside the `'hold' in input` flag means the
+      // assertion failure identifies WHICH mode regressed, not just
+      // "some mode did."
+      const nonPausedModes = NAVIGATION_MODES.filter((m) => m !== 'paused');
+      const captured: { mode: NavigationMode; hasHold: boolean }[] = [];
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      for (const mode of nonPausedModes) {
+        const runner: SceneTimelineRunner = (input) => {
+          captured.push({ mode, hasHold: 'hold' in input });
+        };
+        const loader = createSceneLoader({
+          scenes: createSceneRegistry([sceneA]),
+          compositions: createCompositionRegistry([]),
+          stage: stage.element,
+          buildCtx: stubCtx,
+          createPreloader: () => () => undefined,
+          runTimeline: runner,
+        });
+        await loader.handle({ locator: { kind: 'scene', scene: 'scene-a' }, mode });
+      }
+
+      // One entry per non-paused mode, each must have `hasHold:
+      // false`. Building the expected array from `nonPausedModes`
+      // keeps the assertion in sync if the mode allowlist ever
+      // changes.
+      expect(captured).toEqual(nonPausedModes.map((mode) => ({ mode, hasHold: false })));
+    });
+
+    it('exposes `ctx.mode === "paused"` to every lifecycle hook of the head scene under all locator shapes', async () => {
+      // Parallel to the PUL-F014 standalone and PUL-F015 loop seam
+      // tests. Future runner / chrome / audio surfaces read
+      // `ctx.mode` to decide their own behavior; this test pins the
+      // seam end to end across all four locator shapes that can
+      // appear under `mode=paused`.
+      const seen: { phase: string; locatorKind: string; mode: unknown }[] = [];
+      const recordMode =
+        (phase: string, locatorKind: string) =>
+        (ctx: unknown): unknown => {
+          seen.push({ phase, locatorKind, mode: (ctx as { mode?: NavigationMode }).mode });
+          return null;
+        };
+      const makeScene = (locatorKind: string): SceneModule =>
+        buildScene({
+          id: 'scene-a',
+          create: recordMode('create', locatorKind),
+          timeline: recordMode('timeline', locatorKind) as SceneModule['timeline'],
+          cleanup: recordMode('cleanup', locatorKind),
+        });
+      const stage = buildStage();
+      const buildLoader = (sceneId: string, locatorKind: string) =>
+        createSceneLoader({
+          scenes: createSceneRegistry([makeScene(locatorKind)]),
+          compositions: createCompositionRegistry([{ id: 'full-talk', manifest: [sceneId] }]),
+          stage: stage.element,
+          buildCtx: (mode) => ({ stage: stage.element, mode }),
+          createPreloader: () => () => undefined,
+          runTimeline: noopRunner,
+        });
+
+      await buildLoader('scene-a', 'scene').handle(pausedSceneTarget('scene-a'));
+      await buildLoader('scene-a', 'composition').handle(pausedCompositionTarget('full-talk'));
+      await buildLoader('scene-a', 'composition-scene').handle(
+        pausedCompositionSceneTarget('full-talk', 'scene-a'),
+      );
+      await buildLoader('scene-a', 'composition-index').handle(
+        pausedCompositionIndexTarget('full-talk', 0),
+      );
+
+      // 3 hooks per navigation × 4 locator shapes = 12 entries;
+      // every single one must carry `paused`.
+      expect(seen).toHaveLength(12);
+      for (const entry of seen) {
+        expect(entry.mode).toBe('paused');
+      }
+    });
+
+    it('forwards `beat` to the head scene runner alongside `hold` under `mode=paused`, and surfaces missing-beat as a non-fatal diagnostic', async () => {
+      // PUL-F011 / PUL-F016 are independent at the loader: a URL
+      // like `?scene=x&beat=hook&mode=paused` must deliver both
+      // `beat` and `hold` to the runner. ADR-019 records the
+      // runner-side policy that `hold` wins over `beat` (paused is
+      // first-frame; `mode=scrub` is the inspection mode for
+      // beat-targeting), but that policy is the runner's contract,
+      // not a loader-side filter. A regression that paired the
+      // fields at the loader — e.g. dropping `hold` when `beat` is
+      // supplied — would silently break paused-mode navigation
+      // when a beat is also requested.
+      const captured: {
+        sceneId: string;
+        beat: string | undefined;
+        hold: 'first-frame' | undefined;
+      }[] = [];
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      const errors: unknown[] = [];
+      const runner: SceneTimelineRunner = (input) => {
+        captured.push({
+          sceneId: input.scene.id,
+          beat: input.beat,
+          hold: input.hold,
+        });
+        if (input.beat !== undefined && input.onBeatMissing !== undefined) {
+          input.onBeatMissing();
+        }
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: runner,
+        onError: (err) => {
+          errors.push(err);
+        },
+      });
+
+      await loader.handle({
+        locator: { kind: 'scene', scene: 'scene-a' },
+        mode: 'paused',
+        beat: 'midpoint',
+      });
+
+      expect(captured).toEqual([{ sceneId: 'scene-a', beat: 'midpoint', hold: 'first-frame' }]);
+      expect(errors).toHaveLength(1);
+      expect((errors[0] as Error).message).toContain('beat positioning failed');
+      expect((errors[0] as Error).message).toContain('"midpoint"');
+      expect(stage.attrs.get('data-pulsar-navigation-error')).toBeDefined();
+    });
+
+    it('writes no `data-pulsar-mode-*` suppression attribute on the stage under `mode=paused`', async () => {
+      // Mirrors ADR-016 / ADR-017 / ADR-018 invariant. PUL-F016
+      // forbids the loader from preemptively writing a stage
+      // attribute for paused mode; runner-side or future-surface-
+      // side signaling lives at those surfaces, not at the loader.
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+      });
+
+      await loader.handle(pausedSceneTarget('scene-a'));
+
+      const modeAttrs = Array.from(stage.attrs.keys()).filter((name) =>
+        name.startsWith('data-pulsar-mode-'),
+      );
+      expect(modeAttrs).toEqual([]);
+    });
+
+    it('writes both `data-pulsar-scene-target` and `data-pulsar-composition-target` for a composition target under `mode=paused` (preserves observability of what the URL addressed)', async () => {
+      // The stage attrs communicate "what was addressed," not "what
+      // ran." Truncation drops following entries from execution but
+      // does not drop the composition id from the stage attrs —
+      // mirrors the standalone / loop invariant.
+      const sceneA = buildScene({ id: 'scene-a' });
+      const sceneB = buildScene({ id: 'scene-b' });
+      const stage = buildStage();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA, sceneB]),
+        compositions: createCompositionRegistry([
+          { id: 'full-talk', manifest: ['scene-a', 'scene-b'] },
+        ]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+      });
+
+      await loader.handle(pausedCompositionSceneTarget('full-talk', 'scene-b'));
+
+      expect(stage.attrs.get('data-pulsar-scene-target')).toBe('scene-b');
+      expect(stage.attrs.get('data-pulsar-composition-target')).toBe('full-talk');
+    });
+
+    it('surfaces composition-not-registered as a navigation error under `mode=paused` (no silent fallback)', async () => {
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      const errors: unknown[] = [];
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+        onError: (err) => {
+          errors.push(err);
+        },
+      });
+
+      await loader.handle(pausedCompositionTarget('not-registered'));
+
+      expect(errors).toHaveLength(1);
+      expect((errors[0] as Error).message).toContain(
+        'composition "not-registered" is not registered',
+      );
+      expect(stage.attrs.get('data-pulsar-navigation-error')).toBeDefined();
+    });
+
+    it('surfaces composition-member error under `mode=paused` for an unknown scene in `composition+scene`', async () => {
+      const sceneA = buildScene({ id: 'scene-a' });
+      const sceneZ = buildScene({ id: 'scene-z' });
+      const stage = buildStage();
+      const errors: unknown[] = [];
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA, sceneZ]),
+        compositions: createCompositionRegistry([{ id: 'full-talk', manifest: ['scene-a'] }]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+        onError: (err) => {
+          errors.push(err);
+        },
+      });
+
+      await loader.handle(pausedCompositionSceneTarget('full-talk', 'scene-z'));
+
+      expect(errors).toHaveLength(1);
+      expect((errors[0] as Error).message).toContain(
+        'scene "scene-z" is not a member of composition "full-talk"',
+      );
+    });
+
+    it('surfaces index-out-of-range under `mode=paused`', async () => {
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      const errors: unknown[] = [];
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([{ id: 'full-talk', manifest: ['scene-a'] }]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+        onError: (err) => {
+          errors.push(err);
+        },
+      });
+
+      await loader.handle(pausedCompositionIndexTarget('full-talk', 5));
+
+      expect(errors).toHaveLength(1);
+      expect((errors[0] as Error).message).toContain('index 5 is out of range');
+    });
+
+    it("preserves the addressed head entry's `range` and `behavior` overrides on the runner input under `mode=paused` (composition+index with object-form entry)", async () => {
+      // PUL-F016 / ADR-019: paused truncates the validated
+      // composition slice to the addressed head and forwards `hold`
+      // to that head's runner input. The slice is TRUNCATED rather
+      // than flattened — a flat `{ scene }` would lose object-form
+      // `range` / `behavior` overrides on the head entry, turning
+      // paused into direct-scene flattening (parity with ADR-017's
+      // standalone and ADR-018's loop invariant). This pins all
+      // three slots — `range`, `behavior`, and `hold` — through to
+      // the head runner, plus the truncation itself (the runner
+      // runs exactly once).
+      const sceneA = buildScene({ id: 'scene-a' });
+      const sceneB = buildScene({ id: 'scene-b' });
+      const sceneC = buildScene({ id: 'scene-c' });
+      const stage = buildStage();
+      const captured: {
+        sceneId: string;
+        range: unknown;
+        behavior: unknown;
+        hold: unknown;
+      }[] = [];
+      const runner: SceneTimelineRunner = (input) => {
+        captured.push({
+          sceneId: input.scene.id,
+          range: input.range,
+          behavior: input.behavior,
+          hold: input.hold,
+        });
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA, sceneB, sceneC]),
+        compositions: createCompositionRegistry([
+          {
+            id: 'full-talk',
+            manifest: [
+              'scene-a',
+              { id: 'scene-b', range: 'hook', behavior: { hold: true } },
+              'scene-c',
+            ],
+          },
+        ]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: runner,
+      });
+
+      await loader.handle(pausedCompositionIndexTarget('full-talk', 1));
+
+      // Single runner invocation (truncation), with overrides AND
+      // `hold` reaching the head's runner input together. A
+      // regression that flattened to direct-scene would show
+      // `range: undefined, behavior: undefined`; a regression that
+      // dropped truncation would show a second invocation for
+      // scene-c.
+      expect(captured).toEqual([
+        {
+          sceneId: 'scene-b',
+          range: 'hook',
+          behavior: { hold: true },
+          hold: 'first-frame',
+        },
+      ]);
+    });
+  });
 });

--- a/tests/runtime/scene-navigation.test.ts
+++ b/tests/runtime/scene-navigation.test.ts
@@ -1042,4 +1042,170 @@ describe('loadSceneNavigationTarget (PUL-F008 lifecycle bridge)', () => {
       expect(seen).toEqual([{ beat: 'hook', repeat: 'until-aborted' }]);
     });
   });
+
+  describe('URL paused-mode hold forwarding (PUL-F016)', () => {
+    // ADR-019: under `mode=paused` the runner mounts the addressed
+    // scene and holds it at its first frame without advancing the
+    // timeline. The bridge's only job is to forward the `hold` option
+    // from the loader to the resolver as `headHold`. The resolver
+    // scopes delivery to the head scene's run input only —
+    // hold-at-first-frame is the runner's contract.
+
+    it('forwards `hold` to the runner for a single-scene target', async () => {
+      const seen: { hold?: 'first-frame' }[] = [];
+      const intro = buildScene({ id: 'intro' });
+      const scenes = createSceneRegistry([intro]);
+      const compositions = createCompositionRegistry([]);
+      const target = resolveSceneNavigation(sceneTarget('intro'), {
+        scenes,
+        compositions,
+      }) as SceneNavigationTarget;
+
+      await loadSceneNavigationTarget(target, {
+        ctx: {},
+        preloadAssets: () => undefined,
+        runTimeline: (input) => {
+          const captured: { hold?: 'first-frame' } = {};
+          if ('hold' in input) captured.hold = input.hold;
+          seen.push(captured);
+        },
+        hold: 'first-frame',
+      });
+
+      expect(seen).toEqual([{ hold: 'first-frame' }]);
+    });
+
+    it('truncates a composition slice to the addressed head when `hold` is supplied — structural defense against runner non-conformance', async () => {
+      // PUL-F016 / ADR-019: under `hold: 'first-frame'` the head's
+      // timeline does not advance — by definition following
+      // composition entries cannot run. The bridge truncates the
+      // slice to a single entry as a structural defense so a runner
+      // that ignores `input.hold` (or returns synchronously by
+      // mistake) cannot silently degrade paused-mode navigation into
+      // normal composition playback. This is layered with the
+      // loader's `applySingleSceneSlice` so direct bridge callers —
+      // outside the loader path — get the same guarantee. Mirrors
+      // the layered defense ADR-018 records for `repeat`.
+      const seen: { id: string; hold: 'first-frame' | undefined }[] = [];
+      const intro = buildScene({ id: 'intro' });
+      const middle = buildScene({ id: 'middle' });
+      const scenes = createSceneRegistry([intro, middle]);
+      const compositions = createCompositionRegistry([
+        { id: 'full-talk', manifest: ['intro', 'middle'] },
+      ]);
+      const target = resolveSceneNavigation(compositionIndexTarget('full-talk', 0), {
+        scenes,
+        compositions,
+      }) as SceneNavigationTarget;
+
+      await loadSceneNavigationTarget(target, {
+        ctx: {},
+        preloadAssets: () => undefined,
+        runTimeline: (input) => {
+          seen.push({ id: input.scene.id, hold: input.hold });
+        },
+        hold: 'first-frame',
+      });
+
+      // Only the head ran; the tail (`middle`) was structurally
+      // dropped. A regression that omitted bridge-level truncation
+      // under `hold` would observe `middle` as a second runner entry
+      // here.
+      expect(seen).toEqual([{ id: 'intro', hold: 'first-frame' }]);
+    });
+
+    it('does not truncate a composition slice when `hold` is absent — non-paused navigations run the full slice', async () => {
+      // The structural defense fires only under `hold` (or `repeat`).
+      // Composition navigation under any non-paused, non-loop mode
+      // must still run every entry — a regression that always
+      // truncated would silently break normal composition playback.
+      const seen: string[] = [];
+      const intro = buildScene({ id: 'intro' });
+      const middle = buildScene({ id: 'middle' });
+      const scenes = createSceneRegistry([intro, middle]);
+      const compositions = createCompositionRegistry([
+        { id: 'full-talk', manifest: ['intro', 'middle'] },
+      ]);
+      const target = resolveSceneNavigation(compositionIndexTarget('full-talk', 0), {
+        scenes,
+        compositions,
+      }) as SceneNavigationTarget;
+
+      await loadSceneNavigationTarget(target, {
+        ctx: {},
+        preloadAssets: () => undefined,
+        runTimeline: (input) => {
+          seen.push(input.scene.id);
+        },
+      });
+
+      expect(seen).toEqual(['intro', 'middle']);
+    });
+
+    it('does not forward `hold` when the option is omitted', async () => {
+      const holdPresence: boolean[] = [];
+      const intro = buildScene({ id: 'intro' });
+      const scenes = createSceneRegistry([intro]);
+      const compositions = createCompositionRegistry([]);
+      const target = resolveSceneNavigation(sceneTarget('intro'), {
+        scenes,
+        compositions,
+      }) as SceneNavigationTarget;
+
+      await loadSceneNavigationTarget(target, {
+        ctx: {},
+        preloadAssets: () => undefined,
+        runTimeline: (input) => {
+          holdPresence.push('hold' in input);
+        },
+      });
+
+      expect(holdPresence).toEqual([false]);
+    });
+
+    it('forwards `hold`, `beat`, and `repeat` independently — all three reach the head without coupling', async () => {
+      // The bridge plumbs three independent head-only forwardings. A
+      // regression that paired them — e.g. dropping `hold` when
+      // `repeat` is also supplied, or vice versa — would break valid
+      // URL combinations. Note that `mode=paused` and `mode=loop` are
+      // mutually exclusive at the URL boundary (mode is a single
+      // field), but a programmatic caller can supply both options to
+      // the bridge and both must reach the runner so the runner
+      // policy decides.
+      const seen: {
+        beat?: string;
+        hold?: 'first-frame';
+        repeat?: 'until-aborted';
+      }[] = [];
+      const intro = buildScene({ id: 'intro' });
+      const scenes = createSceneRegistry([intro]);
+      const compositions = createCompositionRegistry([]);
+      const target = resolveSceneNavigation(sceneTarget('intro'), {
+        scenes,
+        compositions,
+      }) as SceneNavigationTarget;
+
+      await loadSceneNavigationTarget(target, {
+        ctx: {},
+        preloadAssets: () => undefined,
+        runTimeline: (input) => {
+          const captured: {
+            beat?: string;
+            hold?: 'first-frame';
+            repeat?: 'until-aborted';
+          } = {};
+          if ('beat' in input) captured.beat = input.beat;
+          if ('hold' in input) captured.hold = input.hold;
+          if ('repeat' in input) captured.repeat = input.repeat;
+          seen.push(captured);
+        },
+        beat: 'hook',
+        onBeatMissing: () => undefined,
+        hold: 'first-frame',
+        repeat: 'until-aborted',
+      });
+
+      expect(seen).toEqual([{ beat: 'hook', hold: 'first-frame', repeat: 'until-aborted' }]);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Lands the loader → runner-input contract for `mode=paused`: the loader passes `hold: 'first-frame'` through the bridge / resolver to the head scene's timeline-runner input when `effectiveMode(target) === 'paused'`. The runner is responsible for honoring the hint (ADR-003's future GSAP runner uses `timeline.seek(0)` + `timeline.pause()`) AND for keeping its returned promise pending until abort — the placeholder runner already follows this shape.
- Extends `applySingleSceneSlice` (loader) and `truncateToHead` (bridge, renamed from `truncateForRepeat`) to also fire under `paused`. Slice truncation makes "no following composition entries run" a structural guarantee that does not depend on runner conformance to `input.hold` — a runner bug or no-op runner under `mode=paused` cannot silently degrade into normal composition playback.
- Ships ADR-019 recording the decision; the design preflight doc; updated CHANGELOG; and the `ctx.mode === 'paused'` seam tests across composition-resolver, scene-navigation, and scene-loader test files. PUL-F016 stays DRAFT and the issue ↔ requirement link is `DOCUMENTS`, mirroring the ADR-016 / ADR-017 / ADR-018 precedent — ACTIVE transitions when ADR-003's GSAP runner lands and actively reads `input.hold === 'first-frame'`, with end-to-end tests alongside these seam tests.

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 633/633 green (28 new tests across the three test files)
- [x] `pre-commit run --all-files` — clean
- [x] Pre-push codex review — 3 cycles (cap override authorized for cycle 3 by user); all real findings addressed; remaining "not implemented end-to-end" finding is the documented contract-layer scope per ADR-019 / ADR-016 / ADR-017 / ADR-018 precedent
- [ ] CI green
- [ ] SonarCloud quality gate green
- [ ] Test-quality review clean

Closes #25