### PR TITLE
Implement PUL-F017 mode=scrub contract layer (ADR-020)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,59 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `docs/adrs/020-workbench-mode-scrub.md` and
+  `docs/design/pul-f017-scrub-mode-preflight.md` — record the
+  PUL-F017 contract layer for `mode=scrub`. Single-scene execution
+  at the addressed head (parallel to `standalone`, `loop`, and
+  `paused`); a runner-side cue-gate hint
+  (`cueGate: 'monotonic-forward'`) for runners with an audio-cue
+  subsystem to gate cue firing to monotonic forward playback only.
+  See ADR-020 for the URL contract, the runner conformance bar,
+  the single-scene scope rationale, and the DRAFT → ACTIVE
+  transition criteria. Indexed in `docs/adrs/README.md`.
+- `src/runtime/composition-resolver.ts` —
+  `SceneTimelineRunInput` gains optional
+  `cueGate?: 'monotonic-forward'` and `ResolveCompositionOptions`
+  gains optional `headCueGate?: 'monotonic-forward'`. The resolver
+  forwards `headCueGate` to plan[0]'s run input only (head-only,
+  parallel to `headBeat`, `headRepeat`, and `headHold`); subsequent
+  scenes never receive `cueGate`. Literal-typed union for future
+  variant extension.
+- `src/runtime/scene-navigation.ts` —
+  `LoadSceneNavigationTargetOptions` gains optional
+  `cueGate?: 'monotonic-forward'`;
+  `loadSceneNavigationTarget()` forwards it to
+  `resolveComposition` as `headCueGate`. The bridge truncates a
+  composition slice to its addressed head when `cueGate` is
+  supplied (the `truncateToHead` predicate widens to fire when ANY
+  of `repeat` / `hold` / `cueGate` is supplied), layered with the
+  loader's `applySingleSceneSlice`.
+- `src/runtime/scene-loader.ts` — when
+  `effectiveMode(target) === 'scrub'`, the loader passes
+  `cueGate: 'monotonic-forward'` through the bridge; non-scrub
+  modes leave the key absent (key-presence semantics). The
+  single-scene-execution helper that landed for `standalone`,
+  `loop`, and `paused` is widened to include `scrub`.
+- `src/main.ts` — placeholder timeline runner docstring
+  acknowledges `input.cueGate`. The placeholder has no audio-cue
+  subsystem so it trivially satisfies the gate (no cues to fire).
+- `tests/runtime/composition-resolver.test.ts`,
+  `tests/runtime/scene-navigation.test.ts`, and
+  `tests/runtime/scene-loader.test.ts` — new
+  `'... scrub-mode … cue-gate … forwarding (PUL-F017)'` describe
+  blocks pinning the resolver, bridge, and loader behavior:
+  head-only delivery, key-presence semantics, no contamination
+  under non-scrub modes, slice truncation, cleanup-once, the
+  `ctx.mode === 'scrub'` seam across all four locator shapes,
+  beat / cueGate independence, composition validation invariants,
+  stage attribute behavior, and `range` / `behavior` preservation
+  through the truncated slice.
+
+PUL-F017 stays DRAFT after this PR; the issue ↔ requirement link
+is `DOCUMENTS` per the ADR-016 / ADR-017 / ADR-018 / ADR-019
+precedent. ACTIVE transitions when ADR-003's GSAP runner +
+ADR-004's audio engine + a workbench scrub-controls UI surface
+all land with end-to-end tests (see ADR-020).
 - `docs/adrs/019-workbench-mode-paused.md` — records the PUL-F016
   contract: under `mode=paused` the loader truncates the validated
   composition slice to the addressed head entry (parallel to

--- a/docs/adrs/020-workbench-mode-scrub.md
+++ b/docs/adrs/020-workbench-mode-scrub.md
@@ -1,0 +1,515 @@
+# ADR-020: Workbench Mode `scrub` — Runner Cue-Gate Hint at the Loader/Runner Seam
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-09
+
+## Context
+
+ADR-007 names seven workbench modes: `present`, `standalone`, `loop`,
+`paused`, `scrub`, `screenshot`, `prompter`. ADR-013 fixes the URL
+grammar boundary that carries `mode=` to the runtime. ADR-014 fixes
+the scene navigation dispatch layer. ADR-015 fixes URL beat
+positioning. ADR-016 (`mode=present`), ADR-017 (`mode=standalone`),
+ADR-018 (`mode=loop`), and ADR-019 (`mode=paused`) establish the
+precedent for landing a mode's contract layer plus seam tests while
+the dependent rendering surfaces are still pending: PUL-F013,
+PUL-F014, PUL-F015, and PUL-F016 all stayed DRAFT after their
+respective contract PRs because chrome / audio / GSAP runner /
+presenter input surfaces are not yet implemented.
+
+PUL-F017 specifies `mode=scrub`:
+
+> In `mode=scrub`, the runtime SHALL display timeline controls
+> allowing the user to scrub forward, backward, and to named beats.
+> Audio cues SHALL fire only on monotonic forward playback.
+
+The non-trivial parts of that statement decompose this way:
+
+- "Display timeline controls allowing the user to scrub forward,
+  backward, and to named beats" — a workbench chrome surface that
+  does not yet exist (parallel to ADR-016's pending presenter chrome
+  / audio surfaces). The controls UI needs a transport API on the
+  timeline runner (seek, scrub, play/pause), which depends on
+  ADR-003's GSAP runner. Today the placeholder runner has no
+  transport API. Mounting the seam (`ctx.mode === 'scrub'` reaching
+  every lifecycle hook of the head scene) is what makes the future
+  controls UI implementable without further contract changes.
+- "Audio cues SHALL fire only on monotonic forward playback" — a
+  runner-side contract: under `scrub`, the timeline runner MUST
+  suppress audio cues whose time crossing was not produced by
+  monotonic forward time progression. ADR-003's GSAP runner does
+  not yet exist; the placeholder runner in `src/main.ts` has no real
+  timeline (`scene.timeline(ctx)` returns `null`) and no audio
+  engine (ADR-004's Howler integration is not yet implemented). With
+  no cue ever fired, "audio cues fire only on monotonic forward
+  playback" is vacuously satisfied today — but vacuous truth is not
+  enforcement.
+
+The question this ADR answers is: where does the loader → runner
+contract for `mode=scrub` live, and on what contract does PUL-F017
+transition to ACTIVE?
+
+## Decision
+
+### Scope: scrub is single-scene, explicitly
+
+`mode=scrub` is **single-scene execution at the addressed head**, not
+a composition-wide transport mode. PUL-F017's "the user can scrub
+forward, backward, and to named beats" describes interaction with
+ONE timeline; "named beats" are scene-scoped per ADR-015 and
+PUL-F011. Composition-wide scrubbing (a unified transport across
+multiple scenes' timelines) is explicitly out of scope: the runtime
+has no cross-scene timeline abstraction, no cross-scene transport
+API, and no manifest-level timeline aggregation — adding any of
+those would be a wholly new architectural layer beyond what
+PUL-F017 calls for. The user navigates to a specific scene to
+scrub it.
+
+The URL contract for "which scene to scrub" reuses the existing
+PUL-F008 / ADR-014 locator shapes (PUL-F007 / ADR-013 grammar):
+
+- `?scene=x&mode=scrub` — scrub scene `x` directly.
+- `?composition=c&mode=scrub` — scrub the head scene of composition
+  `c`.
+- `?composition=c&scene=x&mode=scrub` — scrub scene `x` within
+  composition `c`.
+- `?composition=c&index=N&mode=scrub` — scrub the entry at index
+  `N` within composition `c`.
+
+To scrub a different scene in the same composition, the user
+addresses that scene by id or index in a fresh URL — same pattern
+the rest of the URL grammar uses for scene selection. The
+composition context is preserved in `data-pulsar-composition-target`
+so external observers (agents, screenshot tooling) see what URL
+addressed, but execution stays scene-scoped because scrub's
+interactive timeline does not hand off to following entries.
+
+This single-scene scope is the same precedent ADR-019 already
+establishes when it routes beat-targeted timeline inspection to
+`mode=scrub` — beat is scene-scoped, so "scrub … to named beats" is
+inherently scene-scoped too. The four single-scene-execution modes
+(standalone / loop / paused / scrub) all share the same
+slice-truncation transform because they all share the structural
+"no following entries run" promise; they differ only in the head's
+runner-side semantic.
+
+### Plumbing
+
+`mode=scrub` is dispatched at the loader (`src/runtime/scene-loader.ts`)
+as a runner-input field forwarded to the timeline-runner adapter on
+the head scene's run input only. When `effectiveMode(target) === 'scrub'`
+the loader passes `cueGate: 'monotonic-forward'` through
+`loadSceneNavigationTarget()` and the resolver to
+`SceneTimelineRunInput.cueGate`.
+
+The runner-side conformance bar is conditional but firm:
+
+- A runner that schedules audio cues MUST fire each cue only on
+  monotonic forward crossings of its trigger time when
+  `input.cueGate === 'monotonic-forward'`. Backwards scrub,
+  jump-to-beat, hydration, and direct seek MUST NOT produce
+  cue-fire events. ADR-003's future GSAP runner enforces this by
+  consulting GSAP's tween direction / progress delta / time-crossing
+  semantics; the runtime-level SHALL in PUL-F017 ("audio cues SHALL
+  fire only on monotonic forward playback") is delivered by
+  combining loader mode dispatch + this runner-side MUST.
+- A runner that does NOT have an audio-cue subsystem trivially
+  satisfies the gate because no cues exist to fire. The placeholder
+  timeline runner today is in this category — it has no real
+  timeline and no audio engine, so "ignore the `cueGate` field" is
+  correct conformance. ADR-004's audio engine PR is what introduces
+  the consumer that activates the MUST.
+
+This wording is intentionally tighter than ADR-018's `repeat` and
+ADR-019's `hold` because PUL-F017's clause uses SHALL on a
+behavior (cue firing) that has a concrete subsystem boundary
+(audio). For `repeat` / `hold` every runner with a timeline can
+honor the hint, so the conformance is uniform; for `cueGate`, only
+runners with audio cues have a behavior to gate.
+
+The "display timeline controls" clause is satisfied by a separate
+workbench chrome surface beyond the runner. That surface reads
+`ctx.mode === 'scrub'` (the seam established by PUL-F012 / ADR-007)
+and renders forward / backward / named-beat controls that drive the
+runner's transport API. The controls surface is gated on ADR-003's
+GSAP runner landing AND that runner exposing a transport API the
+controls can drive. Until both land, the seam is what this PR ships
+to make the future controls surface implementable.
+
+The hint is **head-only**. Under composition targets the slice's
+first entry is the addressed scene; following composition entries
+never receive `cueGate`. This scoping is structural: under scrub the
+slice is truncated upstream so the head's interactive timeline does
+not hand off to following entries. Forwarding `cueGate` to non-head
+scenes would imply a following entry could itself run under scrub
+semantics, which contradicts the requirement's single-timeline-
+controls scoping. The plumbing is parallel to PUL-F011 / ADR-015's
+`headBeat`, PUL-F015 / ADR-018's `headRepeat`, and PUL-F016 /
+ADR-019's `headHold` head-only forwarding — same shape, different
+field.
+
+`SceneTimelineRunInput.cueGate` is declared as a literal-typed field
+(`'monotonic-forward'`) rather than a boolean so future cue-gating
+semantics (e.g., `'all-suppressed'` for deterministic frame capture
+under `mode=screenshot`, or a future `'paused-aware'` variant) can
+extend the union without breaking existing runners. A runner that
+ignores the field, or that only recognizes `'monotonic-forward'`,
+gracefully degrades to no-gating behavior (cues fire on every
+crossing — i.e., default playback semantics). The resolver and
+bridge do not interpret the value.
+
+The slice IS **truncated** under `mode=scrub` to the addressed head
+entry — the same shape transform `mode=standalone` (ADR-017),
+`mode=loop` (ADR-018), and `mode=paused` (ADR-019) apply. Without
+truncation, a runner that ignores `input.cueGate` (a placeholder, a
+buggy GSAP wiring, a future test runner) would let the resolver
+advance to the next composition entry and scrub-mode would silently
+degrade into normal composition playback. That violates the
+documented scrub guarantee: "timeline controls allowing the user to
+scrub forward, backward, and to named beats" presupposes one
+timeline; advancing to a following entry breaks that promise.
+
+Truncating the slice makes "no following entries run" a structural
+guarantee that does not depend on runner conformance. The four
+single-scene-execution modes (`standalone`, `loop`, `paused`, and
+`scrub`) share the same slice transform; they differ only in the
+head's runner-side semantic — standalone plays normally, loop sets
+`input.repeat = 'until-aborted'`, paused sets
+`input.hold = 'first-frame'`, scrub sets
+`input.cueGate = 'monotonic-forward'`. The shape transform is
+shared because the structural promise ("no following entries run")
+is identical; the runner-side behaviors live where they belong.
+
+The slice is **truncated, not flattened.** Replacing the resolved
+target with `{ scene }` (no composition) would lose the head entry's
+per-entry `range` / `behavior` overrides (object-form entries per
+ADR-002 / ADR-011), turning scrub into direct-scene flattening —
+same foot-gun ADR-017 / ADR-018 / ADR-019 call out. The truncated
+`manifestSlice` (length 1) continues through the composition branch
+in `loadSceneNavigationTarget()`, and the existing runner-input
+plumbing forwards `range` / `behavior` per ADR-011.
+
+PUL-F017 stays DRAFT after this PR lands, mirroring the ADR-016 /
+PUL-F013, ADR-017 / PUL-F014, ADR-018 / PUL-F015, and ADR-019 /
+PUL-F016 precedent. This PR ships:
+
+- The loader → runner-input contract: `cueGate: 'monotonic-forward'`
+  reaches the head scene's run input under
+  `effectiveMode === 'scrub'`.
+- The seam: `ctx.mode === 'scrub'` reaches every lifecycle hook of
+  the head scene through the existing PUL-F012 plumbing.
+- Tests pinning the seam, the head-only scoping, the
+  no-other-mode contamination, and the existing invariants under
+  `scrub` (composition validation still runs; no
+  `data-pulsar-mode-*` attribute; beat forwarding preserved;
+  `range` / `behavior` overrides preserved).
+
+What it does NOT yet ship is the active *monotonic-forward
+cue-gating* behavior or the timeline-controls UI:
+
+- ADR-003's GSAP runner is not implemented. The placeholder runner
+  has no real timeline and no audio engine to gate cues against; it
+  parks until abort. With no cue ever fired, the placeholder
+  vacuously satisfies "audio cues fire only on monotonic forward
+  playback" but cannot exercise the gate.
+- ADR-004's Howler audio engine is not implemented. Audio cues
+  themselves do not yet exist; the gate has no consumer.
+- The workbench scrub-controls UI surface does not exist. The
+  forward / backward / named-beat controls require a transport API
+  on the runner that the GSAP runner has not yet exposed.
+
+PUL-F017 transitions DRAFT → ACTIVE when ALL THREE hold:
+
+1. ADR-003's GSAP runner lands AND it actively reads
+   `input.cueGate === 'monotonic-forward'` and gates audio-cue
+   firing by direction, with end-to-end tests showing backwards
+   scrub, jump-to-beat, hydration, and direct seek do not fire
+   cues while monotonic forward playback does.
+2. ADR-004's audio engine lands so audio cues exist as a real
+   subsystem the gate can constrain.
+3. A workbench scrub-controls surface lands that reads
+   `ctx.mode === 'scrub'` and renders forward / backward /
+   named-beat controls driving the runner's transport API, with
+   end-to-end tests of all three control modes.
+
+Until all three land, the issue ↔ requirement link stays as
+`DOCUMENTS` and PUL-F017 stays DRAFT — matching how ADR-016 /
+PUL-F013, ADR-017 / PUL-F014, ADR-018 / PUL-F015, and ADR-019 /
+PUL-F016 record "land the contract layer; keep the requirement
+DRAFT until the dependent subsystems land."
+
+### Boundary
+
+The cue-gate hint flows from the loader because:
+
+- The loader already derives `effectiveMode(target)` for `ctx.mode`
+  (ADR-007 / PUL-F012). Reusing the same derivation for `cueGate`
+  keeps mode-aware logic in one place — no second `target.mode`
+  inspection on a different layer.
+- The composition resolver MUST stay mode-opaque (ADR-011 — pure
+  orchestrator, no adapter knowledge). The resolver plumbs
+  `headCueGate` exactly the way it plumbs `headBeat`, `headRepeat`,
+  and `headHold`: as an opaque forwarding field with no semantics
+  it interprets. The loader is the only thing that maps
+  `effectiveMode === 'scrub'` to `cueGate: 'monotonic-forward'`.
+- `resolveSceneNavigation()` MUST run validation regardless of mode:
+  unregistered compositions, unknown member scenes, ambiguous
+  `composition+scene` locators, out-of-range indexes, and empty
+  compositions still surface as navigation errors under
+  `mode=scrub`. No silent fallback to direct scene lookup.
+- `loadSceneNavigationTarget()` already plumbs head-only options
+  (`beat` / `onBeatMissing` / `repeat` / `hold`); adding `cueGate`
+  to that list reuses the same shape rather than inventing a new
+  bridge surface.
+
+### Stage attribute behavior
+
+`data-pulsar-scene-target` (head scene id) AND
+`data-pulsar-composition-target` (composition id) are both set on
+the stage when the URL named a composition under `mode=scrub`. The
+attrs communicate "what was addressed," not "what's running" — same
+invariant as `mode=standalone` (ADR-017), `mode=loop` (ADR-018), and
+`mode=paused` (ADR-019). No `data-pulsar-mode-*` suppression
+attribute is preemptively written under `scrub` (parity with
+ADR-016 / ADR-017 / ADR-018 / ADR-019); the future scrub-controls
+UI surface is free to use that namespace if it actually needs a
+stage-level signal.
+
+### Beat semantics
+
+`beat=` under `mode=scrub` is forwarded to the head scene's runner
+unchanged. PUL-F017 explicitly names "to named beats" as part of
+scrub's UX ("the user can scrub … to named beats"), so beat
+forwarding is the natural scrub-to-beat path the future controls UI
+will drive. The runner sees both `input.beat` and `input.cueGate`
+on the same input bundle.
+
+Unlike `mode=paused` — where ADR-019's runner-side policy is "first
+frame wins" so the runner SHOULD ignore `input.beat` — `mode=scrub`
+HONORS `input.beat` as the initial cursor position. The user's
+first interaction with scrub controls is at that position;
+subsequent forward / backward / jump-to-beat scrubbing replaces it.
+The cue gate does not relax for the initial seek to the beat label:
+the initial seek is a direct seek (not monotonic forward play), so
+no cues fire even if the seek crossed cue trigger times. This is
+the documented behavior the future GSAP runner pins.
+
+Missing-label diagnostics surface via the existing non-fatal
+`onBeatMissing` path (ADR-015): a URL like
+`?scene=x&beat=does-not-exist&mode=scrub` does not unmount the
+scene; the diagnostic appears on `data-pulsar-navigation-error` /
+`onError` and the user lands at the timeline's first beat (the
+default cursor position).
+
+### Composition slice behavior
+
+Truncated to the addressed head entry, parallel to `mode=standalone`
+(ADR-017), `mode=loop` (ADR-018), and `mode=paused` (ADR-019). The
+single-scene-execution helper at the loader is shared:
+`applySingleSceneSlice` runs for all four modes (`standalone`,
+`loop`, `paused`, `scrub`). Following composition entries do not
+run; the head scene's `cueGate: 'monotonic-forward'` reaches the
+runner input and the runner is responsible for the actual
+monotonic-forward cue gating.
+
+The composition slice MUST be validated by `resolveSceneNavigation()`
+BEFORE the truncation transform. Unregistered compositions, unknown
+member scenes, ambiguous `composition+scene` locators, and
+out-of-range indexes still surface as navigation errors under
+`mode=scrub` — the same invariant ADR-017 / ADR-018 / ADR-019 hold
+for standalone, loop, and paused.
+
+The bridge ALSO truncates a composition slice when `cueGate` is
+supplied (`truncateToHead` shared with the `repeat` / `hold` paths)
+— a structural defense layered with the loader's
+`applySingleSceneSlice` so direct bridge callers (test harnesses,
+future export pipelines) get the same scrub-mode single-scene-
+execution guarantee. The two truncations are idempotent.
+
+### UI controls scope
+
+The "display timeline controls" clause IS in PUL-F017's scope — but
+the controls UI is a workbench chrome surface that lives in a
+follow-up PR alongside ADR-003's GSAP runner and ADR-004's audio
+engine. Building the controls today against the placeholder runner
+would either (a) build a chrome that does nothing because the
+runner has no transport API to drive, or (b) add a runner transport
+API ahead of ADR-003, which would constrain the future GSAP runner
+to a contract chosen without a real timeline engine in front of us.
+
+The seam (`ctx.mode === 'scrub'` reaching every lifecycle hook,
+pinned by the seam test in this PR) is what makes the future
+controls surface implementable. The chrome will read the seam,
+mount its forward / backward / named-beat controls, and drive the
+GSAP runner's transport API.
+
+## Consequences
+
+### Positive
+
+- Mode → runner-input plumbing lives at the loader, the same place
+  PUL-F012 derives `ctx.mode`, PUL-F015 derives `repeat`, and
+  PUL-F016 derives `hold`. One mode dispatch site, not four.
+- The resolver stays mode-opaque (ADR-011): `headCueGate` is plumbed
+  the same way `headBeat`, `headRepeat`, and `headHold` already are,
+  with no new resolver semantics.
+- The runner contract is a single optional input field
+  (`cueGate?: 'monotonic-forward'`). A runner that ignores it
+  (placeholder, future non-scrub test runners) gracefully degrades;
+  a runner that honors it (future GSAP) reads one field instead of
+  inferring scrub semantics from `ctx.mode`.
+- Following ADR-016 / ADR-017 / ADR-018 / ADR-019's precedent keeps
+  the DRAFT → ACTIVE bar consistent across mode requirements:
+  ACTIVE means the named behavior is actively delivered end to end,
+  not just structurally scaffolded.
+- No premature abstraction. No `ModePolicy` record, no shared
+  mode-hint type, no policy table. When a future mode needs a
+  different shape of runner hint, it adds its own field; if multiple
+  modes converge on a shared representation, that representation
+  lands then with at least two consumers informing its shape. The
+  four single-scene-execution modes (standalone, loop, paused,
+  scrub) share `applySingleSceneSlice` because they share a
+  structural invariant, but they do NOT share a runner-input field
+  — each owns its own (`repeat`, `hold`, `cueGate`, none).
+
+### Negative
+
+- PUL-F017 stays DRAFT until ADR-003's GSAP runner, ADR-004's audio
+  engine, AND a scrub-controls UI surface all land. A reviewer
+  reading the requirement in isolation may expect ACTIVE on first
+  delivery; the DRAFT-with-contract-and-seams state is intentional
+  and matches the PUL-F011 / PUL-F013 / PUL-F014 / PUL-F015 /
+  PUL-F016 precedent.
+- Adding `cueGate` to `SceneTimelineRunInput` widens the runner
+  adapter surface. Every runner adapter (placeholder today, future
+  GSAP, test harnesses) sees the new field. Test runners that don't
+  care about scrub semantics ignore it; this is the cost of
+  extending the input shape. The alternative (a separate runner
+  parameter) would be larger surface, not smaller.
+- The seam tests are necessary but not sufficient: they prove the
+  hook exists and behaves correctly under `mode=scrub`, but they do
+  not prove that a future GSAP runner will plug in correctly, that
+  a future audio engine will respect the gate, or that a future
+  controls UI will drive the runner correctly. The surface PRs
+  that land each of those subsystems are responsible for adding
+  their own end-to-end tests.
+
+### Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| A future runner ignores `input.cueGate` and the regression goes unnoticed | The seam tests pin "loader sets `input.cueGate = 'monotonic-forward'` under `mode=scrub`." A runner that ignores the hint produces wrong runtime behavior (cues fire on backwards scrub). When the GSAP runner lands, its own end-to-end test proves the hint is honored. |
+| `cueGate` accumulates as a kitchen-sink field for unrelated cue-gating semantics | The literal-typed union (`'monotonic-forward'`) constrains valid values. Adding a new variant (`'all-suppressed'`, `{ direction: 'forward', skipThreshold: 100 }`) is an explicit type extension, visible in code review. |
+| Slice truncation flattens to direct-scene and loses object-form `range` / `behavior` overrides | The seam test "preserves the addressed head entry's `range` and `behavior` overrides on the runner input under `mode=scrub` (composition+index with object-form entry)" pins object-form head-entry plumbing through the truncated slice. A flatten-by-mistake would lose those overrides. |
+| A runner that ignores `input.cueGate` silently degrades scrub into normal composition playback | Slice truncation makes "no following entries run" structural — a no-op runner under `mode=scrub` runs the head's lifecycle once and then completes the navigation, rather than advancing to a tail entry that should not have run. |
+| PUL-F017 lingers DRAFT forever because the GSAP runner / audio engine / controls UI keep slipping | DRAFT is a feature here: it tells reviewers the scrub-mode contract is partly delivered (boundary + seam) and gates ACTIVE on actual cue gating + UI controls. The GSAP runner PR (ADR-003), the audio engine PR (ADR-004), and the future scrub-controls UI PR are the natural triggers to revisit PUL-F017's status. |
+| A non-parser caller forges a `NavigationTarget` with `mode: 'scrub'` mid-flight | The defense-in-depth check `validateModeGrammar` already rejects unknown modes at the loader boundary; `'scrub'` is in the `NAVIGATION_MODES` allowlist, and `effectiveMode` is the only consumer of the field. |
+
+## Current state (2026-05-09)
+
+This PR delivers the contract boundary and seam-pinning layer:
+
+- `src/runtime/composition-resolver.ts` — `SceneTimelineRunInput`
+  gains optional `cueGate?: 'monotonic-forward'`;
+  `ResolveCompositionOptions` gains optional `headCueGate?:
+  'monotonic-forward'`; the resolver forwards `headCueGate` to
+  plan[0]'s run input only.
+- `src/runtime/scene-navigation.ts` —
+  `LoadSceneNavigationTargetOptions` gains optional `cueGate?:
+  'monotonic-forward'`; `loadSceneNavigationTarget()` forwards it to
+  `resolveComposition` as `headCueGate`. The bridge truncates a
+  composition slice when `cueGate` is supplied (the shared
+  `truncateToHead` predicate fires when ANY of `repeat` / `hold` /
+  `cueGate` is supplied).
+- `src/runtime/scene-loader.ts` — when `effectiveMode(target) ===
+  'scrub'`, the loader passes `cueGate: 'monotonic-forward'` through
+  the bridge; otherwise the key is omitted (key-presence semantics).
+  The single-scene-execution helper `applySingleSceneSlice` widens
+  to include `'scrub'` so the slice is truncated to the addressed
+  head under any of the four single-scene modes (standalone, loop,
+  paused, scrub) — the SHAPE transform is shared, the runner-side
+  semantic difference (`input.cueGate`) is what differentiates
+  scrub from the others.
+- `src/main.ts` — placeholder timeline runner docstring
+  acknowledges `input.cueGate`. The placeholder ignores the hint;
+  parking until abort vacuously satisfies "audio cues fire only on
+  monotonic forward playback" because no cue ever fires. ADR-003's
+  GSAP runner will read the hint and gate cues by direction.
+- `tests/runtime/composition-resolver.test.ts` — new
+  `'URL scrub-mode runner cue-gate-hint forwarding (PUL-F017)'`
+  describe block.
+- `tests/runtime/scene-navigation.test.ts` — new `'URL scrub-mode
+  cue-gate forwarding (PUL-F017)'` describe block under
+  `loadSceneNavigationTarget`.
+- `tests/runtime/scene-loader.test.ts` — new `'scrub-mode runner
+  cue-gate-hint forwarding (PUL-F017)'` describe block.
+- `docs/design/pul-f017-scrub-mode-preflight.md` — codex
+  architecture preflight design context (preserved from the
+  preflight tool's returned summary; the codex sandbox failed to
+  write design files during preflight, so the guardrails are
+  reproduced verbatim — same handling pattern as
+  `pul-f015-loop-mode-preflight.md` and
+  `pul-f016-paused-mode-preflight.md`).
+- This ADR.
+
+PUL-F017 remains DRAFT. Issue #26 links to PUL-F017 via `DOCUMENTS`.
+This PR is **not** an implementation of PUL-F017's "audio cues SHALL
+fire only on monotonic forward playback" clause nor of the "display
+timeline controls" clause — it lands the contract boundary and the
+seam. The ACTIVE transition is gated on ADR-003's GSAP runner
+honoring `input.cueGate`, ADR-004's audio engine providing real
+cues, AND a workbench scrub-controls surface reading `ctx.mode ===
+'scrub'` and driving the runner's transport API, each with
+end-to-end tests alongside the seam tests in this PR. Treating this
+PR as satisfying PUL-F017 would be a traceability/status mismatch.
+
+## Related ADRs
+
+- [ADR-003](003-gsap-timeline-engine.md) — the timeline runner is
+  the seam through which monotonic-forward cue gating will flow
+  when the GSAP runner lands. Today the runner is a placeholder, so
+  scrub behavior is structurally vacuous.
+- [ADR-004](004-howler-audio-engine.md) — audio cues are the
+  consumer of the cue gate. Today there is no audio engine, so the
+  gate has no consumer.
+- [ADR-007](007-browser-workbench.md) — defines the seven workbench
+  modes and the URL-only-source invariant for mode selection.
+  Specifically references `mode=scrub` as the timing/beat-alignment
+  inspection mode.
+- [ADR-008](008-agent-native-authoring.md) — manifests-over-flow-
+  control underpins the no-mode-suppression-in-resolver constraint.
+- [ADR-011](011-composition-resolver-orchestration.md) — the
+  resolver is opaque to mode; mode-derived behavior lives at the
+  adapters it forwards to. The resolver plumbs `headCueGate`
+  unchanged, the same way it plumbs `headBeat`, `headRepeat`, and
+  `headHold`.
+- [ADR-013](013-url-navigation-grammar-boundary.md) — the parser
+  preserves `mode` and forbids recovering it from any non-URL
+  source.
+- [ADR-014](014-url-scene-target-selection.md) — scene navigation
+  dispatch is mode-blind; it resolves the active slice and hands
+  off to the loader for mode dispatch.
+- [ADR-015](015-url-beat-positioning.md) — precedent for "the
+  resolver plumbs a head-only optional field; runner owns the
+  semantics; loader fails fast at the paired-required boundary."
+  ADR-020's `headCueGate` mirrors `headBeat`'s shape.
+- [ADR-016](016-workbench-mode-present.md) — establishes the
+  contract-layer-plus-seam-tests precedent. PUL-F013 stays DRAFT
+  pending chrome / audio / GSAP runner / presenter input.
+- [ADR-017](017-workbench-mode-standalone.md) — applies the same
+  precedent to PUL-F014 with the slice-truncation seam.
+- [ADR-018](018-workbench-mode-loop.md) — PUL-F015 shares the
+  slice-truncation transform; runner-side semantic difference is
+  `input.repeat`. ADR-020's `cueGate` is the same shape with a
+  different literal value.
+- [ADR-019](019-workbench-mode-paused.md) — PUL-F016 shares the
+  slice-truncation transform; runner-side semantic difference is
+  `input.hold`. ADR-019 explicitly names `mode=scrub` as the
+  appropriate beat-targeting timeline-inspection mode (vs.
+  paused's layout/styling inspection); PUL-F017's "to named beats"
+  clause delivers on that delegation.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -45,3 +45,4 @@ Each ADR includes:
 | [017](017-workbench-mode-standalone.md) | Workbench Mode `standalone` — Single-Scene Execution at the Loader | Accepted |
 | [018](018-workbench-mode-loop.md) | Workbench Mode `loop` — Runner Repeat Hint at the Loader/Runner Seam | Accepted |
 | [019](019-workbench-mode-paused.md) | Workbench Mode `paused` — Runner Hold-at-First-Frame Hint at the Loader/Runner Seam | Accepted |
+| [020](020-workbench-mode-scrub.md) | Workbench Mode `scrub` — Runner Cue-Gate Hint at the Loader/Runner Seam | Accepted |

--- a/docs/design/pul-f017-scrub-mode-preflight.md
+++ b/docs/design/pul-f017-scrub-mode-preflight.md
@@ -1,0 +1,206 @@
+# PUL-F017 Scrub Mode Preflight
+
+PUL-F017 specifies `mode=scrub`: display timeline controls allowing
+the user to scrub forward, backward, and to named beats; audio cues
+SHALL fire only on monotonic forward playback. This is a
+timing-and-beat-alignment-inspection mode for runtime review. It is
+not a presenter transport state, a paused layout-review mode, a
+deterministic visual-regression mode, a screenshot mode, or a new
+scene model.
+
+ADR-007 already defines `scrub` as a workbench mode. ADR-011 already
+defines the resolver as a lifecycle orchestrator with an injected
+timeline runner. The runner-input shape introduced by ADR-018
+(`repeat`) and extended by ADR-019 (`hold`) is the precedent for
+adding a new head-only optional field; ADR-020 records the
+analogous `cueGate` field for scrub.
+
+## Sandbox note
+
+The codex preflight tool's sandbox failed to write design files
+during this preflight run (`bwrap` setup error), so this document is
+a manual transcription of the preflight tool's returned guardrails
+text plus the architecture decisions that follow from it — same
+handling pattern as `pul-f015-loop-mode-preflight.md` and
+`pul-f016-paused-mode-preflight.md`. The structured decisions are
+recorded in ADR-020.
+
+## Boundary
+
+`scrub` selection must reuse the existing navigation path:
+
+- `src/runtime/navigation.ts` owns the `mode` URL grammar and the
+  `NAVIGATION_MODES` allowlist.
+- `effectiveMode()` owns effective mode derivation.
+- `src/runtime/scene-loader.ts` owns per-navigation mode dispatch,
+  `ctx.mode` construction, cancellation, stage diagnostics, and
+  error surfacing. It is also the dispatch point that maps
+  `effectiveMode === 'scrub'` to `cueGate: 'monotonic-forward'`.
+- `src/runtime/scene-navigation.ts` owns target resolution and
+  composition slicing. Its `scene` field is the addressed head
+  scene.
+- `src/runtime/composition-resolver.ts` owns preload → create →
+  timeline → cleanup ordering, abort propagation, and exactly-once
+  cleanup. It must remain mode-opaque; `headCueGate` is plumbed
+  the same way `headBeat`, `headRepeat`, and `headHold` are.
+- The timeline runner owns timeline playhead behavior. Under
+  `mode=scrub` the runner reads `input.cueGate === 'monotonic-forward'`
+  and gates audio-cue firing by direction.
+- The future workbench scrub-controls UI surface (separate PR)
+  owns the forward / backward / named-beat controls. It reads
+  `ctx.mode === 'scrub'` (the seam this PR establishes) and drives
+  the runner's transport API.
+
+Do not add a second route, mode enum, `scrub` boolean, scene schema
+field, manifest flag, local URL parser, or scrub-specific resolver.
+URL input remains the only source of mode selection; `scrub` must
+not be recovered from localStorage, sessionStorage, cookies,
+`history.state`, or prior in-memory navigation state.
+
+## Required Reuse
+
+Implementation must reuse these cross-cutting concerns:
+
+- Identifier validation: `src/runtime/identifier.ts`.
+- URL and mode validation: `parseNavigationSearch()` and
+  `NAVIGATION_MODES`.
+- Effective mode derivation: `effectiveMode()`.
+- Scene and composition validation:
+  `assertSceneModule()`, `createSceneRegistry()`,
+  `assertCompositionManifest()`, and `createCompositionRegistry()`.
+- Navigation resolution: `resolveSceneNavigation()` and
+  `loadSceneNavigationTarget()`.
+- Lifecycle orchestration: `resolveComposition()` with injected
+  `createPreloader()` and `runTimeline()` adapters.
+- Asset handling: `createAssetPreloader()` with the existing
+  scheme, redirect, `baseUrl`, and `AbortSignal` rules. Scrub mode
+  does not change preload semantics — the addressed scene's assets
+  must still be loaded before `create(ctx)` runs.
+- Error rendering: `describeError()` plus the existing
+  `data-pulsar-navigation-error` stage diagnostic and `onError`
+  sink.
+- Cancellation and cleanup: one per-navigation `AbortController`,
+  forwarded to preload and timeline adapters; cleanup remains
+  resolver-owned.
+- Slice-truncation helper: the `applySingleSceneSlice` loader-side
+  helper and the `truncateToHead` bridge-level helper introduced
+  for `standalone` (ADR-017) and extended for `loop` (ADR-018) and
+  `paused` (ADR-019) are extended again to fire under `scrub`. The
+  shape transform is shared; the predicate widens.
+- Beat lookup / naming contract: `beat=` under `mode=scrub` is the
+  natural scrub-to-named-beat path PUL-F017's "to named beats"
+  clause anticipates. Reuse the existing PUL-F011 / ADR-015
+  forwarding (`headBeat` / `onBeatMissing`).
+
+## Scope: single-scene only
+
+Scrub is **single-scene execution at the addressed head**. PUL-F017's
+"timeline controls" are over ONE timeline; "named beats" are
+scene-scoped per ADR-015. There is no composition-wide scrubbing —
+the runtime has no cross-scene timeline abstraction or transport
+API, and PUL-F017 does not call for one. The user addresses a
+specific scene (directly via `?scene=x&mode=scrub`, or within a
+composition via `?composition=c&scene=x&mode=scrub` /
+`?composition=c&index=N&mode=scrub`) and scrubs that scene's
+timeline. To scrub a different scene in the same composition, the
+user navigates to a fresh URL targeting that scene. The four
+single-scene modes (standalone / loop / paused / scrub) share the
+same slice-truncation transform because they share the same
+structural "no following entries run" promise.
+
+## Scrub Contract
+
+Scrub mode means: resolve the addressed scene through the existing
+URL/registry/composition path, preload declared assets, run normal
+`create(ctx)` and `timeline(ctx)`, then hand control of the
+timeline's playhead to the workbench scrub-controls UI surface.
+Audio cues fire only when the user's interaction produces monotonic
+forward time progression; backwards scrub, jump-to-beat, hydration,
+and direct seek do not fire cues.
+
+- A direct `scene` target presents that scene's timeline for
+  scrubbing.
+- A `composition` target presents the first scene's timeline;
+  following composition entries do not run.
+- A `composition+scene` or `composition+index` target presents the
+  resolved head scene's timeline, preserving the head entry's
+  `range` / `behavior` overrides; following composition entries do
+  not run.
+- `beat=<label>` under `mode=scrub` IS honored as the initial
+  cursor position. Unlike paused mode (where ADR-019 records "first
+  frame wins"), scrub explicitly names beats as a navigation
+  target ("to named beats"). The initial seek to the beat label
+  is a direct seek, not monotonic forward play, so no cues fire
+  for crossings during that initial seek; subsequent forward
+  scrubbing past those crossings DOES fire cues.
+
+The requirement says timeline controls and audio cues. Do not
+implement scrub by skipping `create(ctx)`, by skipping
+`timeline(ctx)`, or by short-circuiting the lifecycle. Scene setup
+runs normally; the timeline-controls UI and the cue gate are
+runner-side concerns delivered by future PRs alongside ADR-003 /
+ADR-004.
+
+## Required Constraints (preflight guardrails)
+
+These are binding unless they are clearly wrong:
+
+- Treat `mode=scrub` as a browser workbench/runtime mode under
+  ADR-007, not a new authoring workflow.
+- Scrub controls are UI over the existing timeline/beat/cue model.
+  Do not create duplicate beat, marker, cue, or mode schemas.
+- Audio cue eligibility belongs in the existing playback/cue
+  scheduling layer (when ADR-004 lands), not in timeline control
+  components.
+- Cues fire only for normalized monotonic forward playback
+  intervals. Reverse scrub, direct seek, jump-to-beat, drag
+  preview, hydration, and resync must be silent.
+- Scrub state is transient runtime state. Do not persist cursor,
+  hover, selected beat, or inspection direction into authored
+  performance data.
+
+## Cross-Cutting Concerns To Reuse
+
+- Existing `mode` parsing/routing/validation for `mode=scrub`.
+- Existing timeline duration/time normalization and boundary
+  clamping (when ADR-003's GSAP runner lands).
+- Existing beat lookup/naming contract for named beat navigation.
+- Existing playback clock/state machine and cue scheduler/audio
+  service (when ADR-003 / ADR-004 land).
+- Existing browser-safe error handling for invalid beat targets,
+  invalid time values, and unavailable audio.
+- Existing logging/observability conventions; avoid high-volume
+  pointer-move logs.
+- Existing frontend test harness for controls and playback
+  behavior.
+- Repo workflow: update `CHANGELOG.md` only when source changes,
+  and create IMPLEMENTS/TESTS traceability links only after
+  implementation satisfies PUL-F017.
+
+## Gotchas And Anti-Patterns
+
+- Do not fire cues from React/component event handlers (when a
+  controls UI lands).
+- Do not scatter `if (mode === 'scrub')` cue suppression across
+  unrelated code.
+- Do not treat beat labels as separate UI-only data.
+- Do not replay skipped cues after a seek or beat jump.
+- Do not rebuild the audio graph on every scrub movement (when
+  ADR-004 lands).
+- Use epsilon-aware time comparisons when the GSAP runner lands;
+  floating point jitter must not create duplicate cue fires.
+- Throttle pointer-driven timeline updates through existing UI
+  patterns to avoid render storms (when a controls UI lands).
+
+## Non-Goals And Boundaries
+
+- No new persistence format.
+- No new timeline, beat, cue, exception, validation, or workflow
+  abstraction unless existing contracts are genuinely absent.
+- No authoring/editing of beats or cues.
+- No production analytics expansion unless the project already has
+  safe telemetry for comparable playback events.
+- No timeline-controls UI in this PR — that surface ships with
+  ADR-003's GSAP runner and a transport API on the runner.
+- No real audio cue gating in this PR — that ships with ADR-004's
+  audio engine.

--- a/src/main.ts
+++ b/src/main.ts
@@ -105,6 +105,19 @@ const createPreloader = (signal: AbortSignal): ReturnType<typeof createAssetPrel
 // when multiple are set on the same input — paused is a
 // layout/styling-inspection mode, not a transport state.
 //
+// PUL-F017 / ADR-020: when the URL carries `mode=scrub` the loader
+// sets `input.cueGate = 'monotonic-forward'`. The placeholder
+// ignores the hint — it has no real timeline and no audio engine
+// (ADR-004's Howler integration) to gate cues against, and parking
+// until abort vacuously satisfies "audio cues fire only on
+// monotonic forward playback" because no cue ever fires. The
+// future GSAP runner (ADR-003) reads the hint and gates audio-cue
+// firing by direction (forward crossings fire; backwards scrub /
+// jump-to-beat / direct seek do not). The "display timeline
+// controls" clause of PUL-F017 is a workbench chrome surface that
+// reads `ctx.mode === 'scrub'` (the seam), not `input.cueGate`;
+// the controls UI is a separate future surface beyond the runner.
+//
 // Abort ordering: the abort check runs BEFORE the missing-beat
 // diagnostic so a navigation that was superseded between
 // `scene.timeline(ctx)` resolution and the runner's first turn does

--- a/src/runtime/composition-resolver.ts
+++ b/src/runtime/composition-resolver.ts
@@ -181,6 +181,55 @@ export interface SceneTimelineRunInput {
    * completes for the repeat to fire on.
    */
   readonly hold?: 'first-frame';
+  /**
+   * Cue-gate hint for the head scene's timeline (PUL-F017 / ADR-020).
+   * When `'monotonic-forward'`:
+   *
+   * - A runner that schedules audio cues MUST fire each cue only on
+   *   monotonic forward crossings of its trigger time. Backwards
+   *   scrub, jump-to-beat, hydration, and direct seek MUST NOT
+   *   produce cue-fire events. This is the runner-side enforcement
+   *   of PUL-F017's "audio cues SHALL fire only on monotonic
+   *   forward playback" SHALL — the runtime-level SHALL is
+   *   delivered by combining loader mode dispatch (`cueGate` set on
+   *   the head's run input under `mode=scrub`) + runner conformance
+   *   (this field's MUST).
+   * - A runner that does NOT have an audio-cue subsystem (e.g., the
+   *   placeholder timeline runner today; a future Node-side test
+   *   harness that never schedules audio) has no cues to gate and
+   *   trivially satisfies the gate. The placeholder runner's
+   *   "ignore the field" behavior is correct because there are no
+   *   cues to suppress.
+   *
+   * The hint also signals scrub-mode is active; the future
+   * scrub-controls UI surface drives the timeline's playhead through
+   * the runner's transport API while the runner consults
+   * `input.cueGate` to decide whether each cue's time crossing
+   * counts as monotonic-forward.
+   *
+   * Only present on the run input for the FIRST scene of the resolved
+   * composition slice — subsequent scenes never receive `cueGate`
+   * because under scrub the slice is truncated upstream and the
+   * head's interactive timeline never hands off to following
+   * entries. Absent when the navigation target had no `mode=scrub`
+   * parameter.
+   *
+   * Discriminated by literal type so future cue-gating semantics
+   * (e.g. an `'all-suppressed'` variant for deterministic frame
+   * capture under `mode=screenshot`) can extend the union without
+   * breaking audio-capable runners that only recognize the existing
+   * variant. A runner that recognizes a future variant it does not
+   * understand SHOULD log a warning and fall back to its strictest
+   * known gating policy (rather than silently dropping the gate).
+   * The resolver does not interpret the value.
+   *
+   * `cueGate`, `repeat`, and `hold` are independent fields on the
+   * runner input; the URL grammar makes their parent modes
+   * (`scrub`, `loop`, `paused`) mutually exclusive (mode is a single
+   * field), but a programmatic caller could supply more than one
+   * and the runner's policy decides which wins.
+   */
+  readonly cueGate?: 'monotonic-forward';
 }
 
 /**
@@ -281,6 +330,23 @@ export interface ResolveCompositionOptions {
    * the loader boundary, where mode dispatch lives).
    */
   readonly headHold?: 'first-frame';
+  /**
+   * URL scrub-mode cue-gate hint (PUL-F017 / ADR-020) to forward to
+   * the FIRST scene's run input as
+   * {@link SceneTimelineRunInput.cueGate}. Subsequent scenes never
+   * receive a cue-gate hint — under `mode=scrub` the slice is
+   * truncated upstream so the head's interactive timeline does not
+   * hand off to following composition entries. Absent when the
+   * navigation target had no `mode=scrub` parameter.
+   *
+   * The resolver does not interpret the value — honoring "audio
+   * cues fire only on monotonic forward playback" is the runner's
+   * contract per ADR-020. A runner that ignores the field
+   * gracefully degrades to no-gating (a regression the seam tests
+   * in `scene-loader.test.ts` pin against the loader boundary,
+   * where mode dispatch lives).
+   */
+  readonly headCueGate?: 'monotonic-forward';
 }
 
 /**
@@ -359,6 +425,7 @@ function buildRunInput(
   onBeatMissing: (() => void) | undefined,
   repeat: 'until-aborted' | undefined,
   hold: 'first-frame' | undefined,
+  cueGate: 'monotonic-forward' | undefined,
 ): SceneTimelineRunInput {
   const input: { -readonly [K in keyof SceneTimelineRunInput]: SceneTimelineRunInput[K] } = {
     scene: step.scene,
@@ -371,6 +438,7 @@ function buildRunInput(
   if (onBeatMissing !== undefined) input.onBeatMissing = onBeatMissing;
   if (repeat !== undefined) input.repeat = repeat;
   if (hold !== undefined) input.hold = hold;
+  if (cueGate !== undefined) input.cueGate = cueGate;
   return input;
 }
 
@@ -438,6 +506,7 @@ export async function resolveComposition(options: ResolveCompositionOptions): Pr
     onBeatMissing,
     headRepeat,
     headHold,
+    headCueGate,
   } = options;
 
   // PUL-F011 / ADR-015: a `headBeat` without an `onBeatMissing` would
@@ -508,6 +577,13 @@ export async function resolveComposition(options: ResolveCompositionOptions): Pr
     // following entry could itself be held at frame 0, which
     // contradicts the requirement's "the addressed scene" scoping.
     const stepHold = isHead ? headHold : undefined;
+    // `headCueGate` is head-only per ADR-020: under `mode=scrub` the
+    // slice is truncated upstream so the head's interactive timeline
+    // does not hand off to following composition entries. Forwarding
+    // the cue gate to non-head scenes would imply a following entry
+    // could itself run under scrub semantics, which contradicts the
+    // requirement's single-timeline-controls scoping.
+    const stepCueGate = isHead ? headCueGate : undefined;
     await runScene(
       step,
       ctx,
@@ -517,6 +593,7 @@ export async function resolveComposition(options: ResolveCompositionOptions): Pr
       stepOnBeatMissing,
       stepRepeat,
       stepHold,
+      stepCueGate,
     );
     lastCompletedSceneId = step.scene.id;
   }
@@ -576,6 +653,7 @@ async function runScene(
   onBeatMissing: (() => void) | undefined,
   repeat: 'until-aborted' | undefined,
   hold: 'first-frame' | undefined,
+  cueGate: 'monotonic-forward' | undefined,
 ): Promise<void> {
   // Track failure with explicit booleans so `throw undefined` /
   // `Promise.reject(undefined)` are still treated as failures. Using
@@ -593,7 +671,9 @@ async function runScene(
     // non-Promise value is identity, so synchronous timeline factories
     // are unaffected.
     const timeline = await scene.timeline(ctx);
-    await runTimeline(buildRunInput(step, timeline, signal, beat, onBeatMissing, repeat, hold));
+    await runTimeline(
+      buildRunInput(step, timeline, signal, beat, onBeatMissing, repeat, hold, cueGate),
+    );
   } catch (err) {
     phaseFailed = true;
     phaseError = err;

--- a/src/runtime/scene-loader.ts
+++ b/src/runtime/scene-loader.ts
@@ -446,6 +446,19 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
     // boundary (mode is a single field), so at most one of `repeat` /
     // `hold` is non-undefined here.
     const hold: 'first-frame' | undefined = mode === 'paused' ? 'first-frame' : undefined;
+    // PUL-F017 / ADR-020: under `mode=scrub` the runner gates audio
+    // cues to monotonic forward playback only. Same dispatch-point
+    // pattern as `repeat` and `hold`: when `effectiveMode === 'scrub'`,
+    // pass `cueGate: 'monotonic-forward'` through the bridge. The
+    // bridge and resolver scope delivery to the head scene only —
+    // following composition entries do not see `cueGate`, because the
+    // slice is truncated upstream and the head's interactive timeline
+    // never hands off to following entries. `mode=scrub`, `mode=loop`,
+    // and `mode=paused` are mutually exclusive at the URL boundary,
+    // so at most one of `repeat` / `hold` / `cueGate` is non-undefined
+    // here.
+    const cueGate: 'monotonic-forward' | undefined =
+      mode === 'scrub' ? 'monotonic-forward' : undefined;
     return {
       controller,
       settled: loadSceneNavigationTarget(resolved, {
@@ -457,6 +470,7 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
         ...(onBeatMissing === undefined ? {} : { onBeatMissing }),
         ...(repeat === undefined ? {} : { repeat }),
         ...(hold === undefined ? {} : { hold }),
+        ...(cueGate === undefined ? {} : { cueGate }),
       }),
       silent: false,
     };
@@ -484,11 +498,23 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
    * `mode=paused` MUST NOT silently degrade into normal composition
    * playback (parallel to the ADR-018 codex-review argument).
    *
-   * All three modes share the same slice-shape transform — they
+   * PUL-F017 / ADR-020 (`scrub`): the runtime displays timeline
+   * controls allowing the user to scrub forward, backward, and to
+   * named beats while audio cues fire only on monotonic forward
+   * playback. Truncating the slice makes "no following entries run"
+   * a structural guarantee even if the runner ignores the
+   * `cueGate: 'monotonic-forward'` hint — a runner bug or no-op
+   * runner under `mode=scrub` MUST NOT silently degrade into normal
+   * composition playback. Scrub is single-timeline by construction:
+   * one timeline of controls, one head scene; following composition
+   * entries cannot be part of the interactive scrub UX.
+   *
+   * All four modes share the same slice-shape transform — they
    * differ only in the head's runner-side semantic: standalone
    * plays normally, loop sets `input.repeat = 'until-aborted'`,
-   * paused sets `input.hold = 'first-frame'`. The shape transform
-   * is shared because the structural promise ("no following entries
+   * paused sets `input.hold = 'first-frame'`, scrub sets
+   * `input.cueGate = 'monotonic-forward'`. The shape transform is
+   * shared because the structural promise ("no following entries
    * run") is identical.
    *
    * The composition slice — already validated by
@@ -500,8 +526,8 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
    * `range` / `behavior` overrides (object-form entries per ADR-002
    * / ADR-011) reach the runner unchanged: a flat `{ scene }` would
    * lose them and turn the mode into direct-scene flattening,
-   * contradicting ADR-017 / ADR-018 / ADR-019's "preserve head-entry
-   * overrides" contract.
+   * contradicting ADR-017 / ADR-018 / ADR-019 / ADR-020's "preserve
+   * head-entry overrides" contract.
    *
    * Stage attrs (set by the caller before this transform) reflect
    * what the URL ADDRESSED, not what runs:
@@ -517,7 +543,7 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
   ): SceneNavigationTarget => {
     const mode = effectiveMode(target);
     if (
-      (mode !== 'standalone' && mode !== 'loop' && mode !== 'paused') ||
+      (mode !== 'standalone' && mode !== 'loop' && mode !== 'paused' && mode !== 'scrub') ||
       resolved.composition === undefined
     ) {
       return resolved;

--- a/src/runtime/scene-navigation.ts
+++ b/src/runtime/scene-navigation.ts
@@ -159,6 +159,16 @@ export interface LoadSceneNavigationTargetOptions {
    * parameter.
    */
   readonly hold?: 'first-frame';
+  /**
+   * URL scrub-mode cue-gate hint (PUL-F017 / ADR-020) the runner uses
+   * to decide whether to gate audio-cue firing to monotonic forward
+   * playback only. Forwarded to {@link resolveComposition} as
+   * `headCueGate` — the resolver scopes delivery to the head scene's
+   * run input only, so following composition entries never receive
+   * `cueGate`. Absent when the navigation target had no `mode=scrub`
+   * parameter.
+   */
+  readonly cueGate?: 'monotonic-forward';
 }
 
 const NAV_FAIL_PREFIX = 'scene navigation failed:';
@@ -304,14 +314,19 @@ function resolveCompositionAndIndex(
  * - PUL-F016 / ADR-019 (`mode=paused`, `hold: 'first-frame'`): the
  *   head's timeline holds at frame 0 and never advances, so
  *   following composition entries cannot run.
+ * - PUL-F017 / ADR-020 (`mode=scrub`, `cueGate: 'monotonic-forward'`):
+ *   the head's timeline is driven interactively by the future
+ *   scrub-controls UI; following composition entries cannot run
+ *   because there is no monotonic-forward completion to hand off
+ *   on.
  *
  * Truncating the slice at the bridge guarantees that structural
  * promise without depending on the runner's adapter conformance to
- * `input.repeat` / `input.hold`. A direct bridge caller (test
- * harness, future export pipeline, etc.) gets the same guarantee
- * the loader's `applySingleSceneSlice` provides on the loader→bridge
- * path; the two truncations are idempotent (truncating a
- * single-entry slice is a no-op).
+ * `input.repeat` / `input.hold` / `input.cueGate`. A direct bridge
+ * caller (test harness, future export pipeline, etc.) gets the same
+ * guarantee the loader's `applySingleSceneSlice` provides on the
+ * loader→bridge path; the two truncations are idempotent (truncating
+ * a single-entry slice is a no-op).
  *
  * Pure function — no closure captures. Returns the input unchanged
  * when `headOnly` is `false`, when there is no composition slice, or
@@ -425,25 +440,28 @@ export async function loadSceneNavigationTarget(
   target: SceneNavigationTarget,
   options: LoadSceneNavigationTargetOptions,
 ): Promise<void> {
-  // PUL-F015 / ADR-018 + PUL-F016 / ADR-019: under
-  // `repeat: 'until-aborted'` the head's timeline restarts on
-  // completion (loop), and under `hold: 'first-frame'` the head's
-  // timeline never advances (paused). Both modes share the same
-  // structural promise: following composition entries cannot run.
-  // Truncating the slice at the bridge layer makes "no following
-  // entries run" a structural guarantee that does not depend on the
-  // runner honoring `input.repeat` / `input.hold` (codex pre-push
-  // review): a runner bug or no-op runner under either mode MUST NOT
-  // silently degrade into normal composition playback. The
+  // PUL-F015 / ADR-018 + PUL-F016 / ADR-019 + PUL-F017 / ADR-020:
+  // under `repeat: 'until-aborted'` the head's timeline restarts on
+  // completion (loop), under `hold: 'first-frame'` the head's
+  // timeline never advances (paused), and under
+  // `cueGate: 'monotonic-forward'` the head's timeline is driven
+  // interactively by the future scrub-controls UI (scrub). All three
+  // modes share the same structural promise: following composition
+  // entries cannot run. Truncating the slice at the bridge layer
+  // makes "no following entries run" a structural guarantee that
+  // does not depend on the runner honoring `input.repeat` /
+  // `input.hold` / `input.cueGate` (codex pre-push review): a
+  // runner bug or no-op runner under any of the three modes MUST
+  // NOT silently degrade into normal composition playback. The
   // truncation is layered with the loader's `applySingleSceneSlice`
-  // (which already truncates for `mode=standalone`, `mode=loop`, and
-  // `mode=paused`) so direct bridge callers — outside the loader
-  // path — still benefit from the structural guarantee. Truncating
-  // an already-single-entry slice is a no-op, so the layering is
-  // idempotent.
+  // (which already truncates for `mode=standalone`, `mode=loop`,
+  // `mode=paused`, and `mode=scrub`) so direct bridge callers —
+  // outside the loader path — still benefit from the structural
+  // guarantee. Truncating an already-single-entry slice is a no-op,
+  // so the layering is idempotent.
   const effectiveTarget = truncateToHead(
     target,
-    options.repeat !== undefined || options.hold !== undefined,
+    options.repeat !== undefined || options.hold !== undefined || options.cueGate !== undefined,
   );
   const composition = effectiveTarget.composition;
   // Collapse the single-scene vs composition-slice paths into one
@@ -513,5 +531,13 @@ export async function loadSceneNavigationTarget(
     // caller supplied it so a runner that branches on `'hold' in
     // input` sees an absent key rather than `undefined`.
     ...(options.hold === undefined ? {} : { headHold: options.hold }),
+    // `cueGate` is independent of `beat`, `repeat`, and `hold` per
+    // ADR-020: a URL like `?scene=x&mode=scrub` (no beat) is valid,
+    // and so is `?scene=x&beat=hook&mode=scrub` (the natural
+    // scrub-to-named-beat path PUL-F017's "to named beats" clause
+    // anticipates). Spread `headCueGate` only when the caller
+    // supplied it so a runner that branches on `'cueGate' in input`
+    // sees an absent key rather than `undefined`.
+    ...(options.cueGate === undefined ? {} : { headCueGate: options.cueGate }),
   });
 }

--- a/tests/runtime/composition-resolver.test.ts
+++ b/tests/runtime/composition-resolver.test.ts
@@ -1538,3 +1538,123 @@ describe('URL paused-mode runner hold-hint forwarding (PUL-F016)', () => {
     expect(runCalls[0]?.repeat).toBeUndefined();
   });
 });
+
+describe('URL scrub-mode runner cue-gate-hint forwarding (PUL-F017)', () => {
+  // PUL-F017: in `mode=scrub`, the runtime SHALL display timeline
+  // controls allowing the user to scrub forward, backward, and to
+  // named beats; audio cues SHALL fire only on monotonic forward
+  // playback. ADR-020 places mode dispatch at the loader and the
+  // cue-gate semantics at the timeline-runner adapter. The resolver's
+  // job is forwarding the URL-derived `headCueGate` hint to the head
+  // scene's run input only; subsequent scenes in a composition slice
+  // do not receive `cueGate` because under scrub the slice is
+  // truncated upstream and the head's interactive timeline never
+  // hands off to following entries. The resolver does NOT interpret
+  // `headCueGate` itself; honoring "audio cues fire only on monotonic
+  // forward playback" is the runner's contract.
+
+  it("forwards `headCueGate` to plan[0]'s run input only — subsequent scenes get no cueGate", async () => {
+    const runCalls: SceneTimelineRunInput[] = [];
+    const { options } = buildHarness({
+      scenes: [{ id: 'scene-a' }, { id: 'scene-b' }],
+      manifest: ['scene-a', 'scene-b'],
+      runTimeline: (input) => {
+        runCalls.push(input);
+      },
+    });
+    await resolveComposition({ ...options, headCueGate: 'monotonic-forward' });
+    expect(runCalls).toHaveLength(2);
+    expect(runCalls[0]?.scene.id).toBe('scene-a');
+    expect(runCalls[0]?.cueGate).toBe('monotonic-forward');
+    expect(runCalls[1]?.scene.id).toBe('scene-b');
+    expect(runCalls[1]?.cueGate).toBeUndefined();
+    // Parallel to `beat` / `repeat` / `hold` / `range` / `behavior`:
+    // the key is OMITTED from the input object when absent, not set
+    // to `undefined`. The runner can branch on `'cueGate' in input`
+    // rather than checking for `undefined`.
+    expect('cueGate' in (runCalls[1] as object)).toBe(false);
+  });
+
+  it('does not attach `cueGate` when `headCueGate` is absent', async () => {
+    const runCalls: SceneTimelineRunInput[] = [];
+    const { options } = buildHarness({
+      scenes: [{ id: 'scene-a' }],
+      manifest: ['scene-a'],
+      runTimeline: (input) => {
+        runCalls.push(input);
+      },
+    });
+    await resolveComposition(options);
+    expect(runCalls).toHaveLength(1);
+    expect('cueGate' in (runCalls[0] as object)).toBe(false);
+  });
+
+  it('does not interpret `headCueGate` itself — a runner that ignores the hint and returns normally does not error', async () => {
+    // Resolver delegates monotonic-forward cue gating to the runner
+    // per ADR-020. A runner that receives `cueGate: 'monotonic-forward'`
+    // and returns void normally (e.g. the placeholder runner that has
+    // no real timeline and no real audio engine to gate cues against)
+    // must NOT cause the resolver to throw or skip cleanup.
+    const cleanupCalls: string[] = [];
+    const { options } = buildHarness({
+      scenes: [
+        {
+          id: 'scene-a',
+          cleanup: () => {
+            cleanupCalls.push('scene-a');
+          },
+        },
+      ],
+      manifest: ['scene-a'],
+      runTimeline: () => undefined,
+    });
+    await expect(
+      resolveComposition({
+        ...options,
+        headCueGate: 'monotonic-forward',
+      }),
+    ).resolves.toBeUndefined();
+    expect(cleanupCalls).toEqual(['scene-a']);
+  });
+
+  it('forwards `headCueGate` alongside `headBeat`, `headRepeat`, and `headHold` independently — all four reach plan[0] without coupling', async () => {
+    // `headCueGate`, `headBeat`, `headRepeat`, and `headHold` are
+    // four independent head-only forwardings. A regression that
+    // paired them — e.g. requiring `headBeat` whenever `headCueGate`
+    // is set, or dropping `headCueGate` when `headHold` is also
+    // supplied — would break valid combinations a programmatic
+    // bridge caller (test harness, future export pipeline) can
+    // legitimately request. The URL grammar makes the parent modes
+    // (`mode=loop`, `mode=paused`, `mode=scrub`) mutually exclusive
+    // (mode is a single field), so production callers won't supply
+    // more than one of `headRepeat` / `headHold` / `headCueGate`
+    // at once; the test exercises a programmatic caller scenario to
+    // pin that the resolver does not invent coupling between the
+    // four head-only fields. All four must reach plan[0] when all
+    // four are supplied — this is also the regression test for
+    // URLs like `?scene=x&beat=hook&mode=scrub` (scrub + named
+    // beat — exactly what PUL-F017's "to named beats" clause
+    // anticipates) which only sets `headBeat` + `headCueGate`.
+    const runCalls: SceneTimelineRunInput[] = [];
+    const { options } = buildHarness({
+      scenes: [{ id: 'scene-a' }],
+      manifest: ['scene-a'],
+      runTimeline: (input) => {
+        runCalls.push(input);
+      },
+    });
+    await resolveComposition({
+      ...options,
+      headBeat: 'hook',
+      onBeatMissing: () => undefined,
+      headRepeat: 'until-aborted',
+      headHold: 'first-frame',
+      headCueGate: 'monotonic-forward',
+    });
+    expect(runCalls).toHaveLength(1);
+    expect(runCalls[0]?.beat).toBe('hook');
+    expect(runCalls[0]?.repeat).toBe('until-aborted');
+    expect(runCalls[0]?.hold).toBe('first-frame');
+    expect(runCalls[0]?.cueGate).toBe('monotonic-forward');
+  });
+});

--- a/tests/runtime/scene-loader.test.ts
+++ b/tests/runtime/scene-loader.test.ts
@@ -3838,4 +3838,545 @@ describe('createSceneLoader (PUL-F008)', () => {
       ]);
     });
   });
