### PR TITLE
Implement PUL-F018 mode=screenshot contract layer (ADR-021)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,68 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `docs/adrs/021-workbench-mode-screenshot.md` and
+  `docs/design/pul-f018-screenshot-mode-preflight.md` — record the
+  PUL-F018 contract layer for `mode=screenshot`. Single-scene
+  execution at the addressed head (parallel to `standalone`,
+  `loop`, `paused`, and `scrub`); a runner-side capture-bundle
+  hint (`screenshot: 'capture'`) for runners that own the timeline,
+  audio, and randomness paths to deliver the four-axis bundle —
+  frame freeze at `input.beat` (or 0), no animation in progress,
+  all audio suppressed, deterministic randomness — under
+  screenshot capture. Beat is honored as the captured-frame anchor
+  (unlike `mode=paused` where ADR-019 records "first frame wins"),
+  matching PUL-F018's "at the addressed beat (or first frame if no
+  beat)." See ADR-021 for the URL contract, the runner conformance
+  bar, the single-scene scope rationale, the bundle-vs-fragmented-
+  fields rationale, and the DRAFT → ACTIVE transition criteria.
+  Indexed in `docs/adrs/README.md`.
+- `src/runtime/composition-resolver.ts` —
+  `SceneTimelineRunInput` gains optional
+  `screenshot?: 'capture'` and `ResolveCompositionOptions` gains
+  optional `headScreenshot?: 'capture'`. The resolver forwards
+  `headScreenshot` to plan[0]'s run input only (head-only,
+  parallel to `headBeat`, `headRepeat`, `headHold`, and
+  `headCueGate`); subsequent scenes never receive `screenshot`.
+  Literal-typed union for future variant extension.
+- `src/runtime/scene-navigation.ts` —
+  `LoadSceneNavigationTargetOptions` gains optional
+  `screenshot?: 'capture'`; `loadSceneNavigationTarget()` forwards
+  it to `resolveComposition` as `headScreenshot`. The bridge
+  truncates a composition slice to its addressed head when
+  `screenshot` is supplied (the `truncateToHead` predicate widens
+  to fire when ANY of `repeat` / `hold` / `cueGate` / `screenshot`
+  is supplied), layered with the loader's `applySingleSceneSlice`.
+- `src/runtime/scene-loader.ts` — when
+  `effectiveMode(target) === 'screenshot'`, the loader passes
+  `screenshot: 'capture'` through the bridge; non-screenshot modes
+  leave the key absent (key-presence semantics). The single-scene-
+  execution helper that landed for `standalone`, `loop`, `paused`,
+  and `scrub` is widened to include `screenshot`.
+- `src/main.ts` — placeholder timeline runner docstring
+  acknowledges `input.screenshot`. The placeholder has no real
+  timeline, no audio engine, and no scene-side randomness, so it
+  vacuously satisfies the bundle (no animation runs, no audio
+  fires, no random source exists).
+- `tests/runtime/composition-resolver.test.ts`,
+  `tests/runtime/scene-navigation.test.ts`, and
+  `tests/runtime/scene-loader.test.ts` — new
+  `'... screenshot-mode … capture-hint … forwarding (PUL-F018)'`
+  describe blocks pinning the resolver, bridge, and loader
+  behavior: head-only delivery, key-presence semantics, no
+  contamination under non-screenshot modes, slice truncation,
+  cleanup-once, the `ctx.mode === 'screenshot'` seam across all
+  four locator shapes, beat / screenshot independence (and
+  beat-honoring under screenshot), composition validation
+  invariants, stage attribute behavior, and `range` / `behavior`
+  preservation through the truncated slice.
+
+PUL-F018 stays DRAFT after this PR; the issue ↔ requirement link
+is `DOCUMENTS` per the ADR-016 / ADR-017 / ADR-018 / ADR-019 /
+ADR-020 precedent. ACTIVE transitions when ADR-003's GSAP runner
+honoring `input.screenshot` + ADR-004's audio engine producing
+silence under screenshot + a deterministic-randomness convention
+all land with end-to-end tests (see ADR-021).
 - `docs/adrs/020-workbench-mode-scrub.md` and
   `docs/design/pul-f017-scrub-mode-preflight.md` — record the
   PUL-F017 contract layer for `mode=scrub`. Single-scene execution

