### PR TITLE
Implement PUL-F020 presenter controls contract layer (ADR-023)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,122 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `docs/adrs/023-presenter-controls.md` — records the PUL-F020
+  contract layer for presenter input under `mode=present`. Defines
+  the workbench-supplied long-lived `PresenterCommandSource`, the
+  per-navigation `PresenterController` the loader builds when
+  `effectiveMode === 'present'` AND a source is supplied, and the
+  forwarding through the bridge → resolver chain to every scene's
+  run input (NOT head-only — mode=present runs the full slice and
+  presenter commands act on whichever scene is active). Per-handler
+  exception isolation, boundary validation against
+  `PRESENTER_COMMAND_KINDS`, and abort-tied auto-cleanup are the
+  three safety properties pinned in tests today. PUL-F020 stays
+  DRAFT until a real presenter UI surface (keyboard listener /
+  on-screen controls) and a runner that translates commands into
+  GSAP transport calls (ADR-003) land with end-to-end tests. See
+  ADR-023 for the loader-side dispatch rationale, the
+  not-head-only forwarding decision, the safety-property derivation,
+  and the DRAFT → ACTIVE transition criteria. Indexed in
+  `docs/adrs/README.md`.
+- `src/runtime/presenter.ts` — new module exporting
+  `PRESENTER_COMMAND_KINDS`, `PresenterCommand`,
+  `PresenterCommandKind`, `PresenterCommandSource`,
+  `PresenterController`, `isPresenterCommand`, and
+  `createPresenterController`. The factory wraps a long-lived
+  source in a per-navigation controller bound to an `AbortSignal`:
+  every subscription is tracked so the abort listener detaches
+  them all on navigation end, preventing subscription leaks across
+  navigations even when a runner forgets to unsubscribe. Validates
+  incoming command payloads at the boundary; unknown kinds are
+  dropped with an `onError` diagnostic rather than reaching the
+  runner. Per-handler exceptions are isolated through the same
+  `onError` so a buggy subscriber cannot poison emissions for
+  siblings.
+- `src/runtime/composition-resolver.ts` — `SceneTimelineRunInput`
+  gains optional `presenter?: PresenterController`;
+  `ResolveCompositionOptions` gains optional
+  `presenter?: PresenterController`. Forwarded to EVERY scene's
+  run input (NOT head-only) — `mode=present` is the only mode that
+  runs the full composition slice, and presenter commands act on
+  whichever scene is currently active. `runScene` wraps the
+  navigation-level controller in a per-scene child controller bound
+  to a per-scene `AbortController` that fires after the scene's
+  `cleanup(ctx)` completes; a runner that subscribes during scene-A
+  and forgets to unsubscribe cannot leak its handler into scene-B
+  because the per-scene wrapper is torn down before scene-B's
+  `runTimeline` is invoked. The wrapper is built only when a
+  navigation controller is supplied (no per-scene cost for non-
+  present-mode navigations).
+- `src/runtime/scene-navigation.ts` —
+  `LoadSceneNavigationTargetOptions` gains optional
+  `presenter?: PresenterController`. Forwarded to
+  `resolveComposition` via the existing spread-when-defined
+  pattern. The bridge does NOT truncate the slice when `presenter`
+  is supplied — `presenter` is independent of the four head-only
+  runner-input hints (`repeat` / `hold` / `cueGate` /
+  `screenshot`), and mode=present has no head-only structural
+  promise to defend.
+- `src/runtime/scene-loader.ts` — `SceneLoaderOptions` gains
+  optional `presenterCommands?: PresenterCommandSource`. When
+  `effectiveMode(target) === 'present'` AND the source is supplied,
+  `buildLoad` constructs a `PresenterController` via
+  `createPresenterController(source, controller.signal, onError)`
+  and passes it to `loadSceneNavigationTarget` as `presenter`.
+  Other modes never see the controller; the source is not
+  subscribed under any non-present mode (the loader does not even
+  build the controller). Mode-scoping is centralized at this
+  single call site so the rule "presenter input only under
+  mode=present" has one enforcement point.
+- `src/main.ts` — placeholder behavior: `presenterCommands` is
+  intentionally OMITTED. Production reaches the loader's
+  graceful-degradation path; runners see `input.presenter ===
+  undefined`. ADR-023 records the DRAFT → ACTIVE bar (presenter UI
+  module + GSAP runner that translates commands to transport
+  calls + end-to-end tests).
+- `docs/design/pul-f020-presenter-controls-preflight.md` — codex
+  preflight design context naming the boundary, required reuse,
+  guardrails, non-goals, and anti-patterns for PUL-F020. Authored
+  manually (the local-write path of the preflight call failed) but
+  carries the architectural guardrails from the codex summary
+  verbatim (mode=present scoping, GSAP transport calls, no
+  per-scene keyboard listeners, no scrub coupling, no broadening
+  hold into pause/resume).
+- `tests/runtime/presenter.test.ts` — pure-module tests for the
+  new `presenter.ts` module: `PRESENTER_COMMAND_KINDS` shape,
+  `isPresenterCommand` validation surface (every kind, every
+  rejection case), `createPresenterController` source-forwarding,
+  unsubscribe, abort-tied teardown (including pre-aborted signal),
+  post-abort no-op subscribe, unknown-kind drop with onError
+  diagnostic, no-handler emission, sibling isolation under handler
+  exception.
+- `tests/runtime/composition-resolver.test.ts` — new
+  `'URL present-mode runner presenter forwarding (PUL-F020)'`
+  describe block: every-scene forwarding (NOT head-only) for
+  multi-scene plans, omission when absent (no `'presenter' in
+  input` key), runner-ignores graceful degradation, independence
+  from `signal` and the head-only hints (every channel reaches the
+  runner without coupling).
+- `tests/runtime/scene-navigation.test.ts` — new
+  `'URL present-mode presenter forwarding (PUL-F020)'` describe
+  block: single-scene + composition forwarding, NOT-head-only
+  forwarding across composition entries, no slice truncation when
+  `presenter` is supplied, omission when absent.
+- `tests/runtime/scene-loader.test.ts` — new
+  `'presenter-controls dispatch (PUL-F020 / ADR-023)'` describe
+  block: `mode=present` forwarding (single-scene + composition,
+  every-scene), absent-mode forwarding (defaults to present per
+  PUL-F012 / ADR-007), per-mode negative coverage (every
+  non-present mode does not subscribe the source even when one is
+  supplied; `prompter` vacuously satisfies via lifecycle bypass),
+  no-source graceful degradation, every-kind delivery (advance /
+  hold / skip-forward / skip-backward), abort-detaches-subscription
+  across a presenter-driven supersede, cleanup-before-handoff
+  invariant under presenter-driven supersede (the "interruptible
+  without breaking timeline state" clause), unknown-kind drop with
+  onError diagnostic, no preemptive `data-pulsar-mode-*`
+  attribute under `mode=present` even when a presenter source is
+  supplied.
 - `docs/adrs/022-workbench-mode-prompter.md` — records the PUL-F019
   contract layer for `mode=prompter`. Structurally distinct from
   the other six workbench modes: the loader BYPASSES the resolver

--- a/docs/adrs/023-presenter-controls.md
+++ b/docs/adrs/023-presenter-controls.md
@@ -1,0 +1,495 @@
+# ADR-023: Presenter Controls — Per-Navigation Command Source at the Loader/Runner Seam
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-10
+
+## Context
+
+ADR-007 names seven workbench modes: `present`, `standalone`, `loop`,
+`paused`, `scrub`, `screenshot`, `prompter`. ADR-013 fixes the URL
+grammar boundary that carries `mode=` to the runtime. ADR-016
+(`mode=present`) records the present-mode contract boundary and names
+PUL-F020 as one of the four facets that gates PUL-F013 ACTIVE
+("PUL-F020 / PUL-F021 / PUL-F025 wiring presenter UI (advance, hold,
+skip, pause / resume, master mute) to the AbortSignal seam"). ADR-017
+through ADR-022 establish the precedent for landing each
+mode-or-facet's contract layer plus seam tests while the dependent
+input / rendering surfaces are still pending: PUL-F013 through
+PUL-F019 all stayed DRAFT after their contract PRs because the four
+named surfaces (chrome, audio, GSAP runner, presenter input) are not
+yet implemented.
+
+PUL-F020 specifies presenter input under `mode=present`:
+
+> In `mode=present`, the runtime SHALL accept presenter input to
+> advance to the next beat, hold the current beat, skip forward, and
+> skip backward. Beat progression SHALL be interruptible without
+> breaking timeline state.
+
+The clauses decompose:
+
+- "The runtime SHALL accept presenter input to advance / hold /
+  skip-forward / skip-backward" — the runtime needs a way to receive
+  these four named commands and route them to the timeline runner so
+  the runner can translate each into a transport call (ADR-003: GSAP
+  `play()` / `pause()` / `seek()` / `tweenTo()`). The runtime is the
+  receiver; the input source (keyboard listener, on-screen controls,
+  remote presenter protocol) lives at a workbench surface that has
+  not yet landed.
+- "In `mode=present`" — presenter input is scoped to `mode=present`.
+  The other six modes have their own semantics (single-frame
+  capture, hold at first frame, infinite loop, captions-only view,
+  etc.) that presenter commands would corrupt.
+- "Beat progression SHALL be interruptible without breaking timeline
+  state" — a presenter-driven supersede mid-scene must run
+  `cleanup(ctx)` on the in-flight scene exactly once (PUL-F006's
+  mandatory-cleanup invariant). The dispatch path must not introduce
+  a second cleanup pathway or skip cleanup on the abort branch.
+
+The other five workbench-mode ADRs (ADR-017 through ADR-021) all use
+runner-input *hints* — opaque flags (`repeat: 'until-aborted'`,
+`hold: 'first-frame'`, `cueGate: 'monotonic-forward'`,
+`screenshot: 'capture'`) the loader sets and the runner reads. That
+shape is wrong for PUL-F020:
+
+- A flag is one-shot per navigation; presenter commands are a stream
+  of arrivals during a navigation.
+- Flags are head-only because each named mode is single-scene; PUL-F020
+  acts on whichever scene is currently active in the FULL composition
+  slice mode=present runs.
+- Flags can be string literals; presenter commands need a typed
+  discriminator (`{ kind: 'advance' | 'hold' | 'skip-forward' |
+  'skip-backward' }`) plus a subscription channel.
+
+The cleanest seam is a per-navigation *controller* that the workbench
+supplies via a long-lived *source*, similar in spirit to how
+`SceneLoaderOptions.renderPrompter` is supplied (ADR-022). The
+runner subscribes; the controller auto-detaches every subscription
+when the per-navigation `AbortSignal` fires.
+
+The question this ADR answers is: where does the presenter command
+seam live, what shape does it take, and on what contract does
+PUL-F020 transition to ACTIVE?
+
+## Decision
+
+### Scope: presenter is a runtime-side command receiver
+
+PUL-F020 is the *runtime* side of presenter input. Its scope:
+
+- Define a typed presenter command shape and a workbench-supplied
+  source (`PresenterCommandSource`) for command arrivals.
+- Build a per-navigation controller (`PresenterController`) under
+  `mode=present` that proxies the source, validates incoming
+  commands at the boundary, and auto-detaches all subscriptions
+  when the navigation aborts.
+- Forward the controller to every scene's run input via the bridge
+  → resolver chain so the runner can subscribe.
+- Pin the contract with seam tests covering all four kinds, the
+  mode-scoping, the auto-cleanup, and the
+  interruptibility/cleanup invariant.
+
+What PUL-F020 does NOT include in this PR:
+
+- Keyboard listener on `document` / `window`.
+- On-screen presenter UI controls.
+- Remote-presenter protocol (HTTP, WebSocket, etc.).
+- GSAP runner that translates commands to transport calls
+  (ADR-003 territory; the placeholder runner ignores commands and
+  vacuously satisfies the seam — same shape as it ignores `repeat`
+  / `hold` / `cueGate` / `screenshot` today).
+- Pause / resume (PUL-F021 — separate requirement, separate PR).
+- Master mute (PUL-F025 — separate requirement, separate PR).
+
+The codex preflight named four broad anti-patterns that this scope
+explicitly defends against: per-scene keyboard listeners, duplicate
+command schemas, treating skip as scrub or arbitrary millisecond
+seeking, and broadening hold into the separate pause/resume
+requirement. The runtime side's narrow scope — receive typed
+commands at a single boundary, route to the runner, auto-clean on
+navigation end — sidesteps each anti-pattern by construction.
+
+### Plumbing: loader-built per-navigation controller
+
+`mode=present` continues to take the lifecycle-running dispatch path
+(unlike `mode=prompter`, which bypasses the lifecycle entirely per
+ADR-022). The presenter seam is added inline:
+
+1. **Source on `SceneLoaderOptions`.** A new optional
+   `presenterCommands?: PresenterCommandSource` field carries the
+   workbench-supplied input source. The source is long-lived; the
+   loader does not own or construct it. A workbench bootstrap that
+   has not yet wired a presenter UI omits the field, and the loader
+   gracefully degrades — runners see `input.presenter === undefined`
+   and the seam is structurally inert until the workbench wires a
+   real source.
+
+2. **Per-navigation controller in `buildLoad`.** When BOTH
+   `effectiveMode(target) === 'present'` AND
+   `options.presenterCommands !== undefined`, `buildLoad`
+   constructs a `PresenterController` via
+   `createPresenterController(source, controller.signal, onError)`.
+   The controller is bound to this navigation's `AbortController`
+   so the abort listener (registered internally) detaches every
+   runner subscription when the navigation aborts.
+
+   The two scoping conditions are checked at the same call site so
+   the rule "presenter input only under mode=present" is centralized.
+   No other code path builds the controller.
+
+3. **Bridge → resolver forwarding.** The controller flows through
+   `LoadSceneNavigationTargetOptions.presenter` →
+   `ResolveCompositionOptions.presenter` →
+   `SceneTimelineRunInput.presenter`. The bridge does NOT truncate
+   the slice when `presenter` is supplied — `presenter` is
+   independent of the four head-only runner-input hints, every one
+   of which corresponds to a single-scene-execution mode where
+   truncation enforces "no following entries run." Mode=present has
+   no such promise; truncating would silently drop tail-scene
+   presenter handling.
+
+4. **Resolver: not head-only.** Unlike `headBeat` / `headRepeat` /
+   `headHold` / `headCueGate` / `headScreenshot`, `presenter` is
+   forwarded to EVERY plan step (analogous to `signal`). Mode=present
+   runs the FULL composition slice; presenter commands act on
+   whichever scene is currently active in the resolver loop. A
+   head-only forwarding here would silently drop presenter input for
+   every scene after the head — exactly the failure mode the
+   broader-scoping guarantees against.
+
+5. **Runner contract.** The runner receives `input.presenter` (when
+   present) and subscribes via `input.presenter.subscribe(handler)`.
+   `subscribe` returns an unsubscribe callback the runner SHOULD
+   invoke on its own scene-exit path; the controller's auto-detach
+   on abort is a safety net, not a substitute. Translating each
+   command into a transport call is the runner's contract per
+   ADR-003 (advance → play to next beat, hold → pause, skip-forward
+   / skip-backward → seek to next/prev beat). A runner that ignores
+   `input.presenter` gracefully degrades — the placeholder runner
+   does this today because it has no real timeline to drive.
+
+6. **Per-scene wrapping inside the resolver.** The navigation-level
+   controller's auto-detach fires on navigation abort — but a
+   `mode=present` composition runs every scene under one
+   navigation, so a runner that subscribes during scene-A and
+   forgets to unsubscribe at scene-A's exit would keep receiving
+   commands during scene-B. The resolver's `runScene` defends
+   against this by wrapping the navigation controller in a
+   per-scene child controller: a fresh `AbortController` per scene,
+   a `createPresenterController(navController, perSceneSignal)`
+   call, and `perSceneAbort.abort()` after the scene's `cleanup(ctx)`
+   completes. The runner sees the per-scene wrapper as
+   `input.presenter`, not the navigation controller directly. Two
+   safety properties layer cleanly: navigation-end abort cascades
+   through every scene's wrapper (the wrapper's source IS the
+   navigation controller, so when the navigation tears down its
+   source-side subscriptions every wrapper's emissions stop), and
+   per-scene-end abort releases that scene's runner subscriptions
+   before the next scene's runner starts. The wrapper is built
+   only when the navigation controller exists, so non-present-mode
+   navigations pay zero per-scene cost.
+
+### Command shape and validation
+
+`PresenterCommand` is a discriminated union frozen to four kinds:
+
+```
+type PresenterCommandKind = 'advance' | 'hold' | 'skip-forward' | 'skip-backward';
+interface PresenterCommand {
+  readonly kind: PresenterCommandKind;
+}
+```
+
+`PRESENTER_COMMAND_KINDS` is the single source of truth for the
+allowlist (frozen tuple, parallel to `NAVIGATION_MODES`). The type
+guard `isPresenterCommand` is the sole boundary validator the
+controller applies. Unknown kinds are dropped at the controller —
+the handler is not invoked, and an `Error` is surfaced through the
+`onError` sink the loader already injects. No throw, no scene
+unmount; the boundary error is a diagnostic, not a navigation
+failure.
+
+Handler exceptions are isolated per-handler so a buggy subscriber
+cannot poison emissions for siblings — the controller wraps each
+handler in a try/catch that routes thrown errors through `onError`.
+Without isolation, the source's emission loop would propagate the
+throw through every later handler.
+
+### Why a per-navigation controller, not the source directly
+
+A direct hand-off of the source to the runner has two failure modes:
+
+- **Subscription leaks across navigations.** A runner that subscribes
+  and forgets to unsubscribe attaches a handler to the long-lived
+  source for the workbench's lifetime. The next navigation's runner
+  sees double-deliveries, then triple, etc. The per-navigation
+  controller's auto-detach on abort makes the leak structurally
+  impossible.
+- **No boundary validation.** A misbehaving programmatic source
+  (test harness, future remote-presenter bridge) can emit malformed
+  values. The controller's `isPresenterCommand` check at the
+  emission boundary drops them before the runner sees them.
+
+These two properties are what make the contract layer worth landing
+ahead of the UI surface: the seam's safety properties are testable
+today even though no real input source exists yet.
+
+### Boundary
+
+The presenter seam lives at the loader because:
+
+- The loader already derives `effectiveMode(target)` for `ctx.mode`
+  (ADR-007 / PUL-F012). Reusing the same derivation for the
+  presenter scoping keeps mode-aware dispatch in one place.
+- The composition resolver MUST stay mode-opaque (ADR-011 — pure
+  orchestrator, no adapter knowledge). Pushing the mode-scoping
+  into the resolver would force the resolver to inspect a runtime
+  detail that has no place in the orchestrator.
+- The bridge (`loadSceneNavigationTarget`) is mode-opaque by
+  design — it forwards options to the resolver without
+  interpretation. The presenter forwarding here mirrors the
+  signal/beat/repeat/hold/cueGate/screenshot pass-through.
+
+### What this PR does not do
+
+- No keyboard listener on `document` / `window`. ADR-007's URL-only
+  rule applies to mode dispatch; presenter input is a workbench-
+  supplied stream, not a global side-effecting listener. The future
+  presenter UI module owns the keyboard listener; production main.ts
+  omits the `presenterCommands` field today.
+- No `data-pulsar-mode-*` suppression attribute under `mode=present`.
+  ADR-016's invariant holds: this PR does not introduce any
+  preemptive stage attribute under the suppression namespace.
+- No second cleanup path. Presenter-driven aborts route through the
+  existing `AbortController`; the resolver's mandatory-cleanup
+  invariant (PUL-F006) runs `cleanup(ctx)` on the in-flight scene
+  exactly once, just as it does for popstate-driven aborts today.
+
+PUL-F020 stays DRAFT after this PR lands, mirroring the
+ADR-016 / PUL-F013, ADR-017 / PUL-F014, ADR-018 / PUL-F015,
+ADR-019 / PUL-F016, ADR-020 / PUL-F017, ADR-021 / PUL-F018, and
+ADR-022 / PUL-F019 precedent. This PR ships:
+
+- The contract layer: `PresenterCommand`, `PresenterCommandSource`,
+  `PresenterController`, `createPresenterController`,
+  `isPresenterCommand`.
+- The plumbing: loader → bridge → resolver → runner, mode=present
+  only, forwarded to every scene.
+- The seam tests: every command kind, mode-scoping (positive and
+  negative for all six non-present modes), auto-cleanup on abort,
+  cleanup-before-handoff across a presenter-driven supersede, and
+  the boundary-validation drop path.
+
+What it does NOT yet ship is the visible presenter UI surface and
+the runner that translates commands to GSAP transport calls. The
+placeholder timeline runner ignores `input.presenter`. PUL-F020
+transitions DRAFT → ACTIVE when:
+
+1. A presenter UI module (keyboard listener, on-screen controls,
+   or both) lands and surfaces user input as `PresenterCommand`s
+   through a `PresenterCommandSource`.
+2. The GSAP runner (or an equivalent runner with real transport
+   semantics) ships and translates each command kind into a
+   timeline operation that visibly affects beat state.
+3. End-to-end tests confirm advance / hold / skip-forward /
+   skip-backward actually move beat state without breaking the
+   timeline (no leaked listeners, no double-cleanup, no missed
+   commands across the supersede boundary).
+4. Ground Control traceability has the presenter UI module AND the
+   runner module linked as `IMPLEMENTS` PUL-F020 alongside the
+   runtime-side modules' existing `IMPLEMENTS` links.
+
+Until those surfaces land, the issue ↔ requirement link stays as
+`DOCUMENTS` and PUL-F020 stays DRAFT — matching how ADR-016 /
+PUL-F013 through ADR-022 / PUL-F019 record "land the contract layer;
+keep the requirement DRAFT until the dependent surfaces land."
+
+## Consequences
+
+### Positive
+
+- The seam is testable today as a pure module plus a loader-level
+  dispatch test. Both contracts can be pinned without depending on
+  a real keyboard surface or a real timeline runner.
+- Per-navigation auto-cleanup is a safety property the runner
+  cannot violate by forgetting to unsubscribe — the controller's
+  abort listener detaches every outstanding handler on navigation
+  end. Subscription leaks are structurally impossible.
+- Boundary validation is centralized at the controller. A
+  misbehaving programmatic source cannot push malformed commands
+  past the boundary; the runner only sees well-formed
+  `PresenterCommand`s. Adding new kinds is a one-place edit
+  (`PRESENTER_COMMAND_KINDS`) — the validator and the discriminated
+  union both follow.
+- Mode-scoping at the loader keeps the rule "presenter input only
+  under mode=present" in a single line. No code path builds the
+  controller for any other mode; the runner sees absent
+  `input.presenter` for every other mode.
+- The contract surface (`presenterCommands?: PresenterCommandSource`
+  on `SceneLoaderOptions`) is parallel to `renderPrompter` (ADR-022)
+  and `runTimeline`. A future workbench bootstrap plugs in the same
+  way the future captions UI plugs into `renderPrompter`.
+- Following ADR-016 through ADR-022's precedent keeps the DRAFT →
+  ACTIVE bar consistent across mode-and-facet requirements: ACTIVE
+  means the named user-visible behavior is actively delivered end
+  to end, not just structurally scaffolded.
+
+### Negative
+
+- PUL-F020 stays DRAFT until both a real presenter UI surface AND a
+  real timeline runner land. A reviewer reading the requirement in
+  isolation may expect ACTIVE on first delivery; the
+  DRAFT-with-contract-and-seams state is intentional and matches the
+  precedent.
+- `PresenterController` is structurally identical to
+  `PresenterCommandSource` (both have `subscribe(handler): () => void`).
+  The two interfaces are intentionally distinct types so the loader's
+  call site signals "wrap source in a per-navigation controller, then
+  hand the controller to the runner" rather than "hand the source
+  directly." A future contributor who collapses them would lose the
+  per-navigation auto-cleanup and re-introduce the leak failure mode.
+- Adding `presenter` widens both `SceneTimelineRunInput` and
+  `LoadSceneNavigationTargetOptions`. Every direct caller (production
+  bootstrap, test harnesses, future export pipelines) sees the new
+  field. Optional makes the impact small: a caller that doesn't
+  supply it gets graceful degradation.
+- A test harness that supplies `presenterCommands` AND a non-present
+  mode will see the seam structurally inert (the loader does not
+  build the controller). That's correct behavior; a contributor
+  debugging "why isn't my runner subscribing?" needs to verify the
+  mode resolution.
+
+### Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| A future runner forgets to unsubscribe on its own scene-exit path | Two layered safety nets fire on different boundaries. (1) Per-scene auto-detach: the resolver wraps the navigation controller in a per-scene child controller bound to a per-scene signal that fires after the scene's `cleanup(ctx)`. A subscription made during scene-A is released before scene-B's runner starts even if the runner never called the returned unsubscribe. (2) Navigation-level auto-detach: when the navigation aborts (next handle, dispose, popstate), every navigation-controller subscription is released, which cascades to every per-scene wrapper. Tests pin both: per-scene release between scenes within a single composition (resolver test), AND navigation-level release across a presenter-driven supersede (loader test). |
+| A workbench bootstrap subscribes a global keyboard listener and emits commands while no scene is mounted | Source emissions with no controller subscribed are no-ops — the controller is only built for `mode=present` navigations. Tests pin that the source's `handlerCount` stays 0 under non-present modes. |
+| A future code path calls `createPresenterController` outside the loader | The function is exported but has a single production caller (`buildLoad`). Codex preflight names "presenter input belongs to mode=present"; a second caller would need its own ADR justifying why mode-scoping should live in two places. |
+| Unknown command kinds reach the runner from a misbehaving source | `isPresenterCommand` at the controller's emission boundary drops them with an `onError` diagnostic. Tests pin the drop and the diagnostic shape. The runner never sees malformed commands. The loader threads its own `onError` through both the navigation-level controller AND the resolver's per-scene wrapper (via `LoadSceneNavigationTargetOptions.onPresenterError` → `ResolveCompositionOptions.onPresenterError`), so a runner-handler exception caught by the per-scene wrapper still surfaces through the same diagnostic channel as every other navigation-level error. |
+| A runner that subscribes mutates the command (`cmd.kind = 'corrupted'`) and corrupts later subscribers' view of the same emission | The wrapped handler forwards a frozen defensive copy (`Object.freeze({ kind: cmd.kind })`) to each subscriber. The source emits one reference, but every subscriber sees its own frozen object; mutation by one subscriber cannot reach another. |
+| A non-idempotent source's unsubscribe is called twice (abort fires AND the runner explicitly unsubscribes after) | The controller tracks subscriptions through `Subscription` records carrying an `active` flag. Both the per-subscriber unsubscribe and the abort-driven `tearDownAll` check `active` before calling the source's unsubscribe; the second teardown is a no-op. Tests pin "abort then unsubscribe" runs the source's unsubscribe exactly once. |
+| A misbehaving source's unsubscribe is a no-op (it doesn't actually detach) and post-abort emissions still reach the runner | The wrapped handler short-circuits on `!sub.active` BEFORE forwarding to the runner's handler. Even if the source keeps delivering after `tearDownAll` ran, the wrapper's `active` flag (cleared by `tearDownSubscription`) blocks the forward. Tests pin both "post-abort emission from a lying source" and "post-unsubscribe emission from a lying source" — the runner sees nothing. |
+| A handler exception poisons the bus for sibling handlers | Per-handler try/catch isolates exceptions through `onError`. Tests pin that handler-A throwing does not prevent handler-B from receiving the same command. |
+| A presenter-driven supersede leaks the previous scene's resources | The supersede flows through the existing `AbortController` path; the resolver's mandatory-cleanup invariant (PUL-F006) runs `cleanup(ctx)` on the in-flight scene exactly once. Tests pin the cleanup invariant under presenter-driven aborts. The "interruptible without breaking timeline state" clause is satisfied by the existing PUL-F006 invariant; PUL-F020 inherits it. |
+| A reviewer expects skip to jump multiple beats / scenes / frames | PUL-F020 names exactly four commands; "skip forward" / "skip backward" is the runner's interpretation of "navigate by one beat without natural advance." Behaviors like "jump to next scene" or "scrub by N seconds" are scrub-mode (PUL-F017) or future requirements, not extensions of PUL-F020. |
+| A future PR adds a "presenter command" that bypasses the controller (e.g., a scene-side `ctx.advanceBeat()` shortcut) | ADR-007 / PUL-F012 record `ctx.mode` as a read-only seam, not an action surface. A second action surface would need its own ADR; codex review at the PR boundary catches the divergence. |
+
+## Current state (2026-05-10)
+
+This PR delivers the contract boundary and seam-pinning layer:
+
+- `src/runtime/presenter.ts` — new module exporting
+  `PRESENTER_COMMAND_KINDS`, `PresenterCommand`, `PresenterCommandKind`,
+  `PresenterCommandSource`, `PresenterController`,
+  `isPresenterCommand`, and `createPresenterController`. Pure
+  module — no DOM, no global listeners, no mode coupling. The
+  controller's auto-detach on abort and per-handler exception
+  isolation are pinned as separate tests.
+- `src/runtime/composition-resolver.ts` —
+  `SceneTimelineRunInput` gains optional `presenter?: PresenterController`
+  (NOT head-only); `ResolveCompositionOptions` gains optional
+  `presenter?: PresenterController`; `buildRunInput` and `runScene`
+  pass it through. `runScene` builds a per-scene child controller via
+  `createPresenterController(navController, perSceneSignal)` and
+  fires `perSceneAbort.abort()` after the scene's `cleanup(ctx)` so
+  a runner that forgets to unsubscribe at scene-exit cannot leak
+  into the next scene's runner.
+- `src/runtime/scene-navigation.ts` —
+  `LoadSceneNavigationTargetOptions` gains optional `presenter?: PresenterController`,
+  forwarded to `resolveComposition` via the existing
+  spread-when-defined pattern. The bridge does NOT truncate the
+  slice when `presenter` is supplied.
+- `src/runtime/scene-loader.ts` — `SceneLoaderOptions` gains
+  optional `presenterCommands?: PresenterCommandSource`. `buildLoad`
+  builds a per-navigation controller via
+  `createPresenterController(source, controller.signal, onError)`
+  when `effectiveMode === 'present'` AND the source is supplied.
+  Other modes never see the controller.
+- `src/main.ts` — placeholder behavior: omits `presenterCommands`.
+  Production reaches the graceful-degradation path; runners see
+  `input.presenter === undefined`. ADR-023 records the DRAFT →
+  ACTIVE bar (presenter UI module + runner that translates
+  commands to GSAP).
+- `tests/runtime/presenter.test.ts` — pure-module tests for
+  `PRESENTER_COMMAND_KINDS`, `isPresenterCommand`, and
+  `createPresenterController`: every kind, validation rejection
+  surface, source-forwarding, unsubscribe, abort-tied teardown,
+  pre-aborted signal, post-abort no-op subscribe, unknown-kind
+  drop with onError diagnostic, no-source-handler emission, sibling
+  isolation under handler exception.
+- `tests/runtime/composition-resolver.test.ts` — new
+  `'URL present-mode runner presenter forwarding (PUL-F020)'`
+  describe block: every-scene forwarding, omission when absent,
+  runner-ignores graceful degradation, independence from
+  `headBeat` / `headRepeat`.
+- `tests/runtime/scene-navigation.test.ts` — new
+  `'URL present-mode presenter forwarding (PUL-F020)'` describe
+  block: single-scene + composition forwarding, no truncation,
+  omission when absent.
+- `tests/runtime/scene-loader.test.ts` — new
+  `'presenter-controls dispatch (PUL-F020 / ADR-023)'` describe
+  block: present-mode forwarding (single-scene + composition,
+  every-scene), absent-mode (defaults to present), per-mode
+  negative (every non-present mode), no-source graceful
+  degradation, every-kind delivery, abort-detaches-subscription,
+  cleanup-before-handoff across a presenter-driven supersede,
+  unknown-kind drop with onError diagnostic, no preemptive
+  `data-pulsar-mode-*` attribute.
+- This ADR.
+
+PUL-F020 remains DRAFT. Issue #29 links to PUL-F020 via `DOCUMENTS`.
+This PR is **not** an implementation of PUL-F020's "accept presenter
+input" clause end-to-end — the workbench bootstrap supplies no
+source, no presenter UI module exists, and the placeholder timeline
+runner ignores `input.presenter`. The ACTIVE transition is gated on
+the presenter UI surface AND the runner's command-translation
+behavior landing with end-to-end tests; treating this PR as
+satisfying PUL-F020 would be a traceability/status mismatch.
+
+## Related ADRs
+
+- [ADR-003](003-gsap-timeline-engine.md) — the timeline runner is
+  the seam through which presenter commands are translated into
+  transport calls (`play()` / `pause()` / `seek()` / `tweenTo()`).
+- [ADR-004](004-howler-audio-engine.md) — `ctx.audio` is the seam
+  through which audio cleanup will flow on presenter-driven scene
+  exits when the audio service lands.
+- [ADR-007](007-browser-workbench.md) — defines the seven workbench
+  modes and the URL-only-source invariant for mode selection.
+  Presenter input is scoped to `mode=present` here per ADR-007's
+  mode dispatch.
+- [ADR-008](008-agent-native-authoring.md) — manifests-over-flow-
+  control underpins the no-mode-suppression-in-resolver constraint;
+  the presenter seam is data, not a flow-control hook.
+- [ADR-011](011-composition-resolver-orchestration.md) — the
+  resolver is opaque to mode; presenter scoping lives at the loader.
+- [ADR-013](013-url-navigation-grammar-boundary.md) — the parser
+  preserves `mode` and forbids recovering it from any non-URL
+  source. Presenter source attachment is workbench-supplied, not
+  URL-supplied.
+- [ADR-014](014-url-scene-target-selection.md) — scene navigation
+  dispatch is mode-blind; the bridge forwards `presenter` without
+  interpretation.
+- [ADR-015](015-url-beat-positioning.md) — precedent for "deliver
+  the contract layer; keep the requirement DRAFT until the
+  dependent runner lands."
+- [ADR-016](016-workbench-mode-present.md) — establishes the
+  contract-layer-plus-seam-tests precedent for `mode=present` and
+  names PUL-F020 / PUL-F021 / PUL-F025 as the gating presenter-UI
+  deliveries for PUL-F013 ACTIVE.
+- [ADR-017](017-workbench-mode-standalone.md) through
+  [ADR-021](021-workbench-mode-screenshot.md) — runner-input hint
+  pattern (`repeat` / `hold` / `cueGate` / `screenshot`); ADR-023
+  takes a different shape because presenter is a stream, not a
+  one-shot flag, and acts on every scene rather than just the head.
+- [ADR-022](022-workbench-mode-prompter.md) — loader-side
+  lifecycle bypass with adapter; ADR-023 is structurally similar
+  in that the workbench supplies an optional source, but the
+  lifecycle still runs end-to-end (presenter does not bypass
+  anything; it adds a parallel command channel).

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -48,3 +48,4 @@ Each ADR includes:
 | [020](020-workbench-mode-scrub.md) | Workbench Mode `scrub` — Runner Cue-Gate Hint at the Loader/Runner Seam | Accepted |
 | [021](021-workbench-mode-screenshot.md) | Workbench Mode `screenshot` — Runner Capture-Bundle Hint at the Loader/Runner Seam | Accepted |
 | [022](022-workbench-mode-prompter.md) | Workbench Mode `prompter` — Loader-Side Lifecycle Bypass with Captions Aggregation Seam | Accepted |