+
+  describe('scrub-mode runner cue-gate-hint forwarding (PUL-F017)', () => {
+    // PUL-F017 statement: in `mode=scrub`, the runtime SHALL display
+    // timeline controls allowing the user to scrub forward, backward,
+    // and to named beats. Audio cues SHALL fire only on monotonic
+    // forward playback.
+    //
+    // Materially-implementable parts of the statement that this
+    // block pins (ADR-020 records the contract boundary):
+    //   - The loader passes `cueGate: 'monotonic-forward'` to the
+    //     timeline runner adapter when
+    //     `effectiveMode(target) === 'scrub'`. The runner is
+    //     responsible for honoring the hint (e.g. ADR-003's future
+    //     GSAP runner gates audio-cue firing by direction; ADR-004's
+    //     future Howler integration is the consumer).
+    //   - The hint is HEAD-ONLY: under composition targets the head
+    //     scene's runner input carries `cueGate`; following entries
+    //     do not. Following entries do not run at all because the
+    //     slice is truncated to the addressed head — same structural
+    //     defense ADR-018 / ADR-019 record for `mode=loop` /
+    //     `mode=paused`.
+    //   - `ctx.mode === 'scrub'` reaches every lifecycle hook of the
+    //     head scene — the seam the future scrub-controls UI surface
+    //     will read.
+    //   - Other modes (`present`, `standalone`, `loop`, `paused`,
+    //     `screenshot`, `prompter`) and a `mode`-less URL DO NOT set
+    //     `cueGate`. A regression that broadcast `cueGate` under any
+    //     mode would break URLs that depend on no-cue-gating
+    //     semantics (e.g. normal playback under `present`).
+    //   - No `data-pulsar-mode-*` suppression attribute is preempt-
+    //     ively written under `scrub` (parity with ADR-016 / ADR-017
+    //     / ADR-018 / ADR-019).
+    //   - Composition validation (unregistered composition, unknown
+    //     member scene, out-of-range index) STILL surfaces as a
+    //     navigation error under `mode=scrub` — no silent fallback to
+    //     direct scene lookup.
+    //   - Beat semantics under `mode=scrub` are unchanged from
+    //     PUL-F011 at the loader: the head scene's runner sees
+    //     `input.beat`; missing-label diagnostics surface via
+    //     `data-pulsar-navigation-error` / `onError` without
+    //     unmounting. PUL-F017 explicitly names "to named beats" as
+    //     part of scrub's UX, so beat forwarding under `scrub` is
+    //     the natural scrub-to-beat path the future controls UI will
+    //     drive.
+    //   - Object-form head entry's `range` / `behavior` overrides
+    //     reach the runner unchanged. Scrub is single-scene-mount
+    //     with cue-gated playback at the head, NOT direct-scene
+    //     flattening.
+    //
+    // PUL-F017 stays DRAFT after this PR (ADR-020 records the
+    // boundary; following the ADR-016 / ADR-017 / ADR-018 / ADR-019 /
+    // PUL-F013 / PUL-F014 / PUL-F015 / PUL-F016 precedent). The seam
+    // — the loader passes `cueGate: 'monotonic-forward'` and
+    // `ctx.mode === 'scrub'` — IS materially shipped. The actual
+    // monotonic-forward cue-gating behavior is the runner's contract
+    // (ADR-003's GSAP runner + ADR-004's audio engine when they
+    // land) and the timeline-controls UI is a future workbench
+    // chrome surface; both are required for ACTIVE.
+
+    const scrubSceneTarget = (id: string): NavigationTarget => ({
+      locator: { kind: 'scene', scene: id },
+      mode: 'scrub',
+    });
+    const scrubCompositionTarget = (composition: string): NavigationTarget => ({
+      locator: { kind: 'composition', composition },
+      mode: 'scrub',
+    });
+    const scrubCompositionSceneTarget = (composition: string, scene: string): NavigationTarget => ({
+      locator: { kind: 'composition-scene', composition, scene },
+      mode: 'scrub',
+    });
+    const scrubCompositionIndexTarget = (composition: string, index: number): NavigationTarget => ({
+      locator: { kind: 'composition-index', composition, index },
+      mode: 'scrub',
+    });
+
+    it('passes `cueGate: "monotonic-forward"` to the runner for a `scene` target under `mode=scrub`', async () => {
+      // Direct-scene navigation is the simplest scrub path: the
+      // addressed scene IS the head, no slice resolution. A
+      // regression that gated `cueGate` on `target.composition`
+      // being defined would silently drop the hint here.
+      const captured: { sceneId: string; cueGate: 'monotonic-forward' | undefined }[] = [];
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      const runner: SceneTimelineRunner = (input) => {
+        captured.push({ sceneId: input.scene.id, cueGate: input.cueGate });
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: runner,
+      });
+
+      await loader.handle(scrubSceneTarget('scene-a'));
+
+      expect(captured).toEqual([{ sceneId: 'scene-a', cueGate: 'monotonic-forward' }]);
+    });
+
+    it('runs only the head scene of a `composition` target under `mode=scrub` (slice truncation; runner sees `cueGate: "monotonic-forward"` for the head)', async () => {
+      // PUL-F017 / ADR-020: scrub truncates the validated
+      // composition slice to the addressed head, parallel to
+      // standalone (ADR-017), loop (ADR-018), and paused (ADR-019).
+      // Truncation makes "no following entries run" a structural
+      // guarantee — a runner bug or no-op runner under `mode=scrub`
+      // MUST NOT silently degrade into normal composition playback.
+      // Use a non-final-index navigation so the slice has successors
+      // that would be observable if truncation were missing.
+      const captured: { sceneId: string; cueGate: 'monotonic-forward' | undefined }[] = [];
+      const sceneA = buildScene({ id: 'scene-a' });
+      const sceneB = buildScene({ id: 'scene-b' });
+      const sceneC = buildScene({ id: 'scene-c' });
+      const stage = buildStage();
+      const runner: SceneTimelineRunner = (input) => {
+        captured.push({ sceneId: input.scene.id, cueGate: input.cueGate });
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA, sceneB, sceneC]),
+        compositions: createCompositionRegistry([
+          { id: 'full-talk', manifest: ['scene-a', 'scene-b', 'scene-c'] },
+        ]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: runner,
+      });
+
+      await loader.handle(scrubCompositionIndexTarget('full-talk', 0));
+
+      expect(captured).toEqual([{ sceneId: 'scene-a', cueGate: 'monotonic-forward' }]);
+    });
+
+    it('runs only the addressed scene of a `composition+scene` target under `mode=scrub`', async () => {
+      // composition+scene targeting a non-final entry exercises the
+      // slice transform from a different locator shape; pins parity
+      // with the composition-target case above.
+      const captured: { sceneId: string; cueGate: 'monotonic-forward' | undefined }[] = [];
+      const sceneA = buildScene({ id: 'scene-a' });
+      const sceneB = buildScene({ id: 'scene-b' });
+      const sceneC = buildScene({ id: 'scene-c' });
+      const stage = buildStage();
+      const runner: SceneTimelineRunner = (input) => {
+        captured.push({ sceneId: input.scene.id, cueGate: input.cueGate });
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA, sceneB, sceneC]),
+        compositions: createCompositionRegistry([
+          { id: 'full-talk', manifest: ['scene-a', 'scene-b', 'scene-c'] },
+        ]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: runner,
+      });
+
+      await loader.handle(scrubCompositionSceneTarget('full-talk', 'scene-b'));
+
+      expect(captured).toEqual([{ sceneId: 'scene-b', cueGate: 'monotonic-forward' }]);
+    });
+
+    it('runs cleanup exactly once for the head scene under `mode=scrub`, never for dropped slice entries', async () => {
+      // Same invariant as PUL-F014 (ADR-017) under standalone,
+      // PUL-F015 (ADR-018) under loop, PUL-F016 (ADR-019) under
+      // paused: a regression that dropped the slice for execution
+      // but left following scenes wired through the synthesized
+      // registry could double-clean or skip-clean. Pin
+      // exactly-once cleanup on the head and zero cleanup for the
+      // dropped entries.
+      const cleaned: string[] = [];
+      const trace = (id: string): SceneModule =>
+        buildScene({
+          id,
+          cleanup: () => {
+            cleaned.push(id);
+          },
+        });
+      const scenes = [trace('scene-a'), trace('scene-b'), trace('scene-c')];
+      const stage = buildStage();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry(scenes),
+        compositions: createCompositionRegistry([
+          { id: 'full-talk', manifest: scenes.map((s) => s.id) },
+        ]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+      });
+
+      await loader.handle(scrubCompositionTarget('full-talk'));
+
+      expect(cleaned).toEqual(['scene-a']);
+    });
+
+    it('omits the `cueGate` key on the runner input when `mode=scrub` is absent (key-presence semantics)', async () => {
+      // The runner input uses key-presence semantics for optional
+      // fields (parallel to `beat` / `repeat` / `hold` / `range` /
+      // `behavior`): a runner can branch on `'cueGate' in input`
+      // rather than `=== undefined`. A regression that always set
+      // `input.cueGate = undefined` (or any non-`'monotonic-forward'`
+      // value) under non-scrub modes would break that contract.
+      const captured: { hasCueGate: boolean; cueGate: unknown }[] = [];
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      const runner: SceneTimelineRunner = (input) => {
+        captured.push({ hasCueGate: 'cueGate' in input, cueGate: input.cueGate });
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: runner,
+      });
+
+      // No mode at all (defaults to `present`).
+      await loader.handle(sceneTarget('scene-a'));
+
+      expect(captured).toEqual([{ hasCueGate: false, cueGate: undefined }]);
+    });
+
+    it('does not set `cueGate` for any non-scrub mode', async () => {
+      // Walk the seven-mode allowlist (minus `scrub`) and confirm
+      // that none of them produce `cueGate` on the runner input.
+      // Catching every non-scrub mode discriminates against an
+      // over-broad fix that gated `cueGate` on `mode !== undefined`
+      // rather than `mode === 'scrub'`. Capturing the per-iteration
+      // mode alongside the `'cueGate' in input` flag means the
+      // assertion failure identifies WHICH mode regressed, not just
+      // "some mode did."
+      const nonScrubModes = NAVIGATION_MODES.filter((m) => m !== 'scrub');
+      const captured: { mode: NavigationMode; hasCueGate: boolean }[] = [];
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      for (const mode of nonScrubModes) {
+        const runner: SceneTimelineRunner = (input) => {
+          captured.push({ mode, hasCueGate: 'cueGate' in input });
+        };
+        const loader = createSceneLoader({
+          scenes: createSceneRegistry([sceneA]),
+          compositions: createCompositionRegistry([]),
+          stage: stage.element,
+          buildCtx: stubCtx,
+          createPreloader: () => () => undefined,
+          runTimeline: runner,
+        });
+        await loader.handle({ locator: { kind: 'scene', scene: 'scene-a' }, mode });
+      }
+
+      // One entry per non-scrub mode, each must have `hasCueGate:
+      // false`. Building the expected array from `nonScrubModes`
+      // keeps the assertion in sync if the mode allowlist ever
+      // changes.
+      expect(captured).toEqual(nonScrubModes.map((mode) => ({ mode, hasCueGate: false })));
+    });
+
+    it('exposes `ctx.mode === "scrub"` to every lifecycle hook of the head scene under all locator shapes', async () => {
+      // Parallel to the PUL-F014 standalone, PUL-F015 loop, and
+      // PUL-F016 paused seam tests. Future runner / chrome / audio
+      // surfaces (specifically the timeline-controls UI named in the
+      // PUL-F017 statement) read `ctx.mode` to decide their own
+      // behavior; this test pins the seam end to end across all four
+      // locator shapes that can appear under `mode=scrub`.
+      const seen: { phase: string; locatorKind: string; mode: unknown }[] = [];
+      const recordMode =
+        (phase: string, locatorKind: string) =>
+        (ctx: unknown): unknown => {
+          seen.push({ phase, locatorKind, mode: (ctx as { mode?: NavigationMode }).mode });
+          return null;
+        };
+      const makeScene = (locatorKind: string): SceneModule =>
+        buildScene({
+          id: 'scene-a',
+          create: recordMode('create', locatorKind),
+          timeline: recordMode('timeline', locatorKind) as SceneModule['timeline'],
+          cleanup: recordMode('cleanup', locatorKind),
+        });
+      const stage = buildStage();
+      const buildLoader = (sceneId: string, locatorKind: string) =>
+        createSceneLoader({
+          scenes: createSceneRegistry([makeScene(locatorKind)]),
+          compositions: createCompositionRegistry([{ id: 'full-talk', manifest: [sceneId] }]),
+          stage: stage.element,
+          buildCtx: (mode) => ({ stage: stage.element, mode }),
+          createPreloader: () => () => undefined,
+          runTimeline: noopRunner,
+        });
+
+      await buildLoader('scene-a', 'scene').handle(scrubSceneTarget('scene-a'));
+      await buildLoader('scene-a', 'composition').handle(scrubCompositionTarget('full-talk'));
+      await buildLoader('scene-a', 'composition-scene').handle(
+        scrubCompositionSceneTarget('full-talk', 'scene-a'),
+      );
+      await buildLoader('scene-a', 'composition-index').handle(
+        scrubCompositionIndexTarget('full-talk', 0),
+      );
+
+      // 3 hooks per navigation × 4 locator shapes = 12 entries;
+      // every single one must carry `scrub`.
+      expect(seen).toHaveLength(12);
+      for (const entry of seen) {
+        expect(entry.mode).toBe('scrub');
+      }
+    });
+
+    it('forwards `beat` to the head scene runner alongside `cueGate` under `mode=scrub`, and surfaces missing-beat as a non-fatal diagnostic', async () => {
+      // PUL-F011 / PUL-F017 are independent at the loader: a URL
+      // like `?scene=x&beat=hook&mode=scrub` must deliver both
+      // `beat` and `cueGate` to the runner. PUL-F017 explicitly
+      // mentions "named beats" as part of scrub's UX, so a
+      // regression that dropped `beat` when `mode=scrub` is set
+      // would silently break the natural scrub-to-beat path.
+      const captured: {
+        sceneId: string;
+        beat: string | undefined;
+        cueGate: 'monotonic-forward' | undefined;
+      }[] = [];
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      const errors: unknown[] = [];
+      const runner: SceneTimelineRunner = (input) => {
+        captured.push({
+          sceneId: input.scene.id,
+          beat: input.beat,
+          cueGate: input.cueGate,
+        });
+        if (input.beat !== undefined && input.onBeatMissing !== undefined) {
+          input.onBeatMissing();
+        }
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: runner,
+        onError: (err) => {
+          errors.push(err);
+        },
+      });
+
+      await loader.handle({
+        locator: { kind: 'scene', scene: 'scene-a' },
+        mode: 'scrub',
+        beat: 'midpoint',
+      });
+
+      expect(captured).toEqual([
+        { sceneId: 'scene-a', beat: 'midpoint', cueGate: 'monotonic-forward' },
+      ]);
+      expect(errors).toHaveLength(1);
+      expect((errors[0] as Error).message).toContain('beat positioning failed');
+      expect((errors[0] as Error).message).toContain('"midpoint"');
+      expect(stage.attrs.get('data-pulsar-navigation-error')).toBeDefined();
+    });
+
+    it('writes no `data-pulsar-mode-*` suppression attribute on the stage under `mode=scrub`', async () => {
+      // Mirrors ADR-016 / ADR-017 / ADR-018 / ADR-019 invariant.
+      // PUL-F017 forbids the loader from preemptively writing a
+      // stage attribute for scrub mode; runner-side or future-
+      // surface-side signaling (the controls UI) lives at those
+      // surfaces, not at the loader.
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+      });
+
+      await loader.handle(scrubSceneTarget('scene-a'));
+
+      const modeAttrs = Array.from(stage.attrs.keys()).filter((name) =>
+        name.startsWith('data-pulsar-mode-'),
+      );
+      expect(modeAttrs).toEqual([]);
+    });
+
+    it('writes both `data-pulsar-scene-target` and `data-pulsar-composition-target` for a composition target under `mode=scrub` (preserves observability of what the URL addressed)', async () => {
+      // The stage attrs communicate "what was addressed," not "what
+      // ran." Truncation drops following entries from execution but
+      // does not drop the composition id from the stage attrs —
+      // mirrors the standalone / loop / paused invariant.
+      const sceneA = buildScene({ id: 'scene-a' });
+      const sceneB = buildScene({ id: 'scene-b' });
+      const stage = buildStage();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA, sceneB]),
+        compositions: createCompositionRegistry([
+          { id: 'full-talk', manifest: ['scene-a', 'scene-b'] },
+        ]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+      });
+
+      await loader.handle(scrubCompositionSceneTarget('full-talk', 'scene-b'));
+
+      expect(stage.attrs.get('data-pulsar-scene-target')).toBe('scene-b');
+      expect(stage.attrs.get('data-pulsar-composition-target')).toBe('full-talk');
+    });
+
+    it('surfaces composition-not-registered as a navigation error under `mode=scrub` (no silent fallback)', async () => {
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      const errors: unknown[] = [];
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+        onError: (err) => {
+          errors.push(err);
+        },
+      });
+
+      await loader.handle(scrubCompositionTarget('not-registered'));
+
+      expect(errors).toHaveLength(1);
+      expect((errors[0] as Error).message).toContain(
+        'composition "not-registered" is not registered',
+      );
+      expect(stage.attrs.get('data-pulsar-navigation-error')).toBeDefined();
+    });
+
+    it('surfaces composition-member error under `mode=scrub` for an unknown scene in `composition+scene`', async () => {
+      const sceneA = buildScene({ id: 'scene-a' });
+      const sceneZ = buildScene({ id: 'scene-z' });
+      const stage = buildStage();
+      const errors: unknown[] = [];
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA, sceneZ]),
+        compositions: createCompositionRegistry([{ id: 'full-talk', manifest: ['scene-a'] }]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+        onError: (err) => {
+          errors.push(err);
+        },
+      });
+
+      await loader.handle(scrubCompositionSceneTarget('full-talk', 'scene-z'));
+
+      expect(errors).toHaveLength(1);
+      expect((errors[0] as Error).message).toContain(
+        'scene "scene-z" is not a member of composition "full-talk"',
+      );
+    });
+
+    it('surfaces index-out-of-range under `mode=scrub`', async () => {
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      const errors: unknown[] = [];
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([{ id: 'full-talk', manifest: ['scene-a'] }]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+        onError: (err) => {
+          errors.push(err);
+        },
+      });
+
+      await loader.handle(scrubCompositionIndexTarget('full-talk', 5));
+
+      expect(errors).toHaveLength(1);
+      expect((errors[0] as Error).message).toContain('index 5 is out of range');
+    });
+
+    it("preserves the addressed head entry's `range` and `behavior` overrides on the runner input under `mode=scrub` (composition+index with object-form entry)", async () => {
+      // PUL-F017 / ADR-020: scrub truncates the validated
+      // composition slice to the addressed head and forwards
+      // `cueGate` to that head's runner input. The slice is
+      // TRUNCATED rather than flattened — a flat `{ scene }` would
+      // lose object-form `range` / `behavior` overrides on the head
+      // entry, turning scrub into direct-scene flattening (parity
+      // with ADR-017's standalone, ADR-018's loop, and ADR-019's
+      // paused invariant). This pins all three slots — `range`,
+      // `behavior`, and `cueGate` — through to the head runner,
+      // plus the truncation itself (the runner runs exactly once).
+      const sceneA = buildScene({ id: 'scene-a' });
+      const sceneB = buildScene({ id: 'scene-b' });
+      const sceneC = buildScene({ id: 'scene-c' });
+      const stage = buildStage();
+      const captured: {
+        sceneId: string;
+        range: unknown;
+        behavior: unknown;
+        cueGate: unknown;
+      }[] = [];
+      const runner: SceneTimelineRunner = (input) => {
+        captured.push({
+          sceneId: input.scene.id,
+          range: input.range,
+          behavior: input.behavior,
+          cueGate: input.cueGate,
+        });
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA, sceneB, sceneC]),
+        compositions: createCompositionRegistry([
+          {
+            id: 'full-talk',
+            manifest: [
+              'scene-a',
+              { id: 'scene-b', range: 'hook', behavior: { hold: true } },
+              'scene-c',
+            ],
+          },
+        ]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: runner,
+      });
+
+      await loader.handle(scrubCompositionIndexTarget('full-talk', 1));
+
+      expect(captured).toEqual([
+        {
+          sceneId: 'scene-b',
+          range: 'hook',
+          behavior: { hold: true },
+          cueGate: 'monotonic-forward',
+        },
+      ]);
+    });
+  });
 });