--- a/docs/adrs/021-workbench-mode-screenshot.md
+++ b/docs/adrs/021-workbench-mode-screenshot.md
@@ -1,0 +1,594 @@
+# ADR-021: Workbench Mode `screenshot` — Runner Capture-Bundle Hint at the Loader/Runner Seam
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-09
+
+## Context
+
+ADR-007 names seven workbench modes: `present`, `standalone`, `loop`,
+`paused`, `scrub`, `screenshot`, `prompter`. ADR-013 fixes the URL
+grammar boundary that carries `mode=` to the runtime. ADR-014 fixes
+the scene navigation dispatch layer. ADR-015 fixes URL beat
+positioning. ADR-016 (`mode=present`), ADR-017 (`mode=standalone`),
+ADR-018 (`mode=loop`), ADR-019 (`mode=paused`), and ADR-020
+(`mode=scrub`) establish the precedent for landing a mode's contract
+layer plus seam tests while the dependent rendering surfaces are
+still pending: PUL-F013, PUL-F014, PUL-F015, PUL-F016, and PUL-F017
+all stayed DRAFT after their respective contract PRs because chrome
+/ audio / GSAP runner / presenter input / scrub-controls surfaces
+are not yet implemented.
+
+PUL-F018 specifies `mode=screenshot`:
+
+> In `mode=screenshot`, the runtime SHALL render the addressed scene
+> at the addressed beat (or first frame if no beat) with all asset
+> preloads resolved, no animation in progress, all audio suppressed,
+> and any randomness sourced from a deterministic seed.
+
+The non-trivial parts of that statement decompose this way:
+
+- "Render the addressed scene at the addressed beat (or first frame
+  if no beat)" — the runner must seek to `input.beat` if present,
+  else stay at frame 0. The "at the addressed beat" half reuses
+  PUL-F011 / ADR-015 `headBeat` plumbing. Unlike `mode=paused`
+  (ADR-019: "first frame wins"), screenshot HONORS the beat as the
+  addressed-frame anchor — that's literally what the requirement
+  says.
+- "All asset preloads resolved" — already an invariant of PUL-F004 /
+  PUL-F005. The composition resolver awaits `preloadAssets(scene)`
+  before invoking `create(ctx)` for every scene. No new plumbing.
+- "No animation in progress" — after seeking to the beat (or frame
+  0), the runner must HOLD the timeline still. Distinct from
+  `hold: 'first-frame'` (paused) because screenshot's hold position
+  is beat-aware.
+- "All audio suppressed" — the runner / audio engine must produce no
+  audio output under screenshot capture. Broader than
+  `cueGate: 'monotonic-forward'` (scrub) — `cueGate` only gates
+  audio cues scheduled at timeline labels; screenshot suppresses
+  cues AND ambient loops AND any other audio output the engine may
+  produce.
+- "Randomness sourced from a deterministic seed" — scenes that
+  consume randomness (random tween offsets, particle emitters with
+  jittered start times, procedural visuals, etc.) must derive any
+  random values from a stable seed under screenshot capture, so
+  re-loading the same URL produces an identical frame.
+
+ADR-003's GSAP runner is not implemented. The placeholder runner in
+`src/main.ts` has no real timeline (`scene.timeline(ctx)` returns
+`null`), no audio engine (ADR-004's Howler integration is not yet
+implemented), and no scene-side randomness path. With no animation,
+no audio, and no random source, the placeholder vacuously satisfies
+all four runtime axes — but vacuous truth is not enforcement.
+
+The question this ADR answers is: where does the loader → runner
+contract for `mode=screenshot` live, and on what contract does
+PUL-F018 transition to ACTIVE?
+
+## Decision
+
+### Scope: screenshot is single-scene, explicitly
+
+`mode=screenshot` is **single-scene execution at the addressed
+head**, not a composition-wide capture mode. PUL-F018's requirement
+is "the addressed scene at the addressed beat" — one scene, one
+frame. Composition-wide capture (a sequence of frames across
+multiple scenes' timelines, or a video export across a manifest) is
+explicitly out of scope: the runtime has no cross-scene timeline
+abstraction, no manifest-level frame aggregation, and no export
+pipeline — adding any of those would be a wholly new architectural
+layer beyond what PUL-F018 calls for. The user (or capture tooling)
+addresses one specific scene to capture one frame.
+
+The URL contract for "which scene to capture" reuses the existing
+PUL-F008 / ADR-014 locator shapes (PUL-F007 / ADR-013 grammar):
+
+- `?scene=x&mode=screenshot` — capture scene `x` directly.
+- `?composition=c&mode=screenshot` — capture the head scene of
+  composition `c`.
+- `?composition=c&scene=x&mode=screenshot` — capture scene `x`
+  within composition `c`.
+- `?composition=c&index=N&mode=screenshot` — capture the entry at
+  index `N` within composition `c`.
+
+To capture a different scene in the same composition, the user
+addresses that scene by id or index in a fresh URL — same pattern
+the rest of the URL grammar uses for scene selection.
+
+This single-scene scope is the precedent the four other
+single-scene-execution modes (standalone / loop / paused / scrub)
+already establish. The five single-scene-execution modes share the
+same slice-truncation transform because they share the same
+structural "no following entries run" promise; they differ only in
+the head's runner-side semantic.
+
+### Plumbing
+
+`mode=screenshot` is dispatched at the loader
+(`src/runtime/scene-loader.ts`) as a runner-input field forwarded
+to the timeline-runner adapter on the head scene's run input only.
+When `effectiveMode(target) === 'screenshot'` the loader passes
+`screenshot: 'capture'` through `loadSceneNavigationTarget()` and
+the resolver to `SceneTimelineRunInput.screenshot`.
+
+The runner-side conformance bar splits across two seams:
+`input.screenshot` (runner-input field) and `ctx.mode` (per-
+navigation scene context). The split is forced by lifecycle
+ordering: `create(ctx)` and `timeline(ctx)` run BEFORE the
+resolver invokes `runTimeline(input)`, so any clause whose
+enforcement must happen during scene setup cannot be gated by a
+flag on the runner input.
+
+`input.screenshot === 'capture'` covers the **runner-side** axes —
+delivered on or after `runTimeline()` is called. A runner that
+recognizes the field MUST:
+
+1. Seek to `input.beat` if present, else stay at the timeline's
+   start (frame 0). Missing-label handling reuses the existing
+   PUL-F011 / ADR-015 `onBeatMissing` non-fatal path.
+2. HOLD the timeline at that position — no animation in progress,
+   no automatic advance. ADR-003's future GSAP runner achieves
+   this with `timeline.seek(label).pause()` (or `seek(0).pause()`
+   when no beat is supplied), then keeps its returned promise
+   pending until the per-navigation `AbortSignal` fires (same
+   parking pattern PUL-F016 / ADR-019 records for `mode=paused`).
+3. Suppress all audio output the runner controls. ADR-004's future
+   audio engine reads `input.screenshot === 'capture'` (or the
+   scene `ctx.mode === 'screenshot'` seam) and produces no audio
+   output: no cues, no ambient loops, no global mixer output. This
+   is broader than `cueGate: 'monotonic-forward'` (scrub) because
+   screenshot suppresses every audio path, not just cue firing.
+
+`ctx.mode === 'screenshot'` covers the **scene-side** axis —
+delivered to scene code from the moment `create(ctx)` runs:
+
+4. Source any randomness from a deterministic seed so the captured
+   frame is reproducible across runs. Scenes that consume
+   randomness (random tween offsets, particle emitters with
+   jittered start times, procedural visuals, etc.) read
+   `ctx.mode === 'screenshot'` (the existing PUL-F012 / ADR-007
+   seam) and route any random values through a deterministic
+   source — today that means a scene-local PRNG seeded from a
+   stable input (scene id + beat label is a natural choice;
+   ADR-007 reserves the freedom for a workbench-supplied seed
+   surface on `ctx` to land later). The runner's
+   `input.screenshot` flag is NOT the seam for this clause
+   because `create(ctx)` and `timeline(ctx)` run before the
+   runner ever sees `input.screenshot`; gating randomness on the
+   runner input would let scene-setup randomness escape the gate
+   on every navigation. Scene-side determinism flows through
+   `ctx.mode` + a future seed surface; ADR-021 reserves both.
+
+A runner / scene that does NOT exercise the affected subsystems
+trivially satisfies the bundle because none of the affected
+behaviors exist. The placeholder timeline runner today and the
+placeholder scene today are both in this category — no real
+timeline, no audio engine, no scene-side randomness — so
+"ignore the `screenshot` field and ignore `ctx.mode`" is correct
+conformance. ADR-003's GSAP runner, ADR-004's audio engine, and
+a deterministic-randomness convention (consumed by scenes via
+`ctx.mode` plus the seed surface) are what introduce the
+consumers that activate each MUST.
+
+This wording is intentionally tighter than ADR-018's `repeat` and
+ADR-019's `hold` because PUL-F018's clause uses SHALL on a
+behavior bundle (frame freeze, audio suppression, deterministic
+randomness) that has concrete subsystem boundaries (timeline,
+audio, randomness). For `repeat` / `hold` / `cueGate` every
+runner with a timeline (or audio cues) can honor a single hint;
+for `screenshot`, only runners with all three subsystems
+materially deliver the bundle.
+
+The hint is **head-only**. Under composition targets the slice's
+first entry is the addressed scene; following composition entries
+never receive `screenshot`. This scoping is structural: under
+screenshot the slice is truncated upstream so the head's frozen
+timeline does not hand off to following entries. Forwarding
+`screenshot` to non-head scenes would imply a following entry
+could itself produce a deterministic frame, which contradicts the
+requirement's single-scene scoping. The plumbing is parallel to
+PUL-F011 / ADR-015's `headBeat`, PUL-F015 / ADR-018's
+`headRepeat`, PUL-F016 / ADR-019's `headHold`, and PUL-F017 /
+ADR-020's `headCueGate` head-only forwarding — same shape,
+different field.
+
+`SceneTimelineRunInput.screenshot` is declared as a literal-typed
+field (`'capture'`) rather than a boolean so future capture
+semantics (e.g., `'capture-still'` for explicit single-frame, or a
+future multi-frame variant for animated capture) can extend the
+union without breaking existing runners. A runner that ignores the
+field, or that only recognizes `'capture'`, gracefully degrades to
+no-capture behavior (the timeline plays normally, audio fires,
+randomness is non-deterministic — i.e., default playback
+semantics). The resolver and bridge do not interpret the value.
+
+The slice IS **truncated** under `mode=screenshot` to the addressed
+head entry — the same shape transform `mode=standalone` (ADR-017),
+`mode=loop` (ADR-018), `mode=paused` (ADR-019), and `mode=scrub`
+(ADR-020) apply. Without truncation, a runner that ignores
+`input.screenshot` (a placeholder, a buggy GSAP wiring, a future
+test runner) would let the resolver advance to the next composition
+entry and screenshot-mode would silently degrade into normal
+composition playback. That violates the documented screenshot
+guarantee: "render the addressed scene at the addressed beat (or
+first frame)" presupposes one scene, one frame; advancing to a
+following entry breaks that promise.
+
+Truncating the slice makes "no following entries run" a structural
+guarantee that does not depend on runner conformance. The five
+single-scene-execution modes (`standalone`, `loop`, `paused`,
+`scrub`, `screenshot`) share the same slice transform; they differ
+only in the head's runner-side semantic — standalone plays
+normally, loop sets `input.repeat = 'until-aborted'`, paused sets
+`input.hold = 'first-frame'`, scrub sets
+`input.cueGate = 'monotonic-forward'`, screenshot sets
+`input.screenshot = 'capture'`. The shape transform is shared
+because the structural promise ("no following entries run") is
+identical; the runner-side behaviors live where they belong.
+
+The slice is **truncated, not flattened.** Replacing the resolved
+target with `{ scene }` (no composition) would lose the head
+entry's per-entry `range` / `behavior` overrides (object-form
+entries per ADR-002 / ADR-011), turning screenshot into
+direct-scene flattening — same foot-gun ADR-017 / ADR-018 /
+ADR-019 / ADR-020 call out. The truncated `manifestSlice` (length
+1) continues through the composition branch in
+`loadSceneNavigationTarget()`, and the existing runner-input
+plumbing forwards `range` / `behavior` per ADR-011.
+
+PUL-F018 stays DRAFT after this PR lands, mirroring the ADR-016 /
+PUL-F013, ADR-017 / PUL-F014, ADR-018 / PUL-F015, ADR-019 /
+PUL-F016, and ADR-020 / PUL-F017 precedent. This PR ships:
+
+- The loader → runner-input contract: `screenshot: 'capture'`
+  reaches the head scene's run input under
+  `effectiveMode === 'screenshot'`.
+- The seam: `ctx.mode === 'screenshot'` reaches every lifecycle
+  hook of the head scene through the existing PUL-F012 plumbing.
+- Tests pinning the seam, the head-only scoping, the
+  no-other-mode contamination, and the existing invariants under
+  `screenshot` (composition validation still runs; no
+  `data-pulsar-mode-*` attribute; beat forwarding preserved;
+  `range` / `behavior` overrides preserved).
+
+What it does NOT yet ship is the active *capture-bundle* behavior
+(frame freeze, audio suppression, deterministic randomness):
+
+- ADR-003's GSAP runner is not implemented. The placeholder runner
+  has no real timeline to seek-and-freeze; it parks until abort.
+  The placeholder vacuously satisfies "no animation in progress"
+  because no animation ever advances, but cannot exercise the
+  seek-then-freeze contract.
+- ADR-004's Howler audio engine is not implemented. Audio output
+  itself does not yet exist; there is nothing to suppress.
+- A deterministic-randomness convention is not yet established.
+  Scenes today have no scene-side randomness path; the
+  scene-side seed surface (on `ctx`, paired with the existing
+  `ctx.mode === 'screenshot'` seam) has no consumer. The
+  scene-side seam itself (`ctx.mode`) IS already wired by
+  PUL-F012 — what is missing is the seed payload and the scenes
+  that consume it.
+
+PUL-F018 transitions DRAFT → ACTIVE when ALL THREE hold:
+
+1. ADR-003's GSAP runner lands AND it actively reads
+   `input.screenshot === 'capture'` and seeks to `input.beat` (or
+   frame 0) before pausing the timeline, with end-to-end tests
+   showing the timeline does not advance after the initial seek
+   under screenshot mode.
+2. ADR-004's audio engine lands AND under
+   `input.screenshot === 'capture'` (or `ctx.mode === 'screenshot'`
+   on the scene context) produces no audio output — no cues, no
+   ambient loops, no mixer output — with end-to-end tests proving
+   silence under screenshot.
+3. A scene-side deterministic-randomness convention lands —
+   typically a seed surface on `ctx` (e.g., `ctx.seed`) the
+   workbench derives from a stable input (scene id + beat label
+   is a natural choice) AND scenes consume that seed via the
+   existing `ctx.mode === 'screenshot'` seam to route any random
+   values through a deterministic PRNG, with end-to-end tests
+   proving identical pixels across runs. The scene-side surface
+   is required because scene `create(ctx)` and `timeline(ctx)`
+   run before the runner sees `input.screenshot`, so the
+   runner-input field cannot gate scene-setup randomness.
+
+Until all three land, the issue ↔ requirement link stays as
+`DOCUMENTS` and PUL-F018 stays DRAFT — matching how ADR-016 /
+PUL-F013, ADR-017 / PUL-F014, ADR-018 / PUL-F015, ADR-019 /
+PUL-F016, and ADR-020 / PUL-F017 record "land the contract layer;
+keep the requirement DRAFT until the dependent subsystems land."
+
+### Boundary
+
+The capture-bundle hint flows from the loader because:
+
+- The loader already derives `effectiveMode(target)` for `ctx.mode`
+  (ADR-007 / PUL-F012). Reusing the same derivation for
+  `screenshot` keeps mode-aware logic in one place — no second
+  `target.mode` inspection on a different layer.
+- The composition resolver MUST stay mode-opaque (ADR-011 — pure
+  orchestrator, no adapter knowledge). The resolver plumbs
+  `headScreenshot` exactly the way it plumbs `headBeat`,
+  `headRepeat`, `headHold`, and `headCueGate`: as an opaque
+  forwarding field with no semantics it interprets. The loader is
+  the only thing that maps `effectiveMode === 'screenshot'` to
+  `screenshot: 'capture'`.
+- `resolveSceneNavigation()` MUST run validation regardless of
+  mode: unregistered compositions, unknown member scenes,
+  ambiguous `composition+scene` locators, out-of-range indexes,
+  and empty compositions still surface as navigation errors under
+  `mode=screenshot`. No silent fallback to direct scene lookup.
+- `loadSceneNavigationTarget()` already plumbs head-only options
+  (`beat` / `onBeatMissing` / `repeat` / `hold` / `cueGate`);
+  adding `screenshot` to that list reuses the same shape rather
+  than inventing a new bridge surface.
+
+### Stage attribute behavior
+
+`data-pulsar-scene-target` (head scene id) AND
+`data-pulsar-composition-target` (composition id) are both set on
+the stage when the URL named a composition under `mode=screenshot`.
+The attrs communicate "what was addressed," not "what's running" —
+same invariant as `mode=standalone` (ADR-017), `mode=loop`
+(ADR-018), `mode=paused` (ADR-019), and `mode=scrub` (ADR-020). No
+`data-pulsar-mode-*` suppression attribute is preemptively written
+under `screenshot` (parity with ADR-016 / ADR-017 / ADR-018 /
+ADR-019 / ADR-020); future capture tooling that observes the
+runtime is free to use that namespace if it actually needs a
+stage-level signal.
+
+### Beat semantics
+
+`beat=` under `mode=screenshot` is forwarded to the head scene's
+runner unchanged. PUL-F018 explicitly names "at the addressed beat
+(or first frame if no beat)" — beat is the captured-frame anchor.
+The runner sees both `input.beat` and `input.screenshot` on the
+same input bundle.
+
+Unlike `mode=paused` — where ADR-019's runner-side policy is "first
+frame wins" so the runner SHOULD ignore `input.beat` —
+`mode=screenshot` HONORS `input.beat` as the captured-frame
+position. PUL-F018 says "at the addressed beat OR first frame if no
+beat"; the conditional is explicit. The future GSAP runner under
+screenshot calls `timeline.seek(input.beat).pause()` when `beat` is
+present and `timeline.seek(0).pause()` when it is absent. Both
+seeks produce a stable, non-animating frame; there is no
+"play-forward" path under screenshot.
+
+Missing-label diagnostics surface via the existing non-fatal
+`onBeatMissing` path (ADR-015): a URL like
+`?scene=x&beat=does-not-exist&mode=screenshot` does not unmount
+the scene; the diagnostic appears on
+`data-pulsar-navigation-error` / `onError` and the scene lands at
+the timeline's first frame (the default cursor position).
+
+### Composition slice behavior
+
+Truncated to the addressed head entry, parallel to `mode=standalone`
+(ADR-017), `mode=loop` (ADR-018), `mode=paused` (ADR-019), and
+`mode=scrub` (ADR-020). The single-scene-execution helper at the
+loader is shared: `applySingleSceneSlice` runs for all five modes
+(`standalone`, `loop`, `paused`, `scrub`, `screenshot`). Following
+composition entries do not run; the head scene's
+`screenshot: 'capture'` reaches the runner input and the runner is
+responsible for the actual capture-bundle delivery.
+
+The composition slice MUST be validated by `resolveSceneNavigation()`
+BEFORE the truncation transform. Unregistered compositions,
+unknown member scenes, ambiguous `composition+scene` locators, and
+out-of-range indexes still surface as navigation errors under
+`mode=screenshot` — the same invariant ADR-017 / ADR-018 / ADR-019
+/ ADR-020 hold for standalone, loop, paused, and scrub.
+
+The bridge ALSO truncates a composition slice when `screenshot` is
+supplied (`truncateToHead` shared with the `repeat` / `hold` /
+`cueGate` paths) — a structural defense layered with the loader's
+`applySingleSceneSlice` so direct bridge callers (test harnesses,
+future export pipelines) get the same screenshot-mode single-scene-
+execution guarantee. The two truncations are idempotent.
+
+## Consequences
+
+### Positive
+
+- Mode → runner-input plumbing lives at the loader, the same place
+  PUL-F012 derives `ctx.mode`, PUL-F015 derives `repeat`, PUL-F016
+  derives `hold`, and PUL-F017 derives `cueGate`. One mode dispatch
+  site, not five.
+- The resolver stays mode-opaque (ADR-011): `headScreenshot` is
+  plumbed the same way `headBeat`, `headRepeat`, `headHold`, and
+  `headCueGate` already are, with no new resolver semantics.
+- The runner contract is a single optional input field
+  (`screenshot?: 'capture'`). A runner that ignores it
+  (placeholder, future non-screenshot test runners) gracefully
+  degrades; a runner that honors it (future GSAP + audio +
+  determinism stack) reads one field instead of inferring
+  screenshot semantics from `ctx.mode`.
+- The bundle approach (one literal-typed flag instead of
+  `freeze` + `audioMode` + `seed` fields) keeps the runner
+  surface narrow. The four runtime axes travel together because
+  `mode=screenshot` means "capture this frame deterministically";
+  shipping them separately would fragment the surface for a
+  combination that has no other consumer.
+- Following ADR-016 / ADR-017 / ADR-018 / ADR-019 / ADR-020's
+  precedent keeps the DRAFT → ACTIVE bar consistent across mode
+  requirements: ACTIVE means the named behavior is actively
+  delivered end to end, not just structurally scaffolded.
+- No premature abstraction. No `ModePolicy` record, no shared
+  mode-hint type, no policy table. When a future mode needs a
+  different shape of runner hint, it adds its own field; if
+  multiple modes converge on a shared representation, that
+  representation lands then with at least two consumers informing
+  its shape. The five single-scene-execution modes (standalone,
+  loop, paused, scrub, screenshot) share `applySingleSceneSlice`
+  because they share a structural invariant, but they do NOT share
+  a runner-input field — each owns its own (`repeat`, `hold`,
+  `cueGate`, `screenshot`, none).
+
+### Negative
+
+- PUL-F018 stays DRAFT until ADR-003's GSAP runner, ADR-004's
+  audio engine, AND a deterministic-randomness convention all
+  land. A reviewer reading the requirement in isolation may
+  expect ACTIVE on first delivery; the DRAFT-with-contract-and-
+  seams state is intentional and matches the PUL-F011 / PUL-F013
+  / PUL-F014 / PUL-F015 / PUL-F016 / PUL-F017 precedent.
+- Adding `screenshot` to `SceneTimelineRunInput` widens the runner
+  adapter surface. Every runner adapter (placeholder today, future
+  GSAP, test harnesses) sees the new field. Test runners that
+  don't care about screenshot semantics ignore it; this is the
+  cost of extending the input shape. The alternative (a separate
+  runner parameter) would be larger surface, not smaller.
+- The seam tests are necessary but not sufficient: they prove the
+  hook exists and behaves correctly under `mode=screenshot`, but
+  they do not prove that a future GSAP runner will plug in
+  correctly, that a future audio engine will respect the
+  suppression, or that a future randomness convention will be
+  consumed correctly. The surface PRs that land each of those
+  subsystems are responsible for adding their own end-to-end
+  tests.
+- Bundling the four runtime axes (frame freeze, audio
+  suppression, deterministic randomness, no animation) under one
+  flag means a runner cannot opt-in to a subset (e.g., "freeze
+  but don't suppress audio"). This is intentional — the
+  requirement bundles them — but a future need to differentiate
+  would require extending the union (e.g., `'capture-no-audio'`
+  vs `'capture'`). The literal-typed union leaves room for that
+  extension.
+
+### Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| A future runner ignores `input.screenshot` and the regression goes unnoticed | The seam tests pin "loader sets `input.screenshot = 'capture'` under `mode=screenshot`." A runner that ignores the hint produces wrong runtime behavior (timeline advances, audio fires, randomness is non-deterministic). When the GSAP runner / audio engine / randomness convention land, their own end-to-end tests prove the hint is honored. |
+| `screenshot` accumulates as a kitchen-sink field for unrelated capture semantics | The literal-typed union (`'capture'`) constrains valid values. Adding a new variant (`'capture-still'`, `{ frame: 'addressed', audio: false, seed: 42 }`) is an explicit type extension, visible in code review. |
+| Slice truncation flattens to direct-scene and loses object-form `range` / `behavior` overrides | The seam test "preserves the addressed head entry's `range` and `behavior` overrides on the runner input under `mode=screenshot` (composition+index with object-form entry)" pins object-form head-entry plumbing through the truncated slice. A flatten-by-mistake would lose those overrides. |
+| A runner that ignores `input.screenshot` silently degrades screenshot into normal composition playback | Slice truncation makes "no following entries run" structural — a no-op runner under `mode=screenshot` runs the head's lifecycle once and then completes the navigation, rather than advancing to a tail entry that should not have run. |
+| PUL-F018 lingers DRAFT forever because the GSAP runner / audio engine / randomness convention keep slipping | DRAFT is a feature here: it tells reviewers the screenshot-mode contract is partly delivered (boundary + seam) and gates ACTIVE on actual capture-bundle delivery. The GSAP runner PR (ADR-003), the audio engine PR (ADR-004), and a future randomness-convention PR are the natural triggers to revisit PUL-F018's status. |
+| A non-parser caller forges a `NavigationTarget` with `mode: 'screenshot'` mid-flight | The defense-in-depth check `validateModeGrammar` already rejects unknown modes at the loader boundary; `'screenshot'` is in the `NAVIGATION_MODES` allowlist, and `effectiveMode` is the only consumer of the field. |
+| A future runner honors `input.screenshot` for frame freeze and audio but skips deterministic randomness, producing visually different captures across runs | The seam test pins the loader-side hint propagation; the runner-side end-to-end tests for ACTIVE include an "identical pixels across runs" check explicitly. ADR-021 splits the runner-side axes (frame freeze, audio suppression — gated on `input.screenshot`) from the scene-side axis (deterministic randomness — gated on `ctx.mode === 'screenshot'` plus a future seed surface) so the contract is honest about which surface enforces which clause. |
+| A reviewer assumes scene-side randomness is gated on `input.screenshot` and writes a scene that consumes randomness in `create(ctx)` expecting determinism | `create(ctx)` runs before `runTimeline(input)` is invoked, so a flag on the runner input cannot gate `create`-time randomness. ADR-021 explicitly routes the deterministic-randomness clause through the existing `ctx.mode === 'screenshot'` seam (available from `create(ctx)` forward) plus a future seed surface on `ctx`. The runner-input docstring on `SceneTimelineRunInput.screenshot` documents the split inline. |
+| A capture pipeline assumes screenshot mode persists scene state (e.g., camera position, last interaction) and breaks when ADR-007's "URL is the only source of mode" rule is enforced | ADR-007 already forbids recovering mode from non-URL sources; the capture pipeline must encode all addressing in the URL (scene, beat, mode) per the requirement statement. |
+
+## Current state (2026-05-09)
+
+This PR delivers the contract boundary and seam-pinning layer:
+
+- `src/runtime/composition-resolver.ts` — `SceneTimelineRunInput`
+  gains optional `screenshot?: 'capture'`;
+  `ResolveCompositionOptions` gains optional `headScreenshot?:
+  'capture'`; the resolver forwards `headScreenshot` to plan[0]'s
+  run input only.
+- `src/runtime/scene-navigation.ts` —
+  `LoadSceneNavigationTargetOptions` gains optional `screenshot?:
+  'capture'`; `loadSceneNavigationTarget()` forwards it to
+  `resolveComposition` as `headScreenshot`. The bridge truncates a
+  composition slice when `screenshot` is supplied (the shared
+  `truncateToHead` predicate fires when ANY of `repeat` / `hold` /
+  `cueGate` / `screenshot` is supplied).
+- `src/runtime/scene-loader.ts` — when `effectiveMode(target) ===
+  'screenshot'`, the loader passes `screenshot: 'capture'` through
+  the bridge; otherwise the key is omitted (key-presence
+  semantics). The single-scene-execution helper
+  `applySingleSceneSlice` widens to include `'screenshot'` so the
+  slice is truncated to the addressed head under any of the five
+  single-scene modes (standalone, loop, paused, scrub,
+  screenshot) — the SHAPE transform is shared, the runner-side
+  semantic difference (`input.screenshot`) is what differentiates
+  screenshot from the others.
+- `src/main.ts` — placeholder timeline runner docstring
+  acknowledges `input.screenshot`. The placeholder ignores the
+  hint; parking until abort vacuously satisfies the capture
+  bundle because none of the affected subsystems exist yet.
+  ADR-003's GSAP runner + ADR-004's audio engine + a
+  deterministic-randomness convention will read the hint and
+  deliver active behavior.
+- `tests/runtime/composition-resolver.test.ts` — new
+  `'URL screenshot-mode runner capture-hint forwarding (PUL-F018)'`
+  describe block.
+- `tests/runtime/scene-navigation.test.ts` — new `'URL
+  screenshot-mode capture forwarding (PUL-F018)'` describe block
+  under `loadSceneNavigationTarget`.
+- `tests/runtime/scene-loader.test.ts` — new `'screenshot-mode
+  runner capture-hint forwarding (PUL-F018)'` describe block.
+- `docs/design/pul-f018-screenshot-mode-preflight.md` — codex
+  architecture preflight design context (preserved from the
+  preflight tool's returned summary; the codex sandbox failed to
+  write design files during preflight, so the guardrails are
+  reproduced verbatim — same handling pattern as
+  `pul-f015-loop-mode-preflight.md`,
+  `pul-f016-paused-mode-preflight.md`, and
+  `pul-f017-scrub-mode-preflight.md`).
+- This ADR.
+
+PUL-F018 remains DRAFT. Issue #27 links to PUL-F018 via
+`DOCUMENTS`. This PR is **not** an implementation of PUL-F018's
+"render at the addressed beat with no animation, all audio
+suppressed, deterministic randomness" clauses — it lands the
+contract boundary and the seam. The ACTIVE transition is gated on
+ADR-003's GSAP runner honoring `input.screenshot`, ADR-004's audio
+engine providing real silence under `input.screenshot`, AND a
+deterministic-randomness convention that scenes consume under
+`input.screenshot`, each with end-to-end tests alongside the seam
+tests in this PR. Treating this PR as satisfying PUL-F018 would be
+a traceability/status mismatch.
+
+## Related ADRs
+
+- [ADR-003](003-gsap-timeline-engine.md) — the timeline runner is
+  the seam through which seek-to-beat-and-pause will flow when the
+  GSAP runner lands. Today the runner is a placeholder, so
+  screenshot frame freeze is structurally vacuous.
+- [ADR-004](004-howler-audio-engine.md) — audio output is the
+  consumer of the suppression. Today there is no audio engine, so
+  the suppression has no consumer.
+- [ADR-007](007-browser-workbench.md) — defines the seven workbench
+  modes and the URL-only-source invariant for mode selection.
+  Specifically references `mode=screenshot` as the
+  visual-regression hook for agents and reviewers.
+- [ADR-008](008-agent-native-authoring.md) — manifests-over-flow-
+  control underpins the no-mode-suppression-in-resolver constraint.
+- [ADR-011](011-composition-resolver-orchestration.md) — the
+  resolver is opaque to mode; mode-derived behavior lives at the
+  adapters it forwards to. The resolver plumbs `headScreenshot`
+  unchanged, the same way it plumbs `headBeat`, `headRepeat`,
+  `headHold`, and `headCueGate`.
+- [ADR-013](013-url-navigation-grammar-boundary.md) — the parser
+  preserves `mode` and forbids recovering it from any non-URL
+  source.
+- [ADR-014](014-url-scene-target-selection.md) — scene navigation
+  dispatch is mode-blind; it resolves the active slice and hands
+  off to the loader for mode dispatch.
+- [ADR-015](015-url-beat-positioning.md) — precedent for "the
+  resolver plumbs a head-only optional field; runner owns the
+  semantics; loader fails fast at the paired-required boundary."
+  ADR-021's `headScreenshot` mirrors `headBeat`'s shape. PUL-F018
+  explicitly honors beat under screenshot as the captured-frame
+  anchor.
+- [ADR-016](016-workbench-mode-present.md) — establishes the
+  contract-layer-plus-seam-tests precedent. PUL-F013 stays DRAFT
+  pending chrome / audio / GSAP runner / presenter input.
+- [ADR-017](017-workbench-mode-standalone.md) — applies the same
+  precedent to PUL-F014 with the slice-truncation seam.
+- [ADR-018](018-workbench-mode-loop.md) — PUL-F015 shares the
+  slice-truncation transform; runner-side semantic difference is
+  `input.repeat`. ADR-021's `screenshot` is the same shape with a
+  different literal value.
+- [ADR-019](019-workbench-mode-paused.md) — PUL-F016 shares the
+  slice-truncation transform; runner-side semantic difference is
+  `input.hold`. ADR-019 records "first frame wins" for paused;
+  ADR-021 records "beat is honored" for screenshot — the two
+  modes' beat-vs-position policies differ deliberately.
+- [ADR-020](020-workbench-mode-scrub.md) — PUL-F017 shares the
+  slice-truncation transform; runner-side semantic difference is
+  `input.cueGate`. ADR-020 anticipates a future
+  `cueGate: 'all-suppressed'` variant for screenshot; this ADR
+  takes the alternative path of one bundled `screenshot: 'capture'`
+  flag instead, because screenshot suppresses ALL audio output
+  (cues, ambient loops, mixer) — a strict superset of cue gating
+  — plus three other behaviors (frame freeze, deterministic
+  randomness, no animation) that are not cue-gating semantics.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -46,3 +46,4 @@ Each ADR includes:
 | [018](018-workbench-mode-loop.md) | Workbench Mode `loop` — Runner Repeat Hint at the Loader/Runner Seam | Accepted |
 | [019](019-workbench-mode-paused.md) | Workbench Mode `paused` — Runner Hold-at-First-Frame Hint at the Loader/Runner Seam | Accepted |
 | [020](020-workbench-mode-scrub.md) | Workbench Mode `scrub` — Runner Cue-Gate Hint at the Loader/Runner Seam | Accepted |
+| [021](021-workbench-mode-screenshot.md) | Workbench Mode `screenshot` — Runner Capture-Bundle Hint at the Loader/Runner Seam | Accepted |

--- a/docs/design/pul-f018-screenshot-mode-preflight.md
+++ b/docs/design/pul-f018-screenshot-mode-preflight.md
@@ -1,0 +1,247 @@
+# PUL-F018 Screenshot Mode Preflight
+
+PUL-F018 specifies `mode=screenshot`: render the addressed scene at
+the addressed beat (or first frame if no beat) with all asset
+preloads resolved, no animation in progress, all audio suppressed,
+and any randomness sourced from a deterministic seed. This is a
+deterministic visual-regression hook for agents and reviewers. It
+is not a screenshot export subsystem, persistence feature, or
+separate rendering pipeline.
+
+ADR-007 already defines `screenshot` as a workbench mode. ADR-011
+already defines the resolver as a lifecycle orchestrator with an
+injected timeline runner. The runner-input shape introduced by
+ADR-018 (`repeat`), extended by ADR-019 (`hold`), and extended
+again by ADR-020 (`cueGate`) is the precedent for adding a new
+head-only optional field; ADR-021 records the analogous
+`screenshot` field for screenshot capture.
+
+## Sandbox note
+
+The codex preflight tool's sandbox failed to write design files
+during this preflight run (`bwrap` setup error: `bwrap: loopback:
+Failed RTM_NEWADDR: Operation not permitted`), so this document is
+a manual transcription of the preflight tool's returned guardrails
+text plus the architecture decisions that follow from it — same
+handling pattern as `pul-f015-loop-mode-preflight.md`,
+`pul-f016-paused-mode-preflight.md`, and
+`pul-f017-scrub-mode-preflight.md`. The structured decisions are
+recorded in ADR-021.
+
+## Boundary
+
+`screenshot` selection must reuse the existing navigation path:
+
+- `src/runtime/navigation.ts` owns the `mode` URL grammar and the
+  `NAVIGATION_MODES` allowlist.
+- `effectiveMode()` owns effective mode derivation.
+- `src/runtime/scene-loader.ts` owns per-navigation mode dispatch,
+  `ctx.mode` construction, cancellation, stage diagnostics, and
+  error surfacing. It is also the dispatch point that maps
+  `effectiveMode === 'screenshot'` to `screenshot: 'capture'`.
+- `src/runtime/scene-navigation.ts` owns target resolution and
+  composition slicing. Its `scene` field is the addressed head
+  scene.
+- `src/runtime/composition-resolver.ts` owns preload → create →
+  timeline → cleanup ordering, abort propagation, and exactly-once
+  cleanup. It must remain mode-opaque; `headScreenshot` is plumbed
+  the same way `headBeat`, `headRepeat`, `headHold`, and
+  `headCueGate` are.
+- The timeline runner owns timeline playhead behavior. Under
+  `mode=screenshot` the runner reads
+  `input.screenshot === 'capture'` and seeks to the addressed
+  beat (or frame 0) before pausing the timeline.
+- ADR-004's audio engine (when it lands) reads
+  `input.screenshot === 'capture'` (or `ctx.mode === 'screenshot'`
+  on the scene context) and produces no audio output: no cues, no
+  ambient loops, no mixer output.
+- A future deterministic-randomness convention (when it lands)
+  exposes a stable seed that scenes consume for any random values
+  under screenshot.
+
+Do not add a second route, mode enum, `screenshot` boolean, scene
+schema field, manifest flag, local URL parser, or
+screenshot-specific resolver. URL input remains the only source of
+mode selection; `screenshot` must not be recovered from
+localStorage, sessionStorage, cookies, `history.state`, or prior
+in-memory navigation state.
+
+## Required Reuse
+
+Implementation must reuse these cross-cutting concerns:
+
+- Identifier validation: `src/runtime/identifier.ts`.
+- URL and mode validation: `parseNavigationSearch()` and
+  `NAVIGATION_MODES`.
+- Effective mode derivation: `effectiveMode()`.
+- Scene and composition validation:
+  `assertSceneModule()`, `createSceneRegistry()`,
+  `assertCompositionManifest()`, and `createCompositionRegistry()`.
+- Navigation resolution: `resolveSceneNavigation()` and
+  `loadSceneNavigationTarget()`.
+- Lifecycle orchestration: `resolveComposition()` with injected
+  `createPreloader()` and `runTimeline()` adapters.
+- Asset handling: `createAssetPreloader()` with the existing
+  scheme, redirect, `baseUrl`, and `AbortSignal` rules. Screenshot
+  mode does not change preload semantics — the addressed scene's
+  assets must still be loaded before `create(ctx)` runs.
+  PUL-F018's "all asset preloads resolved" clause is already
+  satisfied by the existing PUL-F004 / PUL-F005 invariant.
+- Error rendering: `describeError()` plus the existing
+  `data-pulsar-navigation-error` stage diagnostic and `onError`
+  sink.
+- Cancellation and cleanup: one per-navigation `AbortController`,
+  forwarded to preload and timeline adapters; cleanup remains
+  resolver-owned.
+- Slice-truncation helper: the `applySingleSceneSlice` loader-side
+  helper and the `truncateToHead` bridge-level helper introduced
+  for `standalone` (ADR-017) and extended for `loop` (ADR-018),
+  `paused` (ADR-019), and `scrub` (ADR-020) are extended again to
+  fire under `screenshot`. The shape transform is shared; the
+  predicate widens.
+- Beat lookup / naming contract: `beat=` under `mode=screenshot`
+  is the captured-frame anchor PUL-F018 names directly. Reuse the
+  existing PUL-F011 / ADR-015 forwarding (`headBeat` /
+  `onBeatMissing`).
+
+## Scope: single-scene only
+
+Screenshot is **single-scene execution at the addressed head**.
+PUL-F018's "the addressed scene at the addressed beat" describes
+ONE scene, ONE frame; "first frame if no beat" is the fallback
+position. There is no composition-wide capture — the runtime has
+no cross-scene timeline abstraction or frame-aggregation API, and
+PUL-F018 does not call for one. The user (or capture tooling)
+addresses a specific scene (directly via
+`?scene=x&mode=screenshot`, or within a composition via
+`?composition=c&scene=x&mode=screenshot` /
+`?composition=c&index=N&mode=screenshot`) and captures that
+scene's frame. To capture a different scene in the same
+composition, the URL targets that scene. The five
+single-scene-execution modes (standalone / loop / paused / scrub
+/ screenshot) share the same slice-truncation transform because
+they share the same structural "no following entries run"
+promise.
+
+## Screenshot Contract
+
+Screenshot mode means: resolve the addressed scene through the
+existing URL/registry/composition path, preload declared assets,
+run normal `create(ctx)` and `timeline(ctx)`, then seek the
+timeline to the addressed beat (or frame 0), pause it, suppress
+all audio output, and source any randomness from a deterministic
+seed.
+
+- A direct `scene` target captures that scene's frame.
+- A `composition` target captures the first scene's frame;
+  following composition entries do not run.
+- A `composition+scene` or `composition+index` target captures
+  the resolved head scene's frame, preserving the head entry's
+  `range` / `behavior` overrides; following composition entries
+  do not run.
+- `beat=<label>` under `mode=screenshot` IS honored as the
+  captured-frame anchor. Unlike paused mode (where ADR-019
+  records "first frame wins"), screenshot HONORS beat — that is
+  literally what PUL-F018 says ("at the addressed beat or first
+  frame if no beat"). The runner seeks to the named label, then
+  freezes.
+
+The requirement says deterministic visual capture. Do not
+implement screenshot by skipping `create(ctx)`, by skipping
+`timeline(ctx)`, or by short-circuiting the lifecycle. Scene
+setup runs normally; the seek-and-freeze, audio suppression, and
+deterministic-seed behaviors are runner-side concerns delivered
+by future PRs alongside ADR-003 / ADR-004.
+
+## Required Constraints (preflight guardrails)
+
+These are binding unless they are clearly wrong:
+
+- Treat `mode=screenshot` as a runtime execution mode inside the
+  existing browser workbench architecture documented by ADR-007 /
+  ADR-008. It is not a screenshot export subsystem, persistence
+  feature, or separate rendering pipeline.
+- Reuse the existing workbench mode/address parsing path for
+  `mode=screenshot`. Do not duplicate the workbench mode enum,
+  scene address schema, beat schema, or validation rules.
+- Reuse existing scene and beat addressing schemas; do not
+  introduce parallel DTOs or ad hoc query parsing.
+- Reuse the existing scene loader and asset preload mechanism;
+  screenshot readiness must wait on the real preload contract.
+- Rendering must be driven to a stable addressed state: addressed
+  beat, or first frame if no beat. Do not advance through live
+  animation to reach a beat instead of resolving the addressed
+  beat state directly.
+- Time, animation, audio, and randomness must be controlled at
+  runtime boundaries, not patched piecemeal inside individual
+  scenes.
+- Determinism must be scoped to the screenshot runtime instance
+  so normal interactive mode is unaffected.
+- Do not add a screenshot-specific exception hierarchy, logger,
+  cache, repository, or workflow controller.
+- Do not use global monkey patches for `Math.random`, timers,
+  audio, or animation that leak into normal mode.
+- Suppression of audio is not "set volume to zero" — the audio
+  engine must not start playback or emit side effects under
+  screenshot.
+- Preloads are not done before images, fonts, textures, media
+  posters, or other render-critical assets are decoded/ready.
+  ADR-012's preloader contract already covers fetch + drain;
+  screenshot does not relax it.
+- Allow no arbitrary paths, asset URLs, or unsanitized query
+  values through screenshot addressing.
+- Persisting screenshot mode as user state or changing
+  authoring/runtime defaults is forbidden by ADR-007's
+  URL-only-source rule.
+
+## Cross-Cutting Concerns To Reuse
+
+- Existing `mode` parsing/routing/validation for `mode=screenshot`.
+- Existing scene manifest and beat resolution.
+- Existing asset preload/cache/decode readiness.
+- Existing timeline, animation frame, tween, and scheduler
+  control.
+- Existing audio manager/mixer/global mute behavior (when ADR-004
+  lands).
+- Existing seeded randomness or runtime config injection (when
+  established).
+- Existing error types and error-response handling.
+- Existing logging/diagnostic conventions for runtime readiness
+  failures.
+- Existing test runner and workbench/visual-regression harness.
+- Ground Control traceability: add `IMPLEMENTS` and `TESTS` links
+  only after implementation is complete (the `DOCUMENTS` link from
+  the issue stays until ACTIVE).
+
+## Gotchas And Anti-Patterns
+
+- Treating "no animation in progress" as "wait a bit and capture"
+  needs an explicit stable snapshot state, not a heuristic.
+- Considering preloads done before images, fonts, textures, media
+  posters, or other render-critical assets are decoded/ready will
+  produce non-deterministic captures.
+- Suppressing audio by volume alone (volume=0) leaks side
+  effects: the engine still starts playback and emits cues.
+- Advancing through live animation to reach a beat introduces
+  per-run timing variance and breaks determinism.
+- Persisting screenshot mode as user state or changing
+  authoring/runtime defaults violates ADR-007's URL-only-source
+  rule.
+
+## Non-Goals And Boundaries
+
+- No screenshot storage, image diffing, CI artifact upload, new
+  authoring schema, editor UI controls, or a second rendering
+  engine. The PR ships only the contract layer that lets future
+  capture tooling drive the existing runtime to a deterministic
+  frame.
+- No new persistence format.
+- No new timeline, beat, cue, exception, validation, or workflow
+  abstraction unless existing contracts are genuinely absent.
+- No authoring/editing of beats or seeds.
+- No production analytics expansion unless the project already
+  has safe telemetry for comparable playback events.
+- No GSAP runner, audio engine, or determinism convention in this
+  PR — those ship with ADR-003, ADR-004, and a future
+  determinism-convention PR. Until all three land, PUL-F018 stays
+  DRAFT.

--- a/src/main.ts
+++ b/src/main.ts
@@ -118,6 +118,21 @@ const createPreloader = (signal: AbortSignal): ReturnType<typeof createAssetPrel
 // reads `ctx.mode === 'scrub'` (the seam), not `input.cueGate`;
 // the controls UI is a separate future surface beyond the runner.
 //
+// PUL-F018 / ADR-021: when the URL carries `mode=screenshot` the
+// loader sets `input.screenshot = 'capture'`. The placeholder
+// ignores the hint — it has no real timeline to seek-and-freeze,
+// no audio engine to suppress, and no scene-side randomness to
+// seed, and parking until abort vacuously satisfies "render at the
+// addressed frame with no animation, all audio suppressed, and
+// deterministic randomness" because none of those subsystems exist
+// yet. The future GSAP runner (ADR-003) reads the hint and seeks
+// to `input.beat` (or 0) before calling `timeline.pause()`;
+// ADR-004's audio engine reads the hint and produces no audio
+// output; a deterministic-randomness convention plumbed alongside
+// will let scenes source any random values from a stable seed so
+// captured frames are reproducible across runs. The placeholder's
+// no-op is the correct stand-in until then.
+//
 // Abort ordering: the abort check runs BEFORE the missing-beat
 // diagnostic so a navigation that was superseded between
 // `scene.timeline(ctx)` resolution and the runner's first turn does

--- a/src/runtime/composition-resolver.ts
+++ b/src/runtime/composition-resolver.ts
@@ -636,6 +636,30 @@ export async function resolveComposition(options: ResolveCompositionOptions): Pr
   // PUL-F011: `headBeat` / `onBeatMissing` (when supplied) are forwarded
   // to the FIRST scene's run input only. Subsequent scenes do not
   // receive them — ADR-015 scopes URL beat to the active head scene.
+  // Snapshot the resolved head-only forwardings once. Each is
+  // delivered to the run input of the FIRST plan step only —
+  // subsequent steps see `undefined` for every field. Bundling them
+  // in a single object keeps the per-iteration call site small and
+  // bounds `resolveComposition`'s cognitive complexity as more
+  // mode-specific head fields land (ADR-018 / ADR-019 / ADR-020 /
+  // ADR-021).
+  const headOnly = resolveHeadOnly({
+    headBeat,
+    onBeatMissing,
+    headRepeat,
+    headHold,
+    headCueGate,
+    headScreenshot,
+  });
+  const noHeadOnly: HeadOnlyFields = {
+    beat: undefined,
+    onBeatMissing: undefined,
+    repeat: undefined,
+    hold: undefined,
+    cueGate: undefined,
+    screenshot: undefined,
+  };
+
   let lastCompletedSceneId: string | undefined;
   for (const [index, step] of plan.entries()) {
     throwIfAborted(
@@ -649,53 +673,66 @@ export async function resolveComposition(options: ResolveCompositionOptions): Pr
       signal,
       `aborted after preloading ${quoteId(step.scene.id)}, before scene activation`,
     );
-    const isHead = index === 0;
-    // `onBeatMissing` is paired with `headBeat` per ADR-015. Drop the
-    // callback when no beat is supplied — otherwise the runner would
-    // see `input.onBeatMissing` with no `input.beat` to trigger it
-    // against, an impossible state per the documented contract.
-    const stepBeat = isHead ? headBeat : undefined;
-    const stepOnBeatMissing = stepBeat === undefined ? undefined : onBeatMissing;
-    // `headRepeat` is head-only per ADR-018: under `mode=loop` the
-    // head's timeline never naturally completes, so subsequent scenes
-    // cannot run. Forwarding repeat to non-head scenes would imply a
-    // following entry could itself loop, which contradicts the
-    // requirement's "the addressed scene's timeline" scoping.
-    const stepRepeat = isHead ? headRepeat : undefined;
-    // `headHold` is head-only per ADR-019: under `mode=paused` the
-    // head's timeline never advances, so subsequent scenes cannot
-    // run. Forwarding hold to non-head scenes would imply a
-    // following entry could itself be held at frame 0, which
-    // contradicts the requirement's "the addressed scene" scoping.
-    const stepHold = isHead ? headHold : undefined;
-    // `headCueGate` is head-only per ADR-020: under `mode=scrub` the
-    // slice is truncated upstream so the head's interactive timeline
-    // does not hand off to following composition entries. Forwarding
-    // the cue gate to non-head scenes would imply a following entry
-    // could itself run under scrub semantics, which contradicts the
-    // requirement's single-timeline-controls scoping.
-    const stepCueGate = isHead ? headCueGate : undefined;
-    // `headScreenshot` is head-only per ADR-021: under
-    // `mode=screenshot` the slice is truncated upstream because the
-    // captured frame belongs to one scene. Forwarding the capture
-    // hint to non-head scenes would imply a following entry could
-    // itself produce a deterministic frame, which contradicts the
-    // requirement's single-frame scoping.
-    const stepScreenshot = isHead ? headScreenshot : undefined;
-    await runScene(
-      step,
-      ctx,
-      runTimeline,
-      signal,
-      stepBeat,
-      stepOnBeatMissing,
-      stepRepeat,
-      stepHold,
-      stepCueGate,
-      stepScreenshot,
-    );
+    const stepHeadOnly = index === 0 ? headOnly : noHeadOnly;
+    await runScene(step, ctx, runTimeline, signal, stepHeadOnly);
     lastCompletedSceneId = step.scene.id;
   }
+}
+
+/**
+ * The head-only forwardings the resolver hands to plan[0]'s run
+ * input. Every field is independently optional. Subsequent plan
+ * steps receive a struct with every field set to `undefined` so
+ * the runner sees absent keys (the same key-presence semantics
+ * ADR-015 / ADR-018 / ADR-019 / ADR-020 / ADR-021 record).
+ */
+interface HeadOnlyFields {
+  readonly beat: string | undefined;
+  readonly onBeatMissing: (() => void) | undefined;
+  readonly repeat: 'until-aborted' | undefined;
+  readonly hold: 'first-frame' | undefined;
+  readonly cueGate: 'monotonic-forward' | undefined;
+  readonly screenshot: 'capture' | undefined;
+}
+
+/**
+ * Map the caller-supplied resolver options to the head-only field
+ * struct. Pure function — extracted from `resolveComposition` so the
+ * latter stays within Sonar's cognitive-complexity budget as more
+ * mode-specific head fields land.
+ *
+ * `onBeatMissing` is paired with `headBeat` per ADR-015. Drop the
+ * callback when no beat is supplied — otherwise the runner would
+ * see `input.onBeatMissing` with no `input.beat` to trigger it
+ * against, an impossible state per the documented contract.
+ *
+ * `headRepeat` (ADR-018), `headHold` (ADR-019), `headCueGate`
+ * (ADR-020), and `headScreenshot` (ADR-021) are head-only because
+ * each mode's structural promise (no following entries run under
+ * `mode=loop` / `paused` / `scrub` / `screenshot`) means
+ * forwarding any of them to non-head scenes would imply a
+ * following entry could itself run under that mode's semantics,
+ * which contradicts the requirement scoping. The slice truncation
+ * at the loader / bridge enforces "no following entries run" as a
+ * structural defense; forwarding head-only here is the resolver's
+ * complementary scoping.
+ */
+function resolveHeadOnly(options: {
+  readonly headBeat: string | undefined;
+  readonly onBeatMissing: (() => void) | undefined;
+  readonly headRepeat: 'until-aborted' | undefined;
+  readonly headHold: 'first-frame' | undefined;
+  readonly headCueGate: 'monotonic-forward' | undefined;
+  readonly headScreenshot: 'capture' | undefined;
+}): HeadOnlyFields {
+  return {
+    beat: options.headBeat,
+    onBeatMissing: options.headBeat === undefined ? undefined : options.onBeatMissing,
+    repeat: options.headRepeat,
+    hold: options.headHold,
+    cueGate: options.headCueGate,
+    screenshot: options.headScreenshot,
+  };
 }
 
 /**
@@ -748,12 +785,7 @@ async function runScene(
   ctx: unknown,
   runTimeline: SceneTimelineRunner,
   signal: AbortSignal | undefined,
-  beat: string | undefined,
-  onBeatMissing: (() => void) | undefined,
-  repeat: 'until-aborted' | undefined,
-  hold: 'first-frame' | undefined,
-  cueGate: 'monotonic-forward' | undefined,
-  screenshot: 'capture' | undefined,
+  headOnly: HeadOnlyFields,
 ): Promise<void> {
   // Track failure with explicit booleans so `throw undefined` /
   // `Promise.reject(undefined)` are still treated as failures. Using
@@ -772,7 +804,17 @@ async function runScene(
     // are unaffected.
     const timeline = await scene.timeline(ctx);
     await runTimeline(
-      buildRunInput(step, timeline, signal, beat, onBeatMissing, repeat, hold, cueGate, screenshot),
+      buildRunInput(
+        step,
+        timeline,
+        signal,
+        headOnly.beat,
+        headOnly.onBeatMissing,
+        headOnly.repeat,
+        headOnly.hold,
+        headOnly.cueGate,
+        headOnly.screenshot,
+      ),
     );
   } catch (err) {
     phaseFailed = true;

--- a/src/runtime/composition-resolver.ts
+++ b/src/runtime/composition-resolver.ts
@@ -230,6 +230,63 @@ export interface SceneTimelineRunInput {
    * and the runner's policy decides which wins.
    */
   readonly cueGate?: 'monotonic-forward';
+  /**
+   * Screenshot capture-bundle hint for the head scene's timeline
+   * (PUL-F018 / ADR-021). When `'capture'`, the runner MUST render
+   * the addressed scene at the addressed frame — `input.beat` if
+   * present, else frame 0 — and HOLD there (no animation in
+   * progress); the runner MUST also suppress all audio output it
+   * controls. These are the runner-side axes of PUL-F018's bundle:
+   * frame freeze at beat-or-zero, no animation, audio suppression
+   * via the runner's audio adapter (e.g. ADR-004's future Howler
+   * integration). Both are runner-input concerns because they
+   * happen on or after the runner sees this bundle.
+   *
+   * Scene-side concerns — specifically PUL-F018's "any randomness
+   * sourced from a deterministic seed" clause — are NOT delivered
+   * through this field. Scene `create(ctx)` and `timeline(ctx)`
+   * run BEFORE the runner ever sees `input.screenshot`, so a flag
+   * on the runner input cannot gate randomness consumed during
+   * those phases. Scene-side determinism flows through the
+   * existing PUL-F012 / ADR-007 `ctx.mode === 'screenshot'` seam
+   * (available from `create(ctx)` forward) plus a future
+   * deterministic-seed surface on `ctx` (e.g. `ctx.seed`) the
+   * scene reads. The runner-input `behavior` field is NOT this
+   * surface — `behavior` is a per-entry manifest override
+   * (ADR-002 / ADR-011) consumed by the runner at timeline
+   * execution time, not by `create(ctx)`. ADR-021 records the
+   * split.
+   *
+   * Only present on the run input for the FIRST scene of the
+   * resolved composition slice — subsequent scenes never receive
+   * `screenshot` because under screenshot the slice is truncated
+   * upstream and the captured frame belongs to one scene. Absent
+   * when the navigation target had no `mode=screenshot` parameter.
+   *
+   * Discriminated by literal type so future capture semantics (e.g.
+   * `'capture-still'` vs a future multi-frame variant) can extend
+   * the union without breaking existing runners — a runner that
+   * ignores the field, or that only recognizes `'capture'`,
+   * gracefully degrades to no-capture behavior. The placeholder
+   * timeline runner (which has no real timeline and no audio
+   * engine) ignores the field today and vacuously satisfies the
+   * runner-side axes because none of the affected subsystems are
+   * wired. ADR-003's GSAP runner + ADR-004's Howler integration
+   * deliver the active runner-side behavior; scene-side
+   * determinism is delivered through `ctx.mode` + a future seed
+   * surface. The resolver does not interpret the value.
+   *
+   * `screenshot`, `beat`, `repeat`, `hold`, and `cueGate` are
+   * independent fields on the runner input. The URL grammar makes
+   * the parent modes (`screenshot`, `loop`, `paused`, `scrub`)
+   * mutually exclusive (mode is a single field), but a programmatic
+   * caller could supply more than one and the runner's policy
+   * decides which wins. `beat` under `mode=screenshot` IS honored as
+   * the addressed-frame anchor (PUL-F018 explicitly calls for "at
+   * the addressed beat"), unlike `mode=paused` where ADR-019 records
+   * "first frame wins."
+   */
+  readonly screenshot?: 'capture';
 }
 
 /**
@@ -347,6 +404,37 @@ export interface ResolveCompositionOptions {
    * where mode dispatch lives).
    */
   readonly headCueGate?: 'monotonic-forward';
