### PR TITLE
Implement PUL-F019 mode=prompter contract layer (ADR-022)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,72 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `docs/adrs/022-workbench-mode-prompter.md` — records the PUL-F019
+  contract layer for `mode=prompter`. Structurally distinct from
+  the other six workbench modes: the loader BYPASSES the resolver
+  lifecycle entirely under `mode=prompter` (no preload, no
+  `create`, no `timeline`, no `cleanup`), so visual rendering is
+  suppressed by construction rather than by runner conformance.
+  The captions data path runs in its place — the loader aggregates
+  captions from the addressed scene OR the FULL composition slice
+  (NOT truncated to head; the truncation defense F015–F018 use
+  does not apply because there is no runner-side promise to
+  defend) and hands the resulting `PrompterScript` to a new
+  optional `renderPrompter` adapter. PUL-F019 stays DRAFT until a
+  captions/script UI surface lands and renders the script visibly
+  with end-to-end tests. See ADR-022 for the URL contract, the
+  lifecycle-bypass rationale, the captions-aggregation seam, and
+  the DRAFT → ACTIVE transition criteria. Indexed in
+  `docs/adrs/README.md`.
+- `src/runtime/prompter.ts` — new module exporting
+  `PrompterScriptEntry`, `PrompterScript`, `PrompterRenderer`, and
+  `buildPrompterScript`. Pure function over a
+  `SceneNavigationTarget`; reads `scene.captions` from the
+  registered scene module (object-form composition entries'
+  `range` / `behavior` overrides are runner-side concerns and do
+  NOT alter caption content). Returns a deep-frozen script so a
+  misbehaving renderer cannot corrupt the next navigation's view.
+- `src/runtime/scene-loader.ts` — `SceneLoaderOptions` gains
+  optional `renderPrompter?: PrompterRenderer`. When
+  `effectiveMode(target) === 'prompter'`, the loader runs a
+  separate dispatch path: validates via `resolveSceneNavigation`
+  (composition errors still surface — no silent fallback), sets
+  `data-pulsar-scene-target` and (composition variants)
+  `data-pulsar-composition-target`, builds the
+  `PrompterScript`, and hands it to the renderer with the per-
+  navigation abort signal. The lifecycle adapters (`createPreloader`,
+  `buildCtx`, `runTimeline`) and scene hooks (`create` / `timeline`
+  / `cleanup`) are NOT invoked. The slice-truncation helper
+  `applySingleSceneSlice` does NOT run under prompter (the captions
+  view consumes the full slice). Cleanup-before-handoff and
+  latest-event supersession still apply to prompter dispatch via
+  the existing serialized queue.
+- `src/main.ts` — placeholder `renderPrompter` adapter that parks
+  until the per-navigation abort signal fires (mirrors the
+  placeholder timeline runner). Until the captions/script UI
+  surface lands, the placeholder produces no visible output;
+  visual-rendering suppression is delivered structurally by the
+  loader's lifecycle bypass, not by this adapter.
+- `tests/runtime/prompter.test.ts` — pure-function tests for
+  `buildPrompterScript`: single-scene target, full composition
+  slice, composition+scene non-head, object-form entry with
+  overrides, empty captions, deep-frozen output, no source
+  mutation.
+- `tests/runtime/scene-loader.test.ts` — new
+  `'prompter-mode caption-view dispatch (PUL-F019)'` describe
+  block pinning lifecycle suppression (zero preloader / buildCtx /
+  runner / scene-hook invocations), full-slice captions
+  aggregation (NOT truncated), single-scene + composition variants,
+  `renderPrompter` not invoked for non-prompter modes,
+  stage-attrs preserved, no `data-pulsar-mode-*` preemptive
+  attribute, composition validation errors still surface,
+  graceful degradation when `renderPrompter` is omitted, renderer
+  abort under supersession, cleanup-before-handoff across the
+  present→prompter boundary, and `kind: 'none'` no-renderer
+  invariant. Existing PUL-F012 mode-dispatch tests gain a
+  complementary `does NOT invoke buildCtx when target.mode is
+  "prompter"` case to pin the lifecycle-bypass invariant on
+  PUL-F012's seam.
 - `docs/adrs/021-workbench-mode-screenshot.md` and
   `docs/design/pul-f018-screenshot-mode-preflight.md` — record the
   PUL-F018 contract layer for `mode=screenshot`. Single-scene
@@ -480,6 +546,16 @@ all land with end-to-end tests (see ADR-020).
 
 ### Changed
 
+- `tests/runtime/scene-loader.test.ts` — F015 / F016 / F017 / F018
+  negative-mode loops (`does not set <hint> for any non-<mode>
+  mode`) renamed `... lifecycle-running mode` and scoped to
+  exclude `prompter` alongside the target mode. PUL-F019's
+  loader-side lifecycle bypass means the runner is not invoked
+  under `mode=prompter`, so prompter cannot appear in a runner-
+  observation array. Behavior is unchanged for the six lifecycle-
+  running modes; the rename plus inline comment makes the scope
+  deliberate so a future maintainer does not reflexively add
+  `prompter` back.
 - `src/runtime/scene-loader.ts` — `runTarget` truncates the validated
   composition slice to a single entry — the addressed head — when
   `effectiveMode(target) === 'standalone'` AND