+| [023](023-presenter-controls.md) | Presenter Controls — Per-Navigation Command Source at the Loader/Runner Seam | Accepted |

--- a/docs/design/pul-f020-presenter-controls-preflight.md
+++ b/docs/design/pul-f020-presenter-controls-preflight.md
@@ -1,0 +1,158 @@
+# PUL-F020 Presenter Controls Preflight
+
+PUL-F020 specifies the runtime-side acceptance of presenter input
+under `mode=present`: advance to the next beat, hold the current
+beat, skip forward, and skip backward, with beat progression
+interruptible without breaking timeline state. It is one of the
+four facets ADR-016 names as gating PUL-F013 ACTIVE; the visible
+presenter UI surface and the GSAP runner that translates commands
+to transport calls are out of scope for this requirement and are
+the gating deliveries for PUL-F020 ACTIVE.
+
+## Boundary
+
+Presenter input must flow through the existing navigation /
+lifecycle boundary:
+
+- `src/runtime/navigation.ts` owns the `mode` URL grammar and the
+  `NAVIGATION_MODES` allowlist. Presenter input is not a URL
+  parameter; it is a workbench-supplied stream.
+- `effectiveMode()` owns the absent-mode default to `present`. The
+  loader uses this to scope presenter forwarding to mode=present
+  (explicit OR absent).
+- `src/runtime/scene-loader.ts` owns per-navigation mode dispatch,
+  `ctx.mode` construction, AND the per-navigation
+  `PresenterController` construction.
+- `src/runtime/scene-navigation.ts` owns scene/composition target
+  resolution and the lifecycle bridge; it forwards `presenter`
+  without interpretation.
+- `src/runtime/composition-resolver.ts` owns lifecycle ordering,
+  abort propagation, and cleanup; it forwards `presenter` to every
+  scene's run input.
+- `src/runtime/presenter.ts` is the new pure module that defines
+  the command shape, the source/controller interfaces, and the
+  per-navigation controller factory.
+
+Do not add a parallel keyboard listener at the runtime level, a
+second cleanup pathway for presenter-driven aborts, or a
+per-scene command pump. Mode dispatch and per-navigation
+controller construction live at one seam (`buildLoad` in the
+loader); subscriptions auto-detach via the existing
+`AbortController.signal`.
+
+## Required Reuse
+
+Implementation must reuse these cross-cutting concerns:
+
+- URL grammar and mode validation: `parseNavigationSearch()`,
+  `NAVIGATION_MODES`, `effectiveMode()`. Do not introduce a
+  parallel "is present" check or a duplicate mode allowlist.
+- Lifecycle orchestration: `loadSceneNavigationTarget()` and
+  `resolveComposition()`. Forward `presenter` through the existing
+  spread-when-defined pattern parallel to `signal`.
+- Abort and cleanup: one per-navigation `AbortController`. The
+  presenter controller's auto-detach binds to the same signal that
+  drives lifecycle cleanup; no separate cleanup wiring.
+- Error rendering: the loader's `onError` sink. Boundary
+  diagnostics from the controller (unknown command kind, handler
+  exception) flow through the same channel as every other
+  runtime-level error.
+- Frozen invariants: `Object.freeze` for the command-kind allowlist
+  and the command discriminator object so a misbehaving runner
+  cannot mutate them post-emission. `deepFreeze` is not needed
+  (commands are flat).
+- Identifier validation: `src/runtime/identifier.ts` is not used
+  here (commands are kind-based, not id-based).
+
+## Guardrails
+
+- Presenter input is scoped to `mode=present`. The loader builds
+  the controller only when `effectiveMode(target) === 'present'`
+  AND `presenterCommands` is supplied. No leak into standalone /
+  loop / paused / scrub / screenshot / prompter.
+- Commands are translated to timeline operations by the runner,
+  not the runtime core. ADR-003 names GSAP `play()` / `pause()` /
+  `seek()` / `tweenTo()` as the legitimate transport calls. No
+  `setTimeout` / `setInterval` polling for command arrivals.
+- The runtime does not attach keyboard listeners. The future
+  presenter UI module (a workbench surface) attaches listeners,
+  translates them to `PresenterCommand`s, and emits via a
+  `PresenterCommandSource`. ADR-007's "URL is the only source for
+  mode" rule extends here: the runtime does not look at
+  `window.location` or any global to decide whether commands are
+  active; the workbench-supplied source IS the gate.
+- The controller's auto-detach is a safety net, not a substitute
+  for runner hygiene. A runner that subscribes SHOULD still call
+  the returned unsubscribe on its own scene-exit path; the abort-
+  driven detach catches the runner that forgets.
+- Boundary validation drops unknown command kinds. The runner does
+  not see malformed commands; the diagnostic flows through
+  `onError`. Do not throw from the boundary; do not unmount the
+  scene to report a malformed command.
+- The interruptibility clause ("beat progression SHALL be
+  interruptible without breaking timeline state") is satisfied by
+  the existing PUL-F006 mandatory-cleanup invariant. Do not
+  introduce a second cleanup path or skip cleanup on the abort
+  branch.
+
+## Non-Goals
+
+PUL-F020 should not implement:
+
+- Pause / resume (PUL-F021 — separate requirement).
+- Master mute (PUL-F025 — separate requirement).
+- Scene-level skip ("jump to next/prev scene"). The four named
+  commands are beat-level navigation within the active scene;
+  scene-level navigation is a URL-grammar concern (PUL-F008 / PUL-F011).
+- Scrub controls (PUL-F017 / `mode=scrub`). Skip is a discrete
+  beat jump, not a continuous millisecond seek.
+- A remote-presenter protocol (HTTP, WebSocket, etc.). The source
+  is workbench-supplied; how it gathers input (keyboard, on-screen
+  controls, future remote-presenter bridge) is the source's
+  concern.
+- The visible presenter UI surface (keyboard listener, on-screen
+  controls). PUL-F020 ACTIVE depends on this surface; the
+  contract layer ships first per the ADR-016 / ADR-017 / ADR-018 /
+  ADR-019 / ADR-020 / ADR-021 / ADR-022 precedent.
+- The GSAP runner that translates commands to transport calls
+  (ADR-003 territory). PUL-F020 ACTIVE depends on this runner.
+
+## Anti-Patterns
+
+- Attaching keyboard listeners at the scene level. Scenes receive
+  commands through the runner's `input.presenter` subscription
+  (when the runner needs that signal); they do not run their own
+  input pumps.
+- Duplicating `PRESENTER_COMMAND_KINDS` or re-validating command
+  shapes inside the runner. The controller's `isPresenterCommand`
+  check is the single boundary; the runner sees only well-formed
+  commands.
+- Treating skip as scrub. Skip is a beat-level jump; scrub is a
+  continuous-seek interaction model owned by `mode=scrub`.
+- Treating hold as pause. Hold pauses the current beat (timeline
+  paused at the current position); pause / resume is a separate
+  full-composition transport state owned by PUL-F021.
+- Building a long-lived controller that survives across
+  navigations. The controller is per-navigation; subscriptions
+  auto-detach when the navigation aborts. A long-lived controller
+  re-introduces the leak failure mode the per-navigation design
+  defends against.
+- Reading mode from `window.location` to decide whether to subscribe
+  inside the runner. The runner subscribes when `input.presenter`
+  is present; the loader's mode-scoping decides presence.
+- Building a second exception hierarchy for presenter errors. The
+  controller's boundary diagnostics use the existing `onError`
+  sink with plain `Error` objects. Callers pattern-match on the
+  prefix `presenter command rejected:` if they need to (the
+  message naming follows the resolver's `composition resolution
+  failed:` envelope precedent — same prefix-style diagnostic
+  surface, no separate type).
+- Using `setTimeout` / polling to schedule command arrivals. The
+  source emits synchronously; the controller forwards
+  synchronously; the runner translates to GSAP transport calls
+  that are themselves frame-aligned (ADR-003).
+- Creating a `data-pulsar-mode-*` suppression attribute under
+  `mode=present` to gate the runner's subscription. ADR-016 forbids
+  preemptive suppression attributes under `mode=present`. The
+  runner's behavior is gated by `input.presenter`'s presence, not
+  by stage-attribute introspection.

--- a/src/main.ts
+++ b/src/main.ts
@@ -192,6 +192,19 @@ const buildCtx = (mode: NavigationMode): WorkbenchSceneCtx => ({ stage, mode });
 // PUL-F019 (visible captions UI + end-to-end tests).
 const renderPrompter: PrompterRenderer = () => undefined;
 
+// Presenter command source (PUL-F020 / ADR-023): intentionally
+// OMITTED here. PUL-F020 ships only the runtime-side contract
+// layer in this PR — the loader builds a per-navigation
+// `PresenterController` when `mode=present` AND
+// `presenterCommands` is supplied. By omitting the field, the
+// loader gracefully degrades (runners see `input.presenter ===
+// undefined`) and the seam stays structurally inert until a real
+// presenter UI surface lands. The future workbench surface owns
+// the keyboard listener / on-screen controls and emits
+// `PresenterCommand`s through a `PresenterCommandSource`; ADR-023
+// records the DRAFT → ACTIVE bar (presenter UI module + GSAP
+// runner that translates commands to transport calls + end-to-end
+// tests).
 const loader = createSceneLoader({
   scenes: sceneRegistry,
   compositions: compositionRegistry,

--- a/src/runtime/composition-resolver.ts
+++ b/src/runtime/composition-resolver.ts
@@ -48,6 +48,7 @@ import {
   findUnregisteredEntries,
 } from './composition';
 import { describeError } from './error';
+import { type PresenterController, createPresenterController } from './presenter';
 import type { SceneRegistry } from './registry';
 import type { SceneModule } from './scene';
 
@@ -287,6 +288,36 @@ export interface SceneTimelineRunInput {
    * "first frame wins."
    */
   readonly screenshot?: 'capture';
+  /**
+   * Presenter command controller (PUL-F020 / ADR-023). Forwarded to
+   * EVERY scene's run input under `mode=present` (NOT a head-only
+   * field): mode=present runs the FULL composition slice, and
+   * presenter commands act on whichever scene is currently active.
+   * Analogous to {@link signal} in shape, not to the head-only
+   * runner-input hints (`repeat` / `hold` / `cueGate` / `screenshot`
+   * — those modes are single-scene by construction).
+   *
+   * The runner subscribes via `presenter.subscribe(handler)` to
+   * receive {@link import('./presenter').PresenterCommand}s. The
+   * controller auto-detaches every subscription when the
+   * per-navigation `AbortSignal` fires, so a runner that forgets to
+   * unsubscribe cannot leak across navigations. The controller also
+   * validates incoming commands at its boundary (unknown kinds are
+   * dropped before reaching the runner).
+   *
+   * Translation of each command into a timeline operation
+   * (advance → play to next beat, hold → pause at current beat,
+   * skip-forward / skip-backward → seek to next/prev beat) is the
+   * runner's contract per ADR-003 (GSAP transport API). A runner
+   * that ignores `input.presenter` gracefully degrades — the
+   * placeholder runner does this today because it has no real
+   * timeline to drive.
+   *
+   * Absent for every mode other than `present` (the loader scopes
+   * delivery; the resolver does not enforce mode coherence because
+   * mode dispatch is a loader concern per ADR-007).
+   */
+  readonly presenter?: PresenterController;
 }
 
 /**
@@ -435,6 +466,46 @@ export interface ResolveCompositionOptions {
    * mode dispatch lives.
    */
   readonly headScreenshot?: 'capture';
+  /**
+   * URL present-mode presenter controller (PUL-F020 / ADR-023) to
+   * forward to EVERY scene's run input as
+   * {@link SceneTimelineRunInput.presenter}. Unlike the head-only
+   * forwardings above, `presenter` is NOT scoped to plan[0]:
+   * `mode=present` is the only mode that runs the FULL composition
+   * slice (no truncation), and presenter commands act on whichever
+   * scene is currently active. Analogous to {@link signal} in the
+   * resolver's forwarding semantics.
+   *
+   * The resolver does not interpret the controller — translating
+   * {@link import('./presenter').PresenterCommand}s into timeline
+   * operations is the runner's contract per ADR-003 / ADR-023. A
+   * runner that ignores `input.presenter` (e.g. the placeholder
+   * runner with no real timeline) gracefully degrades to no-op
+   * command handling.
+   *
+   * Absent for every mode other than `present` because the loader
+   * scopes delivery (the resolver does not enforce mode coherence;
+   * mode dispatch is a loader concern per ADR-007). A direct bridge
+   * caller that supplies `presenter` for a non-present-mode
+   * navigation will see the controller forwarded to the runner, but
+   * production navigation through the loader cannot reach that
+   * state.
+   */
+  readonly presenter?: PresenterController;
+  /**
+   * Optional diagnostic sink for the per-scene presenter wrapper
+   * (PUL-F020 / ADR-023). When the resolver wraps `presenter` in a
+   * per-scene child controller, it threads this sink so the
+   * wrapper's boundary diagnostics (unknown command kind, runner-
+   * handler exception) surface through the same channel as every
+   * other navigation-level error. Absent: per-scene wrapper drops
+   * diagnostics silently (matches the navigation controller's
+   * behavior when the loader didn't supply its own `onError`).
+   *
+   * Threaded only when a `presenter` is supplied — non-present-mode
+   * navigations have no wrapper and ignore this field.
+   */
+  readonly onPresenterError?: (err: unknown) => void;
 }
 
 /**
@@ -504,6 +575,11 @@ function throwIfAborted(signal: AbortSignal | undefined, detail: string): void {
  * `beat` and `onBeatMissing` are caller-supplied per-call (resolver
  * passes them only for the head plan step); the rest are per-entry
  * (resolver derives from the manifest snapshot).
+ *
+ * `presenter` is forwarded to every plan step (NOT head-only) per
+ * PUL-F020 / ADR-023 — `mode=present` is the only mode that runs
+ * the full composition slice, and presenter commands act on
+ * whichever scene is currently active.
  */
 function buildRunInput(
   step: PlanStep,
@@ -515,6 +591,7 @@ function buildRunInput(
   hold: 'first-frame' | undefined,
   cueGate: 'monotonic-forward' | undefined,
   screenshot: 'capture' | undefined,
+  presenter: PresenterController | undefined,
 ): SceneTimelineRunInput {
   const input: { -readonly [K in keyof SceneTimelineRunInput]: SceneTimelineRunInput[K] } = {
     scene: step.scene,
@@ -529,6 +606,7 @@ function buildRunInput(
   if (hold !== undefined) input.hold = hold;
   if (cueGate !== undefined) input.cueGate = cueGate;
   if (screenshot !== undefined) input.screenshot = screenshot;
+  if (presenter !== undefined) input.presenter = presenter;
   return input;
 }
 
@@ -598,6 +676,8 @@ export async function resolveComposition(options: ResolveCompositionOptions): Pr
     headHold,
     headCueGate,
     headScreenshot,
+    presenter,
+    onPresenterError,
   } = options;
 
   // PUL-F011 / ADR-015: a `headBeat` without an `onBeatMissing` would
@@ -674,7 +754,7 @@ export async function resolveComposition(options: ResolveCompositionOptions): Pr
       `aborted after preloading ${quoteId(step.scene.id)}, before scene activation`,
     );
     const stepHeadOnly = index === 0 ? headOnly : noHeadOnly;
-    await runScene(step, ctx, runTimeline, signal, stepHeadOnly);
+    await runScene(step, ctx, runTimeline, signal, stepHeadOnly, presenter, onPresenterError);
     lastCompletedSceneId = step.scene.id;
   }
 }
@@ -786,7 +866,34 @@ async function runScene(
   runTimeline: SceneTimelineRunner,
   signal: AbortSignal | undefined,
   headOnly: HeadOnlyFields,
+  presenter: PresenterController | undefined,
+  onPresenterError: ((err: unknown) => void) | undefined,
 ): Promise<void> {
+  // PUL-F020 / ADR-023: when the loader supplied a navigation-level
+  // `presenter` controller, wrap it in a PER-SCENE child controller
+  // bound to a per-scene `AbortController` that we fire after the
+  // scene's cleanup. Without this wrapping, a runner that subscribes
+  // via `input.presenter.subscribe(...)` and forgets to unsubscribe
+  // when the scene exits would keep receiving commands during the
+  // NEXT scene's runner — violating "presenter commands act on the
+  // active scene." The navigation-level controller's auto-detach on
+  // navigation abort is the navigation-end safety net; the per-scene
+  // wrapping is the per-scene-end safety net. Both layers compose:
+  // a navigation-level abort cascades through the per-scene wrapper
+  // automatically (the wrapper's source is the navigation controller,
+  // so when the navigation tears down its source-side subscriptions
+  // the wrapper's emissions stop).
+  //
+  // Allocated only when the resolver actually has a presenter to
+  // wrap; the per-scene controller is undefined for the common
+  // no-presenter path so the per-scene plumbing has zero cost in
+  // non-present-mode navigations.
+  const perSceneAbort = presenter === undefined ? undefined : new AbortController();
+  const perScenePresenter =
+    presenter === undefined || perSceneAbort === undefined
+      ? undefined
+      : createPresenterController(presenter, perSceneAbort.signal, onPresenterError);
+
   // Track failure with explicit booleans so `throw undefined` /
   // `Promise.reject(undefined)` are still treated as failures. Using
   // `phaseError !== undefined` as the sentinel would silently swallow
@@ -814,6 +921,7 @@ async function runScene(
         headOnly.hold,
         headOnly.cueGate,
         headOnly.screenshot,
+        perScenePresenter,
       ),
     );
   } catch (err) {
@@ -829,6 +937,15 @@ async function runScene(
     cleanupFailed = true;
     cleanupError = err;
   }
+
+  // Tear the per-scene presenter controller down AFTER cleanup so a
+  // runner that subscribed in `runTimeline` and forgot to unsubscribe
+  // still sees its subscription release before the next scene's
+  // runner is invoked. Cleanup runs first so any cleanup hook that
+  // legitimately calls into the runner (no current pattern, but
+  // defensive) still observes presenter commands. Idempotent:
+  // aborting an already-aborted signal is a no-op.
+  perSceneAbort?.abort();
 
   finalizeSceneFailure(scene, phase, phaseFailed, phaseError, cleanupFailed, cleanupError);
 }

--- a/src/runtime/presenter.ts
+++ b/src/runtime/presenter.ts
@@ -1,0 +1,276 @@
+// Presenter controls — PUL-F020 / ADR-023.
+//
+// Defines the runtime-side contract layer for accepting presenter
+// commands under `mode=present`. The runtime does not own the input
+// surface (keyboard, on-screen controls, remote presenter); a future
+// workbench bootstrap supplies a {@link PresenterCommandSource} that
+// the loader wraps in a per-navigation {@link PresenterController}
+// before forwarding it to the timeline runner via
+// {@link import('./composition-resolver').SceneTimelineRunInput.presenter}.
+//
+// The runner — not this module — translates a command into a timeline
+// operation (ADR-003: GSAP `play()` / `pause()` / `seek()` /
+// `tweenTo()`). PUL-F020 stays DRAFT until a real presenter UI lands
+// AND end-to-end tests confirm advance / hold / skip-forward /
+// skip-backward actually move beat state without breaking the
+// timeline.
+//
+// References:
+//  - PUL-F020 — runtime SHALL accept presenter input under
+//    `mode=present` for advance / hold / skip-forward / skip-backward;
+//    beat progression SHALL be interruptible without breaking
+//    timeline state.
+//  - ADR-023 — workbench presenter controls: command source +
+//    per-navigation controller seam.
+//  - ADR-003 — GSAP timeline engine. The runner consumes
+//    {@link PresenterCommand} and dispatches via GSAP's transport API.
+//  - ADR-007 — workbench mode dispatch; presenter input is scoped to
+//    `mode=present`.
+//  - ADR-016 — ADR-016 names PUL-F020 as one of the four facets that
+//    gates PUL-F013 ACTIVE.
+
+/**
+ * The four command kinds PUL-F020 names. Centralized as a single
+ * source of truth so the validator and the discriminated-union type
+ * cannot drift. Frozen so a misbehaving caller cannot mutate the
+ * allowlist at runtime.
+ */
+export const PRESENTER_COMMAND_KINDS = Object.freeze([
+  'advance',
+  'hold',
+  'skip-forward',
+  'skip-backward',
+] as const);
+
+/** Element type of {@link PRESENTER_COMMAND_KINDS}. */
+export type PresenterCommandKind = (typeof PRESENTER_COMMAND_KINDS)[number];
+
+/**
+ * One presenter command. Discriminated by `kind` so future extensions
+ * (e.g., timed advance with duration) can add fields per-kind without
+ * breaking the existing four-shape contract.
+ */
+export interface PresenterCommand {
+  readonly kind: PresenterCommandKind;
+}
+
+/**
+ * The workbench-supplied input surface for presenter commands.
+ * Lives across navigations: the loader does not construct or own
+ * the source; it merely subscribes to it for the lifetime of each
+ * `mode=present` navigation through a per-navigation
+ * {@link PresenterController}.
+ *
+ * `subscribe` returns an unsubscribe callback. Implementations
+ * SHOULD invoke a handler synchronously when a command arrives so
+ * the runner can correlate command receipt to the active scene's
+ * timeline state without microtask gaps.
+ */
+export interface PresenterCommandSource {
+  subscribe(handler: (cmd: PresenterCommand) => void): () => void;
+}
+
+/**
+ * Per-navigation handle the timeline runner receives on
+ * {@link import('./composition-resolver').SceneTimelineRunInput.presenter}.
+ * Same `subscribe(handler): () => void` shape as
+ * {@link PresenterCommandSource} but with two safety properties:
+ *
+ *  - **Auto-cleanup on abort.** Every subscription is registered with
+ *    the per-navigation `AbortSignal`. When the navigation aborts
+ *    (next handle, dispose, popstate, presenter-driven scene exit),
+ *    every outstanding subscription is detached from the source and
+ *    no further emissions reach the runner. A runner that forgets to
+ *    unsubscribe cannot leak across navigations.
+ *  - **Boundary validation.** Commands flowing through the controller
+ *    are validated against {@link PRESENTER_COMMAND_KINDS}; unknown
+ *    kinds are dropped without throwing and surfaced through the
+ *    optional `onError` sink (parallel to the loader's error
+ *    surface).
+ *
+ * The controller is constructed by the loader via
+ * {@link createPresenterController} for each `mode=present`
+ * navigation when the workbench supplied a source. Other modes
+ * never see a controller.
+ */
+export interface PresenterController {
+  subscribe(handler: (cmd: PresenterCommand) => void): () => void;
+}
+
+/**
+ * Type guard for {@link PresenterCommand}. Used at the controller's
+ * boundary to drop malformed values from a programmatic source
+ * (test harness, future remote-presenter bridge, etc.) before they
+ * reach the runner. Pure function — no closure captures.
+ */
+export function isPresenterCommand(value: unknown): value is PresenterCommand {
+  if (typeof value !== 'object' || value === null) return false;
+  // Reject arrays explicitly so `[]` does not satisfy the
+  // `'kind' in value` shape check below by virtue of an inherited
+  // `kind` property (none today, but defensive against future
+  // prototype pollution).
+  if (Array.isArray(value)) return false;
+  const kind = (value as { kind?: unknown }).kind;
+  if (typeof kind !== 'string') return false;
+  return (PRESENTER_COMMAND_KINDS as readonly string[]).includes(kind);
+}
+
+/**
+ * Build a {@link PresenterController} bound to `source` and
+ * `signal`. The controller proxies `subscribe` through the source,
+ * tracks every outstanding subscription, validates incoming
+ * commands, and detaches all subscriptions when the signal aborts.
+ *
+ * Parameters:
+ *  - `source` — the long-lived workbench command source.
+ *  - `signal` — the per-navigation `AbortSignal` from the loader's
+ *    `AbortController`. Aborting this signal tears down every
+ *    subscription this controller created.
+ *  - `onError` — optional sink for boundary diagnostics (unknown
+ *    command kind, handler exception). Defaults to a silent drop
+ *    so test harnesses without an error sink do not need to wire
+ *    one. The loader passes its own `onError` so production
+ *    diagnostics flow through the same channel as every other
+ *    runtime-level error.
+ *
+ * Idempotent on a pre-aborted signal: when `signal.aborted` is
+ * true at construction time, `subscribe` is a no-op that returns
+ * a no-op unsubscribe. No source subscription is created.
+ */
+export function createPresenterController(
+  source: PresenterCommandSource,
+  signal: AbortSignal,
+  onError?: (err: unknown) => void,
+): PresenterController {
+  // One record per active subscription. `active` is the single
+  // source of truth for "this subscription is live" — both the
+  // per-subscriber unsubscribe AND the abort-driven tearDownAll
+  // check it before calling `sourceUnsub`, so a non-idempotent
+  // source receives at most one unsubscribe per registration even
+  // when both teardown paths fire (codex review: abort-then-runner-
+  // unsubscribe and per-scene-after-nav-abort are real overlapping
+  // paths). The wrapped handler also checks `active` before
+  // forwarding, so post-abort emissions cannot reach the runner
+  // even if a misbehaving source ignored or threw on its
+  // unsubscribe.
+  interface Subscription {
+    active: boolean;
+    sourceUnsub: () => void;
+  }
+  const subscriptions: Subscription[] = [];
+  let aborted = signal.aborted;
+
+  const reportError = (err: unknown): void => {
+    if (onError === undefined) return;
+    try {
+      onError(err);
+    } catch {
+      // The error sink itself threw. There is no further surface
+      // to surface that on, and re-raising would propagate through
+      // the source's emission loop (potentially skipping later
+      // handlers — same failure mode the per-handler isolation
+      // below defends against). Swallow; the boundary already did
+      // its job by dropping the malformed command.
+    }
+  };
+
+  const tearDownSubscription = (sub: Subscription): void => {
+    if (!sub.active) return;
+    // Mark inactive BEFORE calling sourceUnsub so the wrapped
+    // handler's `!sub.active` guard fires for any in-flight
+    // emissions the source is still mid-iteration over (covers
+    // sources whose unsubscribe is asynchronous-leaning or whose
+    // accounting is non-idempotent).
+    sub.active = false;
+    try {
+      sub.sourceUnsub();
+    } catch (err) {
+      // A misbehaving source could throw on unsubscribe; record
+      // the diagnostic but keep tearing the rest down. Without
+      // the catch a single bad source would strand the remaining
+      // subscriptions.
+      reportError(err);
+    }
+  };
+
+  const tearDownAll = (): void => {
+    aborted = true;
+    // Drain into a local copy so concurrent mutation (an
+    // unsubscribe callback that triggers another unsubscribe)
+    // cannot skip entries. Splice-clear the live array first so
+    // any later code path sees an empty registry.
+    const drained = subscriptions.splice(0, subscriptions.length);
+    for (const sub of drained) {
+      tearDownSubscription(sub);
+    }
+  };
+
+  if (aborted) {
+    // Signal already fired before construction. Nothing to wire;
+    // subscribe will fall through to the aborted no-op below.
+  } else {
+    signal.addEventListener('abort', tearDownAll, { once: true });
+  }
+
+  const subscribe = (handler: (cmd: PresenterCommand) => void): (() => void) => {
+    if (aborted) {
+      // Post-abort subscribes are inert by contract — no source
+      // attachment, no emissions, no leak.
+      return () => undefined;
+    }
+    // Pre-allocate the subscription record so the wrapped handler
+    // closure can capture it. `sourceUnsub` is patched in
+    // immediately after `source.subscribe(wrapped)` returns.
+    const sub: Subscription = { active: true, sourceUnsub: () => undefined };
+    // Validate-and-forward wrapper. Five guards layer here:
+    //   1. `!sub.active` — post-abort or post-unsubscribe emission
+    //      from a misbehaving source whose own unsubscribe didn't
+    //      actually detach. Without this, a bad source could
+    //      deliver commands to a runner whose subscription was
+    //      torn down. This is the leak-prevention invariant
+    //      (codex review).
+    //   2. `aborted` — controller-level abort guard. Same defense
+    //      as `!sub.active` but cheaper to check (one bool).
+    //   3. `isPresenterCommand` — boundary validation; unknown
+    //      kinds are dropped with an `onError` diagnostic.
+    //   4. Frozen defensive copy of the command — one subscriber
+    //      cannot mutate `kind` and corrupt later subscribers'
+    //      view of the same emission (the source emits ONE
+    //      reference to every wrapped handler).
+    //   5. Per-handler try/catch — a buggy subscriber cannot
+    //      poison emissions for siblings; exceptions flow through
+    //      `onError`.
+    const wrapped = (cmd: unknown): void => {
+      if (!sub.active || aborted) return;
+      if (!isPresenterCommand(cmd)) {
+        reportError(
+          new Error(
+            `presenter command rejected: payload does not match the PresenterCommand shape (allowed kinds: ${PRESENTER_COMMAND_KINDS.join(', ')})`,
+          ),
+        );
+        return;
+      }
+      const safe: PresenterCommand = Object.freeze({ kind: cmd.kind });
+      try {
+        handler(safe);
+      } catch (err) {
+        reportError(err);
+      }
+    };
+    sub.sourceUnsub = source.subscribe(wrapped);
+    subscriptions.push(sub);
+    return () => {
+      // Idempotent: re-calling does nothing because
+      // `tearDownSubscription` short-circuits on `!sub.active`.
+      // Also covers the abort-then-runner-unsubscribe race where
+      // the abort listener already drained this sub; the
+      // remove-then-tear-down sequence handles either order
+      // safely.
+      const idx = subscriptions.indexOf(sub);
+      if (idx >= 0) subscriptions.splice(idx, 1);
+      tearDownSubscription(sub);
+    };
+  };
+
+  return { subscribe };
+}

--- a/src/runtime/scene-loader.ts
+++ b/src/runtime/scene-loader.ts
@@ -39,6 +39,7 @@ import {
   type NavigationTarget,
   effectiveMode,
 } from './navigation';
+import { type PresenterCommandSource, createPresenterController } from './presenter';
 import {
   type PrompterDispose,
   type PrompterRenderer,
@@ -169,6 +170,26 @@ export interface SceneLoaderOptions {
    * UI surface lands.
    */
   readonly renderPrompter?: PrompterRenderer;
+  /**
+   * Workbench-supplied presenter command source (PUL-F020 / ADR-023).
+   * Lives across navigations; the loader does not own or construct
+   * it. When supplied AND the per-navigation `effectiveMode(target)`
+   * is `'present'`, the loader wraps it in a per-navigation
+   * {@link import('./presenter').PresenterController} bound to the
+   * navigation's `AbortController.signal` and forwards the controller
+   * to the timeline runner via `input.presenter`. Other modes never
+   * see the controller — presenter input is scoped to `mode=present`
+   * by ADR-007. Per-navigation auto-cleanup means a runner that
+   * subscribes via `input.presenter.subscribe(...)` and forgets to
+   * unsubscribe cannot leak across navigations.
+   *
+   * Optional: a workbench bootstrap that has not yet wired a
+   * presenter UI omits the field. Under that configuration the
+   * loader does not build a controller, runners see
+   * `input.presenter === undefined`, and the seam is structurally
+   * inert until the workbench wires a real source.
+   */
+  readonly presenterCommands?: PresenterCommandSource;
   /**
    * Sink for navigation errors (resolution failure, lifecycle phase
    * throw). Defaults to `console.error` in production but is
@@ -525,6 +546,34 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
     // exclusive at the URL boundary, so at most one of `repeat` /
     // `hold` / `cueGate` / `screenshot` is non-undefined here.
     const screenshot: 'capture' | undefined = mode === 'screenshot' ? 'capture' : undefined;
+    // PUL-F020 / ADR-023: under `mode=present` the loader builds a
+    // per-navigation `PresenterController` bound to this load's
+    // `controller.signal` and forwards it to every scene's run input
+    // via the bridge → resolver. Two scoping conditions: the mode
+    // must resolve to `'present'` (URL `mode=present` OR absent
+    // `mode=`, both of which `effectiveMode` collapses), AND the
+    // workbench must have supplied a `presenterCommands` source.
+    // When either condition is unmet, `presenter` is `undefined` and
+    // the spread below omits it from the bridge call so a runner
+    // that branches on `'presenter' in input` sees an absent key
+    // (parity with the `repeat` / `hold` / `cueGate` / `screenshot`
+    // / `beat` plumbing).
+    //
+    // Auto-cleanup: the controller registers `controller.signal`'s
+    // abort listener internally. When the navigation aborts (next
+    // handle, dispose, popstate, presenter-driven scene exit), every
+    // outstanding runner subscription is detached from the source.
+    // A runner that subscribes via `input.presenter.subscribe(...)`
+    // and forgets to unsubscribe cannot leak across navigations.
+    //
+    // Per ADR-007, mode dispatch lives in the runtime core, not at
+    // adapters; this is the central enforcement point for "presenter
+    // input only under mode=present" — no other code path builds the
+    // controller.
+    const presenter =
+      mode === 'present' && options.presenterCommands !== undefined
+        ? createPresenterController(options.presenterCommands, controller.signal, onError)
+        : undefined;
     return {
       controller,
       settled: loadSceneNavigationTarget(resolved, {
@@ -538,6 +587,12 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
         ...(hold === undefined ? {} : { hold }),
         ...(cueGate === undefined ? {} : { cueGate }),
         ...(screenshot === undefined ? {} : { screenshot }),
+        // Forward `presenter` AND the `onError` sink so the
+        // resolver's per-scene wrapper around `presenter` can
+        // route runner-handler exceptions / unknown-kind drops
+        // through the same diagnostic channel as every other
+        // navigation-level error (codex review, cycle 2).
+        ...(presenter === undefined ? {} : { presenter, onPresenterError: onError }),
       }),
       silent: false,
     };

--- a/src/runtime/scene-navigation.ts
+++ b/src/runtime/scene-navigation.ts
@@ -39,6 +39,7 @@ import {
 } from './composition-resolver';
 import type { NavigationTarget } from './navigation';
 import { deepFreeze } from './object';
+import type { PresenterController } from './presenter';
 import { type SceneRegistry, createSceneRegistry } from './registry';
 import type { SceneModule } from './scene';
 
@@ -193,6 +194,44 @@ export interface LoadSceneNavigationTargetOptions {
    * coherence — ctx is opaque per ADR-011.
    */
   readonly screenshot?: 'capture';
+  /**
+   * URL present-mode presenter controller (PUL-F020 / ADR-023). The
+   * loader builds a per-navigation
+   * {@link import('./presenter').PresenterController} bound to its
+   * `AbortController.signal` when `effectiveMode(target) === 'present'`
+   * AND the workbench supplied a `presenterCommands` source, then
+   * forwards it here. The bridge passes it to {@link resolveComposition}
+   * as `presenter`; the resolver hands it to EVERY scene's run input
+   * (NOT head-only) because mode=present runs the FULL composition
+   * slice and presenter commands act on whichever scene is active.
+   *
+   * The bridge does NOT truncate the slice when `presenter` is
+   * supplied — `presenter` is independent of the four head-only
+   * runner-input hints (`repeat` / `hold` / `cueGate` /
+   * `screenshot`), every one of which corresponds to a single-
+   * scene-execution mode where truncation enforces "no following
+   * entries run." Mode=present has no such promise; truncating
+   * would silently drop tail-scene presenter handling.
+   *
+   * Absent for every mode other than `present` because the loader
+   * scopes delivery (the bridge does not enforce mode coherence;
+   * mode dispatch is a loader concern per ADR-007). Direct bridge
+   * callers — outside the loader path — supplying `presenter` for
+   * a non-present-mode navigation will see the controller forwarded
+   * to every scene's run input, but production navigation through
+   * the loader cannot reach that state.
+   */
+  readonly presenter?: PresenterController;
+  /**
+   * Optional diagnostic sink for the per-scene presenter wrapper
+   * (PUL-F020 / ADR-023). Forwarded to {@link resolveComposition}
+   * as `onPresenterError`. The loader threads its own `onError`
+   * here so a runner-handler exception (or an unknown command kind
+   * that reaches a per-scene wrapper) surfaces through the same
+   * diagnostic channel as every other navigation-level error.
+   * Absent: the per-scene wrapper drops diagnostics silently.
+   */
+  readonly onPresenterError?: (err: unknown) => void;
 }
 
 const NAV_FAIL_PREFIX = 'scene navigation failed:';
@@ -584,5 +623,25 @@ export async function loadSceneNavigationTarget(
     // `'screenshot' in input` sees an absent key rather than
     // `undefined`.
     ...(options.screenshot === undefined ? {} : { headScreenshot: options.screenshot }),
+    // `presenter` is independent of `beat`, `repeat`, `hold`,
+    // `cueGate`, and `screenshot` per ADR-023: presenter input is
+    // only valid under `mode=present` (the loader scopes delivery),
+    // and that mode has no head-only structural promise to defend.
+    // Spread `presenter` only when the caller supplied it so a
+    // runner that branches on `'presenter' in input` sees an absent
+    // key rather than `undefined`. The resolver forwards it to
+    // EVERY scene's run input (NOT head-only) — mode=present runs
+    // the full slice and presenter commands act on whichever scene
+    // is active.
+    ...(options.presenter === undefined ? {} : { presenter: options.presenter }),
+    // `onPresenterError` is paired with `presenter` per ADR-023 —
+    // a sink without a controller has nothing to surface
+    // diagnostics from. Drop the sink when no presenter is
+    // supplied; otherwise spread it so the per-scene wrapper inside
+    // the resolver routes its boundary diagnostics through the
+    // loader's `onError` channel.
+    ...(options.presenter === undefined || options.onPresenterError === undefined
+      ? {}
+      : { onPresenterError: options.onPresenterError }),
   });
 }