+  /**
+   * URL screenshot-mode capture hint (PUL-F018 / ADR-021) to forward
+   * to the FIRST scene's run input as
+   * {@link SceneTimelineRunInput.screenshot}. Subsequent scenes
+   * never receive a screenshot hint — under `mode=screenshot` the
+   * slice is truncated upstream so the captured frame belongs to
+   * one scene; following composition entries cannot run because the
+   * runtime is rendering a single deterministic frame. Absent when
+   * the navigation target had no `mode=screenshot` parameter.
+   *
+   * The resolver does not interpret the value — honoring the
+   * runner-side axes of the capture bundle (frame freeze at
+   * beat-or-zero, no animation, all audio suppressed) is the
+   * runner's contract per ADR-021. The fourth axis of PUL-F018's
+   * statement — "any randomness sourced from a deterministic
+   * seed" — is NOT the runner's contract via this field; it
+   * flows through the scene-side `ctx.mode === 'screenshot'` seam
+   * (PUL-F012 / ADR-007) plus a future scene-side seed surface
+   * on `ctx`, because scene `create(ctx)` and `timeline(ctx)`
+   * run BEFORE this field reaches the runner. A runner that
+   * ignores the field gracefully degrades (the placeholder runner
+   * today vacuously satisfies the runner-side axes because none
+   * of the affected subsystems exist; ADR-003's GSAP runner +
+   * ADR-004's audio engine deliver active runner-side behavior
+   * when they land; scene-side determinism is delivered through
+   * `ctx`). A regression that gated `headScreenshot` on an
+   * unrelated condition is pinned by the seam tests in
+   * `scene-loader.test.ts` against the loader boundary, where
+   * mode dispatch lives.
+   */
+  readonly headScreenshot?: 'capture';
 }
 
 /**
@@ -426,6 +514,7 @@ function buildRunInput(
   repeat: 'until-aborted' | undefined,
   hold: 'first-frame' | undefined,
   cueGate: 'monotonic-forward' | undefined,
+  screenshot: 'capture' | undefined,
 ): SceneTimelineRunInput {
   const input: { -readonly [K in keyof SceneTimelineRunInput]: SceneTimelineRunInput[K] } = {
     scene: step.scene,
@@ -439,6 +528,7 @@ function buildRunInput(
   if (repeat !== undefined) input.repeat = repeat;
   if (hold !== undefined) input.hold = hold;
   if (cueGate !== undefined) input.cueGate = cueGate;
+  if (screenshot !== undefined) input.screenshot = screenshot;
   return input;
 }
 
@@ -507,6 +597,7 @@ export async function resolveComposition(options: ResolveCompositionOptions): Pr
     headRepeat,
     headHold,
     headCueGate,
+    headScreenshot,
   } = options;
 
   // PUL-F011 / ADR-015: a `headBeat` without an `onBeatMissing` would
@@ -584,6 +675,13 @@ export async function resolveComposition(options: ResolveCompositionOptions): Pr
     // could itself run under scrub semantics, which contradicts the
     // requirement's single-timeline-controls scoping.
     const stepCueGate = isHead ? headCueGate : undefined;
+    // `headScreenshot` is head-only per ADR-021: under
+    // `mode=screenshot` the slice is truncated upstream because the
+    // captured frame belongs to one scene. Forwarding the capture
+    // hint to non-head scenes would imply a following entry could
+    // itself produce a deterministic frame, which contradicts the
+    // requirement's single-frame scoping.
+    const stepScreenshot = isHead ? headScreenshot : undefined;
     await runScene(
       step,
       ctx,
@@ -594,6 +692,7 @@ export async function resolveComposition(options: ResolveCompositionOptions): Pr
       stepRepeat,
       stepHold,
       stepCueGate,
+      stepScreenshot,
     );
     lastCompletedSceneId = step.scene.id;
   }
@@ -654,6 +753,7 @@ async function runScene(
   repeat: 'until-aborted' | undefined,
   hold: 'first-frame' | undefined,
   cueGate: 'monotonic-forward' | undefined,
+  screenshot: 'capture' | undefined,
 ): Promise<void> {
   // Track failure with explicit booleans so `throw undefined` /
   // `Promise.reject(undefined)` are still treated as failures. Using
@@ -672,7 +772,7 @@ async function runScene(
     // are unaffected.
     const timeline = await scene.timeline(ctx);
     await runTimeline(
-      buildRunInput(step, timeline, signal, beat, onBeatMissing, repeat, hold, cueGate),
+      buildRunInput(step, timeline, signal, beat, onBeatMissing, repeat, hold, cueGate, screenshot),
     );
   } catch (err) {
     phaseFailed = true;

--- a/src/runtime/scene-loader.ts
+++ b/src/runtime/scene-loader.ts
@@ -63,7 +63,8 @@ export interface StageElement {
  *
  * `mode` exposes the effective workbench mode the runtime selected
  * for the current navigation (PUL-F012 / ADR-007). Scenes that need
- * mode-aware behavior — `screenshot` audio suppression, `loop`
+ * mode-aware behavior — `screenshot` capture-bundle (frame freeze,
+ * audio suppression, deterministic seed) per ADR-021, `loop`
  * indefinite repetition — read it here rather than re-implementing
  * mode detection. Per ADR-007 the runtime core is the dispatch
  * point; the field is set per navigation by {@link createSceneLoader}.
@@ -459,6 +460,20 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
     // here.
     const cueGate: 'monotonic-forward' | undefined =
       mode === 'scrub' ? 'monotonic-forward' : undefined;
+    // PUL-F018 / ADR-021: under `mode=screenshot` the runner renders
+    // the addressed scene at the addressed beat (or first frame),
+    // holds the timeline still, suppresses all audio, and sources
+    // any randomness from a deterministic seed. Same dispatch-point
+    // pattern as `repeat` / `hold` / `cueGate`: when
+    // `effectiveMode === 'screenshot'`, pass `screenshot: 'capture'`
+    // through the bridge. The bridge and resolver scope delivery to
+    // the head scene only — following composition entries do not
+    // see `screenshot`, because the slice is truncated upstream and
+    // the captured frame belongs to one scene. `mode=screenshot`,
+    // `mode=scrub`, `mode=loop`, and `mode=paused` are mutually
+    // exclusive at the URL boundary, so at most one of `repeat` /
+    // `hold` / `cueGate` / `screenshot` is non-undefined here.
+    const screenshot: 'capture' | undefined = mode === 'screenshot' ? 'capture' : undefined;
     return {
       controller,
       settled: loadSceneNavigationTarget(resolved, {
@@ -471,6 +486,7 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
         ...(repeat === undefined ? {} : { repeat }),
         ...(hold === undefined ? {} : { hold }),
         ...(cueGate === undefined ? {} : { cueGate }),
+        ...(screenshot === undefined ? {} : { screenshot }),
       }),
       silent: false,
     };
@@ -509,13 +525,26 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
    * one timeline of controls, one head scene; following composition
    * entries cannot be part of the interactive scrub UX.
    *
-   * All four modes share the same slice-shape transform — they
+   * PUL-F018 / ADR-021 (`screenshot`): the runtime renders the
+   * addressed scene at the addressed beat (or first frame) with
+   * the timeline held still, all audio suppressed, and any
+   * randomness sourced from a deterministic seed. Truncating the
+   * slice makes "no following entries run" a structural guarantee
+   * even if the runner ignores the `screenshot: 'capture'` hint —
+   * a runner bug or no-op runner under `mode=screenshot` MUST NOT
+   * silently degrade into normal composition playback. Screenshot
+   * is single-frame-capture by construction: one deterministic
+   * frame, one head scene; following composition entries cannot
+   * be part of a single-frame snapshot.
+   *
+   * All five modes share the same slice-shape transform — they
    * differ only in the head's runner-side semantic: standalone
    * plays normally, loop sets `input.repeat = 'until-aborted'`,
    * paused sets `input.hold = 'first-frame'`, scrub sets
-   * `input.cueGate = 'monotonic-forward'`. The shape transform is
-   * shared because the structural promise ("no following entries
-   * run") is identical.
+   * `input.cueGate = 'monotonic-forward'`, screenshot sets
+   * `input.screenshot = 'capture'`. The shape transform is shared
+   * because the structural promise ("no following entries run") is
+   * identical.
    *
    * The composition slice — already validated by
    * `resolveSceneNavigation` so unregistered compositions /
@@ -526,8 +555,8 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
    * `range` / `behavior` overrides (object-form entries per ADR-002
    * / ADR-011) reach the runner unchanged: a flat `{ scene }` would
    * lose them and turn the mode into direct-scene flattening,
-   * contradicting ADR-017 / ADR-018 / ADR-019 / ADR-020's "preserve
-   * head-entry overrides" contract.
+   * contradicting ADR-017 / ADR-018 / ADR-019 / ADR-020 / ADR-021's
+   * "preserve head-entry overrides" contract.
    *
    * Stage attrs (set by the caller before this transform) reflect
    * what the URL ADDRESSED, not what runs:
@@ -543,7 +572,11 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
   ): SceneNavigationTarget => {
     const mode = effectiveMode(target);
     if (
-      (mode !== 'standalone' && mode !== 'loop' && mode !== 'paused' && mode !== 'scrub') ||
+      (mode !== 'standalone' &&
+        mode !== 'loop' &&
+        mode !== 'paused' &&
+        mode !== 'scrub' &&
+        mode !== 'screenshot') ||
       resolved.composition === undefined
     ) {
       return resolved;

--- a/src/runtime/scene-navigation.ts
+++ b/src/runtime/scene-navigation.ts
@@ -169,6 +169,30 @@ export interface LoadSceneNavigationTargetOptions {
    * parameter.
    */
   readonly cueGate?: 'monotonic-forward';