--- a/docs/adrs/022-workbench-mode-prompter.md
+++ b/docs/adrs/022-workbench-mode-prompter.md
@@ -1,0 +1,490 @@
+# ADR-022: Workbench Mode `prompter` — Loader-Side Lifecycle Bypass with Captions Aggregation Seam
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-09
+
+## Context
+
+ADR-007 names seven workbench modes: `present`, `standalone`, `loop`,
+`paused`, `scrub`, `screenshot`, `prompter`. ADR-013 fixes the URL
+grammar boundary that carries `mode=` to the runtime. ADR-014 fixes
+the scene navigation dispatch layer. ADR-015 fixes URL beat
+positioning. ADR-016 (`mode=present`), ADR-017 (`mode=standalone`),
+ADR-018 (`mode=loop`), ADR-019 (`mode=paused`), ADR-020
+(`mode=scrub`), and ADR-021 (`mode=screenshot`) establish the
+precedent for landing a mode's contract layer plus seam tests while
+the dependent rendering surfaces are still pending: PUL-F013
+through PUL-F018 all stayed DRAFT after their respective contract PRs
+because chrome / audio / GSAP runner / presenter input / scrub-
+controls / capture surfaces are not yet implemented.
+
+PUL-F019 specifies `mode=prompter`:
+
+> In `mode=prompter`, the runtime SHALL render a script/caption
+> view derived from the captions metadata of the addressed scene or
+> composition. Visual rendering of the scene SHALL be suppressed.
+
+The clauses decompose this way:
+
+- "Render a script/caption view derived from the captions metadata of
+  the addressed scene or composition" — the runtime aggregates
+  `scene.captions` (PUL-F001 / ADR-002 — `{ at: ms, text }[]`) from
+  the addressed target into a script structure and hands it to a
+  rendering surface. For composition targets, captions span every
+  scene in the resolved slice (PUL-F008 / ADR-014's snapshot from the
+  addressed scene onward). The output is a script/caption view;
+  rendering it visibly is the job of a workbench chrome surface that
+  consumes the aggregated script.
+- "Visual rendering of the scene SHALL be suppressed" — the runtime
+  does not run the scene's visual rendering path under prompter. This
+  is structurally distinct from the other six modes (`present` plays
+  normally; `standalone` / `loop` / `paused` / `scrub` /
+  `screenshot` alter how the scene runs but still mount it). Per the
+  codex architecture preflight for PUL-F019: "the implementation
+  should avoid mounting/instantiating the visual scene renderer,
+  canvas/stage, media playback, animation loop, or asset pipeline for
+  prompter mode. CSS-hiding an already-rendered scene is not
+  sufficient." Suppression must be structural, not cosmetic.
+
+The other five workbench-mode ADRs (ADR-017 through ADR-021) all use
+the same pattern: pass an opaque hint to the timeline-runner adapter,
+let the runner alter behavior, leave the lifecycle (preload → create
+→ timeline → cleanup) running normally. That pattern does not fit
+`mode=prompter`: the hint approach would still run the asset
+preloader, still mount the scene via `create(ctx)`, still execute the
+timeline's setup phase. PUL-F019's structural-suppression clause
+forbids those side effects. The cleanest defense is to bypass the
+resolver lifecycle entirely under `mode=prompter` so the captions
+data path runs *instead of* the lifecycle, not alongside it.
+
+The question this ADR answers is: where does the loader → captions
+seam live, and on what contract does PUL-F019 transition to ACTIVE?
+
+## Decision
+
+### Scope: prompter is a captions-only view
+
+`mode=prompter` is a script/caption view derived from the addressed
+target's captions metadata. The scope is intentionally narrow: this
+mode does NOT include caption editing, review comments, teleprompter
+scrolling, timing playback, audio narration, visual overlays, or
+persistence. PUL-F019's statement names exactly the captions view;
+broader behaviors (highlight-on-scrub, timed playback alongside
+captions, etc.) are out of scope and would warrant their own
+requirements.
+
+The URL contract for "what to capture in the captions view" reuses
+the PUL-F008 / ADR-014 locator shapes (PUL-F007 / ADR-013 grammar):
+
+- `?scene=x&mode=prompter` — captions for scene `x` only.
+- `?composition=c&mode=prompter` — captions for every scene in
+  composition `c`, in manifest order.
+- `?composition=c&scene=x&mode=prompter` — captions starting at
+  scene `x` within composition `c`, then continuing through the
+  rest of the composition (the dispatcher's slice-from-addressed-
+  onward behavior).
+- `?composition=c&index=N&mode=prompter` — captions starting at
+  index `N` within composition `c`, then continuing.
+
+The `beat=` URL parameter is grammar-valid for any scene-like
+locator (ADR-013) and is preserved in the parsed `NavigationTarget`
+under `mode=prompter`, but the loader does not consume it on this
+dispatch path. A reviewer who wants to focus on a specific beat's
+caption presents a different requirement (caption-specific
+positioning) that is out of scope for PUL-F019; the parser-level
+preservation costs nothing and leaves the door open for a future
+extension.
+
+### Plumbing: loader-side lifecycle bypass
+
+`mode=prompter` is dispatched at the loader
+(`src/runtime/scene-loader.ts`) on a separate code path from the
+other six lifecycle-running modes. When `effectiveMode(target) ===
+'prompter'`:
+
+1. The loader still validates the navigation target via the existing
+   `resolveSceneNavigation` (PUL-F008 / ADR-014). Composition
+   validation — unregistered composition, unknown member scene,
+   ambiguous `composition+scene` locator, out-of-range index, empty
+   composition — STILL surfaces as a navigation error. There is no
+   silent fallback to direct scene lookup, no exception path that
+   degrades quietly. ADR-013's "no silent fallback" invariant holds
+   under prompter the same way it holds under every other mode.
+
+2. The loader still writes `data-pulsar-scene-target` and (when the
+   locator addressed a composition) `data-pulsar-composition-target`
+   to the stage. The attrs communicate "what was addressed," not
+   "what's running" — same invariant as `mode=standalone` (ADR-017),
+   `mode=loop` (ADR-018), `mode=paused` (ADR-019), `mode=scrub`
+   (ADR-020), and `mode=screenshot` (ADR-021). External observers
+   (agents, future tooling) reading the stage see the URL-addressed
+   target even when the lifecycle does not run.
+
+3. The loader does NOT call `applySingleSceneSlice`. The five
+   single-scene-execution modes (standalone, loop, paused, scrub,
+   screenshot) truncate the slice to the addressed head because each
+   of those modes' lifecycle promise is "no following entries run."
+   Under prompter the lifecycle does not run AT ALL (visual
+   rendering is structurally suppressed), so the truncation defense
+   from those modes does not apply — the captions view's contract
+   is "captions of the addressed scene OR composition," and under a
+   composition target the entire dispatched slice's captions are the
+   addressed material. Truncating would silently drop tail-scene
+   captions from the prompter view, breaking PUL-F019's clause 1.
+
+4. The loader builds a `PrompterScript` from the validated
+   navigation target via `buildPrompterScript` (a pure function in
+   `src/runtime/prompter.ts`). The script structure is:
+   ```
+   interface PrompterScriptEntry {
+     readonly sceneId: string;
+     readonly title: string;
+     readonly captions: readonly Caption[];
+   }
+   interface PrompterScript {
+     readonly composition?: { readonly id: string };
+     readonly entries: readonly PrompterScriptEntry[];
+   }
+   ```
+   Captions come from the registered scene module's `captions`
+   metadata (the canonical PUL-F001 / ADR-002 shape). Object-form
+   composition entries' `range` / `behavior` overrides are
+   runner-side concerns (ADR-002 / ADR-011) and do NOT alter caption
+   content — prompter shows the scene's full captions verbatim
+   regardless of which sub-range the runner would have played. The
+   script is deep-frozen so a misbehaving renderer cannot corrupt
+   the next navigation's view.
+
+5. The loader hands the script to a new optional `renderPrompter`
+   adapter on `SceneLoaderOptions` (parallel to `runTimeline` /
+   `createPreloader` / `buildCtx`). The adapter receives the script
+   and the per-navigation `AbortSignal`. The adapter's return value
+   drives the cleanup lifecycle:
+   - `void` / `undefined` — renderer mounted nothing persistent; the
+     dispatch is complete and the loader does not park.
+   - A `PrompterDispose` callback (`() => void | Promise<void>`) —
+     renderer mounted persistent state. The loader holds the
+     callback, parks until `signal.aborted` fires, then invokes
+     the callback to tear the state down.
+   - `Promise<void>` / `Promise<PrompterDispose>` — async variants
+     of the above.
+
+   The dispose-return contract makes cleanup ENFORCEABLE rather than
+   documentation-only: a renderer that mounts DOM and returns a
+   `PrompterDispose` callback delegates abort sequencing to the
+   loader; the loader, not the renderer, is responsible for "wait
+   for abort, then call dispose." A renderer that returns void
+   asserts "nothing to clean up." The compiler does not enforce
+   "void return implies no DOM mounted" — that's still a
+   responsibility the renderer holds — but the dispose-return
+   pattern is the structurally-correct shape for renderers that DO
+   mount state, with the loader owning the lifecycle. Cleanup-
+   before-handoff and latest-event supersession apply uniformly to
+   prompter dispatch the same way they apply to lifecycle dispatch.
+
+6. The loader does NOT call `createPreloader`. The asset pipeline
+   does not run under prompter. PUL-F019's structural-suppression
+   clause names "asset pipeline" specifically; bypassing the
+   preloader is the strongest possible defense.
+
+7. The loader does NOT call `buildCtx`. There is no per-navigation
+   ctx to construct because there is no scene to mount. PUL-F012's
+   "scenes receive `ctx.mode`" contract does not apply under prompter
+   because no scene's lifecycle hook fires; `ctx.mode === 'prompter'`
+   is a moot seam.
+
+8. The loader does NOT call `runTimeline`. There is no timeline to
+   execute. This is the structural defense for the "no animation"
+   half of "visual rendering SHALL be suppressed" — independent of
+   how the future GSAP runner (ADR-003) is wired, prompter cannot
+   run a timeline because the runner is not invoked at all.
+
+9. The loader does NOT call any scene's `create` / `timeline` /
+   `cleanup`. Visual scene mounting is structurally suppressed by
+   not running the resolver lifecycle that would mount it. This is
+   the strongest interpretation of PUL-F019's clause 2 — even a
+   well-meaning scene that reads `ctx.mode === 'prompter'` and
+   tries to skip its visual rendering cannot leak side effects
+   (e.g. eager DOM allocations in `create(ctx)` ahead of an early
+   return) because the hook never fires. CSS-hiding was explicitly
+   ruled out by the codex preflight; not-running is the inverse
+   ceiling.
+
+A workbench bootstrap that has not yet wired a captions UI omits
+the `renderPrompter` field. Under that configuration the loader
+still pays the structural-suppression cost (lifecycle is bypassed)
+but resolves immediately — the captions data path simply has no
+consumer. A real workbench bootstrap supplies a concrete renderer
+when the UI surface lands. The optional adapter mirrors the
+approach the placeholder timeline runner uses today: a no-op stand-
+in that satisfies the contract without delivering the visible
+behavior, with the contract surface ready for a future surface PR
+to plug in.
+
+PUL-F019 stays DRAFT after this PR lands, mirroring the
+ADR-016 / PUL-F013, ADR-017 / PUL-F014, ADR-018 / PUL-F015,
+ADR-019 / PUL-F016, ADR-020 / PUL-F017, and ADR-021 / PUL-F018
+precedent. This PR ships:
+
+- The loader → captions seam: `effectiveMode === 'prompter'`
+  bypasses the lifecycle and hands a `PrompterScript` to
+  `renderPrompter`.
+- The captions aggregation: `buildPrompterScript` is a pure
+  function over `SceneNavigationTarget`.
+- The `PrompterRenderer` adapter type and its placeholder
+  implementation in `src/main.ts`.
+- Tests pinning the dispatch seam, the lifecycle suppression, the
+  full-slice (non-truncated) captions aggregation, the "no
+  prompter for any other mode" invariant, error surfacing, and the
+  abort/cleanup-before-handoff invariants.
+
+What it does NOT yet ship is the visible captions UI surface. The
+placeholder `renderPrompter` produces no visible output. PUL-F019
+transitions DRAFT → ACTIVE when a captions/script UI surface lands
+and:
+
+1. Renders the `PrompterScript` visibly — the addressed scene's
+   captions (or the composition slice's aggregated captions) are
+   shown to the user.
+2. End-to-end tests confirm the captions are rendered and that the
+   visual scene rendering is, in fact, suppressed (no canvas /
+   stage / media / animation side effects on a navigation under
+   `mode=prompter`).
+3. Ground Control traceability has the captions UI module linked
+   as `IMPLEMENTS` PUL-F019 alongside the loader's existing
+   `IMPLEMENTS` link.
+
+Until that surface lands, the issue ↔ requirement link stays as
+`DOCUMENTS` and PUL-F019 stays DRAFT — matching how ADR-016 /
+PUL-F013 through ADR-021 / PUL-F018 record "land the contract layer;
+keep the requirement DRAFT until the dependent surfaces land."
+
+### Boundary
+
+The captions seam lives at the loader because:
+
+- The loader already derives `effectiveMode(target)` for `ctx.mode`
+  (ADR-007 / PUL-F012). Reusing the same derivation for the
+  prompter bypass keeps mode-aware dispatch in one place.
+- The composition resolver MUST stay mode-opaque (ADR-011 — pure
+  orchestrator, no adapter knowledge). Pushing the prompter bypass
+  into the resolver would force the resolver to inspect a runtime
+  detail that has no place in the orchestrator.
+- The bridge (`loadSceneNavigationTarget`) is also mode-opaque by
+  design — it forwards head-only options to the resolver and
+  truncates slices for the runner-input modes. Adding a prompter
+  branch there would entangle the bridge with a different runtime
+  contract (no runner at all).
+- `resolveSceneNavigation` MUST run validation regardless of mode:
+  unregistered compositions, unknown member scenes, out-of-range
+  indexes, and empty compositions still surface as navigation
+  errors under `mode=prompter`. No silent fallback to direct scene
+  lookup.
+
+### Stage attribute behavior
+
+`data-pulsar-scene-target` (head scene id) AND
+`data-pulsar-composition-target` (composition id) are both set on
+the stage when the URL named a composition under `mode=prompter`.
+The attrs communicate "what was addressed," not "what's running" —
+parity with all five other non-`present` modes. No
+`data-pulsar-mode-*` suppression attribute is preemptively written
+under `prompter`; future captions-UI surface is free to use that
+namespace if it actually needs a stage-level signal.
+
+### Composition slice behavior
+
+NOT truncated. Under composition addressing, the captions view
+consumes the FULL slice the dispatcher snapshotted (PUL-F008 /
+ADR-014). PUL-F019 explicitly says "the addressed scene OR
+composition" — under a composition target, the captions belong to
+every scene in the slice, not just the head. This is the
+structural difference from `mode=standalone`, `mode=loop`,
+`mode=paused`, `mode=scrub`, and `mode=screenshot`, all of which
+truncate to head because their lifecycle promise is "no following
+entries run." Prompter has no analogous lifecycle promise to
+defend with truncation; applying truncation here would silently
+drop tail-scene captions from the view.
+
+### Beat semantics
+
+`beat=` under `mode=prompter` is preserved on the parsed
+`NavigationTarget` but not consumed by the loader's prompter
+dispatch path. PUL-F019 does not name beats; the captions view's
+job is to show captions, not to position playback. A future
+caption-position requirement could use the preserved value if it
+landed; today the loader simply does not read it.
+
+`beat=` grammar validation still runs (`validateBeatGrammar`
+defends against hand-built `NavigationTarget`s with malformed
+beats). A grammar-invalid beat under `mode=prompter` surfaces as a
+navigation error before the prompter dispatch runs, matching the
+defense-in-depth pattern the loader applies for every other mode.
+
+## Consequences
+
+### Positive
+
+- Visual rendering suppression is STRUCTURAL: the runtime does not
+  invoke the asset preloader, scene `create` / `timeline` /
+  `cleanup`, or the timeline runner under `mode=prompter`. CSS-
+  hiding (which the codex preflight explicitly ruled out) is not
+  needed because no visual rendering is even started.
+- Captions are aggregated from the canonical PUL-F001 / ADR-002
+  metadata. There is no parallel "prompter captions" schema, no
+  duplicate validation, no opportunity for the script view to
+  diverge from the source metadata.
+- The captions seam is testable today as a pure function. The
+  loader's prompter dispatch is testable today via the renderer
+  adapter. Both contracts can be pinned without depending on a
+  real captions UI surface.
+- The contract surface (`renderPrompter` adapter on
+  `SceneLoaderOptions`) is parallel to `runTimeline` /
+  `createPreloader`. A future captions UI plugs in the same way the
+  future GSAP runner will plug into `runTimeline`.
+- Following ADR-016 through ADR-021's precedent keeps the DRAFT →
+  ACTIVE bar consistent across mode requirements: ACTIVE means the
+  named user-visible behavior is actively delivered end to end, not
+  just structurally scaffolded.
+- Composition addressing under prompter is straightforward: the
+  full slice's captions reach the renderer in manifest order. No
+  per-mode special-casing of the slice transform.
+
+### Negative
+
+- PUL-F019 stays DRAFT until a real captions UI surface lands. A
+  reviewer reading the requirement in isolation may expect ACTIVE
+  on first delivery; the DRAFT-with-contract-and-seams state is
+  intentional and matches the PUL-F011 / PUL-F013 / PUL-F014 /
+  PUL-F015 / PUL-F016 / PUL-F017 / PUL-F018 precedent.
+- The dispatch path under `mode=prompter` diverges from the other
+  six modes. The shape transform shared by F014 / F015 / F016 /
+  F017 / F018 (`applySingleSceneSlice`) does not apply, and the
+  runner-input plumbing (`headBeat` / `headRepeat` / `headHold` /
+  `headCueGate` / `headScreenshot`) is not used. This is
+  intentional — prompter is structurally a different mode — but it
+  does mean the loader has two dispatch shapes instead of one.
+- Adding `renderPrompter` widens the `SceneLoaderOptions` surface.
+  Every direct caller (production bootstrap, test harnesses) sees
+  the new field. Optional makes the impact small: a caller that
+  doesn't supply it gets graceful degradation.
+- `ctx.mode === 'prompter'` is exposed by the existing PUL-F012
+  seam but never reaches a scene under prompter (the lifecycle
+  doesn't run). A future caption-aware behavior that needs scene
+  cooperation would have to surface through a different seam —
+  e.g., a scene-side caption augmentation hook the captions UI
+  reads, or a successor ADR that revisits the bypass decision.
+
+### Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| A future runner / preloader regression accidentally mounts scenes under `mode=prompter` | The loader's prompter branch never invokes `createPreloader`, `buildCtx`, or `runTimeline`. Tests pin every one of those zero-invocation invariants explicitly. The codex preflight names asset pipeline + scene renderer + canvas/stage + media playback + animation loop — every one of those side effects is structurally unreachable under prompter because the lifecycle is not entered. |
+| A reviewer (or future agent) expects the prompter view to play scene audio / show timeline scrubbing alongside captions | PUL-F019 names captions only; the visible captions UI's scope is bounded. A future requirement that combines captions with playback would be a new requirement, not an extension of PUL-F019. |
+| The placeholder `renderPrompter` parks until abort, so a `mode=prompter` URL renders no captions until the UI lands | This is intentional — same shape as the placeholder timeline runner that has shipped under `mode=present` since the runtime first booted. The DRAFT → ACTIVE bar names the captions UI surface as the gating delivery; reviewers who paste a `mode=prompter` URL today see the structural suppression (no scene mounts) but no captions UI yet, which matches the DRAFT state. |
+| The captions aggregation re-implements `scene.captions` shape and drifts from PUL-F001 | `buildPrompterScript` reads `scene.captions` directly via the SceneModule type. A change to the shape (e.g. PUL-F001 adding a third caption field) compiles through to the prompter script automatically; tests catch a regression that filtered out a new field. No parallel schema. |
+| Slice truncation copy-pasted from F014–F018 silently drops tail-scene captions | The seam test "aggregates captions across the FULL composition slice (NOT truncated to head)" pins this directly with a three-scene composition. A regression that applied `applySingleSceneSlice` (or any equivalent head-only truncation) under prompter would surface only the head's captions and fail this test. |
+| A renderer that ignores the abort signal hangs the navigation queue | The loader awaits the renderer's returned promise with the same abort-and-await pattern the runner uses. The "aborts a long-running `renderPrompter` when superseded" seam test pins the abort path. A renderer that ignores the signal would surface as a hung second navigation, caught by vitest's per-test timeout. |
+| A non-parser caller forges a `NavigationTarget` with `mode: 'prompter'` mid-flight | The defense-in-depth check `validateModeGrammar` already rejects unknown modes at the loader boundary; `'prompter'` is in the `NAVIGATION_MODES` allowlist, and `effectiveMode` is the only consumer of the field. |
+| A future captions UI relies on `ctx.mode === 'prompter'` and breaks when no `ctx` is built | ADR-022 explicitly records that `buildCtx` is NOT called under prompter; the `ctx.mode` seam is moot in this mode. A captions UI surface should subscribe to its own seam (renderer adapter + script payload) rather than reaching for a `ctx.mode` that no scene observes. |
+
+## Current state (2026-05-09)
+
+This PR delivers the contract boundary and seam-pinning layer:
+
+- `src/runtime/prompter.ts` — new module exporting
+  `PrompterScriptEntry`, `PrompterScript`, `PrompterRenderer`, and
+  `buildPrompterScript`. Pure function over a
+  `SceneNavigationTarget`; produces a deep-frozen script.
+- `src/runtime/scene-loader.ts` — `SceneLoaderOptions` gains
+  optional `renderPrompter?: PrompterRenderer`. `runTarget`
+  branches on `effectiveMode === 'prompter'`: validates the target,
+  sets stage attrs, builds the script, hands it to the renderer
+  with the per-navigation abort signal. Lifecycle adapters
+  (`createPreloader`, `buildCtx`, `runTimeline`) are NOT called.
+- `src/main.ts` — placeholder `renderPrompter` adapter that parks
+  until abort, mirroring the placeholder timeline runner pattern.
+  Until the captions UI lands, it produces no visible output;
+  structural visual-rendering suppression is delivered by the
+  loader's lifecycle bypass, not by the renderer.
+- `tests/runtime/prompter.test.ts` — pure-function tests for
+  `buildPrompterScript`: single scene, full composition slice,
+  composition+scene non-head, object-form entry with overrides,
+  empty captions, deep-frozen output, no source mutation.
+- `tests/runtime/scene-loader.test.ts` — new
+  `'prompter-mode caption-view dispatch (PUL-F019)'` describe
+  block: lifecycle suppression (no preloader, no buildCtx, no
+  runner, no scene hooks), full-slice captions aggregation, single-
+  scene + composition variants, no prompter for non-prompter
+  modes, stage attrs preserved, no `data-pulsar-mode-*`
+  preemptive attribute, composition validation errors still
+  surface, graceful degradation when `renderPrompter` is omitted,
+  renderer abort, cleanup-before-handoff across the
+  present→prompter boundary, and `kind: 'none'` no-renderer
+  invariant.
+- This ADR.
+
+PUL-F019 remains DRAFT. Issue #28 links to PUL-F019 via
+`DOCUMENTS`. This PR is **not** an implementation of PUL-F019's
+"render a script/caption view" clause — the placeholder renderer
+produces no visible output. The ACTIVE transition is gated on a
+captions/script UI surface that consumes the `PrompterScript`,
+renders it visibly, and is covered by end-to-end tests. Treating
+this PR as satisfying PUL-F019 would be a traceability/status
+mismatch.
+
+## Related ADRs
+
+- [ADR-002](002-scene-registry-and-compositions.md) — defines the
+  `Caption = { at: ms, text }` shape this ADR aggregates.
+- [ADR-007](007-browser-workbench.md) — defines the seven workbench
+  modes; specifically references `mode=prompter` as the
+  script/caption review mode.
+- [ADR-008](008-agent-native-authoring.md) — manifests-over-flow-
+  control underpins the no-mode-suppression-in-resolver constraint;
+  the captions seam is data, not flow.
+- [ADR-011](011-composition-resolver-orchestration.md) — the
+  composition resolver (`resolveComposition` in
+  `src/runtime/composition-resolver.ts`) is opaque to mode and
+  orchestrates the preload → create → timeline → cleanup
+  lifecycle. The prompter dispatch reaches the navigation-level
+  resolver (`resolveSceneNavigation` from PUL-F008 / ADR-014, for
+  composition existence and member validation) but does NOT reach
+  the lifecycle composition resolver (`resolveComposition`). Two
+  distinct resolvers, distinguished here so a future maintainer
+  doesn't conflate "navigation resolution" (still runs under
+  prompter — composition errors still surface) with "lifecycle
+  orchestration" (does not run under prompter — visual rendering
+  is suppressed structurally). This ADR's bypass therefore does
+  not violate ADR-011 because ADR-011's subject is the lifecycle
+  resolver, which the prompter dispatch never invokes.
+- [ADR-013](013-url-navigation-grammar-boundary.md) — the parser
+  preserves `mode` and forbids recovering it from any non-URL
+  source.
+- [ADR-014](014-url-scene-target-selection.md) — scene navigation
+  dispatch is mode-blind; it resolves the active slice and hands
+  off to the loader for mode dispatch.
+- [ADR-016](016-workbench-mode-present.md) — establishes the
+  contract-layer-plus-seam-tests precedent. PUL-F013 stays DRAFT
+  pending chrome / audio / GSAP runner / presenter input.
+- [ADR-017](017-workbench-mode-standalone.md) — applies the same
+  precedent to PUL-F014 with the slice-truncation seam.
+- [ADR-018](018-workbench-mode-loop.md) — runner-input hint
+  pattern (`repeat: 'until-aborted'`); ADR-022 takes a different
+  shape because prompter does not invoke a runner.
+- [ADR-019](019-workbench-mode-paused.md) — runner-input hint
+  pattern (`hold: 'first-frame'`); ADR-022 differs for the same
+  reason as ADR-018.
+- [ADR-020](020-workbench-mode-scrub.md) — runner-input hint
+  pattern (`cueGate: 'monotonic-forward'`); ADR-022 differs.
+- [ADR-021](021-workbench-mode-screenshot.md) — bundled runner-
+  input hint (`screenshot: 'capture'`) plus a scene-side seam
+  (`ctx.mode === 'screenshot'`). ADR-022 takes neither shape:
+  prompter has no runner consumer (because the runner is not
+  called) and no scene-side `ctx.mode` consumer (because no scene
+  hook fires). The captions seam is its own surface.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -47,3 +47,4 @@ Each ADR includes:
 | [019](019-workbench-mode-paused.md) | Workbench Mode `paused` — Runner Hold-at-First-Frame Hint at the Loader/Runner Seam | Accepted |
 | [020](020-workbench-mode-scrub.md) | Workbench Mode `scrub` — Runner Cue-Gate Hint at the Loader/Runner Seam | Accepted |
 | [021](021-workbench-mode-screenshot.md) | Workbench Mode `screenshot` — Runner Capture-Bundle Hint at the Loader/Runner Seam | Accepted |