--- a/tests/runtime/composition-resolver.test.ts
+++ b/tests/runtime/composition-resolver.test.ts
@@ -7,6 +7,7 @@ import {
   type SceneTimelineRunner,
   resolveComposition,
 } from '../../src/runtime/composition-resolver';
+import { createPresenterController } from '../../src/runtime/presenter';
 import { createSceneRegistry } from '../../src/runtime/registry';
 import type { SceneModule } from '../../src/runtime/scene';
 
@@ -1783,5 +1784,191 @@ describe('URL screenshot-mode runner capture-hint forwarding (PUL-F018)', () => 
     expect(runCalls[0]?.hold).toBe('first-frame');
     expect(runCalls[0]?.cueGate).toBe('monotonic-forward');
     expect(runCalls[0]?.screenshot).toBe('capture');
+  });
+});
+
+describe('URL present-mode runner presenter forwarding (PUL-F020)', () => {
+  // PUL-F020: in `mode=present`, the runtime SHALL accept presenter
+  // input (advance, hold, skip-forward, skip-backward); beat
+  // progression SHALL be interruptible without breaking timeline
+  // state. ADR-023 places mode dispatch at the loader and the
+  // command-translation semantics (a kind → GSAP transport call) at
+  // the timeline-runner adapter. Unlike the head-only forwardings
+  // (`headBeat` / `headRepeat` / `headHold` / `headCueGate` /
+  // `headScreenshot`), `presenter` is forwarded to EVERY scene's
+  // run input because mode=present runs the FULL composition slice
+  // (no truncation) and presenter commands act on whichever scene
+  // is currently active. The shape is analogous to `signal`, not to
+  // the head-only hints. The resolver does NOT interpret the
+  // controller itself; subscribing and translating commands is the
+  // runner's contract.
+
+  it('forwards a `presenter` controller to EVERY scene in a multi-scene plan (NOT head-only) — commands delegate from the navigation controller', async () => {
+    // The resolver wraps the navigation-level controller in a
+    // PER-SCENE child controller (see ADR-023). The runner sees a
+    // distinct wrapper per scene, not the navigation controller
+    // directly — this is the per-scene-end safety net that detaches
+    // a forgotten subscription before the next scene starts. The
+    // wrapper still delegates to the source: a command emitted via
+    // the source reaches the wrapper subscriber.
+    const sourceHandlers = new Set<
+      (cmd: import('../../src/runtime/presenter').PresenterCommand) => void
+    >();
+    const source = {
+      subscribe(handler: (cmd: import('../../src/runtime/presenter').PresenterCommand) => void) {
+        sourceHandlers.add(handler);
+        return () => {
+          sourceHandlers.delete(handler);
+        };
+      },
+    };
+    const ac = new AbortController();
+    const presenter = createPresenterController(source, ac.signal);
+
+    const runReceivedKinds: { sceneId: string; kinds: string[] }[] = [];
+    const { options } = buildHarness({
+      scenes: [{ id: 'scene-a' }, { id: 'scene-b' }, { id: 'scene-c' }],
+      manifest: ['scene-a', 'scene-b', 'scene-c'],
+      runTimeline: (input) => {
+        const kinds: string[] = [];
+        // Subscribe; must observe a command emitted DURING this
+        // scene. Scene-id-keyed so the test assertion stays
+        // distinct per scene.
+        input.presenter?.subscribe((cmd) => kinds.push(cmd.kind));
+        // Emit while the wrapper subscription is live.
+        for (const h of sourceHandlers) h({ kind: 'advance' });
+        runReceivedKinds.push({ sceneId: input.scene.id, kinds });
+      },
+    });
+    await resolveComposition({ ...options, presenter });
+    expect(runReceivedKinds).toEqual([
+      { sceneId: 'scene-a', kinds: ['advance'] },
+      { sceneId: 'scene-b', kinds: ['advance'] },
+      { sceneId: 'scene-c', kinds: ['advance'] },
+    ]);
+  });
+
+  it('detaches scene-A subscriptions before scene-B runs (per-scene auto-cleanup; runner that forgets to unsubscribe cannot leak across scenes)', async () => {
+    // Codex review: the navigation-level controller's auto-detach
+    // only fires on navigation abort. Without per-scene wrapping,
+    // scene-A's runner that forgets to unsubscribe would keep
+    // receiving commands during scene-B, violating "presenter
+    // commands act on the active scene."
+    const sourceHandlers = new Set<
+      (cmd: import('../../src/runtime/presenter').PresenterCommand) => void
+    >();
+    const source = {
+      subscribe(handler: (cmd: import('../../src/runtime/presenter').PresenterCommand) => void) {
+        sourceHandlers.add(handler);
+        return () => {
+          sourceHandlers.delete(handler);
+        };
+      },
+    };
+    const ac = new AbortController();
+    const presenter = createPresenterController(source, ac.signal);
+
+    // Each scene's "runner" subscribes and never unsubscribes
+    // explicitly. The per-scene wrapper must release the
+    // subscription on its own when the scene exits.
+    const sceneACommands: string[] = [];
+    const sceneBCommands: string[] = [];
+    const { options } = buildHarness({
+      scenes: [{ id: 'scene-a' }, { id: 'scene-b' }],
+      manifest: ['scene-a', 'scene-b'],
+      runTimeline: (input) => {
+        if (input.scene.id === 'scene-a') {
+          input.presenter?.subscribe((cmd) => sceneACommands.push(cmd.kind));
+        } else {
+          input.presenter?.subscribe((cmd) => sceneBCommands.push(cmd.kind));
+          // Emit AFTER subscribing during scene-b. If scene-a's
+          // subscription leaked, sceneACommands would now grow.
+          for (const h of sourceHandlers) h({ kind: 'advance' });
+        }
+      },
+    });
+    await resolveComposition({ ...options, presenter });
+    expect(sceneACommands).toEqual([]);
+    expect(sceneBCommands).toEqual(['advance']);
+  });
+
+  it('omits `presenter` from every run input when not supplied (no `presenter in input` key)', async () => {
+    const runCalls: SceneTimelineRunInput[] = [];
+    const { options } = buildHarness({
+      scenes: [{ id: 'scene-a' }, { id: 'scene-b' }],
+      manifest: ['scene-a', 'scene-b'],
+      runTimeline: (input) => {
+        runCalls.push(input);
+      },
+    });
+    await resolveComposition(options);
+    expect(runCalls).toHaveLength(2);
+    for (const call of runCalls) {
+      expect('presenter' in (call as object)).toBe(false);
+    }
+  });
+
+  it('does not interpret the controller — a runner that ignores `presenter` and returns normally does not error', async () => {
+    // Resolver delegates command translation to the runner per
+    // ADR-023. A runner that receives `input.presenter` and never
+    // subscribes (e.g. the placeholder runner that has no real
+    // timeline to drive) must NOT cause the resolver to throw or
+    // skip cleanup.
+    const cleanupCalls: string[] = [];
+    const { options } = buildHarness({
+      scenes: [
+        {
+          id: 'scene-a',
+          cleanup: () => {
+            cleanupCalls.push('scene-a');
+          },
+        },
+      ],
+      manifest: ['scene-a'],
+      runTimeline: () => undefined,
+    });
+    const ac = new AbortController();
+    const presenter = createPresenterController({ subscribe: () => () => undefined }, ac.signal);
+    await expect(resolveComposition({ ...options, presenter })).resolves.toBeUndefined();
+    expect(cleanupCalls).toEqual(['scene-a']);
+  });
+
+  it('forwards `presenter` alongside `signal` and the head-only hints independently — every channel reaches the runner without coupling', async () => {
+    // `presenter`, `signal`, and the head-only forwardings are
+    // independent channels. A regression that paired them — e.g.
+    // dropping `presenter` when `headRepeat` is also supplied —
+    // would silently disable presenter input under combinations a
+    // direct bridge caller can request. Pinning the independence
+    // forces the resolver to forward each channel on its own
+    // gating condition.
+    const runCalls: SceneTimelineRunInput[] = [];
+    const { options } = buildHarness({
+      scenes: [{ id: 'scene-a' }],
+      manifest: ['scene-a'],
+      runTimeline: (input) => {
+        runCalls.push(input);
+      },
+    });
+    const ac = new AbortController();
+    const presenter = createPresenterController({ subscribe: () => () => undefined }, ac.signal);
+    const lifecycleSignal = new AbortController().signal;
+    await resolveComposition({
+      ...options,
+      signal: lifecycleSignal,
+      headBeat: 'midpoint',
+      onBeatMissing: () => undefined,
+      headRepeat: 'until-aborted',
+      presenter,
+    });
+    expect(runCalls).toHaveLength(1);
+    // Per ADR-023 the runner sees a per-scene wrapper, not the
+    // navigation controller directly. Assert the wrapper was
+    // present alongside the other independent channels — they
+    // must all coexist on the same run input.
+    expect(runCalls[0]?.presenter).toBeDefined();
+    expect(runCalls[0]?.presenter).not.toBe(presenter);
+    expect(runCalls[0]?.signal).toBe(lifecycleSignal);
+    expect(runCalls[0]?.beat).toBe('midpoint');
+    expect(runCalls[0]?.repeat).toBe('until-aborted');
   });
 });