+  /**
+   * URL screenshot-mode capture-bundle hint (PUL-F018 / ADR-021) the
+   * runner uses to decide whether to render the addressed scene at
+   * the addressed beat (or first frame), hold the timeline still,
+   * and suppress all audio. Forwarded to {@link resolveComposition}
+   * as `headScreenshot` — the resolver scopes delivery to the head
+   * scene's run input only, so following composition entries never
+   * receive `screenshot`. Absent when the navigation target had no
+   * `mode=screenshot` parameter.
+   *
+   * Direct bridge callers (test harnesses, future export pipelines)
+   * supplying `screenshot: 'capture'` MUST also build {@link ctx}
+   * with `mode: 'screenshot'` — PUL-F018's "any randomness sourced
+   * from a deterministic seed" clause flows through the scene-side
+   * `ctx.mode === 'screenshot'` seam (PUL-F012 / ADR-007), not
+   * through the runner input, because scene `create(ctx)` and
+   * `timeline(ctx)` run before this option reaches the runner. The
+   * loader path always pairs the two seams from the same parsed
+   * `target.mode`, so production navigation is coherent by
+   * construction; the contract here is for direct bridge callers.
+   * The bridge does not (and cannot) inspect ctx to enforce
+   * coherence — ctx is opaque per ADR-011.
+   */
+  readonly screenshot?: 'capture';
 }
 
 const NAV_FAIL_PREFIX = 'scene navigation failed:';