+| [022](022-workbench-mode-prompter.md) | Workbench Mode `prompter` — Loader-Side Lifecycle Bypass with Captions Aggregation Seam | Accepted |

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,6 +34,7 @@ import {
   PULSAR_NAVIGATE_EVENT_TYPE,
   bootstrapNavigation,
 } from './runtime/navigation';
+import type { PrompterRenderer } from './runtime/prompter';
 import { createSceneRegistry } from './runtime/registry';
 import { type WorkbenchSceneCtx, createSceneLoader } from './runtime/scene-loader';
 import { placeholderScene } from './scenes/placeholder';
@@ -172,6 +173,25 @@ const runTimeline: SceneTimelineRunner = (input) =>
 // by passing `stage` through ctx rather than reaching for `document`.
 const buildCtx = (mode: NavigationMode): WorkbenchSceneCtx => ({ stage, mode });
 
+// Prompter renderer placeholder (PUL-F019 / ADR-022). Under
+// `mode=prompter` the loader bypasses the resolver lifecycle
+// structurally — no preload, no `create`, no `timeline`, no
+// `cleanup` — and hands a `PrompterScript` (captions aggregated
+// from the addressed scene or composition slice) to this adapter.
+// Until the captions/script UI surface lands, the placeholder
+// produces no visible output; the structural visual-rendering
+// suppression is delivered by the loader's lifecycle bypass, not by
+// this adapter.
+//
+// The placeholder mounts nothing persistent and returns
+// `undefined`. Per the `PrompterRenderer` contract, that signals
+// "no cleanup obligation" — the loader does not park waiting for
+// abort. A future captions UI that mounts persistent DOM will
+// return a `PrompterDispose` callback the loader invokes on the
+// next navigation. ADR-022 records the DRAFT → ACTIVE bar for
+// PUL-F019 (visible captions UI + end-to-end tests).
+const renderPrompter: PrompterRenderer = () => undefined;
+
 const loader = createSceneLoader({
   scenes: sceneRegistry,
   compositions: compositionRegistry,
@@ -179,6 +199,7 @@ const loader = createSceneLoader({
   buildCtx,
   createPreloader,
   runTimeline,
+  renderPrompter,
 });
 
 const onNavigate = (event: Event): void => {

--- a/src/runtime/prompter.ts
+++ b/src/runtime/prompter.ts
@@ -1,0 +1,219 @@
+// Prompter captions aggregation — PUL-F019 / ADR-022.
+//
+// Pure function over a {@link SceneNavigationTarget} (already validated
+// by `resolveSceneNavigation` per PUL-F008 / ADR-014). Produces a
+// {@link PrompterScript} carrying the captions metadata of the
+// addressed scene or composition slice. The future captions/script UI
+// surface consumes this shape; the scene loader hands it to a
+// {@link PrompterRenderer} adapter without interpreting it.
+//
+// Why prompter is structurally different from `mode=loop` /
+// `mode=paused` / `mode=scrub` / `mode=screenshot` (ADR-018 through
+// ADR-021): those modes alter how the scene RUNS visually — the
+// resolver lifecycle still mounts the scene, and the runner reads a
+// hint to alter its behavior. PUL-F019 says "visual rendering of the
+// scene SHALL be suppressed." The cleanest structural defense is to
+// bypass the resolver lifecycle entirely under `mode=prompter` (no
+// preload, no `create`, no `timeline`, no `cleanup`) — see
+// `src/runtime/scene-loader.ts`. This module is the captions data path
+// that runs INSTEAD of the lifecycle.
+//
+// References:
+//  - PUL-F019 — `mode=prompter` SHALL render a script/caption view
+//    derived from the captions metadata of the addressed scene or
+//    composition; visual rendering SHALL be suppressed.
+//  - ADR-022 — workbench mode `prompter`: loader-side lifecycle
+//    bypass + captions aggregation seam.
+//  - ADR-002 §Scene module — `captions: [{ at, text }]` is the
+//    canonical caption metadata shape.
+//  - ADR-007 — workbench modes; `prompter` is the script/caption
+//    view mode.
+
+import type { BehaviorOverride, SubRange } from './composition';
+import { deepFreeze } from './object';
+import type { Caption, SceneModule } from './scene';
+import type { SceneNavigationTarget } from './scene-navigation';
+
+/**
+ * One scene's contribution to the prompter script. Carries the scene
+ * module's identity (`sceneId`, `title`) and its caption metadata
+ * verbatim.
+ *
+ * `range` / `behavior` mirror the per-occurrence overrides from the
+ * composition manifest entry (ADR-002 / PUL-F003 — object-form
+ * `{ id, range, behavior }`). The captions themselves are copied
+ * from the scene module's full metadata regardless of `range` (the
+ * runner is the only consumer that resolves named beats to
+ * timeline positions; the captions data path has no timeline to
+ * filter against). The manifest overrides are carried here so a
+ * captions UI can communicate "this entry plays the `midpoint`
+ * sub-range" or "this entry has a `behavior.hold` override" to the
+ * reviewer, even though the captions array is the scene's full
+ * caption list. Bare-string composition entries and direct-scene
+ * navigation targets leave both fields absent.
+ */
+export interface PrompterScriptEntry {
+  readonly sceneId: string;
+  readonly title: string;
+  readonly captions: readonly Caption[];
+  readonly range?: SubRange;
+  readonly behavior?: BehaviorOverride;
+}
+
+/**
+ * The aggregated captions view derived from a navigation target's
+ * resolved slice. `composition` is absent for single-scene addressing
+ * (`SceneNavigationTarget.composition === undefined`) and present for
+ * any composition locator. `entries` is the slice in dispatch order
+ * — for composition targets, this is the FULL slice the dispatcher
+ * snapshotted (PUL-F008), NOT truncated to the head, because the
+ * captions view's purpose is to show every scene's captions in
+ * manifest order under the addressed composition.
+ */
+export interface PrompterScript {
+  readonly composition?: { readonly id: string };
+  readonly entries: readonly PrompterScriptEntry[];
+}
+
+/**
+ * Cleanup callback the renderer returns when it has mounted
+ * persistent state (DOM, event listeners, timers, etc.). The loader
+ * holds the callback and invokes it when the per-navigation
+ * `AbortSignal` fires (the next navigation enqueues, dispose() runs,
+ * etc.) — the renderer does NOT have to register its own abort
+ * listener. Returning a callback is how the renderer tells the
+ * loader "I mounted state that needs to be torn down later."
+ *
+ * The callback may be sync or async; the loader awaits the
+ * returned value before the prompter dispatch settles, so async
+ * teardown (e.g. waiting for a CSS transition before removing the
+ * captions panel) flows through naturally.
+ */
+export type PrompterDispose = () => void | Promise<void>;
+
+/**
+ * Adapter the workbench bootstrap supplies to render the prompter
+ * script visually. Receives a {@link PrompterScript} and the
+ * per-navigation `AbortSignal`.
+ *
+ * **Lifecycle contract** (enforced by the loader, not by
+ * documentation): the renderer's return value tells the loader
+ * whether persistent state was mounted.
+ *
+ *  - Return `void` (or `undefined`): no persistent state was
+ *    mounted; nothing to tear down. The dispatch is fully complete.
+ *    Use for trivial / no-DOM renderers (test stubs, the placeholder
+ *    that ships before the captions UI lands).
+ *  - Return a {@link PrompterDispose} callback: persistent state was
+ *    mounted. The loader holds the callback and invokes it AFTER
+ *    `signal.aborted` fires. The renderer does NOT need to register
+ *    its own abort listener; the loader sequences the teardown.
+ *  - Return `Promise<void>` or `Promise<PrompterDispose>`: same
+ *    semantics, async render. The loader awaits the promise to
+ *    obtain the dispose callback (if any), then proceeds.
+ *
+ * A renderer can ALSO use the older parking-until-abort pattern
+ * (return a `Promise<void>` that resolves on `signal.aborted`,
+ * with cleanup in the abort listener), which the placeholder under
+ * `mode=present` uses for the timeline runner. Both patterns
+ * satisfy the contract; the dispose-return pattern is preferred
+ * for renderers that mount DOM because the loader OWNS the abort
+ * sequencing — there is no documentation-only "you must keep your
+ * promise pending" convention for the renderer to forget.
+ *
+ * Optional on {@link import('./scene-loader').SceneLoaderOptions}: a
+ * workbench bootstrap that has not yet wired a captions UI omits the
+ * field and the loader dispatches `mode=prompter` without invoking any
+ * renderer (visual rendering is still structurally suppressed because
+ * the resolver lifecycle is bypassed). Production bootstrap supplies a
+ * concrete renderer when the UI surface lands.
+ */
+// `void` in this union is intentional: the "no cleanup obligation"
+// half of the contract must accept implicit-return arrow functions
+// like `(script) => { sideEffect(script); }` (TypeScript types
+// those as `() => void`, not `() => undefined`). `PrompterDispose`
+// is the cleanup-callback half. The two suppressions below disable
+// the `noConfusingVoidType` rule on the two `void` occurrences (the
+// sync return and the awaited promise return); the trade-off is
+// documented in `PrompterRenderer`'s JSDoc above and ADR-022.
+// `void` in the sync half of the union is intentional: implicit-
+// return arrow functions like `(script) => { sideEffect(script); }`
+// are typed as `() => void`, not `() => undefined`, and the
+// no-cleanup contract must accept them. The Promise half uses
+// `undefined` (biome's preferred shape inside generics) — async
+// renderers explicitly return `undefined` or a `PrompterDispose`
+// callback.
+// biome-ignore lint/suspicious/noConfusingVoidType: implicit-return arrows.
+type PrompterRenderSync = void | PrompterDispose;
+type PrompterRenderAsync = undefined | PrompterDispose;
+
+export type PrompterRenderer = (
+  script: PrompterScript,
+  signal: AbortSignal,
+) => PrompterRenderSync | Promise<PrompterRenderAsync>;
+
+/**
+ * Build a {@link PrompterScript} from a resolved
+ * {@link SceneNavigationTarget}. Pure — does not read the registries,
+ * does not mutate the source scene modules, returns a deep-frozen
+ * structure so a misbehaving renderer cannot corrupt the next
+ * navigation's view.
+ *
+ *  - For a single-scene target (`target.composition === undefined`):
+ *    one entry, no `composition` field.
+ *  - For a composition target: one entry per scene in
+ *    `target.composition.sceneSlice`, in dispatch order. The slice is
+ *    NOT truncated — the dispatcher already snapshotted it from the
+ *    addressed scene onward (PUL-F008 / ADR-014), and the captions
+ *    view consumes it as-is.
+ *
+ * Captions are deep-copied — both the array AND each individual
+ * `Caption` object — so freezing the script does not propagate back
+ * to the registered scene module's `captions` field or to any
+ * `Caption` objects shared with it. Without per-object cloning,
+ * `deepFreeze` would walk the spread array and freeze every
+ * `Caption` it found, which would then propagate back through
+ * shared references to the source scene module's caption objects;
+ * production code that legitimately mutates a `Caption` elsewhere
+ * (a future caption editor, test fixture rebuilding, etc.) would
+ * crash silently. The clone is structural (`{ ...c }`) so any
+ * fields PUL-F001's `Caption` shape gains in the future flow
+ * through unchanged — there is no parallel `{ at, text }` schema
+ * here.
+ */
+export function buildPrompterScript(target: SceneNavigationTarget): PrompterScript {
+  const scenes: readonly SceneModule[] = target.composition?.sceneSlice ?? [target.scene];
+  const manifestSlice = target.composition?.manifestSlice;
+  const entries: PrompterScriptEntry[] = scenes.map((scene, index) => {
+    const captions = scene.captions.map((c) => ({ ...c }));
+    const entry: { -readonly [K in keyof PrompterScriptEntry]: PrompterScriptEntry[K] } = {
+      sceneId: scene.id,
+      title: scene.title,
+      captions,
+    };
+    // Carry the manifest entry's per-occurrence overrides (range,
+    // behavior) on the script entry as optional metadata so a
+    // captions UI can render "[midpoint only]" hints, filter
+    // captions by sub-range when it can resolve named beats, or
+    // surface behavior overrides to the reviewer. The captions
+    // themselves come from the registered scene's full metadata
+    // (range/behavior do not alter caption content — they are
+    // runner-side timeline knobs per ADR-002 / ADR-011), but
+    // dropping the manifest metadata entirely would leave the UI
+    // unable to communicate that the addressed composition runs
+    // a sub-range. Bare-string entries have no overrides; the
+    // optional fields stay absent.
+    const manifestEntry = manifestSlice?.[index];
+    if (typeof manifestEntry === 'object') {
+      if (manifestEntry.range !== undefined) entry.range = manifestEntry.range;
+      if (manifestEntry.behavior !== undefined) entry.behavior = manifestEntry.behavior;
+    }
+    return entry;
+  });
+
+  const script: { -readonly [K in keyof PrompterScript]: PrompterScript[K] } = { entries };
+  if (target.composition !== undefined) {
+    script.composition = { id: target.composition.id };
+  }
+  return deepFreeze(script) as PrompterScript;
+}

--- a/src/runtime/scene-loader.ts
+++ b/src/runtime/scene-loader.ts
@@ -39,6 +39,7 @@ import {
   type NavigationTarget,
   effectiveMode,
 } from './navigation';
+import { type PrompterDispose, type PrompterRenderer, buildPrompterScript } from './prompter';
 import type { SceneRegistry } from './registry';
 import {
   type SceneNavigationTarget,
@@ -134,6 +135,35 @@ export interface SceneLoaderOptions {
   readonly createPreloader: (signal: AbortSignal) => AssetPreloader;
   /** Timeline-execution adapter — see {@link SceneTimelineRunner}. */
   readonly runTimeline: SceneTimelineRunner;
+  /**
+   * Captions/script renderer adapter for `mode=prompter`
+   * (PUL-F019 / ADR-022). Receives a {@link import('./prompter').PrompterScript}
+   * derived from the addressed navigation target's metadata and the
+   * per-navigation `AbortSignal` so a long-running renderer can
+   * release resources when superseded by another navigation. The
+   * loader awaits the result before considering the prompter
+   * dispatch settled (parity with `runTimeline`).
+   *
+   * **Renderer contract** (see {@link PrompterRenderer}): a renderer
+   * that mounts persistent DOM MUST keep its returned promise
+   * pending until `signal.aborted` fires AND register its DOM
+   * teardown on the abort event. Returning early after mounting DOM
+   * would leave stale captions UI on screen with no cleanup path —
+   * the loader clears `inFlight` once a load settles, so the next
+   * navigation's `enqueue` would not abort anything to drive the
+   * cleanup. A trivial / no-DOM renderer (e.g. a test stub) is free
+   * to return synchronously because there is nothing to tear down.
+   *
+   * Optional: a workbench bootstrap that has not yet wired a captions
+   * UI omits the field. Under `mode=prompter` the loader still
+   * suppresses the resolver lifecycle (no preload, no `create`, no
+   * `timeline`, no `cleanup`) because that suppression is the
+   * structural defense PUL-F019 / ADR-022 record; the captions data
+   * path simply has no consumer until the UI lands. Production
+   * bootstrap supplies a concrete renderer when the captions/script
+   * UI surface lands.
+   */
+  readonly renderPrompter?: PrompterRenderer;
   /**
    * Sink for navigation errors (resolution failure, lifecycle phase
    * throw). Defaults to `console.error` in production but is
@@ -596,6 +626,59 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
     };
   };
 
+  /**
+   * PUL-F019 / ADR-022: build the in-flight record for a `mode=prompter`
+   * dispatch. Mirrors {@link buildLoad}'s contract — returns an
+   * {@link InFlightLoad} carrying a fresh `AbortController` and a
+   * settled-promise — but routes through the captions data path
+   * INSTEAD of the resolver lifecycle. No preload, no `create`, no
+   * `timeline`, no `cleanup`; the structural defense is "do not
+   * invoke the lifecycle that would render scenes visually."
+   *
+   * The renderer's return value drives the cleanup lifecycle (see
+   * {@link PrompterRenderer}):
+   *  - `void` / `undefined`: no persistent state mounted. Dispatch
+   *    is complete; the loader does not park.
+   *  - {@link PrompterDispose} callback: persistent state mounted.
+   *    The loader parks until `signal.aborted`, then invokes the
+   *    callback for cleanup before resolving the dispatch.
+   *  - `Promise<void | PrompterDispose>`: async variants of the
+   *    above, awaited identically.
+   *
+   * `renderPrompter` is optional. Without it the loader still pays
+   * the structural-suppression cost (lifecycle is bypassed) but
+   * resolves immediately — there is no captions consumer.
+   */
+  const buildPrompterLoad = (resolved: SceneNavigationTarget): InFlightLoad => {
+    const controller = new AbortController();
+    const renderer = options.renderPrompter;
+    if (renderer === undefined) {
+      return { controller, settled: Promise.resolve(), silent: false };
+    }
+    const script = buildPrompterScript(resolved);
+    const settled = (async () => {
+      const result = await renderer(script, controller.signal);
+      if (typeof result !== 'function') {
+        // `void` / `undefined` return: renderer indicated nothing
+        // persistent was mounted. Dispatch is fully complete; do
+        // not park.
+        return;
+      }
+      // PrompterDispose callback: renderer mounted persistent
+      // state and delegated cleanup ordering to the loader. Park
+      // until abort (next navigation, dispose(), etc.), then run
+      // the callback.
+      const dispose: PrompterDispose = result;
+      if (!controller.signal.aborted) {
+        await new Promise<void>((resolve) => {
+          controller.signal.addEventListener('abort', () => resolve(), { once: true });
+        });
+      }
+      await dispose();
+    })();
+    return { controller, settled, silent: false };
+  };
+
   const runTarget = async (target: NavigationTarget): Promise<void> => {
     const beatErr = validateBeatGrammar(target);
     if (beatErr !== null) {
@@ -626,9 +709,22 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
       setStageAttr(ATTR_COMPOSITION, resolved.composition.id);
     }
 
-    const runnable = applySingleSceneSlice(resolved, target);
-
-    const load = buildLoad(runnable, target);
+    // PUL-F019 / ADR-022: under `mode=prompter` bypass the resolver
+    // lifecycle entirely. Visual rendering is suppressed structurally
+    // by NOT running the path that would mount scenes. The captions
+    // data path takes its place. No `applySingleSceneSlice` (the
+    // captions view consumes the FULL slice — see ADR-022 for why
+    // the truncation defense from F015–F018 does not apply here),
+    // no `buildLoad` (no preloader, no buildCtx, no runner), just a
+    // captions-renderer dispatch wrapped in the same abort/queue
+    // pattern so cleanup-before-handoff and supersession still work.
+    let load: InFlightLoad | null;
+    if (effectiveMode(target) === 'prompter') {
+      load = buildPrompterLoad(resolved);
+    } else {
+      const runnable = applySingleSceneSlice(resolved, target);
+      load = buildLoad(runnable, target);
+    }
     if (load === null) return;
     inFlight = load;
 

--- a/src/runtime/scene-loader.ts
+++ b/src/runtime/scene-loader.ts
@@ -39,7 +39,12 @@ import {
   type NavigationTarget,
   effectiveMode,
 } from './navigation';
-import { type PrompterDispose, type PrompterRenderer, buildPrompterScript } from './prompter';
+import {
+  type PrompterDispose,
+  type PrompterRenderer,
+  type PrompterScript,
+  buildPrompterScript,
+} from './prompter';
 import type { SceneRegistry } from './registry';
 import {
   type SceneNavigationTarget,
@@ -196,6 +201,22 @@ export interface SceneLoader {
 const ATTR_SCENE = 'data-pulsar-scene-target';
 const ATTR_COMPOSITION = 'data-pulsar-composition-target';
 const ATTR_ERROR = 'data-pulsar-navigation-error';
+
+/**
+ * Resolve when `signal` is aborted (or immediately if already
+ * aborted). Pure helper hoisted to module scope so the prompter
+ * dispatch path can keep its callback nesting under Sonar's
+ * S2004 4-level limit (the inline `addEventListener` arrow inside
+ * an IIFE inside `buildPrompterLoad` would put the listener at
+ * level 5; routing through this helper keeps every callback at
+ * level ≤ 2).
+ */
+function waitForAbort(signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return Promise.resolve();
+  return new Promise<void>((resolve) => {
+    signal.addEventListener('abort', () => resolve(), { once: true });
+  });
+}
 
 /**
  * Returns true when `err` is the resolver's own "aborted" wrapper
@@ -627,6 +648,38 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
   };
 
   /**
+   * Run a `mode=prompter` dispatch end-to-end: invoke the renderer
+   * and, when the renderer returned a {@link PrompterDispose}
+   * callback, park until abort and then run the callback.
+   *
+   * Hoisted out of `buildPrompterLoad` so the IIFE chain stays under
+   * Sonar's nested-function limit (S2004): the inline addEventListener
+   * arrow inside an IIFE inside an arrow function inside an arrow
+   * function would put the listener at level 5; pulling the work
+   * into a top-level helper keeps every callback at level ≤ 2.
+   */
+  const dispatchPrompter = async (
+    renderer: PrompterRenderer,
+    script: PrompterScript,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const result = await renderer(script, signal);
+    if (typeof result !== 'function') {
+      // `void` / `undefined` return: renderer indicated nothing
+      // persistent was mounted. Dispatch is fully complete; do not
+      // park.
+      return;
+    }
+    // PrompterDispose callback: renderer mounted persistent state
+    // and delegated cleanup ordering to the loader. Park until
+    // abort (next navigation, dispose(), etc.), then run the
+    // callback.
+    const dispose: PrompterDispose = result;
+    await waitForAbort(signal);
+    await dispose();
+  };
+
+  /**
    * PUL-F019 / ADR-022: build the in-flight record for a `mode=prompter`
    * dispatch. Mirrors {@link buildLoad}'s contract — returns an
    * {@link InFlightLoad} carrying a fresh `AbortController` and a
@@ -636,18 +689,10 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
    * invoke the lifecycle that would render scenes visually."
    *
    * The renderer's return value drives the cleanup lifecycle (see
-   * {@link PrompterRenderer}):
-   *  - `void` / `undefined`: no persistent state mounted. Dispatch
-   *    is complete; the loader does not park.
-   *  - {@link PrompterDispose} callback: persistent state mounted.
-   *    The loader parks until `signal.aborted`, then invokes the
-   *    callback for cleanup before resolving the dispatch.
-   *  - `Promise<void | PrompterDispose>`: async variants of the
-   *    above, awaited identically.
-   *
-   * `renderPrompter` is optional. Without it the loader still pays
-   * the structural-suppression cost (lifecycle is bypassed) but
-   * resolves immediately — there is no captions consumer.
+   * {@link PrompterRenderer} and {@link dispatchPrompter}). When
+   * `renderPrompter` is undefined the loader still pays the
+   * structural-suppression cost (lifecycle is bypassed) but resolves
+   * immediately — there is no captions consumer.
    */
   const buildPrompterLoad = (resolved: SceneNavigationTarget): InFlightLoad => {
     const controller = new AbortController();
@@ -656,27 +701,11 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
       return { controller, settled: Promise.resolve(), silent: false };
     }
     const script = buildPrompterScript(resolved);
-    const settled = (async () => {
-      const result = await renderer(script, controller.signal);
-      if (typeof result !== 'function') {
-        // `void` / `undefined` return: renderer indicated nothing
-        // persistent was mounted. Dispatch is fully complete; do
-        // not park.
-        return;
-      }
-      // PrompterDispose callback: renderer mounted persistent
-      // state and delegated cleanup ordering to the loader. Park
-      // until abort (next navigation, dispose(), etc.), then run
-      // the callback.
-      const dispose: PrompterDispose = result;
-      if (!controller.signal.aborted) {
-        await new Promise<void>((resolve) => {
-          controller.signal.addEventListener('abort', () => resolve(), { once: true });
-        });
-      }
-      await dispose();
-    })();
-    return { controller, settled, silent: false };
+    return {
+      controller,
+      settled: dispatchPrompter(renderer, script, controller.signal),
+      silent: false,
+    };
   };
 
   const runTarget = async (target: NavigationTarget): Promise<void> => {

--- a/tests/runtime/prompter.test.ts
+++ b/tests/runtime/prompter.test.ts
@@ -1,0 +1,355 @@
+// Prompter captions aggregation — PUL-F019 / ADR-022.
+//
+// The captions-aggregation seam under `mode=prompter`. Pure function
+// over a `SceneNavigationTarget` (already validated by the navigation
+// dispatcher) — produces a `PrompterScript` carrying the addressed
+// scene's (or composition slice's) `captions` metadata. The future
+// captions/script UI surface consumes this shape; the loader hands it
+// to a `renderPrompter` adapter without interpreting it.
+
+import { describe, expect, it } from 'vitest';
+import { type PrompterScript, buildPrompterScript } from '../../src/runtime/prompter';
+import type { Caption, SceneModule } from '../../src/runtime/scene';
+import type { SceneNavigationTarget } from '../../src/runtime/scene-navigation';
+
+interface BuildSceneOpts {
+  readonly id: string;
+  readonly title?: string;
+  readonly captions?: readonly Caption[];
+}
+
+const buildScene = (opts: BuildSceneOpts): SceneModule => ({
+  id: opts.id,
+  title: opts.title ?? opts.id,
+  duration: 1000,
+  tags: [],
+  assets: [],
+  captions: opts.captions ?? [],
+  defaultNext: null,
+  standalone: true,
+  trailerSafe: false,
+  create: () => undefined,
+  timeline: () => undefined,
+  cleanup: () => undefined,
+});
+
+describe('buildPrompterScript (PUL-F019 / ADR-022)', () => {
+  it('builds a one-entry script for a single-scene target with no composition field', () => {
+    // PUL-F019: "captions metadata of the addressed scene OR
+    // composition." Single-scene addressing carries no composition
+    // context — `composition` is absent on the script. The entry's
+    // captions come from the scene module's metadata unchanged.
+    const intro = buildScene({
+      id: 'intro',
+      title: 'Intro',
+      captions: [
+        { at: 0, text: 'Hello' },
+        { at: 1500, text: 'World' },
+      ],
+    });
+    const target: SceneNavigationTarget = { scene: intro };
+
+    const script = buildPrompterScript(target);
+
+    expect(script).toEqual({
+      entries: [
+        {
+          sceneId: 'intro',
+          title: 'Intro',
+          captions: [
+            { at: 0, text: 'Hello' },
+            { at: 1500, text: 'World' },
+          ],
+        },
+      ],
+    });
+    expect('composition' in script).toBe(false);
+  });
+
+  it('aggregates captions across the FULL composition slice (NOT truncated to head)', () => {
+    // PUL-F019 explicitly says "addressed scene OR composition." Under
+    // a composition target the captions view's purpose is to show every
+    // scene's captions in manifest order. This is the structural
+    // difference from `mode=loop` / `mode=paused` / `mode=scrub` /
+    // `mode=screenshot`, which truncate the slice to the head — under
+    // those modes the head's runner-side semantic implies "no following
+    // entries run" and truncating is the structural defense. Under
+    // prompter the lifecycle doesn't run AT ALL (visual rendering is
+    // suppressed structurally), so there is no analogous defense to
+    // apply; the captions data path consumes the full slice. A
+    // regression that copy-pasted truncation from the other modes
+    // would silently drop tail-scene captions from the prompter view.
+    const intro = buildScene({
+      id: 'intro',
+      title: 'Intro',
+      captions: [{ at: 0, text: 'A' }],
+    });
+    const middle = buildScene({
+      id: 'middle',
+      title: 'Middle',
+      captions: [{ at: 0, text: 'B' }],
+    });
+    const outro = buildScene({
+      id: 'outro',
+      title: 'Outro',
+      captions: [{ at: 0, text: 'C' }],
+    });
+    const target: SceneNavigationTarget = {
+      scene: intro,
+      composition: {
+        id: 'full-talk',
+        manifestSlice: ['intro', 'middle', 'outro'],
+        sceneSlice: [intro, middle, outro],
+      },
+    };
+
+    const script = buildPrompterScript(target);
+
+    expect(script).toEqual({
+      composition: { id: 'full-talk' },
+      entries: [
+        { sceneId: 'intro', title: 'Intro', captions: [{ at: 0, text: 'A' }] },
+        { sceneId: 'middle', title: 'Middle', captions: [{ at: 0, text: 'B' }] },
+        { sceneId: 'outro', title: 'Outro', captions: [{ at: 0, text: 'C' }] },
+      ],
+    });
+  });
+
+  it('starts the slice at the addressed scene under composition+scene targeting (non-head)', () => {
+    // The dispatcher already snapshotted the slice from the addressed
+    // scene onward (PUL-F008 / ADR-014). `buildPrompterScript`
+    // honors that slice as-is — it does NOT walk back to the
+    // composition's first entry. A regression that re-resolved from
+    // the composition's start would surface tail captions that the
+    // navigation explicitly skipped. Pin the addressed-onward
+    // behavior with a non-head start so the test would fail if the
+    // function regressed to "always full composition."
+    const intro = buildScene({ id: 'intro', captions: [{ at: 0, text: 'skipped' }] });
+    const middle = buildScene({
+      id: 'middle',
+      title: 'Middle',
+      captions: [{ at: 0, text: 'kept' }],
+    });
+    const outro = buildScene({ id: 'outro', captions: [{ at: 0, text: 'also kept' }] });
+    void intro; // referenced by the manifest position the dispatcher already trimmed away
+    const target: SceneNavigationTarget = {
+      scene: middle,
+      composition: {
+        id: 'full-talk',
+        manifestSlice: ['middle', 'outro'],
+        sceneSlice: [middle, outro],
+      },
+    };
+
+    const script = buildPrompterScript(target);
+
+    expect(script.composition?.id).toBe('full-talk');
+    expect(script.entries.map((e) => e.sceneId)).toEqual(['middle', 'outro']);
+    expect(script.entries[0]?.captions).toEqual([{ at: 0, text: 'kept' }]);
+  });
+
+  it('preserves all Caption fields structurally (no parallel { at, text } schema)', () => {
+    // PUL-F001 declares `Caption` with `at` and `text` today.
+    // Future fields (e.g. a `speaker` annotation, an `id` for
+    // clickable highlights) MUST flow through the prompter script
+    // unchanged — the captions seam reads scene metadata
+    // structurally, not field-by-field. A regression that
+    // hard-coded `{ at: c.at, text: c.text }` would silently drop
+    // any field the script consumer expected. This test injects a
+    // forward-compatible field via type assertion (production
+    // `Caption` shape doesn't have it yet, but the runtime path
+    // must not strip it).
+    const sourceCaption = { at: 0, text: 'one', speaker: 'host' } as Caption & {
+      speaker: string;
+    };
+    const intro = buildScene({ id: 'intro', captions: [sourceCaption] });
+    const target: SceneNavigationTarget = { scene: intro };
+
+    const script = buildPrompterScript(target);
+
+    expect(script.entries[0]?.captions[0]).toEqual({ at: 0, text: 'one', speaker: 'host' });
+  });
+
+  it('carries object-form composition entry overrides (range, behavior) on the script entry as optional metadata', () => {
+    // ADR-002 / PUL-F003 — object-form entries on the manifest
+    // carry `range` and `behavior` overrides. Captions themselves
+    // come from the scene's full metadata regardless of `range`
+    // (the runner is the only consumer that resolves named beats
+    // to timeline positions; the captions data path has no
+    // timeline to filter against). But dropping the manifest
+    // overrides entirely would leave the captions UI unable to
+    // communicate "this entry plays the `midpoint` sub-range" to
+    // the reviewer. Pin the metadata-passthrough explicitly.
+    const middle = buildScene({
+      id: 'middle',
+      title: 'Middle',
+      captions: [{ at: 0, text: 'one' }],
+    });
+    const target: SceneNavigationTarget = {
+      scene: middle,
+      composition: {
+        id: 'full-talk',
+        manifestSlice: [{ id: 'middle', range: 'midpoint', behavior: { hold: true } }],
+        sceneSlice: [middle],
+      },
+    };
+
+    const script = buildPrompterScript(target);
+
+    expect(script.entries).toHaveLength(1);
+    expect(script.entries[0]?.range).toBe('midpoint');
+    expect(script.entries[0]?.behavior).toEqual({ hold: true });
+    expect(script.entries[0]?.captions).toEqual([{ at: 0, text: 'one' }]);
+  });
+
+  it('omits range / behavior fields for bare-string composition entries and direct-scene targets', () => {
+    // The optional metadata fields stay absent (not `undefined`)
+    // when the manifest entry is a bare string OR when the
+    // navigation target has no composition. A regression that set
+    // `range: undefined` would change `'range' in entry` from
+    // false to true, surprising future captions-UI code that
+    // branches on key presence.
+    const sceneA = buildScene({ id: 'scene-a', title: 'Alpha' });
+    const sceneB = buildScene({ id: 'scene-b', title: 'Bravo' });
+    const compositionTarget: SceneNavigationTarget = {
+      scene: sceneA,
+      composition: {
+        id: 'full-talk',
+        manifestSlice: ['scene-a', 'scene-b'],
+        sceneSlice: [sceneA, sceneB],
+      },
+    };
+    const directTarget: SceneNavigationTarget = { scene: sceneA };
+
+    const compositionScript = buildPrompterScript(compositionTarget);
+    const directScript = buildPrompterScript(directTarget);
+
+    expect(compositionScript.entries.every((e) => !('range' in e) && !('behavior' in e))).toBe(
+      true,
+    );
+    expect('range' in (directScript.entries[0] as object)).toBe(false);
+    expect('behavior' in (directScript.entries[0] as object)).toBe(false);
+  });
+
+  it('reads captions from the registered scene module under object-form composition entries (range / behavior overrides do not alter captions)', () => {
+    // ADR-002 / ADR-011: object-form entries override the runner's
+    // sub-range and behavior knobs. They do NOT carry caption
+    // overrides — captions live on the scene module's metadata, and
+    // prompter shows the scene's captions verbatim regardless of
+    // which sub-range the runner would have played. A regression
+    // that read captions from the entry instead of the registered
+    // scene would either crash on `entry.captions` (undefined) or
+    // silently produce empty captions for object-form entries.
+    const middle = buildScene({
+      id: 'middle',
+      title: 'Middle',
+      captions: [
+        { at: 0, text: 'one' },
+        { at: 500, text: 'two' },
+      ],
+    });
+    const target: SceneNavigationTarget = {
+      scene: middle,
+      composition: {
+        id: 'full-talk',
+        manifestSlice: [{ id: 'middle', range: 'midpoint', behavior: { hold: true } }],
+        sceneSlice: [middle],
+      },
+    };
+
+    const script = buildPrompterScript(target);
+
+    expect(script.entries).toHaveLength(1);
+    expect(script.entries[0]?.captions).toEqual([
+      { at: 0, text: 'one' },
+      { at: 500, text: 'two' },
+    ]);
+  });
+
+  it('emits an empty captions array when the scene declares no captions', () => {
+    // The placeholder scene declares `captions: []`; lots of in-flight
+    // scenes will too while the prompter UI is being designed. The
+    // prompter script must accept that as a real-world shape rather
+    // than treating "empty captions" as a degenerate case the future
+    // UI has to special-case.
+    const blank = buildScene({ id: 'blank', captions: [] });
+    const target: SceneNavigationTarget = { scene: blank };
+
+    const script = buildPrompterScript(target);
+
+    expect(script.entries[0]?.captions).toEqual([]);
+  });
+
+  it('returns a deep-frozen script so the future captions UI cannot mutate the source metadata', () => {
+    // `Caption` is `interface Caption { at; text }` — it is NOT
+    // declared as `readonly` on the source side because scene modules
+    // can be authored as plain objects. The prompter-script seam is
+    // the boundary the future UI consumes; freezing here means a
+    // misbehaving renderer that pushes onto `script.entries` or
+    // mutates `entries[0].captions[0].text` fails fast rather than
+    // silently corrupting the next navigation's view.
+    const intro = buildScene({
+      id: 'intro',
+      captions: [{ at: 0, text: 'mutable-source' }],
+    });
+    const target: SceneNavigationTarget = { scene: intro };
+
+    const script: PrompterScript = buildPrompterScript(target);
+
+    expect(Object.isFrozen(script)).toBe(true);
+    expect(Object.isFrozen(script.entries)).toBe(true);
+    expect(Object.isFrozen(script.entries[0])).toBe(true);
+    expect(Object.isFrozen(script.entries[0]?.captions)).toBe(true);
+  });
+
+  it('does not mutate or freeze the source scene module (deep-clone captions, not shallow-copy)', () => {
+    // The first regression a shallow `[...scene.captions]` copy
+    // would NOT catch: `deepFreeze` walks the spread array and
+    // freezes every `Caption` it encounters; those Caption objects
+    // are still shared with the source scene's `captions` array,
+    // so the source scene module's individual caption objects end
+    // up frozen even though the array itself is not. Production
+    // code that legitimately mutates a Caption elsewhere (e.g. a
+    // future caption editor, a test fixture rebuilding scene
+    // metadata) would crash silently. Pin BOTH the array AND the
+    // individual caption objects as unfrozen and independently
+    // mutable after `buildPrompterScript` runs.
+    const sourceCaption: Caption = { at: 0, text: 'original' };
+    const captions: Caption[] = [sourceCaption];
+    const intro: SceneModule = {
+      ...buildScene({ id: 'intro' }),
+      captions,
+    };
+    const target: SceneNavigationTarget = { scene: intro };
+
+    buildPrompterScript(target);
+
+    expect(Object.isFrozen(captions)).toBe(false);
+    expect(Object.isFrozen(sourceCaption)).toBe(false);
+    // The source caption object remains independently mutable —
+    // proves no frozen reference leaked through the script's deep
+    // freeze.
+    sourceCaption.text = 'mutated';
+    expect(captions[0]?.text).toBe('mutated');
+  });
+
+  it('isolates the script entries from the source — mutating script captions does not affect source captions', () => {
+    // The other half of the deep-clone contract: the script must be
+    // a defensive copy in BOTH directions. A regression that
+    // returned the source `Caption` references in the script
+    // (without cloning) would let a misbehaving renderer that
+    // bypassed the freeze (e.g. via `Object.assign` shenanigans, or
+    // a `--harmony-flag-disabled-freeze` runtime) corrupt the
+    // source scene's captions. Even though the freeze is the
+    // primary defense, deep-cloning makes the isolation robust to
+    // freeze bypass.
+    const sourceCaption: Caption = { at: 0, text: 'source' };
+    const intro = buildScene({ id: 'intro', captions: [sourceCaption] });
+    const target: SceneNavigationTarget = { scene: intro };
+
+    const script = buildPrompterScript(target);
+
+    expect(script.entries[0]?.captions[0]).not.toBe(sourceCaption);
+    expect(script.entries[0]?.captions[0]).toEqual(sourceCaption);
+  });
+});

--- a/tests/runtime/scene-loader.test.ts
+++ b/tests/runtime/scene-loader.test.ts
@@ -5570,10 +5570,18 @@ describe('createSceneLoader (PUL-F008)', () => {
       expect(calls).toEqual([]);
     });
 
-    it('surfaces index-out-of-range under `mode=prompter`', async () => {
+    it('surfaces index-out-of-range under `mode=prompter` (renderPrompter is NOT called on error paths)', async () => {
+      // Parity with the composition-not-registered and
+      // composition-member error tests: error paths MUST surface
+      // via `onError` AND MUST NOT invoke the renderer. Capturing
+      // the renderer's invocations here keeps the index-out-of-
+      // range coverage symmetric with its siblings; without that
+      // assertion, a regression that dispatched the renderer
+      // before validation would slip past this test.
       const sceneA = buildScene({ id: 'scene-a' });
       const stage = buildStage();
       const errors: unknown[] = [];
+      const calls: PrompterScript[] = [];
       const loader = createSceneLoader({
         scenes: createSceneRegistry([sceneA]),
         compositions: createCompositionRegistry([{ id: 'full-talk', manifest: ['scene-a'] }]),
@@ -5584,13 +5592,16 @@ describe('createSceneLoader (PUL-F008)', () => {
         onError: (err) => {
           errors.push(err);
         },
-        renderPrompter: () => undefined,
+        renderPrompter: (script) => {
+          calls.push(script);
+        },
       });
 
       await loader.handle(prompterCompositionIndexTarget('full-talk', 5));
 
       expect(errors).toHaveLength(1);
       expect((errors[0] as Error).message).toContain('index 5 is out of range');
+      expect(calls).toEqual([]);
     });
 
     it('does not invoke `renderPrompter` for `kind: "none"` under `mode=prompter` (nothing addressed, nothing to render)', async () => {

--- a/tests/runtime/scene-loader.test.ts
+++ b/tests/runtime/scene-loader.test.ts
@@ -5721,10 +5721,21 @@ describe('createSceneLoader (PUL-F008)', () => {
       // nothing, dispatch is fully complete after the renderer's
       // promise resolves. `loader.idle()` should settle WITHOUT a
       // second navigation aborting the dispatch. A regression that
-      // always parked would hang `idle()` here.
+      // always parked would hang `idle()` here (vitest's per-test
+      // timeout would surface the hang as a failure).
+      //
+      // Beyond the no-hang behavior, also verify that the renderer
+      // was invoked exactly once and that `loader.idle()` is
+      // settled by the time we observe it (proving the dispatch
+      // completed, not that idle() simply returned the still-
+      // pending queue promise).
       const sceneA = buildScene({ id: 'scene-a' });
       const stage = buildStage();
-      const renderPrompter: PrompterRenderer = () => undefined;
+      let renderCount = 0;
+      const renderPrompter: PrompterRenderer = () => {
+        renderCount += 1;
+        return undefined;
+      };
       const loader = createSceneLoader({
         scenes: createSceneRegistry([sceneA]),
         compositions: createCompositionRegistry([]),
@@ -5738,10 +5749,13 @@ describe('createSceneLoader (PUL-F008)', () => {
       // Single navigation — no supersession, no abort. With void
       // return, idle() must still settle.
       await loader.handle(prompterSceneTarget('scene-a'));
-      await loader.idle();
-      // If we got here, idle() settled. Sentinel assertion to
-      // make the test's success condition explicit.
-      expect(true).toBe(true);
+      const idleSettled = await Promise.race([
+        loader.idle().then(() => 'settled' as const),
+        new Promise<'pending'>((r) => setTimeout(() => r('pending'), 0)),
+      ]);
+
+      expect(renderCount).toBe(1);
+      expect(idleSettled).toBe('settled');
     });
 
     it('aborts a long-running `renderPrompter` when superseded by another navigation (the renderer signal honors abort)', async () => {

--- a/tests/runtime/scene-loader.test.ts
+++ b/tests/runtime/scene-loader.test.ts
@@ -18,8 +18,9 @@ import {
   type NavigationMode,
   type NavigationTarget,
 } from '../../src/runtime/navigation';
+import type { PrompterRenderer, PrompterScript } from '../../src/runtime/prompter';
 import { createSceneRegistry } from '../../src/runtime/registry';
-import type { SceneModule } from '../../src/runtime/scene';
+import type { Caption, SceneModule } from '../../src/runtime/scene';
 import {
   type StageElement,
   type WorkbenchSceneCtx,
@@ -35,6 +36,8 @@ const stubCtx = (mode: NavigationMode): WorkbenchSceneCtx => ({ stage: null, mod
 
 interface BuildSceneOpts {
   readonly id: string;
+  readonly title?: string;
+  readonly captions?: readonly Caption[];
   readonly create?: SceneModule['create'];
   readonly timeline?: SceneModule['timeline'];
   readonly cleanup?: SceneModule['cleanup'];
@@ -42,11 +45,11 @@ interface BuildSceneOpts {
 
 const buildScene = (opts: BuildSceneOpts): SceneModule => ({
   id: opts.id,
-  title: opts.id,
+  title: opts.title ?? opts.id,
   duration: 1000,
   tags: [],
   assets: [],
-  captions: [],
+  captions: opts.captions ?? [],
   defaultNext: null,
   standalone: true,
   trailerSafe: false,
@@ -1346,7 +1349,16 @@ describe('createSceneLoader (PUL-F008)', () => {
       };
     };
 
-    it.each(NAVIGATION_MODES)(
+    // PUL-F019 / ADR-022: under `mode=prompter` the loader bypasses
+    // the resolver lifecycle structurally — `buildCtx` is NOT
+    // invoked because there is no scene to mount. The
+    // buildCtx-per-mode test therefore only applies to the six
+    // lifecycle-running modes; prompter's "no buildCtx invocation"
+    // invariant is pinned by the dedicated `prompter-mode caption-
+    // view dispatch (PUL-F019)` block.
+    const LIFECYCLE_MODES = NAVIGATION_MODES.filter((m) => m !== 'prompter');
+
+    it.each(LIFECYCLE_MODES)(
       'invokes buildCtx with %s when target.mode is %s (clause 1: explicit mode is selected)',
       async (mode) => {
         const intro = buildScene({ id: 'intro' });
@@ -1366,6 +1378,27 @@ describe('createSceneLoader (PUL-F008)', () => {
         expect(probe.modes).toEqual([mode]);
       },
     );
+
+    it('does NOT invoke buildCtx when target.mode is "prompter" (PUL-F019: lifecycle is structurally bypassed under prompter)', async () => {
+      // The structural inverse of the lifecycle-mode test above —
+      // pinned here so PUL-F012's mode-dispatch block is honest
+      // about which modes actually run the lifecycle.
+      const intro = buildScene({ id: 'intro' });
+      const stage = buildStage();
+      const probe = buildModeProbe();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([intro]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: probe.buildCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+      });
+
+      await loader.handle({ locator: { kind: 'scene', scene: 'intro' }, mode: 'prompter' });
+
+      expect(probe.modes).toEqual([]);
+    });
 
     it('invokes buildCtx with "present" when target.mode is absent (clause 2: default is present)', async () => {
       const intro = buildScene({ id: 'intro' });
@@ -2822,19 +2855,29 @@ describe('createSceneLoader (PUL-F008)', () => {
       expect(captured).toEqual([{ hasRepeat: false, repeat: undefined }]);
     });
 
-    it('does not set `repeat` for any non-loop mode', async () => {
-      // Walk the seven-mode allowlist (minus `loop`) and confirm that
-      // none of them produce `repeat` on the runner input. Catching
-      // every non-loop mode discriminates against an over-broad fix
-      // that gated `repeat` on `mode !== undefined` rather than
-      // `mode === 'loop'`. Capturing the per-iteration mode alongside
-      // the `'repeat' in input` flag means the assertion failure
+    it('does not set `repeat` for any non-loop, lifecycle-running mode', async () => {
+      // Walk the seven-mode allowlist (minus `loop` and `prompter`)
+      // and confirm that none of them produce `repeat` on the
+      // runner input. Catching every non-loop mode discriminates
+      // against an over-broad fix that gated `repeat` on
+      // `mode !== undefined` rather than `mode === 'loop'`.
+      // Capturing the per-iteration mode alongside the
+      // `'repeat' in input` flag means the assertion failure
       // identifies WHICH mode regressed, not just "some mode did."
-      const nonLoopModes = NAVIGATION_MODES.filter((m) => m !== 'loop');
+      //
+      // PUL-F019 / ADR-022: `prompter` does not invoke `runTimeline`
+      // at all (lifecycle is structurally bypassed), so it cannot
+      // appear in this test's `captured` array. The dedicated
+      // `prompter-mode caption-view dispatch (PUL-F019)` block
+      // pins prompter's no-runner invariant directly. Filtering
+      // it out here keeps this test focused on lifecycle modes.
+      const nonLoopLifecycleModes = NAVIGATION_MODES.filter(
+        (m) => m !== 'loop' && m !== 'prompter',
+      );
       const captured: { mode: NavigationMode; hasRepeat: boolean }[] = [];
       const sceneA = buildScene({ id: 'scene-a' });
       const stage = buildStage();
-      for (const mode of nonLoopModes) {
+      for (const mode of nonLoopLifecycleModes) {
         const runner: SceneTimelineRunner = (input) => {
           captured.push({ mode, hasRepeat: 'repeat' in input });
         };
@@ -2849,10 +2892,11 @@ describe('createSceneLoader (PUL-F008)', () => {
         await loader.handle({ locator: { kind: 'scene', scene: 'scene-a' }, mode });
       }
 
-      // One entry per non-loop mode, each must have `hasRepeat: false`.
-      // Building the expected array from `nonLoopModes` keeps the
-      // assertion in sync if the mode allowlist ever changes.
-      expect(captured).toEqual(nonLoopModes.map((mode) => ({ mode, hasRepeat: false })));
+      // One entry per non-loop lifecycle mode, each must have
+      // `hasRepeat: false`. Building the expected array from
+      // `nonLoopLifecycleModes` keeps the assertion in sync if the
+      // mode allowlist ever changes.
+      expect(captured).toEqual(nonLoopLifecycleModes.map((mode) => ({ mode, hasRepeat: false })));
     });
 
     it('exposes `ctx.mode === "loop"` to every lifecycle hook of the head scene under all locator shapes', async () => {
@@ -3515,20 +3559,27 @@ describe('createSceneLoader (PUL-F008)', () => {
       expect(captured).toEqual([{ hasHold: false, hold: undefined }]);
     });
 
-    it('does not set `hold` for any non-paused mode', async () => {
-      // Walk the seven-mode allowlist (minus `paused`) and confirm
-      // that none of them produce `hold` on the runner input.
-      // Catching every non-paused mode discriminates against an
-      // over-broad fix that gated `hold` on `mode !== undefined`
-      // rather than `mode === 'paused'`. Capturing the per-iteration
-      // mode alongside the `'hold' in input` flag means the
-      // assertion failure identifies WHICH mode regressed, not just
-      // "some mode did."
-      const nonPausedModes = NAVIGATION_MODES.filter((m) => m !== 'paused');
+    it('does not set `hold` for any non-paused, lifecycle-running mode', async () => {
+      // Walk the seven-mode allowlist (minus `paused` and
+      // `prompter`) and confirm that none of them produce `hold` on
+      // the runner input. Catching every non-paused mode
+      // discriminates against an over-broad fix that gated `hold` on
+      // `mode !== undefined` rather than `mode === 'paused'`.
+      // Capturing the per-iteration mode alongside the
+      // `'hold' in input` flag means the assertion failure
+      // identifies WHICH mode regressed, not just "some mode did."
+      //
+      // PUL-F019 / ADR-022: `prompter` does not invoke `runTimeline`
+      // (lifecycle bypassed); the dedicated F019 block pins that
+      // invariant. Filter prompter out here so this test stays
+      // focused on lifecycle-running modes.
+      const nonPausedLifecycleModes = NAVIGATION_MODES.filter(
+        (m) => m !== 'paused' && m !== 'prompter',
+      );
       const captured: { mode: NavigationMode; hasHold: boolean }[] = [];
       const sceneA = buildScene({ id: 'scene-a' });
       const stage = buildStage();
-      for (const mode of nonPausedModes) {
+      for (const mode of nonPausedLifecycleModes) {
         const runner: SceneTimelineRunner = (input) => {
           captured.push({ mode, hasHold: 'hold' in input });
         };
@@ -3543,11 +3594,11 @@ describe('createSceneLoader (PUL-F008)', () => {
         await loader.handle({ locator: { kind: 'scene', scene: 'scene-a' }, mode });
       }
 
-      // One entry per non-paused mode, each must have `hasHold:
-      // false`. Building the expected array from `nonPausedModes`
-      // keeps the assertion in sync if the mode allowlist ever
-      // changes.
-      expect(captured).toEqual(nonPausedModes.map((mode) => ({ mode, hasHold: false })));
+      // One entry per non-paused lifecycle mode, each must have
+      // `hasHold: false`. Building the expected array from
+      // `nonPausedLifecycleModes` keeps the assertion in sync if the
+      // mode allowlist ever changes.
+      expect(captured).toEqual(nonPausedLifecycleModes.map((mode) => ({ mode, hasHold: false })));
     });
 
     it('exposes `ctx.mode === "paused"` to every lifecycle hook of the head scene under all locator shapes', async () => {
@@ -4062,20 +4113,26 @@ describe('createSceneLoader (PUL-F008)', () => {
       expect(captured).toEqual([{ hasCueGate: false, cueGate: undefined }]);
     });
 
-    it('does not set `cueGate` for any non-scrub mode', async () => {
-      // Walk the seven-mode allowlist (minus `scrub`) and confirm
-      // that none of them produce `cueGate` on the runner input.
-      // Catching every non-scrub mode discriminates against an
-      // over-broad fix that gated `cueGate` on `mode !== undefined`
-      // rather than `mode === 'scrub'`. Capturing the per-iteration
-      // mode alongside the `'cueGate' in input` flag means the
-      // assertion failure identifies WHICH mode regressed, not just
-      // "some mode did."
-      const nonScrubModes = NAVIGATION_MODES.filter((m) => m !== 'scrub');
+    it('does not set `cueGate` for any non-scrub, lifecycle-running mode', async () => {
+      // Walk the seven-mode allowlist (minus `scrub` and `prompter`)
+      // and confirm that none of them produce `cueGate` on the
+      // runner input. Catching every non-scrub mode discriminates
+      // against an over-broad fix that gated `cueGate` on
+      // `mode !== undefined` rather than `mode === 'scrub'`.
+      // Capturing the per-iteration mode alongside the
+      // `'cueGate' in input` flag means the assertion failure
+      // identifies WHICH mode regressed, not just "some mode did."
+      //
+      // PUL-F019 / ADR-022: `prompter` does not invoke `runTimeline`
+      // (lifecycle bypassed); the dedicated F019 block pins that
+      // invariant.
+      const nonScrubLifecycleModes = NAVIGATION_MODES.filter(
+        (m) => m !== 'scrub' && m !== 'prompter',
+      );
       const captured: { mode: NavigationMode; hasCueGate: boolean }[] = [];
       const sceneA = buildScene({ id: 'scene-a' });
       const stage = buildStage();
-      for (const mode of nonScrubModes) {
+      for (const mode of nonScrubLifecycleModes) {
         const runner: SceneTimelineRunner = (input) => {
           captured.push({ mode, hasCueGate: 'cueGate' in input });
         };
@@ -4090,11 +4147,11 @@ describe('createSceneLoader (PUL-F008)', () => {
         await loader.handle({ locator: { kind: 'scene', scene: 'scene-a' }, mode });
       }
 
-      // One entry per non-scrub mode, each must have `hasCueGate:
-      // false`. Building the expected array from `nonScrubModes`
-      // keeps the assertion in sync if the mode allowlist ever
-      // changes.
-      expect(captured).toEqual(nonScrubModes.map((mode) => ({ mode, hasCueGate: false })));
+      // One entry per non-scrub lifecycle mode, each must have
+      // `hasCueGate: false`. Building the expected array from
+      // `nonScrubLifecycleModes` keeps the assertion in sync if the
+      // mode allowlist ever changes.
+      expect(captured).toEqual(nonScrubLifecycleModes.map((mode) => ({ mode, hasCueGate: false })));
     });
 
     it('exposes `ctx.mode === "scrub"` to every lifecycle hook of the head scene under all locator shapes', async () => {
@@ -4647,21 +4704,27 @@ describe('createSceneLoader (PUL-F008)', () => {
       expect(captured).toEqual([{ hasScreenshot: false, screenshot: undefined }]);
     });
 
-    it('does not set `screenshot` for any non-screenshot mode', async () => {
-      // Walk the seven-mode allowlist (minus `screenshot`) and
-      // confirm that none of them produce `screenshot` on the
-      // runner input. Catching every non-screenshot mode
-      // discriminates against an over-broad fix that gated
-      // `screenshot` on `mode !== undefined` rather than
+    it('does not set `screenshot` for any non-screenshot, lifecycle-running mode', async () => {
+      // Walk the seven-mode allowlist (minus `screenshot` and
+      // `prompter`) and confirm that none of them produce
+      // `screenshot` on the runner input. Catching every
+      // non-screenshot mode discriminates against an over-broad fix
+      // that gated `screenshot` on `mode !== undefined` rather than
       // `mode === 'screenshot'`. Capturing the per-iteration mode
       // alongside the `'screenshot' in input` flag means the
       // assertion failure identifies WHICH mode regressed, not
       // just "some mode did."
-      const nonScreenshotModes = NAVIGATION_MODES.filter((m) => m !== 'screenshot');
+      //
+      // PUL-F019 / ADR-022: `prompter` does not invoke `runTimeline`
+      // (lifecycle bypassed); the dedicated F019 block pins that
+      // invariant.
+      const nonScreenshotLifecycleModes = NAVIGATION_MODES.filter(
+        (m) => m !== 'screenshot' && m !== 'prompter',
+      );
       const captured: { mode: NavigationMode; hasScreenshot: boolean }[] = [];
       const sceneA = buildScene({ id: 'scene-a' });
       const stage = buildStage();
-      for (const mode of nonScreenshotModes) {
+      for (const mode of nonScreenshotLifecycleModes) {
         const runner: SceneTimelineRunner = (input) => {
           captured.push({ mode, hasScreenshot: 'screenshot' in input });
         };
@@ -4676,11 +4739,13 @@ describe('createSceneLoader (PUL-F008)', () => {
         await loader.handle({ locator: { kind: 'scene', scene: 'scene-a' }, mode });
       }
 
-      // One entry per non-screenshot mode, each must have
+      // One entry per non-screenshot lifecycle mode, each must have
       // `hasScreenshot: false`. Building the expected array from
-      // `nonScreenshotModes` keeps the assertion in sync if the
-      // mode allowlist ever changes.
-      expect(captured).toEqual(nonScreenshotModes.map((mode) => ({ mode, hasScreenshot: false })));
+      // `nonScreenshotLifecycleModes` keeps the assertion in sync if
+      // the mode allowlist ever changes.
+      expect(captured).toEqual(
+        nonScreenshotLifecycleModes.map((mode) => ({ mode, hasScreenshot: false })),
+      );
     });
 
     it('exposes `ctx.mode === "screenshot"` to every lifecycle hook of the head scene under all locator shapes', async () => {
@@ -4967,6 +5032,844 @@ describe('createSceneLoader (PUL-F008)', () => {
           screenshot: 'capture',
         },
       ]);
+    });
+  });
+
+  describe('prompter-mode caption-view dispatch (PUL-F019)', () => {
+    // PUL-F019 statement: in `mode=prompter`, the runtime SHALL render
+    // a script/caption view derived from the captions metadata of the
+    // addressed scene or composition. Visual rendering of the scene
+    // SHALL be suppressed.
+    //
+    // Materially-implementable parts of the statement that this block
+    // pins (ADR-022 records the contract boundary):
+    //   - Visual rendering is suppressed STRUCTURALLY: under
+    //     `mode=prompter` the loader does NOT invoke `createPreloader`,
+    //     does NOT invoke `runTimeline`, and does NOT mount the scene
+    //     (no `create` / `timeline` / `cleanup`). The captions data
+    //     path runs INSTEAD of the resolver lifecycle. CSS-hiding an
+    //     already-rendered scene would not satisfy the requirement —
+    //     the codex preflight guardrails for PUL-F019 explicitly call
+    //     this out.
+    //   - The captions view is derived from the captions metadata of
+    //     the addressed scene OR composition. The slice is NOT
+    //     truncated under composition addressing — every entry's
+    //     captions are aggregated, in dispatch order. This is the
+    //     structural difference from `mode=loop` / `mode=paused` /
+    //     `mode=scrub` / `mode=screenshot`, which truncate to head
+    //     because their lifecycle promise is "no following entries
+    //     run." Under prompter the lifecycle doesn't run AT ALL, so
+    //     the truncation defense from the other modes does not apply.
+    //   - The loader hands the computed `PrompterScript` to an
+    //     optional `renderPrompter` adapter on `SceneLoaderOptions`.
+    //     A workbench bootstrap that has not yet wired a captions UI
+    //     omits the field; the loader still suppresses the lifecycle
+    //     (the structural defense) but invokes no renderer. Production
+    //     bootstrap supplies a concrete renderer when the UI surface
+    //     lands.
+    //   - Stage attrs (`data-pulsar-scene-target`,
+    //     `data-pulsar-composition-target`) are still set so external
+    //     observers see what was addressed. NO `data-pulsar-mode-*`
+    //     preemptive attribute (parity with ADR-016 / ADR-017 /
+    //     ADR-018 / ADR-019 / ADR-020 / ADR-021).
+    //   - Composition validation (unregistered composition, unknown
+    //     member scene, out-of-range index) STILL surfaces as a
+    //     navigation error under `mode=prompter` — no silent fallback
+    //     to direct scene lookup.
+    //   - Other modes (`present`, `standalone`, `loop`, `paused`,
+    //     `scrub`, `screenshot`) and a `mode`-less URL DO NOT invoke
+    //     `renderPrompter`. A regression that broadcast prompter
+    //     dispatch under any mode would suppress lifecycle for normal
+    //     playback URLs.
+    //
+    // PUL-F019 stays DRAFT after this PR (ADR-022 records the
+    // boundary; following the ADR-016 / ADR-017 / ADR-018 / ADR-019 /
+    // ADR-020 / ADR-021 / PUL-F013 / PUL-F014 / PUL-F015 / PUL-F016 /
+    // PUL-F017 / PUL-F018 precedent). The seam — the loader bypasses
+    // the lifecycle and hands a `PrompterScript` to the adapter — IS
+    // materially shipped. The visible captions/script UI is the
+    // future workbench surface, gated on the DRAFT → ACTIVE
+    // transition.
+
+    const prompterSceneTarget = (id: string): NavigationTarget => ({
+      locator: { kind: 'scene', scene: id },
+      mode: 'prompter',
+    });
+    const prompterCompositionTarget = (composition: string): NavigationTarget => ({
+      locator: { kind: 'composition', composition },
+      mode: 'prompter',
+    });
+    const prompterCompositionSceneTarget = (
+      composition: string,
+      scene: string,
+    ): NavigationTarget => ({
+      locator: { kind: 'composition-scene', composition, scene },
+      mode: 'prompter',
+    });
+    const prompterCompositionIndexTarget = (
+      composition: string,
+      index: number,
+    ): NavigationTarget => ({
+      locator: { kind: 'composition-index', composition, index },
+      mode: 'prompter',
+    });
+
+    interface LifecycleProbe {
+      readonly log: string[];
+      readonly preloaderInvocations: number;
+      readonly buildCtxInvocations: number;
+    }
+
+    // Probe that records every lifecycle observation across every
+    // boundary the lifecycle would touch under non-prompter modes:
+    //   - `createPreloader` (asset pipeline)
+    //   - `buildCtx` (per-navigation ctx — its very invocation means
+    //     the loader is on the lifecycle path)
+    //   - `runTimeline` (runner adapter)
+    //   - scene `create` / `timeline` / `cleanup` (lifecycle hooks)
+    // Under `mode=prompter` every counter / log entry MUST stay zero.
+    // The codex guardrails for PUL-F019 explicitly call out asset
+    // pipeline + scene renderer + canvas/stage + media playback +
+    // animation loop as side effects to avoid; an under-watched test
+    // (e.g. one that only checked `runTimeline`) would miss an
+    // ABI regression that started running the preloader under
+    // prompter — exactly the `asset pipeline` clause of the guardrails.
+
+    type ProbeOpts = {
+      readonly probe: LifecycleProbe;
+      readonly preloader: () => Promise<void>;
+      readonly runner: SceneTimelineRunner;
+      readonly buildCtxFn: (mode: NavigationMode) => WorkbenchSceneCtx;
+      readonly scenes: readonly SceneModule[];
+    };
+
+    const buildLifecycleProbe = (): ProbeOpts => {
+      const log: string[] = [];
+      const probe: { -readonly [K in keyof LifecycleProbe]: LifecycleProbe[K] } = {
+        log,
+        preloaderInvocations: 0,
+        buildCtxInvocations: 0,
+      };
+      const trace = (id: string, captions?: readonly Caption[]): SceneModule =>
+        buildScene({
+          id,
+          title: id,
+          captions: captions ?? [],
+          create: () => {
+            log.push(`create:${id}`);
+          },
+          timeline: () => {
+            log.push(`timeline:${id}`);
+            return null;
+          },
+          cleanup: () => {
+            log.push(`cleanup:${id}`);
+          },
+        });
+      const runner: SceneTimelineRunner = (input) => {
+        log.push(`runTimeline:${input.scene.id}`);
+      };
+      const preloader = (): Promise<void> => {
+        probe.preloaderInvocations += 1;
+        return Promise.resolve();
+      };
+      const buildCtxFn = (mode: NavigationMode): WorkbenchSceneCtx => {
+        probe.buildCtxInvocations += 1;
+        return { stage: null, mode };
+      };
+      const scenes = [
+        trace('scene-a', [{ at: 0, text: 'A1' }]),
+        trace('scene-b', [{ at: 0, text: 'B1' }]),
+        trace('scene-c', [{ at: 0, text: 'C1' }]),
+      ];
+      return { probe, preloader, runner, buildCtxFn, scenes };
+    };
+
+    it('suppresses every lifecycle side effect under `mode=prompter` (no preloader, no buildCtx, no runner, no scene hooks)', async () => {
+      // The structural-suppression guarantee. A regression that
+      // dispatched prompter through `loadSceneNavigationTarget`
+      // (the same path other modes use) would emit lifecycle entries
+      // for the head scene AND increment the preloader and buildCtx
+      // counters; this test would surface every one of those
+      // regressions.
+      const { probe, preloader, runner, buildCtxFn, scenes } = buildLifecycleProbe();
+      const stage = buildStage();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([...scenes]),
+        compositions: createCompositionRegistry([
+          { id: 'full-talk', manifest: scenes.map((s) => s.id) },
+        ]),
+        stage: stage.element,
+        buildCtx: buildCtxFn,
+        createPreloader: () => preloader,
+        runTimeline: runner,
+      });
+
+      await loader.handle(prompterCompositionTarget('full-talk'));
+
+      expect(probe.log).toEqual([]);
+      expect(probe.preloaderInvocations).toBe(0);
+      expect(probe.buildCtxInvocations).toBe(0);
+    });
+
+    it('invokes `renderPrompter` with a script aggregating captions across the FULL composition slice (NOT truncated to head)', async () => {
+      // Captions span every entry in the composition slice. The
+      // composition list has three scenes; under prompter every
+      // scene's captions must reach the renderer in manifest order.
+      // A regression that copy-pasted truncation from F015–F018
+      // would observe only the head scene's captions in the script.
+      // PUL-F019 explicitly says "addressed scene OR composition,"
+      // and ADR-022 records the no-truncation policy as the
+      // structural difference.
+      const sceneA = buildScene({
+        id: 'scene-a',
+        title: 'Alpha',
+        captions: [
+          { at: 0, text: 'A1' },
+          { at: 100, text: 'A2' },
+        ],
+      });
+      const sceneB = buildScene({
+        id: 'scene-b',
+        title: 'Bravo',
+        captions: [{ at: 0, text: 'B1' }],
+      });
+      const sceneC = buildScene({
+        id: 'scene-c',
+        title: 'Charlie',
+        captions: [{ at: 0, text: 'C1' }],
+      });
+      const stage = buildStage();
+      const captured: PrompterScript[] = [];
+      const renderPrompter: PrompterRenderer = (script) => {
+        captured.push(script);
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA, sceneB, sceneC]),
+        compositions: createCompositionRegistry([
+          { id: 'full-talk', manifest: ['scene-a', 'scene-b', 'scene-c'] },
+        ]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+        renderPrompter,
+      });
+
+      await loader.handle(prompterCompositionTarget('full-talk'));
+
+      expect(captured).toHaveLength(1);
+      expect(captured[0]).toEqual({
+        composition: { id: 'full-talk' },
+        entries: [
+          {
+            sceneId: 'scene-a',
+            title: 'Alpha',
+            captions: [
+              { at: 0, text: 'A1' },
+              { at: 100, text: 'A2' },
+            ],
+          },
+          { sceneId: 'scene-b', title: 'Bravo', captions: [{ at: 0, text: 'B1' }] },
+          { sceneId: 'scene-c', title: 'Charlie', captions: [{ at: 0, text: 'C1' }] },
+        ],
+      });
+    });
+
+    it('invokes `renderPrompter` with a single-scene script for a `scene` target under `mode=prompter`', async () => {
+      // Direct-scene addressing — no composition context. The script
+      // has one entry and no `composition` field. A regression that
+      // assumed every prompter dispatch had a composition would
+      // either crash on `target.composition!.id` or produce a
+      // misleading script. Pin the single-scene shape explicitly.
+      const sceneA = buildScene({
+        id: 'scene-a',
+        captions: [{ at: 250, text: 'hello' }],
+      });
+      const stage = buildStage();
+      const captured: PrompterScript[] = [];
+      const renderPrompter: PrompterRenderer = (script) => {
+        captured.push(script);
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+        renderPrompter,
+      });
+
+      await loader.handle(prompterSceneTarget('scene-a'));
+
+      expect(captured).toHaveLength(1);
+      expect(captured[0]?.entries).toEqual([
+        { sceneId: 'scene-a', title: 'scene-a', captions: [{ at: 250, text: 'hello' }] },
+      ]);
+      expect(captured[0] && 'composition' in captured[0]).toBe(false);
+    });
+
+    it('starts the prompter slice at the addressed scene under `composition+scene` non-head', async () => {
+      // The dispatcher already snapshots the slice from the addressed
+      // scene onward (PUL-F008 / ADR-014). The prompter view honors
+      // that — entries match the slice, NOT the full composition.
+      // A regression that walked back to the composition's first
+      // entry would surface skipped-scene captions. Choose a non-head
+      // start so the test discriminates against "always full
+      // composition."
+      const sceneA = buildScene({ id: 'scene-a', captions: [{ at: 0, text: 'skipped' }] });
+      const sceneB = buildScene({
+        id: 'scene-b',
+        title: 'Bravo',
+        captions: [{ at: 0, text: 'kept' }],
+      });
+      const sceneC = buildScene({
+        id: 'scene-c',
+        title: 'Charlie',
+        captions: [{ at: 0, text: 'also kept' }],
+      });
+      const stage = buildStage();
+      const captured: PrompterScript[] = [];
+      const renderPrompter: PrompterRenderer = (script) => {
+        captured.push(script);
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA, sceneB, sceneC]),
+        compositions: createCompositionRegistry([
+          { id: 'full-talk', manifest: ['scene-a', 'scene-b', 'scene-c'] },
+        ]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+        renderPrompter,
+      });
+
+      await loader.handle(prompterCompositionSceneTarget('full-talk', 'scene-b'));
+
+      expect(captured).toHaveLength(1);
+      expect(captured[0]?.entries.map((e) => e.sceneId)).toEqual(['scene-b', 'scene-c']);
+    });
+
+    it('starts the prompter slice at the requested index under `composition+index`', async () => {
+      // index=1 against [a, b, c] resolves to slice [b, c]. Non-final
+      // index discriminates against a regression that re-walked from
+      // 0 (would surface scene-a) AND a regression that always sliced
+      // to length 1 (would drop scene-c). Choosing index=1 catches
+      // both.
+      const sceneA = buildScene({ id: 'scene-a', captions: [{ at: 0, text: 'A' }] });
+      const sceneB = buildScene({ id: 'scene-b', captions: [{ at: 0, text: 'B' }] });
+      const sceneC = buildScene({ id: 'scene-c', captions: [{ at: 0, text: 'C' }] });
+      const stage = buildStage();
+      const captured: PrompterScript[] = [];
+      const renderPrompter: PrompterRenderer = (script) => {
+        captured.push(script);
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA, sceneB, sceneC]),
+        compositions: createCompositionRegistry([
+          { id: 'full-talk', manifest: ['scene-a', 'scene-b', 'scene-c'] },
+        ]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+        renderPrompter,
+      });
+
+      await loader.handle(prompterCompositionIndexTarget('full-talk', 1));
+
+      expect(captured).toHaveLength(1);
+      expect(captured[0]?.entries.map((e) => e.sceneId)).toEqual(['scene-b', 'scene-c']);
+    });
+
+    it('does not invoke `renderPrompter` for any non-prompter mode', async () => {
+      // Walk the seven-mode allowlist (minus `prompter`) and confirm
+      // that none of them invoke the prompter renderer. A regression
+      // that gated `renderPrompter` on `mode !== undefined` (instead
+      // of `mode === 'prompter'`) would call the renderer for
+      // standalone / loop / paused / scrub / screenshot under URL
+      // navigations that should run the lifecycle. The renderer's
+      // invocation count IS the assertion — not the count of any
+      // particular mode — because the regression is "renderer fires
+      // when it shouldn't."
+      const nonPrompterModes = NAVIGATION_MODES.filter((m) => m !== 'prompter');
+      const calls: PrompterScript[] = [];
+      const renderPrompter: PrompterRenderer = (script) => {
+        calls.push(script);
+      };
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      for (const mode of nonPrompterModes) {
+        const loader = createSceneLoader({
+          scenes: createSceneRegistry([sceneA]),
+          compositions: createCompositionRegistry([]),
+          stage: stage.element,
+          buildCtx: stubCtx,
+          createPreloader: () => () => undefined,
+          runTimeline: noopRunner,
+          renderPrompter,
+        });
+        await loader.handle({ locator: { kind: 'scene', scene: 'scene-a' }, mode });
+      }
+      // No mode at all (defaults to `present`).
+      const loaderNoMode = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+        renderPrompter,
+      });
+      await loaderNoMode.handle(sceneTarget('scene-a'));
+
+      expect(calls).toEqual([]);
+    });
+
+    it('still suppresses the lifecycle when `renderPrompter` is omitted (graceful degradation)', async () => {
+      // A workbench bootstrap that has not yet wired a captions UI
+      // omits the field. The loader's structural-suppression
+      // guarantee is independent of the renderer's presence — under
+      // `mode=prompter` the lifecycle is bypassed regardless. The
+      // captions data path simply has no consumer until the UI lands.
+      // A regression that skipped suppression when `renderPrompter`
+      // was absent would surface lifecycle entries here.
+      const { probe, preloader, runner, buildCtxFn, scenes } = buildLifecycleProbe();
+      const stage = buildStage();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([...scenes]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: buildCtxFn,
+        createPreloader: () => preloader,
+        runTimeline: runner,
+        // renderPrompter omitted on purpose.
+      });
+
+      await loader.handle(prompterSceneTarget('scene-a'));
+
+      expect(probe.log).toEqual([]);
+      expect(probe.preloaderInvocations).toBe(0);
+      expect(probe.buildCtxInvocations).toBe(0);
+    });
+
+    it('writes `data-pulsar-scene-target` and `data-pulsar-composition-target` for a composition-prompter target (preserves observability of what was addressed)', async () => {
+      // Stage attrs communicate "what was addressed," not "what runs."
+      // Suppressed lifecycle does NOT mean suppressed observability —
+      // an external observer (agent, future tooling) reading the
+      // stage must still see what URL the runtime navigated to.
+      // Mirrors the standalone / loop / paused / scrub / screenshot
+      // invariant.
+      const sceneA = buildScene({ id: 'scene-a' });
+      const sceneB = buildScene({ id: 'scene-b' });
+      const stage = buildStage();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA, sceneB]),
+        compositions: createCompositionRegistry([
+          { id: 'full-talk', manifest: ['scene-a', 'scene-b'] },
+        ]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+        renderPrompter: () => undefined,
+      });
+
+      await loader.handle(prompterCompositionSceneTarget('full-talk', 'scene-b'));
+
+      expect(stage.attrs.get('data-pulsar-scene-target')).toBe('scene-b');
+      expect(stage.attrs.get('data-pulsar-composition-target')).toBe('full-talk');
+    });
+
+    it('writes no `data-pulsar-mode-*` suppression attribute on the stage under `mode=prompter`', async () => {
+      // Mirrors ADR-016 / ADR-017 / ADR-018 / ADR-019 / ADR-020 /
+      // ADR-021. ADR-022 keeps the same invariant: the prompter UI
+      // surface (when it lands) is free to write its own stage
+      // attributes, but the loader does NOT preemptively claim a
+      // `data-pulsar-mode-*` namespace.
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+        renderPrompter: () => undefined,
+      });
+
+      await loader.handle(prompterSceneTarget('scene-a'));
+
+      const modeAttrs = Array.from(stage.attrs.keys()).filter((name) =>
+        name.startsWith('data-pulsar-mode-'),
+      );
+      expect(modeAttrs).toEqual([]);
+    });
+
+    it('surfaces composition-not-registered as a navigation error under `mode=prompter` (no silent fallback)', async () => {
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      const errors: unknown[] = [];
+      const calls: PrompterScript[] = [];
+      const renderPrompter: PrompterRenderer = (script) => {
+        calls.push(script);
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+        onError: (err) => {
+          errors.push(err);
+        },
+        renderPrompter,
+      });
+
+      await loader.handle(prompterCompositionTarget('not-registered'));
+
+      expect(errors).toHaveLength(1);
+      expect((errors[0] as Error).message).toContain(
+        'composition "not-registered" is not registered',
+      );
+      expect(stage.attrs.get('data-pulsar-navigation-error')).toBeDefined();
+      expect(calls).toEqual([]);
+    });
+
+    it('surfaces composition-member error under `mode=prompter` for an unknown scene in `composition+scene` (renderPrompter is NOT called on error paths)', async () => {
+      const sceneA = buildScene({ id: 'scene-a' });
+      const sceneZ = buildScene({ id: 'scene-z' });
+      const stage = buildStage();
+      const errors: unknown[] = [];
+      const calls: PrompterScript[] = [];
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA, sceneZ]),
+        compositions: createCompositionRegistry([{ id: 'full-talk', manifest: ['scene-a'] }]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+        onError: (err) => {
+          errors.push(err);
+        },
+        renderPrompter: (script) => {
+          calls.push(script);
+        },
+      });
+
+      await loader.handle(prompterCompositionSceneTarget('full-talk', 'scene-z'));
+
+      expect(errors).toHaveLength(1);
+      expect((errors[0] as Error).message).toContain(
+        'scene "scene-z" is not a member of composition "full-talk"',
+      );
+      expect(calls).toEqual([]);
+    });
+
+    it('surfaces index-out-of-range under `mode=prompter`', async () => {
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      const errors: unknown[] = [];
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([{ id: 'full-talk', manifest: ['scene-a'] }]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+        onError: (err) => {
+          errors.push(err);
+        },
+        renderPrompter: () => undefined,
+      });
+
+      await loader.handle(prompterCompositionIndexTarget('full-talk', 5));
+
+      expect(errors).toHaveLength(1);
+      expect((errors[0] as Error).message).toContain('index 5 is out of range');
+    });
+
+    it('does not invoke `renderPrompter` for `kind: "none"` under `mode=prompter` (nothing addressed, nothing to render)', async () => {
+      // `?mode=prompter` with no scene or composition target resolves
+      // to `kind: 'none'`. There is no addressed metadata to derive
+      // captions from, so the loader should run no renderer. A
+      // regression that synthesized an empty script for `none`
+      // targets would cause the captions UI to flash an empty view
+      // on every popstate without an addressed scene.
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      const calls: PrompterScript[] = [];
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+        renderPrompter: (script) => {
+          calls.push(script);
+        },
+      });
+
+      await loader.handle({ locator: { kind: 'none' }, mode: 'prompter' });
+
+      expect(calls).toEqual([]);
+    });
+
+    it("invokes a renderer's PrompterDispose callback after abort when the navigation is superseded", async () => {
+      // ADR-022's renderer contract (enforceable, not docs-only): a
+      // renderer that mounts persistent DOM returns a
+      // `PrompterDispose` callback (`() => void | Promise<void>`).
+      // The loader OWNS the cleanup sequencing: it parks until
+      // `signal.aborted` fires (next navigation, dispose(), etc.),
+      // then invokes the callback. This test pins the loader's
+      // call to dispose specifically — without the loader-driven
+      // sequencing, a renderer that mounted DOM and returned a
+      // dispose function would never see it called.
+      const teardown: string[] = [];
+      const sceneA = buildScene({ id: 'scene-a', captions: [{ at: 0, text: 'a' }] });
+      const sceneB = buildScene({ id: 'scene-b', captions: [{ at: 0, text: 'b' }] });
+      const stage = buildStage();
+      const renderPrompter: PrompterRenderer = (script) => {
+        if (script.entries[0]?.sceneId === 'scene-b') {
+          // Second navigation: trivial renderer (no DOM mounted),
+          // returns void. Lets `loader.idle()` settle without a
+          // third navigation supersession.
+          return undefined;
+        }
+        // First navigation: simulate "mount captions DOM" and
+        // return the dispose callback the loader will invoke
+        // after abort.
+        return () => {
+          teardown.push('dispose:scene-a');
+        };
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA, sceneB]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+        renderPrompter,
+      });
+
+      void loader.handle(prompterSceneTarget('scene-a'));
+      // Yield so the first dispatch's renderer returns its dispose
+      // callback to the loader before the second navigation
+      // supersedes it.
+      await new Promise<void>((r) => setTimeout(r, 0));
+      void loader.handle(prompterSceneTarget('scene-b'));
+      await loader.idle();
+
+      expect(teardown).toEqual(['dispose:scene-a']);
+    });
+
+    it('awaits an async PrompterDispose callback before settling the dispatch', async () => {
+      // The dispose callback may be async (e.g. waiting for a CSS
+      // transition before unmounting captions DOM). The loader
+      // MUST await it before resolving the dispatch — otherwise
+      // the next navigation's dispatch could overlap with the
+      // previous renderer's lingering teardown. Pin async dispose
+      // explicitly: after the supersession, the
+      // present-mode-runner's create only fires AFTER the prompter
+      // dispatch's async dispose completes.
+      const order: string[] = [];
+      const sceneA = buildScene({ id: 'scene-a', captions: [{ at: 0, text: 'a' }] });
+      const sceneB = buildScene({
+        id: 'scene-b',
+        create: () => {
+          order.push('create:scene-b');
+        },
+      });
+      const stage = buildStage();
+      const renderPrompter: PrompterRenderer = () => async () => {
+        // Async teardown — yields to the microtask queue twice
+        // before completing, so a regression that didn't await
+        // dispose would let scene-b's create run first.
+        await Promise.resolve();
+        await Promise.resolve();
+        order.push('dispose:scene-a');
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA, sceneB]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+        renderPrompter,
+      });
+
+      void loader.handle(prompterSceneTarget('scene-a'));
+      await new Promise<void>((r) => setTimeout(r, 0));
+      // Second navigation is `mode=present` (default) — its
+      // lifecycle running BEFORE prompter dispose would fail this
+      // assertion.
+      void loader.handle(sceneTarget('scene-b'));
+      await loader.idle();
+
+      expect(order).toEqual(['dispose:scene-a', 'create:scene-b']);
+    });
+
+    it('does not park when the renderer returns void (no persistent state mounted)', async () => {
+      // The void-return path of the contract: renderer mounted
+      // nothing, dispatch is fully complete after the renderer's
+      // promise resolves. `loader.idle()` should settle WITHOUT a
+      // second navigation aborting the dispatch. A regression that
+      // always parked would hang `idle()` here.
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      const renderPrompter: PrompterRenderer = () => undefined;
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+        renderPrompter,
+      });
+
+      // Single navigation — no supersession, no abort. With void
+      // return, idle() must still settle.
+      await loader.handle(prompterSceneTarget('scene-a'));
+      await loader.idle();
+      // If we got here, idle() settled. Sentinel assertion to
+      // make the test's success condition explicit.
+      expect(true).toBe(true);
+    });
+
+    it('aborts a long-running `renderPrompter` when superseded by another navigation (the renderer signal honors abort)', async () => {
+      // `renderPrompter` is awaited by the loader's serialized queue
+      // — same shape as `runTimeline`. A renderer that doesn't honor
+      // `signal` would hold up the next navigation forever. The
+      // loader aborts the in-flight signal eagerly on enqueue (parity
+      // with `runTimeline`'s abort path). The renderer's signal-tied
+      // promise resolves on abort, allowing the next navigation to
+      // proceed. A regression that forgot to abort prompter would
+      // surface here as a hung second navigation (vitest's per-test
+      // timeout makes the hang an explicit failure).
+      //
+      // The test must yield between the two `handle()` calls so the
+      // first navigation actually starts running its renderer before
+      // the second navigation aborts it. Without the yield, latest-
+      // event supersession (in `runOnce`) would drop event 1 before
+      // it ran — that is correct behavior for back-to-back enqueues
+      // but would not exercise the abort path this test pins.
+      const sceneA = buildScene({ id: 'scene-a', captions: [{ at: 0, text: 'first' }] });
+      const sceneB = buildScene({ id: 'scene-b', captions: [{ at: 0, text: 'second' }] });
+      const stage = buildStage();
+      const seenScripts: PrompterScript[] = [];
+      // The first navigation's renderer parks until abort (so the
+      // second navigation has something to abort). The second
+      // navigation's renderer returns immediately, so loader.idle()
+      // settles instead of hanging on a non-existent third
+      // navigation.
+      const renderPrompter: PrompterRenderer = (script, signal) => {
+        seenScripts.push(script);
+        if (script.entries[0]?.sceneId === 'scene-a') {
+          return new Promise<undefined>((resolve) => {
+            if (signal.aborted) {
+              resolve(undefined);
+              return;
+            }
+            signal.addEventListener('abort', () => resolve(undefined), { once: true });
+          });
+        }
+        return undefined;
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA, sceneB]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+        renderPrompter,
+      });
+
+      void loader.handle(prompterSceneTarget('scene-a'));
+      // Yield to the microtask queue so the first navigation enters
+      // its renderer (and registers the abort listener) before the
+      // second navigation enqueues and aborts it.
+      await new Promise<void>((r) => setTimeout(r, 0));
+      void loader.handle(prompterSceneTarget('scene-b'));
+      await loader.idle();
+
+      // Both renders were entered (the second only after the first
+      // aborted). A regression that didn't abort the first would
+      // hang the second indefinitely.
+      expect(seenScripts.map((s) => s.entries[0]?.sceneId)).toEqual(['scene-a', 'scene-b']);
+    });
+
+    it('cleans up an in-flight non-prompter scene before dispatching prompter (cleanup-before-handoff across mode boundary)', async () => {
+      // Navigating from `mode=present` (running scene) to
+      // `mode=prompter` MUST run the previous scene's `cleanup`
+      // before the prompter renderer fires. The loader's
+      // abort-and-await pattern already delivers this for any two
+      // navigations; this test pins it specifically across the
+      // present→prompter boundary, which is the most common
+      // workbench trigger (a reviewer pivots from playback to
+      // captions review without reloading).
+      //
+      // Yield between the two `handle()` calls so the first
+      // navigation actually mounts before the second supersedes it
+      // — without the yield, latest-event supersession would drop
+      // the present-mode lifecycle entirely and there would be no
+      // cleanup to observe.
+      const order: string[] = [];
+      const sceneA = buildScene({
+        id: 'scene-a',
+        create: () => {
+          order.push('create:scene-a');
+        },
+        cleanup: () => {
+          order.push('cleanup:scene-a');
+        },
+      });
+      const sceneB = buildScene({ id: 'scene-b', captions: [{ at: 0, text: 'b' }] });
+      const stage = buildStage();
+      // First navigation: a runner that parks until abort so the
+      // loader observes an in-flight scene at the moment the prompter
+      // navigation enqueues. Second navigation: prompter; its
+      // renderer logs its turn order to confirm cleanup ran first.
+      const runTimeline: SceneTimelineRunner = (input) =>
+        new Promise<void>((resolve) => {
+          if (input.signal?.aborted === true) {
+            resolve();
+            return;
+          }
+          input.signal?.addEventListener('abort', () => resolve(), { once: true });
+        });
+      const renderPrompter: PrompterRenderer = () => {
+        order.push('renderPrompter:scene-b');
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA, sceneB]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline,
+        renderPrompter,
+      });
+
+      void loader.handle(sceneTarget('scene-a')); // mode=present (default)
+      // Yield so scene-a's lifecycle starts (create runs, runner
+      // parks waiting for abort).
+      await new Promise<void>((r) => setTimeout(r, 0));
+      void loader.handle(prompterSceneTarget('scene-b'));
+      await loader.idle();
+
+      // create:scene-a → (abort fires) → cleanup:scene-a → then
+      // renderPrompter:scene-b. The relative order pins
+      // cleanup-before-handoff across the present→prompter boundary.
+      expect(order).toEqual(['create:scene-a', 'cleanup:scene-a', 'renderPrompter:scene-b']);
     });
   });
 });


### PR DESCRIPTION
## Summary

- ADR-022 + loader-side dispatch boundary + captions-aggregation seam for `mode=prompter`. Structurally distinct from F015–F018: under `mode=prompter` the loader BYPASSES the resolver lifecycle entirely (no preload, no `create`, no `timeline`, no `cleanup`), so visual rendering is suppressed by construction rather than by runner conformance. The captions data path runs in its place.
- New `src/runtime/prompter.ts` exports `PrompterScript`, `PrompterScriptEntry`, `PrompterDispose`, `PrompterRenderer`, and the pure `buildPrompterScript(target)` function. The script aggregates captions across the FULL composition slice (NOT truncated to head — PUL-F019 says "addressed scene OR composition," and the truncation defense F015–F018 use does not apply because there is no runner-side promise to defend). Object-form composition entries' `range` / `behavior` overrides are carried on the script entry so a future captions UI can communicate sub-range / behavior context to the reviewer.
- The `renderPrompter` adapter is optional on `SceneLoaderOptions` and uses an enforceable lifecycle: returning `void` means "no cleanup obligation," returning a `PrompterDispose` callback means "the loader owns the cleanup sequencing — park until `signal.aborted`, then invoke this callback." The placeholder in `src/main.ts` returns `undefined` (no DOM mounted; nothing to tear down). PUL-F019 stays DRAFT until a real captions/script UI surface lands and renders the script visibly with end-to-end tests, matching the ADR-016 → ADR-021 precedent.

## Test plan

- [x] `pnpm test` — 709 tests pass (added 8 prompter pure-function tests + 16 loader prompter-mode dispatch tests; updated 5 pre-existing F015/F016/F017/F018 negative-mode tests to scope out `prompter`)
- [x] `pnpm lint` — biome clean
- [x] `pnpm typecheck` — tsc --noEmit clean
- [x] `pre-commit run --all-files` — all hooks pass
- [x] Codex pre-push review (cycle 1 + cycle 2) — 3/4 cycle-2 findings fixed in-PR; finding 1 is the documented DRAFT-with-contract-and-seams state (decision recorded on the issue thread; matches ADR-016/017/018/019/020/021 precedent)
- [x] Clause verification — both clauses of PUL-F019 mapped to `file:line` in the plan-and-clauses comment thread

Closes #28