--- a/tests/runtime/presenter.test.ts
+++ b/tests/runtime/presenter.test.ts
@@ -1,0 +1,330 @@
+// Presenter controls — PUL-F020 / ADR-023.
+//
+// Pure tests for the presenter command boundary: the discriminator
+// validator, the per-navigation controller's subscribe / unsubscribe
+// semantics, and the abort-tied auto-cleanup that prevents
+// subscriptions from leaking across navigations. The loader-side
+// dispatch tests live in `scene-loader.test.ts`'s presenter-controls
+// describe block.
+//
+// References:
+//  - PUL-F020 — runtime SHALL accept presenter input under mode=present.
+//  - ADR-023 — presenter command source / per-navigation controller.
+
+import { describe, expect, it, vi } from 'vitest';
+import {
+  PRESENTER_COMMAND_KINDS,
+  type PresenterCommand,
+  type PresenterCommandSource,
+  createPresenterController,
+  isPresenterCommand,
+} from '../../src/runtime/presenter';
+
+const buildSource = (): {
+  source: PresenterCommandSource;
+  emit: (cmd: unknown) => void;
+  handlers: Set<(cmd: PresenterCommand) => void>;
+} => {
+  const handlers = new Set<(cmd: PresenterCommand) => void>();
+  const source: PresenterCommandSource = {
+    subscribe(handler) {
+      handlers.add(handler);
+      return () => {
+        handlers.delete(handler);
+      };
+    },
+  };
+  const emit = (cmd: unknown): void => {
+    for (const h of handlers) h(cmd as PresenterCommand);
+  };
+  return { source, emit, handlers };
+};
+
+describe('PRESENTER_COMMAND_KINDS', () => {
+  it('lists exactly the four kinds PUL-F020 names', () => {
+    expect([...PRESENTER_COMMAND_KINDS]).toEqual([
+      'advance',
+      'hold',
+      'skip-forward',
+      'skip-backward',
+    ]);
+  });
+
+  it('is frozen so callers cannot mutate the allowlist at runtime', () => {
+    expect(Object.isFrozen(PRESENTER_COMMAND_KINDS)).toBe(true);
+  });
+});
+
+describe('isPresenterCommand (PUL-F020 / ADR-023)', () => {
+  it('accepts every kind PUL-F020 names', () => {
+    for (const kind of PRESENTER_COMMAND_KINDS) {
+      expect(isPresenterCommand({ kind })).toBe(true);
+    }
+  });
+
+  it('rejects an unknown kind', () => {
+    expect(isPresenterCommand({ kind: 'rewind' })).toBe(false);
+    expect(isPresenterCommand({ kind: '' })).toBe(false);
+    expect(isPresenterCommand({ kind: 'ADVANCE' })).toBe(false);
+  });
+
+  it('rejects values that are not plain command objects', () => {
+    expect(isPresenterCommand(null)).toBe(false);
+    expect(isPresenterCommand(undefined)).toBe(false);
+    expect(isPresenterCommand('advance')).toBe(false);
+    expect(isPresenterCommand(42)).toBe(false);
+    expect(isPresenterCommand([])).toBe(false);
+    expect(isPresenterCommand({})).toBe(false);
+  });
+
+  it('rejects when "kind" is the wrong type even if present', () => {
+    expect(isPresenterCommand({ kind: 1 })).toBe(false);
+    expect(isPresenterCommand({ kind: null })).toBe(false);
+    expect(isPresenterCommand({ kind: undefined })).toBe(false);
+  });
+});
+
+describe('createPresenterController (PUL-F020 / ADR-023)', () => {
+  it('forwards every valid command from the source to the subscribed handler', () => {
+    const { source, emit } = buildSource();
+    const controller = new AbortController();
+    const ctl = createPresenterController(source, controller.signal);
+    const seen: PresenterCommand[] = [];
+    ctl.subscribe((cmd) => seen.push(cmd));
+    for (const kind of PRESENTER_COMMAND_KINDS) {
+      emit({ kind });
+    }
+    expect(seen.map((c) => c.kind)).toEqual(['advance', 'hold', 'skip-forward', 'skip-backward']);
+  });
+
+  it('returns an unsubscribe that detaches the handler from further emissions', () => {
+    const { source, emit } = buildSource();
+    const controller = new AbortController();
+    const ctl = createPresenterController(source, controller.signal);
+    const seen: PresenterCommand[] = [];
+    const unsub = ctl.subscribe((cmd) => seen.push(cmd));
+    emit({ kind: 'advance' });
+    unsub();
+    emit({ kind: 'hold' });
+    expect(seen.map((c) => c.kind)).toEqual(['advance']);
+  });
+
+  it('auto-tears-down every outstanding subscription when the signal aborts', () => {
+    const { source, emit, handlers } = buildSource();
+    const controller = new AbortController();
+    const ctl = createPresenterController(source, controller.signal);
+    const seenA: PresenterCommand[] = [];
+    const seenB: PresenterCommand[] = [];
+    ctl.subscribe((cmd) => seenA.push(cmd));
+    ctl.subscribe((cmd) => seenB.push(cmd));
+    emit({ kind: 'advance' });
+    controller.abort();
+    emit({ kind: 'hold' });
+    expect(seenA.map((c) => c.kind)).toEqual(['advance']);
+    expect(seenB.map((c) => c.kind)).toEqual(['advance']);
+    // The controller must remove its own source subscription too — a
+    // controller that left handlers attached to the source would leak
+    // memory across navigations even though emissions are blocked.
+    expect(handlers.size).toBe(0);
+  });
+
+  it('subscribe-after-abort returns a no-op unsubscribe and never emits', () => {
+    const { source, emit, handlers } = buildSource();
+    const controller = new AbortController();
+    const ctl = createPresenterController(source, controller.signal);
+    controller.abort();
+    const seen: PresenterCommand[] = [];
+    const unsub = ctl.subscribe((cmd) => seen.push(cmd));
+    emit({ kind: 'advance' });
+    expect(seen).toEqual([]);
+    expect(handlers.size).toBe(0);
+    expect(() => unsub()).not.toThrow();
+  });
+
+  it('treats a signal that is already aborted at construction as fully torn down', () => {
+    const { source, emit, handlers } = buildSource();
+    const controller = new AbortController();
+    controller.abort();
+    const ctl = createPresenterController(source, controller.signal);
+    const seen: PresenterCommand[] = [];
+    ctl.subscribe((cmd) => seen.push(cmd));
+    emit({ kind: 'advance' });
+    expect(seen).toEqual([]);
+    expect(handlers.size).toBe(0);
+  });
+
+  it('drops unknown command kinds at the controller boundary and reports via onError', () => {
+    const { source, emit } = buildSource();
+    const controller = new AbortController();
+    const onError = vi.fn();
+    const ctl = createPresenterController(source, controller.signal, onError);
+    const seen: PresenterCommand[] = [];
+    ctl.subscribe((cmd) => seen.push(cmd));
+    emit({ kind: 'rewind' });
+    emit({ kind: 'advance' });
+    emit(null);
+    emit({ kind: 'hold' });
+    expect(seen.map((c) => c.kind)).toEqual(['advance', 'hold']);
+    // Two diagnostics: one for `{ kind: 'rewind' }`, one for `null`.
+    expect(onError).toHaveBeenCalledTimes(2);
+    for (const call of onError.mock.calls) {
+      expect(call[0]).toBeInstanceOf(Error);
+      expect((call[0] as Error).message).toMatch(/presenter/i);
+    }
+  });
+
+  it('drops unknown commands silently when no onError sink is provided', () => {
+    const { source, emit } = buildSource();
+    const controller = new AbortController();
+    const ctl = createPresenterController(source, controller.signal);
+    const seen: PresenterCommand[] = [];
+    ctl.subscribe((cmd) => seen.push(cmd));
+    expect(() => emit({ kind: 'rewind' })).not.toThrow();
+    expect(seen).toEqual([]);
+  });
+
+  it('does not crash when the source emits and no handler is subscribed', () => {
+    const { source, emit } = buildSource();
+    const controller = new AbortController();
+    createPresenterController(source, controller.signal);
+    expect(() => emit({ kind: 'advance' })).not.toThrow();
+  });
+
+  it('isolates subscribers — unsubscribing one does not detach another', () => {
+    const { source, emit } = buildSource();
+    const controller = new AbortController();
+    const ctl = createPresenterController(source, controller.signal);
+    const seenA: PresenterCommand[] = [];
+    const seenB: PresenterCommand[] = [];
+    const unsubA = ctl.subscribe((cmd) => seenA.push(cmd));
+    ctl.subscribe((cmd) => seenB.push(cmd));
+    emit({ kind: 'advance' });
+    unsubA();
+    emit({ kind: 'hold' });
+    expect(seenA.map((c) => c.kind)).toEqual(['advance']);
+    expect(seenB.map((c) => c.kind)).toEqual(['advance', 'hold']);
+  });
+
+  it('a handler that throws does not prevent later handlers from running', () => {
+    // The controller MUST isolate handler exceptions so a buggy
+    // subscriber cannot poison the bus for others. Without this, an
+    // exception in handler A would propagate through the source's
+    // emission loop and skip handler B.
+    const { source, emit } = buildSource();
+    const controller = new AbortController();
+    const onError = vi.fn();
+    const ctl = createPresenterController(source, controller.signal, onError);
+    const seenB: PresenterCommand[] = [];
+    ctl.subscribe(() => {
+      throw new Error('handler-a explosion');
+    });
+    ctl.subscribe((cmd) => seenB.push(cmd));
+    emit({ kind: 'advance' });
+    expect(seenB.map((c) => c.kind)).toEqual(['advance']);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect((onError.mock.calls[0]?.[0] as Error).message).toMatch(/handler-a explosion/);
+  });
+
+  it('forwards a frozen defensive copy so a handler cannot mutate `kind` and corrupt sibling subscribers', () => {
+    // Codex review (cycle 1): the source emits one command object
+    // reference to every wrapped handler. Without per-handler
+    // freezing, handler A could mutate `cmd.kind` and handler B
+    // (called next in the source's emission loop) would observe the
+    // mutated value. Pin that the controller hands each handler an
+    // INDEPENDENT frozen copy.
+    const { source, emit } = buildSource();
+    const controller = new AbortController();
+    const ctl = createPresenterController(source, controller.signal);
+    const seenA: PresenterCommand[] = [];
+    const seenB: PresenterCommand[] = [];
+    ctl.subscribe((cmd) => {
+      seenA.push(cmd);
+      // Try to mutate. Frozen objects throw in strict mode; either
+      // way, the next subscriber must not observe the corruption.
+      try {
+        (cmd as { kind: string }).kind = 'corrupted';
+      } catch {
+        // Object.freeze throws on assignment in strict mode; expected.
+      }
+    });
+    ctl.subscribe((cmd) => seenB.push(cmd));
+    emit({ kind: 'advance' });
+    expect(seenA[0]?.kind).toBe('advance');
+    expect(seenB[0]?.kind).toBe('advance');
+  });
+
+  it('calls a non-idempotent source unsubscribe at most once even when abort and runner-unsubscribe both fire', () => {
+    // Codex review (cycle 2): a runner that calls its returned
+    // unsubscribe AFTER the controller's signal already aborted
+    // (or the per-scene wrapper aborts AFTER the navigation-level
+    // wrapper aborted) would call source.unsubscribe a second time.
+    // A non-idempotent source could corrupt its accounting. Pin
+    // that the controller calls each source unsubscribe exactly
+    // once.
+    const handlers: ((cmd: PresenterCommand) => void)[] = [];
+    let unsubCalls = 0;
+    const source: PresenterCommandSource = {
+      subscribe(handler) {
+        handlers.push(handler);
+        return () => {
+          unsubCalls += 1;
+        };
+      },
+    };
+    const controller = new AbortController();
+    const ctl = createPresenterController(source, controller.signal);
+    const runnerUnsub = ctl.subscribe(() => undefined);
+    controller.abort();
+    runnerUnsub();
+    runnerUnsub();
+    expect(unsubCalls).toBe(1);
+  });
+
+  it('blocks emissions to a subscriber whose source unsubscribe failed to detach (post-abort emission guard)', () => {
+    // Codex review (cycle 2): a misbehaving source whose own
+    // unsubscribe doesn't actually remove the handler would still
+    // deliver post-abort commands to the runner — the leak the
+    // controller is supposed to prevent. Pin that the wrapped
+    // handler's per-subscription `active` flag short-circuits
+    // emissions even when the source is broken.
+    const handlers: ((cmd: PresenterCommand) => void)[] = [];
+    const source: PresenterCommandSource = {
+      subscribe(handler) {
+        handlers.push(handler);
+        // Intentionally lie: don't actually remove the handler.
+        return () => undefined;
+      },
+    };
+    const controller = new AbortController();
+    const ctl = createPresenterController(source, controller.signal);
+    const seen: PresenterCommand[] = [];
+    ctl.subscribe((cmd) => seen.push(cmd));
+    controller.abort();
+    // Source still delivers because its unsubscribe is a lie.
+    for (const h of handlers) h({ kind: 'advance' });
+    // The controller's per-subscription `active` flag must block
+    // the wrapped handler from forwarding to the runner's handler.
+    expect(seen).toEqual([]);
+  });
+
+  it('blocks emissions to a subscriber after its own unsubscribe even when the source still delivers', () => {
+    // Mirror of the post-abort guard but driven by the runner's
+    // explicit unsubscribe. A source whose unsubscribe is a no-op
+    // would otherwise leak commands to a runner that explicitly
+    // detached.
+    const handlers: ((cmd: PresenterCommand) => void)[] = [];
+    const source: PresenterCommandSource = {
+      subscribe(handler) {
+        handlers.push(handler);
+        return () => undefined;
+      },
+    };
+    const controller = new AbortController();
+    const ctl = createPresenterController(source, controller.signal);
+    const seen: PresenterCommand[] = [];
+    const unsub = ctl.subscribe((cmd) => seen.push(cmd));
+    unsub();
+    for (const h of handlers) h({ kind: 'advance' });
+    expect(seen).toEqual([]);
+  });
+});