@@ -319,14 +343,19 @@ function resolveCompositionAndIndex(
  *   scrub-controls UI; following composition entries cannot run
  *   because there is no monotonic-forward completion to hand off
  *   on.
+ * - PUL-F018 / ADR-021 (`mode=screenshot`, `screenshot: 'capture'`):
+ *   the runtime renders one deterministic frame; the head's
+ *   timeline is held at the addressed beat (or first frame) and
+ *   does not advance, so following composition entries cannot run.
  *
  * Truncating the slice at the bridge guarantees that structural
  * promise without depending on the runner's adapter conformance to
- * `input.repeat` / `input.hold` / `input.cueGate`. A direct bridge
- * caller (test harness, future export pipeline, etc.) gets the same
- * guarantee the loader's `applySingleSceneSlice` provides on the
- * loader→bridge path; the two truncations are idempotent (truncating
- * a single-entry slice is a no-op).
+ * `input.repeat` / `input.hold` / `input.cueGate` /
+ * `input.screenshot`. A direct bridge caller (test harness, future
+ * export pipeline, etc.) gets the same guarantee the loader's
+ * `applySingleSceneSlice` provides on the loader→bridge path; the
+ * two truncations are idempotent (truncating a single-entry slice
+ * is a no-op).
  *
  * Pure function — no closure captures. Returns the input unchanged
  * when `headOnly` is `false`, when there is no composition slice, or
@@ -440,28 +469,34 @@ export async function loadSceneNavigationTarget(
   target: SceneNavigationTarget,
   options: LoadSceneNavigationTargetOptions,
 ): Promise<void> {
-  // PUL-F015 / ADR-018 + PUL-F016 / ADR-019 + PUL-F017 / ADR-020:
-  // under `repeat: 'until-aborted'` the head's timeline restarts on
-  // completion (loop), under `hold: 'first-frame'` the head's
-  // timeline never advances (paused), and under
-  // `cueGate: 'monotonic-forward'` the head's timeline is driven
-  // interactively by the future scrub-controls UI (scrub). All three
-  // modes share the same structural promise: following composition
-  // entries cannot run. Truncating the slice at the bridge layer
-  // makes "no following entries run" a structural guarantee that
-  // does not depend on the runner honoring `input.repeat` /
-  // `input.hold` / `input.cueGate` (codex pre-push review): a
-  // runner bug or no-op runner under any of the three modes MUST
+  // PUL-F015 / ADR-018 + PUL-F016 / ADR-019 + PUL-F017 / ADR-020 +
+  // PUL-F018 / ADR-021: under `repeat: 'until-aborted'` the head's
+  // timeline restarts on completion (loop), under
+  // `hold: 'first-frame'` the head's timeline never advances
+  // (paused), under `cueGate: 'monotonic-forward'` the head's
+  // timeline is driven interactively by the future scrub-controls UI
+  // (scrub), and under `screenshot: 'capture'` the head's timeline
+  // is held at the addressed beat (or first frame) for a
+  // deterministic frame capture (screenshot). All four modes share
+  // the same structural promise: following composition entries
+  // cannot run. Truncating the slice at the bridge layer makes "no
+  // following entries run" a structural guarantee that does not
+  // depend on the runner honoring `input.repeat` / `input.hold` /
+  // `input.cueGate` / `input.screenshot` (codex pre-push review):
+  // a runner bug or no-op runner under any of the four modes MUST
   // NOT silently degrade into normal composition playback. The
   // truncation is layered with the loader's `applySingleSceneSlice`
   // (which already truncates for `mode=standalone`, `mode=loop`,
-  // `mode=paused`, and `mode=scrub`) so direct bridge callers —
-  // outside the loader path — still benefit from the structural
-  // guarantee. Truncating an already-single-entry slice is a no-op,
-  // so the layering is idempotent.
+  // `mode=paused`, `mode=scrub`, and `mode=screenshot`) so direct
+  // bridge callers — outside the loader path — still benefit from
+  // the structural guarantee. Truncating an already-single-entry
+  // slice is a no-op, so the layering is idempotent.
   const effectiveTarget = truncateToHead(
     target,
-    options.repeat !== undefined || options.hold !== undefined || options.cueGate !== undefined,
+    options.repeat !== undefined ||
+      options.hold !== undefined ||
+      options.cueGate !== undefined ||
+      options.screenshot !== undefined,
   );
   const composition = effectiveTarget.composition;
   // Collapse the single-scene vs composition-slice paths into one
@@ -539,5 +574,15 @@ export async function loadSceneNavigationTarget(
     // supplied it so a runner that branches on `'cueGate' in input`
     // sees an absent key rather than `undefined`.
     ...(options.cueGate === undefined ? {} : { headCueGate: options.cueGate }),
+    // `screenshot` is independent of `beat`, `repeat`, `hold`, and
+    // `cueGate` per ADR-021: a URL like `?scene=x&mode=screenshot`
+    // (no beat) is valid (renders at first frame), and so is
+    // `?scene=x&beat=midpoint&mode=screenshot` (the natural
+    // deterministic-frame-capture-at-named-beat path PUL-F018
+    // names directly). Spread `headScreenshot` only when the
+    // caller supplied it so a runner that branches on
+    // `'screenshot' in input` sees an absent key rather than
+    // `undefined`.
+    ...(options.screenshot === undefined ? {} : { headScreenshot: options.screenshot }),
   });
 }