--- a/tests/runtime/scene-navigation.test.ts
+++ b/tests/runtime/scene-navigation.test.ts
@@ -1208,4 +1208,185 @@ describe('loadSceneNavigationTarget (PUL-F008 lifecycle bridge)', () => {
       expect(seen).toEqual([{ beat: 'hook', hold: 'first-frame', repeat: 'until-aborted' }]);
     });
   });
+
+  describe('URL scrub-mode cue-gate forwarding (PUL-F017)', () => {
+    // ADR-020: under `mode=scrub` the runner gates audio cues to
+    // monotonic forward playback. The bridge's only job is to
+    // forward the `cueGate` option from the loader to the resolver
+    // as `headCueGate`. The resolver scopes delivery to the head
+    // scene's run input only — gating the cue stream is the
+    // runner's contract.
+
+    it('forwards `cueGate` to the runner for a single-scene target', async () => {
+      const seen: { cueGate?: 'monotonic-forward' }[] = [];
+      const intro = buildScene({ id: 'intro' });
+      const scenes = createSceneRegistry([intro]);
+      const compositions = createCompositionRegistry([]);
+      const target = resolveSceneNavigation(sceneTarget('intro'), {
+        scenes,
+        compositions,
+      }) as SceneNavigationTarget;
+
+      await loadSceneNavigationTarget(target, {
+        ctx: {},
+        preloadAssets: () => undefined,
+        runTimeline: (input) => {
+          const captured: { cueGate?: 'monotonic-forward' } = {};
+          if ('cueGate' in input) captured.cueGate = input.cueGate;
+          seen.push(captured);
+        },
+        cueGate: 'monotonic-forward',
+      });
+
+      expect(seen).toEqual([{ cueGate: 'monotonic-forward' }]);
+    });
+
+    it('truncates a composition slice to the addressed head when `cueGate` is supplied — structural defense against runner non-conformance', async () => {
+      // PUL-F017 / ADR-020: under `cueGate: 'monotonic-forward'`
+      // scrub is single-scene-execution at the addressed head — by
+      // definition following composition entries do not run because
+      // the user is interactively scrubbing one timeline. The bridge
+      // truncates the slice to a single entry as a structural
+      // defense so a runner that ignores `input.cueGate` cannot
+      // silently degrade scrub-mode navigation into normal
+      // composition playback. This is layered with the loader's
+      // `applySingleSceneSlice` so direct bridge callers — outside
+      // the loader path — get the same guarantee. Mirrors the
+      // layered defense ADR-018 records for `repeat` and ADR-019
+      // records for `hold`.
+      const seen: { id: string; cueGate: 'monotonic-forward' | undefined }[] = [];
+      const intro = buildScene({ id: 'intro' });
+      const middle = buildScene({ id: 'middle' });
+      const scenes = createSceneRegistry([intro, middle]);
+      const compositions = createCompositionRegistry([
+        { id: 'full-talk', manifest: ['intro', 'middle'] },
+      ]);
+      const target = resolveSceneNavigation(compositionIndexTarget('full-talk', 0), {
+        scenes,
+        compositions,
+      }) as SceneNavigationTarget;
+
+      await loadSceneNavigationTarget(target, {
+        ctx: {},
+        preloadAssets: () => undefined,
+        runTimeline: (input) => {
+          seen.push({ id: input.scene.id, cueGate: input.cueGate });
+        },
+        cueGate: 'monotonic-forward',
+      });
+
+      // Only the head ran; the tail (`middle`) was structurally
+      // dropped. A regression that omitted bridge-level truncation
+      // under `cueGate` would observe `middle` as a second runner
+      // entry here.
+      expect(seen).toEqual([{ id: 'intro', cueGate: 'monotonic-forward' }]);
+    });
+
+    it('does not truncate a composition slice when `cueGate` is absent — non-scrub navigations run the full slice', async () => {
+      // The structural defense fires only under `cueGate` (or
+      // `repeat` / `hold`). Composition navigation under any
+      // non-scrub, non-loop, non-paused mode must still run every
+      // entry — a regression that always truncated would silently
+      // break normal composition playback.
+      const seen: string[] = [];
+      const intro = buildScene({ id: 'intro' });
+      const middle = buildScene({ id: 'middle' });
+      const scenes = createSceneRegistry([intro, middle]);
+      const compositions = createCompositionRegistry([
+        { id: 'full-talk', manifest: ['intro', 'middle'] },
+      ]);
+      const target = resolveSceneNavigation(compositionIndexTarget('full-talk', 0), {
+        scenes,
+        compositions,
+      }) as SceneNavigationTarget;
+
+      await loadSceneNavigationTarget(target, {
+        ctx: {},
+        preloadAssets: () => undefined,
+        runTimeline: (input) => {
+          seen.push(input.scene.id);
+        },
+      });
+
+      expect(seen).toEqual(['intro', 'middle']);
+    });
+
+    it('does not forward `cueGate` when the option is omitted', async () => {
+      const cueGatePresence: boolean[] = [];
+      const intro = buildScene({ id: 'intro' });
+      const scenes = createSceneRegistry([intro]);
+      const compositions = createCompositionRegistry([]);
+      const target = resolveSceneNavigation(sceneTarget('intro'), {
+        scenes,
+        compositions,
+      }) as SceneNavigationTarget;
+
+      await loadSceneNavigationTarget(target, {
+        ctx: {},
+        preloadAssets: () => undefined,
+        runTimeline: (input) => {
+          cueGatePresence.push('cueGate' in input);
+        },
+      });
+
+      expect(cueGatePresence).toEqual([false]);
+    });
+
+    it('forwards `cueGate`, `beat`, `repeat`, and `hold` independently — all four reach the head without coupling', async () => {
+      // The bridge plumbs four independent head-only forwardings. A
+      // regression that paired them — e.g. dropping `cueGate` when
+      // `repeat` is also supplied, or vice versa — would break valid
+      // combinations a programmatic caller can legitimately request.
+      // Note that `mode=scrub`, `mode=loop`, and `mode=paused` are
+      // mutually exclusive at the URL boundary (mode is a single
+      // field), but a programmatic caller can supply any combination
+      // of these options to the bridge and all must reach the runner
+      // so the runner-side policy decides.
+      const seen: {
+        beat?: string;
+        cueGate?: 'monotonic-forward';
+        hold?: 'first-frame';
+        repeat?: 'until-aborted';
+      }[] = [];
+      const intro = buildScene({ id: 'intro' });
+      const scenes = createSceneRegistry([intro]);
+      const compositions = createCompositionRegistry([]);
+      const target = resolveSceneNavigation(sceneTarget('intro'), {
+        scenes,
+        compositions,
+      }) as SceneNavigationTarget;
+
+      await loadSceneNavigationTarget(target, {
+        ctx: {},
+        preloadAssets: () => undefined,
+        runTimeline: (input) => {
+          const captured: {
+            beat?: string;
+            cueGate?: 'monotonic-forward';
+            hold?: 'first-frame';
+            repeat?: 'until-aborted';
+          } = {};
+          if ('beat' in input) captured.beat = input.beat;
+          if ('cueGate' in input) captured.cueGate = input.cueGate;
+          if ('hold' in input) captured.hold = input.hold;
+          if ('repeat' in input) captured.repeat = input.repeat;
+          seen.push(captured);
+        },
+        beat: 'hook',
+        onBeatMissing: () => undefined,
+        cueGate: 'monotonic-forward',
+        hold: 'first-frame',
+        repeat: 'until-aborted',
+      });
+
+      expect(seen).toEqual([
+        {
+          beat: 'hook',
+          cueGate: 'monotonic-forward',
+          hold: 'first-frame',
+          repeat: 'until-aborted',
+        },
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Land the loader → bridge → resolver → runner-input plumbing for
  `mode=scrub` — a head-only `cueGate: 'monotonic-forward'` hint
  that audio-capable runners use to gate cue firing to monotonic
  forward playback only.
- Slice truncation at the loader and bridge keeps scrub
  single-scene-execution at the addressed head (parallel to
  `standalone` per ADR-017 / `loop` per ADR-018 / `paused` per
  ADR-019). The seam `ctx.mode === 'scrub'` reaches every lifecycle
  hook of the head scene; the future scrub-controls UI surface
  reads the seam.
- Adds **ADR-020** (the contract decision) and
  `docs/design/pul-f017-scrub-mode-preflight.md` (the design
  preflight context). Updates `docs/adrs/README.md` index and
  `CHANGELOG.md`.

## Status

PUL-F017 stays **DRAFT** after this PR per the ADR-016 / 017 / 018
/ 019 precedent. The issue ↔ requirement link is `DOCUMENTS`.
ACTIVE transitions when ADR-003's GSAP runner + ADR-004's audio
engine + a scrub-controls UI surface all land with end-to-end
tests (see ADR-020's *Current state* section for the full
criteria).

## Runner conformance bar

ADR-020 documents a tighter conformance wording than `repeat` /
`hold`: a runner that schedules audio cues **MUST** fire each cue
only on monotonic forward crossings of its trigger time when
`input.cueGate === 'monotonic-forward'`. A runner without an
audio-cue subsystem (the placeholder today) trivially satisfies
the gate because no cues exist to fire.

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` — all 656 tests green; new scrub-mode describe
      blocks in `composition-resolver.test.ts` (4 tests),
      `scene-navigation.test.ts` (5 tests), and
      `scene-loader.test.ts` (12+ tests) pin every clause across
      resolver / bridge / loader.
- [x] `pre-commit run --all-files` passes
- [x] Pre-push codex review (2 cycles, hard-cap reached).
      Findings + decisions recorded on the issue thread:
      - https://github.com/KeplerOps/pulsar/issues/26#issuecomment-4411768706
      - https://github.com/KeplerOps/pulsar/issues/26#issuecomment-4411782641

Closes #26