--- a/tests/runtime/scene-loader.test.ts
+++ b/tests/runtime/scene-loader.test.ts
@@ -2137,6 +2137,501 @@ describe('createSceneLoader (PUL-F008)', () => {
     });
   });
 
+  describe('presenter-controls dispatch (PUL-F020 / ADR-023)', () => {
+    // PUL-F020 statement: in `mode=present`, the runtime SHALL accept
+    // presenter input to advance to the next beat, hold the current
+    // beat, skip forward, and skip backward. Beat progression SHALL
+    // be interruptible without breaking timeline state.
+    //
+    // This block pins the loader-side dispatch — the seam by which a
+    // workbench-supplied `PresenterCommandSource` reaches the
+    // timeline runner under `mode=present` only, with per-navigation
+    // auto-cleanup tied to the existing `AbortSignal`. This PR does
+    // NOT deliver the visible presenter UI surface (keyboard
+    // listener, on-screen controls); the placeholder source is omitted
+    // in `src/main.ts` so production reaches the loader's
+    // graceful-degradation path. PUL-F020 stays DRAFT until a real
+    // presenter UI lands AND end-to-end tests confirm advance / hold
+    // / skip-forward / skip-backward actually move beat state without
+    // breaking the timeline (ADR-023 records the gating delivery).
+    //
+    // Materially-implementable parts pinned here:
+    //   - `input.presenter` reaches the runner under `mode=present`
+    //     when the workbench supplies `presenterCommands`.
+    //   - `input.presenter` is forwarded to EVERY scene in a
+    //     composition slice (NOT head-only — mode=present runs the
+    //     full slice).
+    //   - `input.presenter` is forwarded under absent-mode URLs
+    //     (mode defaults to present per PUL-F012 / ADR-007).
+    //   - `input.presenter` is omitted under every non-present mode.
+    //   - `input.presenter` is omitted when the workbench does not
+    //     supply `presenterCommands` (graceful degradation).
+    //   - Commands flow through every kind PUL-F020 names (advance,
+    //     hold, skip-forward, skip-backward).
+    //   - Aborting the navigation tears down the runner's
+    //     subscription so emissions after abort do not reach it
+    //     (auto-cleanup on the per-navigation AbortSignal).
+    //   - Cleanup-before-handoff: a navigation that supersedes
+    //     a presenter-mounted scene runs `cleanup(ctx)` on the
+    //     in-flight scene exactly once (PUL-F006 invariant; the
+    //     "interruptible without breaking timeline state" clause).
+    //   - Unknown command kinds are dropped at the controller
+    //     boundary; the loader's `onError` sees a diagnostic.
+
+    interface FakeSource {
+      readonly source: import('../../src/runtime/presenter').PresenterCommandSource;
+      readonly emit: (cmd: unknown) => void;
+      readonly handlerCount: () => number;
+    }
+    const buildFakeSource = (): FakeSource => {
+      const handlers = new Set<
+        (cmd: import('../../src/runtime/presenter').PresenterCommand) => void
+      >();
+      return {
+        source: {
+          subscribe(handler) {
+            handlers.add(handler);
+            return () => {
+              handlers.delete(handler);
+            };
+          },
+        },
+        emit(cmd) {
+          for (const h of handlers) {
+            h(cmd as import('../../src/runtime/presenter').PresenterCommand);
+          }
+        },
+        handlerCount: () => handlers.size,
+      };
+    };
+
+    it('forwards `input.presenter` to the runner under `mode=present` for a single-scene target', async () => {
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      const fake = buildFakeSource();
+      const seen: { hasPresenter: boolean }[] = [];
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: (input) => {
+          seen.push({ hasPresenter: input.presenter !== undefined });
+        },
+        presenterCommands: fake.source,
+      });
+
+      await loader.handle({ locator: { kind: 'scene', scene: 'scene-a' }, mode: 'present' });
+
+      expect(seen).toEqual([{ hasPresenter: true }]);
+    });
+
+    it('forwards `input.presenter` to EVERY scene in a composition under `mode=present` (NOT head-only)', async () => {
+      const sceneA = buildScene({ id: 'scene-a' });
+      const sceneB = buildScene({ id: 'scene-b' });
+      const sceneC = buildScene({ id: 'scene-c' });
+      const stage = buildStage();
+      const fake = buildFakeSource();
+      const seen: { id: string; hasPresenter: boolean }[] = [];
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA, sceneB, sceneC]),
+        compositions: createCompositionRegistry([
+          { id: 'full-talk', manifest: ['scene-a', 'scene-b', 'scene-c'] },
+        ]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: (input) => {
+          seen.push({ id: input.scene.id, hasPresenter: input.presenter !== undefined });
+        },
+        presenterCommands: fake.source,
+      });
+
+      await loader.handle({
+        locator: { kind: 'composition', composition: 'full-talk' },
+        mode: 'present',
+      });
+
+      expect(seen).toEqual([
+        { id: 'scene-a', hasPresenter: true },
+        { id: 'scene-b', hasPresenter: true },
+        { id: 'scene-c', hasPresenter: true },
+      ]);
+    });
+
+    it('forwards `input.presenter` under absent-mode URLs (mode defaults to present)', async () => {
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      const fake = buildFakeSource();
+      const seen: boolean[] = [];
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: (input) => {
+          seen.push(input.presenter !== undefined);
+        },
+        presenterCommands: fake.source,
+      });
+
+      // Absent `mode` URL — defaults to present per PUL-F012 /
+      // ADR-007. A regression that branched on `target.mode ===
+      // 'present'` instead of `effectiveMode(target) === 'present'`
+      // would skip the presenter forwarding here.
+      await loader.handle({ locator: { kind: 'scene', scene: 'scene-a' } });
+
+      expect(seen).toEqual([true]);
+    });
+
+    it.each(NAVIGATION_MODES.filter((m) => m !== 'present'))(
+      'does NOT forward `input.presenter` under non-present mode `%s` even when `presenterCommands` is supplied',
+      async (mode) => {
+        const sceneA = buildScene({ id: 'scene-a' });
+        const stage = buildStage();
+        const fake = buildFakeSource();
+        const seen: { presenterPresent: boolean }[] = [];
+        const noopRendererForPrompter: PrompterRenderer = () => undefined;
+        const loader = createSceneLoader({
+          scenes: createSceneRegistry([sceneA]),
+          compositions: createCompositionRegistry([]),
+          stage: stage.element,
+          buildCtx: stubCtx,
+          createPreloader: () => () => undefined,
+          runTimeline: (input) => {
+            seen.push({ presenterPresent: 'presenter' in input });
+          },
+          renderPrompter: noopRendererForPrompter,
+          presenterCommands: fake.source,
+        });
+
+        await loader.handle({ locator: { kind: 'scene', scene: 'scene-a' }, mode });
+
+        if (mode === 'prompter') {
+          // mode=prompter bypasses the lifecycle entirely (ADR-022),
+          // so `runTimeline` is never invoked and `seen` stays empty.
+          // The "presenter does not leak into prompter" invariant
+          // holds vacuously through the lifecycle bypass — the
+          // captions data path has no `input.presenter` slot.
+          expect(seen).toEqual([]);
+        } else {
+          expect(seen).toEqual([{ presenterPresent: false }]);
+        }
+        // Source should NOT have been subscribed under any non-present
+        // mode — the loader must not even build a controller.
+        expect(fake.handlerCount()).toBe(0);
+      },
+    );
+
+    it('does NOT forward `input.presenter` when `presenterCommands` is omitted (graceful degradation)', async () => {
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      const seen: { presenterPresent: boolean }[] = [];
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: (input) => {
+          seen.push({ presenterPresent: 'presenter' in input });
+        },
+      });
+
+      await loader.handle({ locator: { kind: 'scene', scene: 'scene-a' }, mode: 'present' });
+
+      expect(seen).toEqual([{ presenterPresent: false }]);
+    });
+
+    it('delivers every command kind PUL-F020 names (advance, hold, skip-forward, skip-backward) to the runner', async () => {
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      const fake = buildFakeSource();
+      const received: string[] = [];
+      // The runner subscribes to the presenter, captures every
+      // command it observes, then parks until aborted so the test
+      // can drive commands while the scene is "running."
+      let runnerEntered: () => void = () => undefined;
+      const runnerEnteredPromise = new Promise<void>((resolve) => {
+        runnerEntered = resolve;
+      });
+      const runner: SceneTimelineRunner = (input) => {
+        input.presenter?.subscribe((cmd) => received.push(cmd.kind));
+        runnerEntered();
+        return new Promise<void>((resolve) => {
+          input.signal?.addEventListener('abort', () => resolve(), { once: true });
+        });
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: runner,
+        presenterCommands: fake.source,
+      });
+      void loader.handle({
+        locator: { kind: 'scene', scene: 'scene-a' },
+        mode: 'present',
+      });
+      await runnerEnteredPromise;
+
+      fake.emit({ kind: 'advance' });
+      fake.emit({ kind: 'hold' });
+      fake.emit({ kind: 'skip-forward' });
+      fake.emit({ kind: 'skip-backward' });
+
+      loader.dispose();
+      await loader.idle();
+
+      expect(received).toEqual(['advance', 'hold', 'skip-forward', 'skip-backward']);
+    });
+
+    it('aborting the navigation detaches the runner subscription so post-abort emissions do not reach it', async () => {
+      const sceneA = buildScene({ id: 'scene-a' });
+      const sceneB = buildScene({ id: 'scene-b' });
+      const stage = buildStage();
+      const fake = buildFakeSource();
+      const received: string[] = [];
+      let runnerEntered: () => void = () => undefined;
+      const runnerEnteredPromise = new Promise<void>((resolve) => {
+        runnerEntered = resolve;
+      });
+      const runner: SceneTimelineRunner = (input) => {
+        if (input.scene.id === 'scene-a') {
+          input.presenter?.subscribe((cmd) => received.push(cmd.kind));
+          runnerEntered();
+          return new Promise<void>((resolve) => {
+            input.signal?.addEventListener('abort', () => resolve(), { once: true });
+          });
+        }
+        return undefined;
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA, sceneB]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: runner,
+        presenterCommands: fake.source,
+        onError: () => undefined,
+      });
+
+      const first = loader.handle({
+        locator: { kind: 'scene', scene: 'scene-a' },
+        mode: 'present',
+      });
+      await runnerEnteredPromise;
+      fake.emit({ kind: 'advance' });
+
+      // Superseding navigation aborts scene-a's controller; the
+      // runner's subscription must be detached BEFORE the next
+      // emission so commands do not leak across navigations.
+      const second = loader.handle({
+        locator: { kind: 'scene', scene: 'scene-b' },
+        mode: 'present',
+      });
+      await first;
+      await second;
+
+      fake.emit({ kind: 'hold' });
+
+      expect(received).toEqual(['advance']);
+    });
+
+    it('runs `cleanup(ctx)` on the in-flight scene when a presenter-driven supersede aborts mid-run (interruptible without breaking timeline state)', async () => {
+      // PUL-F020 statement clause: "Beat progression SHALL be
+      // interruptible without breaking timeline state." A
+      // superseding navigation under `mode=present` (which a
+      // presenter UI will drive) MUST trigger the resolver's
+      // mandatory-cleanup invariant on the in-flight scene exactly
+      // once. Without this, "interrupt" would mean "leak the
+      // previous scene's resources."
+      const sceneA = buildScene({
+        id: 'scene-a',
+        cleanup: () => {
+          cleanupRan.push('scene-a');
+        },
+      });
+      const sceneB = buildScene({
+        id: 'scene-b',
+        cleanup: () => {
+          cleanupRan.push('scene-b');
+        },
+      });
+      const cleanupRan: string[] = [];
+      const stage = buildStage();
+      const fake = buildFakeSource();
+      let runnerEntered: () => void = () => undefined;
+      const runnerEnteredPromise = new Promise<void>((resolve) => {
+        runnerEntered = resolve;
+      });
+      let runnerCalls = 0;
+      const runner: SceneTimelineRunner = (input) => {
+        runnerCalls += 1;
+        if (runnerCalls === 1) {
+          input.presenter?.subscribe(() => undefined);
+          runnerEntered();
+          return new Promise<void>((resolve) => {
+            input.signal?.addEventListener('abort', () => resolve(), { once: true });
+          });
+        }
+        return undefined;
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA, sceneB]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: runner,
+        presenterCommands: fake.source,
+        onError: () => undefined,
+      });
+
+      const first = loader.handle({
+        locator: { kind: 'scene', scene: 'scene-a' },
+        mode: 'present',
+      });
+      await runnerEnteredPromise;
+      const second = loader.handle({
+        locator: { kind: 'scene', scene: 'scene-b' },
+        mode: 'present',
+      });
+      await first;
+      await second;
+
+      expect(cleanupRan).toEqual(['scene-a', 'scene-b']);
+    });
+
+    it("routes a runner presenter handler's exception through the loader's `onError` sink (per-scene wrapper threads the diagnostic channel)", async () => {
+      // Codex review (cycle 2): without `onError` threaded through
+      // the resolver's per-scene wrapper, a runner-handler exception
+      // would be caught by the wrapper and silently dropped — the
+      // loader's diagnostic channel would lose the failure even
+      // though the navigation controller's own `onError` still
+      // exists. This test pins the threading: an exception from the
+      // runner's presenter handler reaches the loader's `onError`.
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      const fake = buildFakeSource();
+      const errors: unknown[] = [];
+      let runnerEntered: () => void = () => undefined;
+      const runnerEnteredPromise = new Promise<void>((resolve) => {
+        runnerEntered = resolve;
+      });
+      const runner: SceneTimelineRunner = (input) => {
+        input.presenter?.subscribe(() => {
+          throw new Error('runner-handler exception');
+        });
+        runnerEntered();
+        return new Promise<void>((resolve) => {
+          input.signal?.addEventListener('abort', () => resolve(), { once: true });
+        });
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: runner,
+        presenterCommands: fake.source,
+        onError: (err) => errors.push(err),
+      });
+
+      void loader.handle({
+        locator: { kind: 'scene', scene: 'scene-a' },
+        mode: 'present',
+      });
+      await runnerEnteredPromise;
+      fake.emit({ kind: 'advance' });
+      loader.dispose();
+      await loader.idle();
+
+      // Filter to the handler-exception diagnostic; the dispose
+      // path may surface unrelated errors depending on timing.
+      const handlerErrors = errors.filter(
+        (e) => e instanceof Error && /runner-handler exception/.test(e.message),
+      );
+      expect(handlerErrors).toHaveLength(1);
+    });
+
+    it('drops unknown command kinds at the controller boundary and surfaces a diagnostic via `onError`', async () => {
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      const fake = buildFakeSource();
+      const errors: unknown[] = [];
+      const received: string[] = [];
+      let runnerEntered: () => void = () => undefined;
+      const runnerEnteredPromise = new Promise<void>((resolve) => {
+        runnerEntered = resolve;
+      });
+      const runner: SceneTimelineRunner = (input) => {
+        input.presenter?.subscribe((cmd) => received.push(cmd.kind));
+        runnerEntered();
+        return new Promise<void>((resolve) => {
+          input.signal?.addEventListener('abort', () => resolve(), { once: true });
+        });
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: runner,
+        presenterCommands: fake.source,
+        onError: (err) => errors.push(err),
+      });
+
+      void loader.handle({
+        locator: { kind: 'scene', scene: 'scene-a' },
+        mode: 'present',
+      });
+      await runnerEnteredPromise;
+      fake.emit({ kind: 'rewind' });
+      fake.emit({ kind: 'advance' });
+      loader.dispose();
+      await loader.idle();
+
+      expect(received).toEqual(['advance']);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toBeInstanceOf(Error);
+      expect((errors[0] as Error).message).toMatch(/presenter/i);
+    });
+
+    it('writes no `data-pulsar-mode-*` suppression attribute under `mode=present` even when `presenterCommands` is supplied', async () => {
+      // Layered with the existing PUL-F013-boundary invariant
+      // (ADR-016): adding presenter dispatch must not introduce a
+      // new `data-pulsar-mode-*` suppression attribute under
+      // `mode=present`.
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      const fake = buildFakeSource();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        runTimeline: noopRunner,
+        presenterCommands: fake.source,
+      });
+
+      await loader.handle({ locator: { kind: 'scene', scene: 'scene-a' }, mode: 'present' });
+
+      const modeAttrs = Array.from(stage.attrs.keys()).filter((name) =>
+        name.startsWith('data-pulsar-mode-'),
+      );
+      expect(modeAttrs).toEqual([]);
+    });
+  });
+
   describe('standalone-mode single-scene execution (PUL-F014)', () => {
     // PUL-F014 statement: in `mode=standalone`, the runtime SHALL render
     // a single scene with surrounding chrome, inter-scene transitions,

--- a/tests/runtime/scene-navigation.test.ts
+++ b/tests/runtime/scene-navigation.test.ts
@@ -20,6 +20,7 @@ import {
   createCompositionRegistry,
 } from '../../src/runtime/composition-registry';
 import type { NavigationTarget } from '../../src/runtime/navigation';
+import { createPresenterController } from '../../src/runtime/presenter';
 import { createSceneRegistry } from '../../src/runtime/registry';
 import type { SceneModule } from '../../src/runtime/scene';
 import {
@@ -1602,6 +1603,142 @@ describe('loadSceneNavigationTarget (PUL-F008 lifecycle bridge)', () => {
           screenshot: 'capture',
         },
       ]);
+    });
+  });
+
+  describe('URL present-mode presenter forwarding (PUL-F020)', () => {
+    // ADR-023: under `mode=present` the loader builds a per-navigation
+    // PresenterController bound to the per-navigation AbortSignal and
+    // forwards it via the bridge. The bridge's only job is to forward
+    // the `presenter` option from the loader to the resolver as
+    // `presenter`. Unlike the head-only forwardings, the resolver
+    // hands the controller to EVERY scene in the composition slice
+    // (mode=present runs the full slice; commands act on the active
+    // scene). The bridge does not interpret the controller; runner-
+    // side translation of commands is the runner's contract.
+
+    it('forwards `presenter` to the runner for a single-scene target', async () => {
+      const seen: { hasPresenter: boolean }[] = [];
+      const intro = buildScene({ id: 'intro' });
+      const scenes = createSceneRegistry([intro]);
+      const compositions = createCompositionRegistry([]);
+      const target = resolveSceneNavigation(sceneTarget('intro'), {
+        scenes,
+        compositions,
+      }) as SceneNavigationTarget;
+      const ac = new AbortController();
+      const presenter = createPresenterController({ subscribe: () => () => undefined }, ac.signal);
+
+      await loadSceneNavigationTarget(target, {
+        ctx: {},
+        preloadAssets: () => undefined,
+        runTimeline: (input) => {
+          // Per ADR-023 the runner sees a per-scene wrapper, not
+          // the navigation controller directly. The bridge contract
+          // is "a controller reaches the runner" — the per-scene
+          // wrapping is exercised by the resolver test.
+          seen.push({ hasPresenter: input.presenter !== undefined });
+        },
+        presenter,
+      });
+
+      expect(seen).toEqual([{ hasPresenter: true }]);
+    });
+
+    it('forwards `presenter` to EVERY scene in a composition slice (NOT head-only)', async () => {
+      // Mode=present is the only mode that runs the full composition
+      // slice, and presenter commands act on whichever scene is
+      // currently active. A regression that scoped `presenter` to
+      // plan[0] (matching the head-only `repeat` / `hold` /
+      // `cueGate` / `screenshot` pattern) would silently drop
+      // presenter input for every scene after the head.
+      const seen: { id: string; hasPresenter: boolean }[] = [];
+      const intro = buildScene({ id: 'intro' });
+      const middle = buildScene({ id: 'middle' });
+      const scenes = createSceneRegistry([intro, middle]);
+      const compositions = createCompositionRegistry([
+        { id: 'full-talk', manifest: ['intro', 'middle'] },
+      ]);
+      const target = resolveSceneNavigation(compositionIndexTarget('full-talk', 0), {
+        scenes,
+        compositions,
+      }) as SceneNavigationTarget;
+      const ac = new AbortController();
+      const presenter = createPresenterController({ subscribe: () => () => undefined }, ac.signal);
+
+      await loadSceneNavigationTarget(target, {
+        ctx: {},
+        preloadAssets: () => undefined,
+        runTimeline: (input) => {
+          // Per ADR-023 the runner sees a per-scene wrapper around
+          // the navigation controller. The bridge contract here is
+          // "a controller reaches every scene" — the per-scene
+          // wrapping detail is exercised by the resolver's
+          // per-scene-detach test.
+          seen.push({ id: input.scene.id, hasPresenter: input.presenter !== undefined });
+        },
+        presenter,
+      });
+
+      expect(seen).toEqual([
+        { id: 'intro', hasPresenter: true },
+        { id: 'middle', hasPresenter: true },
+      ]);
+    });
+
+    it('does not truncate a composition slice when `presenter` is supplied — present-mode runs the full slice', async () => {
+      // The loader's `applySingleSceneSlice` truncates only the five
+      // single-scene-execution modes (standalone / loop / paused /
+      // scrub / screenshot); the bridge's `truncateToHead` truncates
+      // only when one of the four head-only runner-input hints is
+      // supplied. A regression that added `presenter` to either
+      // truncation path would silently drop the tail of every
+      // present-mode composition.
+      const seen: string[] = [];
+      const intro = buildScene({ id: 'intro' });
+      const middle = buildScene({ id: 'middle' });
+      const scenes = createSceneRegistry([intro, middle]);
+      const compositions = createCompositionRegistry([
+        { id: 'full-talk', manifest: ['intro', 'middle'] },
+      ]);
+      const target = resolveSceneNavigation(compositionIndexTarget('full-talk', 0), {
+        scenes,
+        compositions,
+      }) as SceneNavigationTarget;
+      const ac = new AbortController();
+      const presenter = createPresenterController({ subscribe: () => () => undefined }, ac.signal);
+
+      await loadSceneNavigationTarget(target, {
+        ctx: {},
+        preloadAssets: () => undefined,
+        runTimeline: (input) => {
+          seen.push(input.scene.id);
+        },
+        presenter,
+      });
+
+      expect(seen).toEqual(['intro', 'middle']);
+    });
+
+    it('does not forward `presenter` when the option is omitted', async () => {
+      const presenterPresence: boolean[] = [];
+      const intro = buildScene({ id: 'intro' });
+      const scenes = createSceneRegistry([intro]);
+      const compositions = createCompositionRegistry([]);
+      const target = resolveSceneNavigation(sceneTarget('intro'), {
+        scenes,
+        compositions,
+      }) as SceneNavigationTarget;
+
+      await loadSceneNavigationTarget(target, {
+        ctx: {},
+        preloadAssets: () => undefined,
+        runTimeline: (input) => {
+          presenterPresence.push('presenter' in input);
+        },
+      });
+
+      expect(presenterPresence).toEqual([false]);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Lands the runtime-side contract layer for presenter input under `mode=present`. PUL-F020 stays DRAFT pending a real presenter UI surface and a runner that translates commands into GSAP transport calls — same precedent ADR-016 / ADR-017 / ADR-018 / ADR-019 / ADR-020 / ADR-021 / ADR-022 set for landing contract + seam tests ahead of dependent surfaces.
- New `src/runtime/presenter.ts` defines `PresenterCommand`, `PresenterCommandSource`, `PresenterController`, and `createPresenterController`. Per-navigation auto-cleanup binds to `AbortSignal`; boundary validation drops unknown command kinds with an `onError` diagnostic; per-handler exception isolation keeps a buggy subscriber from poisoning siblings; each handler gets a frozen defensive copy of the command; `Subscription` records make source-unsubscribe idempotent across the abort-then-explicit-detach race.
- Loader builds a per-navigation controller only when `effectiveMode === 'present'` AND the workbench supplied `presenterCommands`; resolver wraps it in a per-scene child controller bound to a per-scene `AbortController` fired after `cleanup(ctx)` so a runner that subscribes during scene-A and forgets to unsubscribe cannot leak into scene-B.

## Test plan

- [x] `pnpm lint && pnpm typecheck && pnpm test` — 754 tests pass.
- [x] `pre-commit run --all-files` clean.
- [x] Codex preflight (issue 29) ran; design context authored at `docs/design/pul-f020-presenter-controls-preflight.md`.
- [x] Codex pre-push review cycles 1+2 — every finding addressed; fix history posted to issue 29.
- [ ] CI green (waiting on CI).
- [ ] SonarCloud quality gate green (waiting on Sonar).
- [ ] `review-tests` skill — clean.

Closes #29