--- a/tests/runtime/composition-resolver.test.ts
+++ b/tests/runtime/composition-resolver.test.ts
@@ -1658,3 +1658,130 @@ describe('URL scrub-mode runner cue-gate-hint forwarding (PUL-F017)', () => {
     expect(runCalls[0]?.cueGate).toBe('monotonic-forward');
   });
 });
+
+describe('URL screenshot-mode runner capture-hint forwarding (PUL-F018)', () => {
+  // PUL-F018: in `mode=screenshot`, the runtime SHALL render the
+  // addressed scene at the addressed beat (or first frame if no beat)
+  // with all asset preloads resolved, no animation in progress, all
+  // audio suppressed, and any randomness sourced from a deterministic
+  // seed. ADR-021 places mode dispatch at the loader and the
+  // capture-bundle semantics at the timeline-runner adapter. The
+  // resolver's job is forwarding the URL-derived `headScreenshot`
+  // hint to the head scene's run input only; subsequent scenes in a
+  // composition slice do not receive `screenshot` because under
+  // screenshot the slice is truncated upstream and the captured frame
+  // belongs to one scene. The resolver does NOT interpret
+  // `headScreenshot` itself; honoring "freeze at addressed frame, all
+  // audio suppressed, deterministic randomness" is the runner's
+  // contract.
+
+  it("forwards `headScreenshot` to plan[0]'s run input only — subsequent scenes get no screenshot", async () => {
+    const runCalls: SceneTimelineRunInput[] = [];
+    const { options } = buildHarness({
+      scenes: [{ id: 'scene-a' }, { id: 'scene-b' }],
+      manifest: ['scene-a', 'scene-b'],
+      runTimeline: (input) => {
+        runCalls.push(input);
+      },
+    });
+    await resolveComposition({ ...options, headScreenshot: 'capture' });
+    expect(runCalls).toHaveLength(2);
+    expect(runCalls[0]?.scene.id).toBe('scene-a');
+    expect(runCalls[0]?.screenshot).toBe('capture');
+    expect(runCalls[1]?.scene.id).toBe('scene-b');
+    expect(runCalls[1]?.screenshot).toBeUndefined();
+    // Parallel to `beat` / `repeat` / `hold` / `cueGate` / `range` /
+    // `behavior`: the key is OMITTED from the input object when
+    // absent, not set to `undefined`. The runner can branch on
+    // `'screenshot' in input` rather than checking for `undefined`.
+    expect('screenshot' in (runCalls[1] as object)).toBe(false);
+  });
+
+  it('does not attach `screenshot` when `headScreenshot` is absent', async () => {
+    const runCalls: SceneTimelineRunInput[] = [];
+    const { options } = buildHarness({
+      scenes: [{ id: 'scene-a' }],
+      manifest: ['scene-a'],
+      runTimeline: (input) => {
+        runCalls.push(input);
+      },
+    });
+    await resolveComposition(options);
+    expect(runCalls).toHaveLength(1);
+    expect('screenshot' in (runCalls[0] as object)).toBe(false);
+  });
+
+  it('does not interpret `headScreenshot` itself — a runner that ignores the hint and returns normally does not error', async () => {
+    // Resolver delegates the screenshot capture bundle (frame freeze,
+    // audio suppression, deterministic seed) to the runner per
+    // ADR-021. A runner that receives `screenshot: 'capture'` and
+    // returns void normally (e.g. the placeholder runner that has no
+    // real timeline, no audio engine, and no scene-side randomness)
+    // must NOT cause the resolver to throw or skip cleanup.
+    const cleanupCalls: string[] = [];
+    const { options } = buildHarness({
+      scenes: [
+        {
+          id: 'scene-a',
+          cleanup: () => {
+            cleanupCalls.push('scene-a');
+          },
+        },
+      ],
+      manifest: ['scene-a'],
+      runTimeline: () => undefined,
+    });
+    await expect(
+      resolveComposition({
+        ...options,
+        headScreenshot: 'capture',
+      }),
+    ).resolves.toBeUndefined();
+    expect(cleanupCalls).toEqual(['scene-a']);
+  });
+
+  it('forwards `headScreenshot` alongside `headBeat`, `headRepeat`, `headHold`, and `headCueGate` independently — all five reach plan[0] without coupling', async () => {
+    // `headScreenshot`, `headBeat`, `headRepeat`, `headHold`, and
+    // `headCueGate` are five independent head-only forwardings. A
+    // regression that paired them — e.g. dropping `headBeat` when
+    // `headScreenshot` is set, or dropping `headScreenshot` when
+    // `headHold` is also supplied — would break valid combinations a
+    // programmatic bridge caller (test harness, future export
+    // pipeline) can legitimately request. The URL grammar makes the
+    // parent modes (`mode=loop`, `mode=paused`, `mode=scrub`,
+    // `mode=screenshot`) mutually exclusive (mode is a single
+    // field), so production callers won't supply more than one of
+    // `headRepeat` / `headHold` / `headCueGate` / `headScreenshot`
+    // at once; the test exercises a programmatic caller scenario to
+    // pin that the resolver does not invent coupling between the
+    // five head-only fields. All five must reach plan[0] when all
+    // five are supplied — this is also the regression test for URLs
+    // like `?scene=x&beat=midpoint&mode=screenshot` (screenshot at
+    // a named beat — the natural deterministic-frame-capture
+    // anchor PUL-F018 names directly) which only sets `headBeat` +
+    // `headScreenshot`.
+    const runCalls: SceneTimelineRunInput[] = [];
+    const { options } = buildHarness({
+      scenes: [{ id: 'scene-a' }],
+      manifest: ['scene-a'],
+      runTimeline: (input) => {
+        runCalls.push(input);
+      },
+    });
+    await resolveComposition({
+      ...options,
+      headBeat: 'midpoint',
+      onBeatMissing: () => undefined,
+      headRepeat: 'until-aborted',
+      headHold: 'first-frame',
+      headCueGate: 'monotonic-forward',
+      headScreenshot: 'capture',
+    });
+    expect(runCalls).toHaveLength(1);
+    expect(runCalls[0]?.beat).toBe('midpoint');
+    expect(runCalls[0]?.repeat).toBe('until-aborted');
+    expect(runCalls[0]?.hold).toBe('first-frame');
+    expect(runCalls[0]?.cueGate).toBe('monotonic-forward');
+    expect(runCalls[0]?.screenshot).toBe('capture');
+  });
+});

--- a/tests/runtime/scene-loader.test.ts
+++ b/tests/runtime/scene-loader.test.ts
@@ -4379,4 +4379,594 @@ describe('createSceneLoader (PUL-F008)', () => {
       ]);
     });
   });
+
+  describe('screenshot-mode runner capture-hint forwarding (PUL-F018)', () => {
+    // PUL-F018 statement: in `mode=screenshot`, the runtime SHALL
+    // render the addressed scene at the addressed beat (or first
+    // frame if no beat) with all asset preloads resolved, no
+    // animation in progress, all audio suppressed, and any
+    // randomness sourced from a deterministic seed.
+    //
+    // Materially-implementable parts of the statement that this
+    // block pins (ADR-021 records the contract boundary):
+    //   - The loader passes `screenshot: 'capture'` to the
+    //     timeline runner adapter when
+    //     `effectiveMode(target) === 'screenshot'`. The runner is
+    //     responsible for honoring the bundle (frame freeze at
+    //     beat-or-zero, no animation, all audio suppressed,
+    //     deterministic seed).
+    //   - The hint is HEAD-ONLY: under composition targets the head
+    //     scene's runner input carries `screenshot`; following
+    //     entries do not. Following entries do not run at all
+    //     because the slice is truncated to the addressed head —
+    //     same structural defense ADR-018 / ADR-019 / ADR-020 record
+    //     for `mode=loop` / `mode=paused` / `mode=scrub`.
+    //   - `ctx.mode === 'screenshot'` reaches every lifecycle hook
+    //     of the head scene — the seam future capture tooling reads
+    //     when it observes the stage.
+    //   - Other modes (`present`, `standalone`, `loop`, `paused`,
+    //     `scrub`, `prompter`) and a `mode`-less URL DO NOT set
+    //     `screenshot`. A regression that broadcast `screenshot`
+    //     under any mode would break URLs that depend on normal
+    //     playback semantics.
+    //   - No `data-pulsar-mode-*` suppression attribute is preempt-
+    //     ively written under `screenshot` (parity with ADR-016 /
+    //     ADR-017 / ADR-018 / ADR-019 / ADR-020).
+    //   - Composition validation (unregistered composition, unknown
+    //     member scene, out-of-range index) STILL surfaces as a
+    //     navigation error under `mode=screenshot` — no silent
+    //     fallback to direct scene lookup.
+    //   - Beat semantics under `mode=screenshot` are honored as the
+    //     captured-frame anchor: PUL-F018 explicitly says "at the
+    //     addressed beat (or first frame if no beat)," unlike
+    //     `mode=paused` where ADR-019 records "first frame wins."
+    //     The loader forwards `input.beat` alongside
+    //     `input.screenshot`; missing-label diagnostics surface
+    //     via `data-pulsar-navigation-error` / `onError` without
+    //     unmounting.
+    //   - Object-form head entry's `range` / `behavior` overrides
+    //     reach the runner unchanged. Screenshot is single-scene-
+    //     mount with deterministic capture at the head, NOT
+    //     direct-scene flattening.
+    //
+    // PUL-F018 stays DRAFT after this PR (ADR-021 records the
+    // boundary; following the ADR-016 / ADR-017 / ADR-018 / ADR-019
+    // / ADR-020 / PUL-F013 / PUL-F014 / PUL-F015 / PUL-F016 /
+    // PUL-F017 precedent). The seam — the loader passes
+    // `screenshot: 'capture'` and `ctx.mode === 'screenshot'` — IS
+    // materially shipped. The actual capture-bundle behavior
+    // (frame freeze, audio suppression, deterministic randomness)
+    // is the runner's contract (ADR-003's GSAP runner + ADR-004's
+    // audio engine + a deterministic-randomness convention when
+    // they land); all three are required for ACTIVE.
+
+    const screenshotSceneTarget = (id: string): NavigationTarget => ({
+      locator: { kind: 'scene', scene: id },
+      mode: 'screenshot',
+    });
+    const screenshotCompositionTarget = (composition: string): NavigationTarget => ({
+      locator: { kind: 'composition', composition },
+      mode: 'screenshot',
+    });
+    const screenshotCompositionSceneTarget = (
+      composition: string,
+      scene: string,
+    ): NavigationTarget => ({
+      locator: { kind: 'composition-scene', composition, scene },
+      mode: 'screenshot',
+    });
+    const screenshotCompositionIndexTarget = (
+      composition: string,
+      index: number,
+    ): NavigationTarget => ({
+      locator: { kind: 'composition-index', composition, index },
+      mode: 'screenshot',
+    });
+
+    it('passes `screenshot: "capture"` to the runner for a `scene` target under `mode=screenshot`', async () => {
+      // Direct-scene navigation is the simplest screenshot path:
+      // the addressed scene IS the head, no slice resolution. A
+      // regression that gated `screenshot` on `target.composition`
+      // being defined would silently drop the hint here.
+      const captured: { sceneId: string; screenshot: 'capture' | undefined }[] = [];
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      const runner: SceneTimelineRunner = (input) => {
+        captured.push({ sceneId: input.scene.id, screenshot: input.screenshot });
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: runner,
+      });
+
+      await loader.handle(screenshotSceneTarget('scene-a'));
+
+      expect(captured).toEqual([{ sceneId: 'scene-a', screenshot: 'capture' }]);
+    });
+
+    it('runs only the head scene of a `composition` target under `mode=screenshot` (slice truncation; runner sees `screenshot: "capture"` for the head)', async () => {
+      // PUL-F018 / ADR-021: screenshot truncates the validated
+      // composition slice to the addressed head, parallel to
+      // standalone (ADR-017), loop (ADR-018), paused (ADR-019), and
+      // scrub (ADR-020). Truncation makes "no following entries
+      // run" a structural guarantee — a runner bug or no-op runner
+      // under `mode=screenshot` MUST NOT silently degrade into
+      // normal composition playback. The plain `composition`
+      // locator (no scene id, no index) exercises the path that
+      // resolves the head from the manifest's first entry; a
+      // regression that only dropped `screenshot: 'capture'` for
+      // this locator (vs the composition+index path the next test
+      // covers) would slip past a test that named itself
+      // "composition target" but actually used composition+index.
+      const captured: { sceneId: string; screenshot: 'capture' | undefined }[] = [];
+      const sceneA = buildScene({ id: 'scene-a' });
+      const sceneB = buildScene({ id: 'scene-b' });
+      const sceneC = buildScene({ id: 'scene-c' });
+      const stage = buildStage();
+      const runner: SceneTimelineRunner = (input) => {
+        captured.push({ sceneId: input.scene.id, screenshot: input.screenshot });
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA, sceneB, sceneC]),
+        compositions: createCompositionRegistry([
+          { id: 'full-talk', manifest: ['scene-a', 'scene-b', 'scene-c'] },
+        ]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: runner,
+      });
+
+      await loader.handle(screenshotCompositionTarget('full-talk'));
+
+      expect(captured).toEqual([{ sceneId: 'scene-a', screenshot: 'capture' }]);
+    });
+
+    it('runs only the head scene of a `composition+index` target under `mode=screenshot` (slice truncation pinned for the index locator too)', async () => {
+      // The composition+index locator exercises the slice-from-N
+      // path; pins parity with the plain composition target above.
+      // Use a non-final-index navigation so the slice has
+      // successors that would be observable if truncation were
+      // missing.
+      const captured: { sceneId: string; screenshot: 'capture' | undefined }[] = [];
+      const sceneA = buildScene({ id: 'scene-a' });
+      const sceneB = buildScene({ id: 'scene-b' });
+      const sceneC = buildScene({ id: 'scene-c' });
+      const stage = buildStage();
+      const runner: SceneTimelineRunner = (input) => {
+        captured.push({ sceneId: input.scene.id, screenshot: input.screenshot });
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA, sceneB, sceneC]),
+        compositions: createCompositionRegistry([
+          { id: 'full-talk', manifest: ['scene-a', 'scene-b', 'scene-c'] },
+        ]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: runner,
+      });
+
+      await loader.handle(screenshotCompositionIndexTarget('full-talk', 0));
+
+      expect(captured).toEqual([{ sceneId: 'scene-a', screenshot: 'capture' }]);
+    });
+
+    it('runs only the addressed scene of a `composition+scene` target under `mode=screenshot`', async () => {
+      // composition+scene targeting a non-final entry exercises the
+      // slice transform from a different locator shape; pins parity
+      // with the composition-target case above.
+      const captured: { sceneId: string; screenshot: 'capture' | undefined }[] = [];
+      const sceneA = buildScene({ id: 'scene-a' });
+      const sceneB = buildScene({ id: 'scene-b' });
+      const sceneC = buildScene({ id: 'scene-c' });
+      const stage = buildStage();
+      const runner: SceneTimelineRunner = (input) => {
+        captured.push({ sceneId: input.scene.id, screenshot: input.screenshot });
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA, sceneB, sceneC]),
+        compositions: createCompositionRegistry([
+          { id: 'full-talk', manifest: ['scene-a', 'scene-b', 'scene-c'] },
+        ]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: runner,
+      });
+
+      await loader.handle(screenshotCompositionSceneTarget('full-talk', 'scene-b'));
+
+      expect(captured).toEqual([{ sceneId: 'scene-b', screenshot: 'capture' }]);
+    });
+
+    it('runs cleanup exactly once for the head scene under `mode=screenshot`, never for dropped slice entries', async () => {
+      // Same invariant as PUL-F014 (ADR-017) under standalone,
+      // PUL-F015 (ADR-018) under loop, PUL-F016 (ADR-019) under
+      // paused, PUL-F017 (ADR-020) under scrub: a regression that
+      // dropped the slice for execution but left following scenes
+      // wired through the synthesized registry could double-clean
+      // or skip-clean. Pin exactly-once cleanup on the head and
+      // zero cleanup for the dropped entries.
+      const cleaned: string[] = [];
+      const trace = (id: string): SceneModule =>
+        buildScene({
+          id,
+          cleanup: () => {
+            cleaned.push(id);
+          },
+        });
+      const scenes = [trace('scene-a'), trace('scene-b'), trace('scene-c')];
+      const stage = buildStage();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry(scenes),
+        compositions: createCompositionRegistry([
+          { id: 'full-talk', manifest: scenes.map((s) => s.id) },
+        ]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+      });
+
+      await loader.handle(screenshotCompositionTarget('full-talk'));
+
+      expect(cleaned).toEqual(['scene-a']);
+    });
+
+    it('omits the `screenshot` key on the runner input when `mode=screenshot` is absent (key-presence semantics)', async () => {
+      // The runner input uses key-presence semantics for optional
+      // fields (parallel to `beat` / `repeat` / `hold` / `cueGate`
+      // / `range` / `behavior`): a runner can branch on
+      // `'screenshot' in input` rather than `=== undefined`. A
+      // regression that always set `input.screenshot = undefined`
+      // (or any non-`'capture'` value) under non-screenshot modes
+      // would break that contract.
+      const captured: { hasScreenshot: boolean; screenshot: unknown }[] = [];
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      const runner: SceneTimelineRunner = (input) => {
+        captured.push({ hasScreenshot: 'screenshot' in input, screenshot: input.screenshot });
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: runner,
+      });
+
+      // No mode at all (defaults to `present`).
+      await loader.handle(sceneTarget('scene-a'));
+
+      expect(captured).toEqual([{ hasScreenshot: false, screenshot: undefined }]);
+    });
+
+    it('does not set `screenshot` for any non-screenshot mode', async () => {
+      // Walk the seven-mode allowlist (minus `screenshot`) and
+      // confirm that none of them produce `screenshot` on the
+      // runner input. Catching every non-screenshot mode
+      // discriminates against an over-broad fix that gated
+      // `screenshot` on `mode !== undefined` rather than
+      // `mode === 'screenshot'`. Capturing the per-iteration mode
+      // alongside the `'screenshot' in input` flag means the
+      // assertion failure identifies WHICH mode regressed, not
+      // just "some mode did."
+      const nonScreenshotModes = NAVIGATION_MODES.filter((m) => m !== 'screenshot');
+      const captured: { mode: NavigationMode; hasScreenshot: boolean }[] = [];
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      for (const mode of nonScreenshotModes) {
+        const runner: SceneTimelineRunner = (input) => {
+          captured.push({ mode, hasScreenshot: 'screenshot' in input });
+        };
+        const loader = createSceneLoader({
+          scenes: createSceneRegistry([sceneA]),
+          compositions: createCompositionRegistry([]),
+          stage: stage.element,
+          buildCtx: stubCtx,
+          createPreloader: () => () => undefined,
+          runTimeline: runner,
+        });
+        await loader.handle({ locator: { kind: 'scene', scene: 'scene-a' }, mode });
+      }
+
+      // One entry per non-screenshot mode, each must have
+      // `hasScreenshot: false`. Building the expected array from
+      // `nonScreenshotModes` keeps the assertion in sync if the
+      // mode allowlist ever changes.
+      expect(captured).toEqual(nonScreenshotModes.map((mode) => ({ mode, hasScreenshot: false })));
+    });
+
+    it('exposes `ctx.mode === "screenshot"` to every lifecycle hook of the head scene under all locator shapes', async () => {
+      // Parallel to the PUL-F014 standalone, PUL-F015 loop,
+      // PUL-F016 paused, and PUL-F017 scrub seam tests. Future
+      // capture tooling that observes the runtime reads `ctx.mode`
+      // (or the equivalent stage seam) to decide its own behavior;
+      // this test pins the seam end to end across all four locator
+      // shapes that can appear under `mode=screenshot`.
+      const seen: { phase: string; locatorKind: string; mode: unknown }[] = [];
+      const recordMode =
+        (phase: string, locatorKind: string) =>
+        (ctx: unknown): unknown => {
+          seen.push({ phase, locatorKind, mode: (ctx as { mode?: NavigationMode }).mode });
+          return null;
+        };
+      const makeScene = (locatorKind: string): SceneModule =>
+        buildScene({
+          id: 'scene-a',
+          create: recordMode('create', locatorKind),
+          timeline: recordMode('timeline', locatorKind) as SceneModule['timeline'],
+          cleanup: recordMode('cleanup', locatorKind),
+        });
+      const stage = buildStage();
+      const buildLoader = (sceneId: string, locatorKind: string) =>
+        createSceneLoader({
+          scenes: createSceneRegistry([makeScene(locatorKind)]),
+          compositions: createCompositionRegistry([{ id: 'full-talk', manifest: [sceneId] }]),
+          stage: stage.element,
+          buildCtx: (mode) => ({ stage: stage.element, mode }),
+          createPreloader: () => () => undefined,
+          runTimeline: noopRunner,
+        });
+
+      await buildLoader('scene-a', 'scene').handle(screenshotSceneTarget('scene-a'));
+      await buildLoader('scene-a', 'composition').handle(screenshotCompositionTarget('full-talk'));
+      await buildLoader('scene-a', 'composition-scene').handle(
+        screenshotCompositionSceneTarget('full-talk', 'scene-a'),
+      );
+      await buildLoader('scene-a', 'composition-index').handle(
+        screenshotCompositionIndexTarget('full-talk', 0),
+      );
+
+      // 3 hooks per navigation × 4 locator shapes = 12 entries;
+      // every single one must carry `screenshot`.
+      expect(seen).toHaveLength(12);
+      for (const entry of seen) {
+        expect(entry.mode).toBe('screenshot');
+      }
+    });
+
+    it('forwards `beat` to the head scene runner alongside `screenshot` under `mode=screenshot`, and surfaces missing-beat as a non-fatal diagnostic', async () => {
+      // PUL-F018 explicitly says "at the addressed beat (or first
+      // frame if no beat)," so a URL like
+      // `?scene=x&beat=midpoint&mode=screenshot` must deliver both
+      // `beat` and `screenshot` to the runner. Unlike `mode=paused`
+      // (ADR-019: "first frame wins"), screenshot HONORS the beat
+      // as the addressed-frame anchor; the runner seeks to the
+      // beat and then freezes. A regression that dropped `beat`
+      // when `mode=screenshot` is set would silently break the
+      // natural deterministic-frame-capture-at-named-beat path
+      // PUL-F018 names directly.
+      const captured: {
+        sceneId: string;
+        beat: string | undefined;
+        screenshot: 'capture' | undefined;
+      }[] = [];
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      const errors: unknown[] = [];
+      const runner: SceneTimelineRunner = (input) => {
+        captured.push({
+          sceneId: input.scene.id,
+          beat: input.beat,
+          screenshot: input.screenshot,
+        });
+        if (input.beat !== undefined && input.onBeatMissing !== undefined) {
+          input.onBeatMissing();
+        }
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: runner,
+        onError: (err) => {
+          errors.push(err);
+        },
+      });
+
+      await loader.handle({
+        locator: { kind: 'scene', scene: 'scene-a' },
+        mode: 'screenshot',
+        beat: 'midpoint',
+      });
+
+      expect(captured).toEqual([{ sceneId: 'scene-a', beat: 'midpoint', screenshot: 'capture' }]);
+      expect(errors).toHaveLength(1);
+      expect((errors[0] as Error).message).toContain('beat positioning failed');
+      expect((errors[0] as Error).message).toContain('"midpoint"');
+      expect(stage.attrs.get('data-pulsar-navigation-error')).toBeDefined();
+    });
+
+    it('writes no `data-pulsar-mode-*` suppression attribute on the stage under `mode=screenshot`', async () => {
+      // Mirrors ADR-016 / ADR-017 / ADR-018 / ADR-019 / ADR-020
+      // invariant. PUL-F018 forbids the loader from preemptively
+      // writing a stage attribute for screenshot mode; runner-side
+      // or future-tooling-side signaling lives at those surfaces,
+      // not at the loader.
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+      });
+
+      await loader.handle(screenshotSceneTarget('scene-a'));
+
+      const modeAttrs = Array.from(stage.attrs.keys()).filter((name) =>
+        name.startsWith('data-pulsar-mode-'),
+      );
+      expect(modeAttrs).toEqual([]);
+    });
+
+    it('writes both `data-pulsar-scene-target` and `data-pulsar-composition-target` for a composition target under `mode=screenshot` (preserves observability of what the URL addressed)', async () => {
+      // The stage attrs communicate "what was addressed," not "what
+      // ran." Truncation drops following entries from execution
+      // but does not drop the composition id from the stage attrs
+      // — mirrors the standalone / loop / paused / scrub
+      // invariant.
+      const sceneA = buildScene({ id: 'scene-a' });
+      const sceneB = buildScene({ id: 'scene-b' });
+      const stage = buildStage();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA, sceneB]),
+        compositions: createCompositionRegistry([
+          { id: 'full-talk', manifest: ['scene-a', 'scene-b'] },
+        ]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+      });
+
+      await loader.handle(screenshotCompositionSceneTarget('full-talk', 'scene-b'));
+
+      expect(stage.attrs.get('data-pulsar-scene-target')).toBe('scene-b');
+      expect(stage.attrs.get('data-pulsar-composition-target')).toBe('full-talk');
+    });
+
+    it('surfaces composition-not-registered as a navigation error under `mode=screenshot` (no silent fallback)', async () => {
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      const errors: unknown[] = [];
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+        onError: (err) => {
+          errors.push(err);
+        },
+      });
+
+      await loader.handle(screenshotCompositionTarget('not-registered'));
+
+      expect(errors).toHaveLength(1);
+      expect((errors[0] as Error).message).toContain(
+        'composition "not-registered" is not registered',
+      );
+      expect(stage.attrs.get('data-pulsar-navigation-error')).toBeDefined();
+    });
+
+    it('surfaces composition-member error under `mode=screenshot` for an unknown scene in `composition+scene`', async () => {
+      const sceneA = buildScene({ id: 'scene-a' });
+      const sceneZ = buildScene({ id: 'scene-z' });
+      const stage = buildStage();
+      const errors: unknown[] = [];
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA, sceneZ]),
+        compositions: createCompositionRegistry([{ id: 'full-talk', manifest: ['scene-a'] }]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+        onError: (err) => {
+          errors.push(err);
+        },
+      });
+
+      await loader.handle(screenshotCompositionSceneTarget('full-talk', 'scene-z'));
+
+      expect(errors).toHaveLength(1);
+      expect((errors[0] as Error).message).toContain(
+        'scene "scene-z" is not a member of composition "full-talk"',
+      );
+    });
+
+    it('surfaces index-out-of-range under `mode=screenshot`', async () => {
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      const errors: unknown[] = [];
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([{ id: 'full-talk', manifest: ['scene-a'] }]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+        onError: (err) => {
+          errors.push(err);
+        },
+      });
+
+      await loader.handle(screenshotCompositionIndexTarget('full-talk', 5));
+
+      expect(errors).toHaveLength(1);
+      expect((errors[0] as Error).message).toContain('index 5 is out of range');
+    });
+
+    it("preserves the addressed head entry's `range` and `behavior` overrides on the runner input under `mode=screenshot` (composition+index with object-form entry)", async () => {
+      // PUL-F018 / ADR-021: screenshot truncates the validated
+      // composition slice to the addressed head and forwards
+      // `screenshot` to that head's runner input. The slice is
+      // TRUNCATED rather than flattened — a flat `{ scene }` would
+      // lose object-form `range` / `behavior` overrides on the
+      // head entry, turning screenshot into direct-scene
+      // flattening (parity with ADR-017's standalone, ADR-018's
+      // loop, ADR-019's paused, and ADR-020's scrub invariant).
+      // This pins all three slots — `range`, `behavior`, and
+      // `screenshot` — through to the head runner, plus the
+      // truncation itself (the runner runs exactly once).
+      const sceneA = buildScene({ id: 'scene-a' });
+      const sceneB = buildScene({ id: 'scene-b' });
+      const sceneC = buildScene({ id: 'scene-c' });
+      const stage = buildStage();
+      const captured: {
+        sceneId: string;
+        range: unknown;
+        behavior: unknown;
+        screenshot: unknown;
+      }[] = [];
+      const runner: SceneTimelineRunner = (input) => {
+        captured.push({
+          sceneId: input.scene.id,
+          range: input.range,
+          behavior: input.behavior,
+          screenshot: input.screenshot,
+        });
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA, sceneB, sceneC]),
+        compositions: createCompositionRegistry([
+          {
+            id: 'full-talk',
+            manifest: [
+              'scene-a',
+              { id: 'scene-b', range: 'midpoint', behavior: { hold: true } },
+              'scene-c',
+            ],
+          },
+        ]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: runner,
+      });
+
+      await loader.handle(screenshotCompositionIndexTarget('full-talk', 1));
+
+      expect(captured).toEqual([
+        {
+          sceneId: 'scene-b',
+          range: 'midpoint',
+          behavior: { hold: true },
+          screenshot: 'capture',
+        },
+      ]);
+    });
+  });
 });

--- a/tests/runtime/scene-navigation.test.ts
+++ b/tests/runtime/scene-navigation.test.ts
@@ -1389,4 +1389,219 @@ describe('loadSceneNavigationTarget (PUL-F008 lifecycle bridge)', () => {
       ]);
     });
   });
+
+  describe('URL screenshot-mode capture forwarding (PUL-F018)', () => {
+    // ADR-021: under `mode=screenshot` the runner renders the
+    // addressed scene at the addressed beat (or first frame), holds
+    // the timeline still, suppresses all audio, and sources any
+    // randomness from a deterministic seed. The bridge's only job is
+    // to forward the `screenshot` option from the loader to the
+    // resolver as `headScreenshot`. The resolver scopes delivery to
+    // the head scene's run input only — honoring the capture bundle
+    // is the runner's contract.
+
+    it('forwards `screenshot` to the runner for a single-scene target', async () => {
+      const seen: { screenshot?: 'capture' }[] = [];
+      const intro = buildScene({ id: 'intro' });
+      const scenes = createSceneRegistry([intro]);
+      const compositions = createCompositionRegistry([]);
+      const target = resolveSceneNavigation(sceneTarget('intro'), {
+        scenes,
+        compositions,
+      }) as SceneNavigationTarget;
+
+      await loadSceneNavigationTarget(target, {
+        // Direct bridge callers (this test, future export
+        // pipelines, etc.) MUST build a ctx coherent with the
+        // runner-input `screenshot` flag, because PUL-F018's
+        // determinism clause flows through the scene-side
+        // `ctx.mode === 'screenshot'` seam (ADR-021's split).
+        // Passing `screenshot: 'capture'` to the bridge with a
+        // ctx whose mode disagreed (e.g. `mode: 'present'`)
+        // would leave scene `create(ctx)` thinking it's not in
+        // capture mode while the runner thinks it is.
+        ctx: { mode: 'screenshot' },
+        preloadAssets: () => undefined,
+        runTimeline: (input) => {
+          const captured: { screenshot?: 'capture' } = {};
+          if ('screenshot' in input) captured.screenshot = input.screenshot;
+          seen.push(captured);
+        },
+        screenshot: 'capture',
+      });
+
+      expect(seen).toEqual([{ screenshot: 'capture' }]);
+    });
+
+    it('truncates a composition slice to the addressed head when `screenshot` is supplied — structural defense against runner non-conformance', async () => {
+      // PUL-F018 / ADR-021: under `screenshot: 'capture'`
+      // screenshot is single-scene-execution at the addressed head —
+      // by definition following composition entries do not run
+      // because the runtime is rendering one deterministic frame.
+      // The bridge truncates the slice to a single entry as a
+      // structural defense so a runner that ignores
+      // `input.screenshot` cannot silently degrade screenshot-mode
+      // navigation into normal composition playback. This is
+      // layered with the loader's `applySingleSceneSlice` so direct
+      // bridge callers — outside the loader path — get the same
+      // guarantee. Mirrors the layered defense ADR-018 / ADR-019 /
+      // ADR-020 record for `repeat` / `hold` / `cueGate`.
+      const seen: { id: string; screenshot: 'capture' | undefined }[] = [];
+      const intro = buildScene({ id: 'intro' });
+      const middle = buildScene({ id: 'middle' });
+      const scenes = createSceneRegistry([intro, middle]);
+      const compositions = createCompositionRegistry([
+        { id: 'full-talk', manifest: ['intro', 'middle'] },
+      ]);
+      const target = resolveSceneNavigation(compositionIndexTarget('full-talk', 0), {
+        scenes,
+        compositions,
+      }) as SceneNavigationTarget;
+
+      await loadSceneNavigationTarget(target, {
+        // ADR-021's split: callers supplying `screenshot:
+        // 'capture'` to the bridge must also build a ctx whose
+        // mode is coherent. See the prior test for rationale.
+        ctx: { mode: 'screenshot' },
+        preloadAssets: () => undefined,
+        runTimeline: (input) => {
+          seen.push({ id: input.scene.id, screenshot: input.screenshot });
+        },
+        screenshot: 'capture',
+      });
+
+      // Only the head ran; the tail (`middle`) was structurally
+      // dropped. A regression that omitted bridge-level truncation
+      // under `screenshot` would observe `middle` as a second
+      // runner entry here.
+      expect(seen).toEqual([{ id: 'intro', screenshot: 'capture' }]);
+    });
+
+    it('does not truncate a composition slice when `screenshot` is absent — non-screenshot navigations run the full slice', async () => {
+      // The structural defense fires only under `screenshot` (or
+      // `repeat` / `hold` / `cueGate`). Composition navigation
+      // under any non-screenshot, non-loop, non-paused, non-scrub
+      // mode must still run every entry — a regression that always
+      // truncated would silently break normal composition playback.
+      const seen: string[] = [];
+      const intro = buildScene({ id: 'intro' });
+      const middle = buildScene({ id: 'middle' });
+      const scenes = createSceneRegistry([intro, middle]);
+      const compositions = createCompositionRegistry([
+        { id: 'full-talk', manifest: ['intro', 'middle'] },
+      ]);
+      const target = resolveSceneNavigation(compositionIndexTarget('full-talk', 0), {
+        scenes,
+        compositions,
+      }) as SceneNavigationTarget;
+
+      await loadSceneNavigationTarget(target, {
+        ctx: {},
+        preloadAssets: () => undefined,
+        runTimeline: (input) => {
+          seen.push(input.scene.id);
+        },
+      });
+
+      expect(seen).toEqual(['intro', 'middle']);
+    });
+
+    it('does not forward `screenshot` when the option is omitted', async () => {
+      const screenshotPresence: boolean[] = [];
+      const intro = buildScene({ id: 'intro' });
+      const scenes = createSceneRegistry([intro]);
+      const compositions = createCompositionRegistry([]);
+      const target = resolveSceneNavigation(sceneTarget('intro'), {
+        scenes,
+        compositions,
+      }) as SceneNavigationTarget;
+
+      await loadSceneNavigationTarget(target, {
+        ctx: {},
+        preloadAssets: () => undefined,
+        runTimeline: (input) => {
+          screenshotPresence.push('screenshot' in input);
+        },
+      });
+
+      expect(screenshotPresence).toEqual([false]);
+    });
+
+    it('forwards `screenshot`, `beat`, `repeat`, `hold`, and `cueGate` independently — all five reach the head without coupling', async () => {
+      // The bridge plumbs five independent head-only forwardings. A
+      // regression that paired them — e.g. dropping `screenshot`
+      // when `cueGate` is also supplied, or vice versa — would
+      // break valid combinations a programmatic caller can
+      // legitimately request. Note that `mode=screenshot`,
+      // `mode=scrub`, `mode=loop`, and `mode=paused` are mutually
+      // exclusive at the URL boundary (mode is a single field),
+      // but a programmatic caller can supply any combination of
+      // these options to the bridge and all must reach the runner
+      // so the runner-side policy decides. This is also the
+      // regression test for URLs like
+      // `?scene=x&beat=midpoint&mode=screenshot` — the natural
+      // deterministic-frame-capture-at-named-beat path PUL-F018
+      // names directly.
+      const seen: {
+        beat?: string;
+        cueGate?: 'monotonic-forward';
+        hold?: 'first-frame';
+        repeat?: 'until-aborted';
+        screenshot?: 'capture';
+      }[] = [];
+      const intro = buildScene({ id: 'intro' });
+      const scenes = createSceneRegistry([intro]);
+      const compositions = createCompositionRegistry([]);
+      const target = resolveSceneNavigation(sceneTarget('intro'), {
+        scenes,
+        compositions,
+      }) as SceneNavigationTarget;
+
+      await loadSceneNavigationTarget(target, {
+        // This test exercises a programmatic caller that supplies
+        // combinations the URL grammar can't produce (modes are
+        // mutually exclusive at the URL boundary). There is no
+        // single coherent `ctx.mode` for "all four modes at once,"
+        // so an opaque `{}` ctx is intentional here — the
+        // assertion is about runner-input plumbing, not about the
+        // scene-side `ctx.mode` seam. Production callers (loader
+        // path) always pair the runner-input fields with a
+        // coherent `ctx.mode`; that pairing is exercised by the
+        // single-mode tests above.
+        ctx: {},
+        preloadAssets: () => undefined,
+        runTimeline: (input) => {
+          const captured: {
+            beat?: string;
+            cueGate?: 'monotonic-forward';
+            hold?: 'first-frame';
+            repeat?: 'until-aborted';
+            screenshot?: 'capture';
+          } = {};
+          if ('beat' in input) captured.beat = input.beat;
+          if ('cueGate' in input) captured.cueGate = input.cueGate;
+          if ('hold' in input) captured.hold = input.hold;
+          if ('repeat' in input) captured.repeat = input.repeat;
+          if ('screenshot' in input) captured.screenshot = input.screenshot;
+          seen.push(captured);
+        },
+        beat: 'midpoint',
+        onBeatMissing: () => undefined,
+        cueGate: 'monotonic-forward',
+        hold: 'first-frame',
+        repeat: 'until-aborted',
+        screenshot: 'capture',
+      });
+
+      expect(seen).toEqual([
+        {
+          beat: 'midpoint',
+          cueGate: 'monotonic-forward',
+          hold: 'first-frame',
+          repeat: 'until-aborted',
+          screenshot: 'capture',
+        },
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Lands the loader → runner-input contract and seam-pinning tests for `mode=screenshot`, mirroring the precedent set by ADR-016 / ADR-017 / ADR-018 / ADR-019 / ADR-020.
- Splits PUL-F018's four runtime axes across two seams (per ADR-021): frame freeze at beat-or-zero + no animation + audio suppression flow through `input.screenshot` (runner-input field); deterministic randomness flows through the existing `ctx.mode === 'screenshot'` seam (PUL-F012 / ADR-007) plus a future scene-side seed surface, because scene `create(ctx)` and `timeline(ctx)` run before the runner sees `input.screenshot`.
- Widens the single-scene-execution slice transform (`applySingleSceneSlice` loader-side, `truncateToHead` bridge-side) to fire under `mode=screenshot`. Composition validation still surfaces as navigation errors. Beat is honored as the captured-frame anchor (unlike `mode=paused` where ADR-019 records "first frame wins").
- PUL-F018 stays DRAFT after this PR. ACTIVE requires ADR-003's GSAP runner honoring `input.screenshot`, ADR-004's audio engine producing silence under screenshot, AND a scene-side seed surface that scenes consume via `ctx.mode`, each with end-to-end tests.

Closes #27

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 680 tests passing (15 new screenshot-mode tests across resolver/bridge/loader)
- [x] `pre-commit run --all-files` — all hooks green
- [x] Codex pre-push review — 2 cycles run; all findings (input/ctx-split clarification, MUST language, test naming, ctx-coherence contract) addressed; decisions posted as comments on issue #27

## Files

**Production:**
- `src/runtime/composition-resolver.ts` — `SceneTimelineRunInput.screenshot?: 'capture'` and `ResolveCompositionOptions.headScreenshot?: 'capture'`; head-only forwarding through `buildRunInput` / `runScene`.
- `src/runtime/scene-navigation.ts` — `LoadSceneNavigationTargetOptions.screenshot?: 'capture'`; `truncateToHead` predicate widened.
- `src/runtime/scene-loader.ts` — `effectiveMode === 'screenshot'` → `screenshot: 'capture'` derivation; `applySingleSceneSlice` widened.
- `src/main.ts` — placeholder runner docstring acknowledges `input.screenshot`; behavior unchanged.

**Tests:**
- `tests/runtime/composition-resolver.test.ts` — new `'URL screenshot-mode runner capture-hint forwarding (PUL-F018)'` describe block (4 tests).
- `tests/runtime/scene-navigation.test.ts` — new `'URL screenshot-mode capture forwarding (PUL-F018)'` describe block (5 tests).
- `tests/runtime/scene-loader.test.ts` — new `'screenshot-mode runner capture-hint forwarding (PUL-F018)'` describe block (15 tests covering all four locator shapes, slice truncation, ctx.mode seam, beat forwarding under screenshot, composition validation invariants, stage attributes, range/behavior preservation).

**Docs:**
- `docs/adrs/021-workbench-mode-screenshot.md` — new ADR.
- `docs/design/pul-f018-screenshot-mode-preflight.md` — codex preflight context (sandbox failed to write during preflight, transcribed manually — same handling pattern as PUL-F015 / F016 / F017).
- `docs/adrs/README.md`, `CHANGELOG.md` — index + changelog updates.