### PR TITLE
Implement PUL-F021 presenter pause/resume command kinds (ADR-024)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,84 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `docs/adrs/024-presenter-pause-resume.md` — records the PUL-F021
+  contract decision: presenter pause/resume extends the existing
+  ADR-023 presenter command seam rather than adding a new URL mode,
+  command source, controller, event bus, cleanup path, or pause-
+  specific schema. `pause` and `resume` join the existing
+  `PRESENTER_COMMAND_KINDS` allowlist; `isPresenterCommand` stays
+  the only command-boundary validator; loader mode-scoping is
+  unchanged (presenter input is `mode=present` only). Pause/resume
+  is runner-owned transport state: a conforming GSAP runner maps
+  `pause` to the active timeline's native pause (preserving the
+  current playhead — the "same point") and `resume` to playback
+  from that playhead, and pause/resume MUST NOT abort the
+  navigation, call `cleanup(ctx)`, remount the scene, rewrite
+  URL/history, or persist the playhead. Duplicate pause-while-paused
+  and resume-while-playing are idempotent no-ops at the runner.
+  ADR-024 also pins the cross-command precedence the runner must
+  honor: `pause` / `resume` are a transport-freeze gate orthogonal to
+  the PUL-F020 beat-pacing kinds (`hold` / `advance` / `skip-*`) —
+  `pause` snapshots beat-pacing state, `resume` restores it without
+  clearing a prior `hold`, and only `resume` unfreezes transport, so
+  seam-test-passing runners cannot diverge on hold vs. pause
+  semantics. PUL-F021 stays DRAFT until a real presenter UI source
+  and the GSAP runner land with end-to-end tests proving the
+  same-point behavior. Indexed in `docs/adrs/README.md`.
+- `docs/design/pul-f021-pause-resume-preflight.md` — codex
+  architecture preflight design context for PUL-F021: the boundary
+  (URL grammar / mode gate / command shape gate / lifecycle), the
+  required reuse of the ADR-023 incumbents, the cross-cutting layer
+  table, guardrails, the `PresenterCommand.kind` extensibility
+  point, non-goals, and anti-patterns. Indexed in
+  `docs/design/README.md`.
+- `src/runtime/presenter.ts` — `PRESENTER_COMMAND_KINDS` extended
+  with `pause` and `resume` (PUL-F021 / ADR-024). `PresenterCommand`,
+  `PresenterCommandKind`, `isPresenterCommand`, `PresenterCommandSource`,
+  `PresenterController`, and `createPresenterController` are unchanged
+  in shape — the new kinds flow through the existing validate-and-
+  forward boundary, frozen-defensive-copy semantics, per-handler
+  exception isolation, and abort-tied auto-cleanup. The runner (not
+  this module) translates `pause` / `resume` into GSAP transport
+  calls; the placeholder runner ignores them as it does the other
+  four kinds. The cross-command precedence — `pause` / `resume` as a
+  transport-freeze gate orthogonal to the beat-pacing kinds, only
+  `resume` unfreezing transport — is ADR-024's runner contract, not
+  enforced by the command seam. Module docstring updated to record
+  the PUL-F021 / ADR-024 contract, the cross-command precedence, and
+  the DRAFT-until-runner gate.
+- `src/runtime/composition-resolver.ts` — `SceneTimelineRunInput.presenter`
+  JSDoc updated: the command → timeline-operation mapping now lists
+  `pause → native pause at the current playhead` and `resume → resume
+  playback from that preserved playhead` (PUL-F021 "same point",
+  ADR-024); it records that `pause` / `resume` are a transport-freeze
+  gate orthogonal to the beat-pacing kinds (only `resume` unfreezes;
+  `pause` snapshots and `resume` restores beat-pacing state without
+  clearing a prior `hold`), points at ADR-024 *Cross-command
+  precedence* as the binding rule, and notes that duplicate
+  pause-while-paused / resume-while-playing are idempotent no-ops at
+  the runner. No behavior change — `pause` / `resume` ride the same
+  per-scene presenter wrapper as the PUL-F020 kinds.
+- `src/runtime/scene-loader.ts` / `src/runtime/scene-navigation.ts`
+  / `src/main.ts` — presenter-seam comments cross-reference PUL-F021
+  / ADR-024 (the command set grew by `pause` / `resume`; the loader
+  dispatch and bridge forwarding are unchanged). `src/main.ts` still
+  omits `presenterCommands`, so the seam stays structurally inert
+  until a presenter UI surface lands.
+- `tests/runtime/presenter.test.ts` — `PRESENTER_COMMAND_KINDS` now
+  pins the six-kind list; new assertions cover `isPresenterCommand`
+  admitting `pause` / `resume` (and rejecting `paused` — the URL
+  inspection mode is not a command); a new `createPresenterController`
+  case pins `pause` then `resume` reaching the runner in order.
+- `tests/runtime/scene-loader.test.ts` — the presenter-controls
+  dispatch every-kind delivery test now emits and asserts `pause` /
+  `resume` alongside the PUL-F020 four; the describe block documents
+  the PUL-F021 / ADR-024 extension.
+- `tests/runtime/composition-resolver.test.ts` — new case in the
+  present-mode presenter forwarding block pins `pause` / `resume`
+  reaching the per-scene wrapper subscriber of whichever scene's
+  runner is active; describe comment documents the PUL-F021 / ADR-024
+  extension.
 - `docs/adrs/023-presenter-controls.md` — records the PUL-F020
   contract layer for presenter input under `mode=present`. Defines
   the workbench-supplied long-lived `PresenterCommandSource`, the

--- a/docs/adrs/024-presenter-pause-resume.md
+++ b/docs/adrs/024-presenter-pause-resume.md
@@ -1,0 +1,168 @@
+# ADR-024: Presenter Pause/Resume - Runner-Owned Transport State on the Existing Presenter Command Seam
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-10
+
+## Context
+
+PUL-F021 specifies:
+
+> The runtime SHALL accept presenter input to pause the active
+> timeline and SHALL accept input to resume from the same point.
+
+ADR-023 already defines the runtime-side presenter input seam for
+PUL-F020: a workbench-supplied `PresenterCommandSource` is wrapped by
+a per-navigation `PresenterController`, scoped by the loader to
+`mode=present`, validated at the command boundary, forwarded through
+the bridge and resolver, and wrapped again per scene so stale
+subscriptions do not leak into the next active scene.
+
+PUL-F021 is adjacent to that seam but not identical to any existing
+concept:
+
+- `mode=paused` (ADR-019) is a URL-selected inspection mode that mounts
+  the addressed head scene at its first frame. It is not live presenter
+  pause/resume.
+- PUL-F020 `hold` is a presenter beat-pacing command. It is not a
+  resumable full transport state with an explicit resume command.
+- `mode=scrub` (ADR-020) is timeline inspection with controls and
+  monotonic audio-cue gating. It is not pause/resume for a live
+  presentation.
+
+The design question is whether PUL-F021 creates a new pause-specific
+input surface, mode, or state object, or whether it extends the
+existing presenter command seam.
+
+## Decision
+
+PUL-F021 extends the existing presenter command seam. It does not add
+a new URL mode, command source, controller, event bus, cleanup path, or
+pause-specific schema.
+
+The canonical command schema remains `PresenterCommand` in
+`src/runtime/presenter.ts`. PUL-F021 adds command kinds for `pause` and
+`resume` to the existing `PRESENTER_COMMAND_KINDS` allowlist and keeps
+`isPresenterCommand` as the single command-boundary validator. Unknown
+kinds remain dropped at the controller boundary and reported through
+the existing `onError` diagnostic sink.
+
+Loader scoping remains unchanged: presenter commands are available
+only when `effectiveMode(target) === 'present'` and the workbench
+supplied `presenterCommands`. Non-present modes do not build a
+presenter controller and therefore cannot receive pause/resume through
+the runtime path.
+
+Pause/resume transport state belongs to the timeline runner, not the
+loader, resolver, scene, or command controller. A conforming GSAP
+runner maps:
+
+- `pause` to the active timeline's native pause operation, preserving
+  the current playhead position.
+- `resume` to native playback from that preserved position.
+
+Pause/resume MUST NOT abort the navigation, call `cleanup(ctx)`, reload
+the scene, re-run `scene.timeline(ctx)`, mutate the URL, write browser
+history, or persist the playhead in localStorage/sessionStorage/cookies.
+The "same point" is the active timeline instance's internal playhead
+position. The runner keeps its returned promise pending while paused,
+then continues normal completion after resume or normal abort cleanup
+when the navigation is superseded.
+
+Duplicate `pause` while already paused and duplicate `resume` while
+already playing are idempotent no-ops. `resume` after the navigation
+or scene wrapper has aborted is ignored by the existing presenter
+controller cleanup semantics.
+
+### Cross-command precedence
+
+`pause` and `resume` form a transport-freeze gate that is *orthogonal*
+to the PUL-F020 beat-pacing commands (`hold`, `advance`,
+`skip-forward`, `skip-backward`). The two concepts compose; neither
+overrides the other. A conforming runner observes this contract so
+that seam-test-passing runners cannot diverge on PUL-F020 hold
+semantics or PUL-F021 same-point pause semantics:
+
+- **Freeze + restore.** `pause` freezes the active timeline's playhead
+  wherever it is — nothing on stage advances — and snapshots the
+  current beat-pacing state (whether the timeline was `hold`-ing at a
+  beat or running toward the next beat). `resume` releases the freeze
+  and continues from that exact playhead with the snapshotted
+  beat-pacing state restored. `resume` does **not** clear a `hold`
+  that was engaged before `pause`, and `pause` does **not** engage
+  `hold`. A `pause` issued while `hold` is engaged resumes back into
+  the held state.
+- **Only `resume` unfreezes.** A `hold` / `advance` / `skip-forward` /
+  `skip-backward` received while paused MUST NOT implicitly resume
+  playback. The runner MAY apply `skip-forward` / `skip-backward` as a
+  seek that moves the frozen playhead (presenter scrubbing while
+  paused) and MAY record `advance` / `hold` intent for when transport
+  resumes, but the stage stays visually frozen until an explicit
+  `resume`. A minimal runner MAY drop a beat-pacing command it cannot
+  honor while paused; what it MUST NOT do is silently resume on any
+  command other than `resume`.
+- **Idempotent edges.** Duplicate `pause` while paused and duplicate
+  `resume` while playing are idempotent no-ops (above); likewise a
+  `resume` received while not paused is a no-op.
+
+`presenter` remains forwarded to every scene run input under
+`mode=present`; it is still not head-only and it does not truncate the
+composition slice. Pause/resume acts on whichever scene's runner is
+currently active. A future composition-level/master-timeline runner can
+honor the same command kinds at its own transport layer without
+changing the command source contract.
+
+PUL-F021 stays DRAFT until a real presenter UI source and the GSAP
+runner both land with end-to-end tests proving pause freezes the active
+timeline and resume continues from the same playhead position. The
+placeholder runner may ignore the new commands because it has no real
+timeline to pause or resume.
+
+## Consequences
+
+### Positive
+
+- PUL-F021 reuses the validated, abort-tied presenter command boundary
+  from ADR-023.
+- There is one presenter command schema and one command allowlist.
+- Pause/resume does not create a second lifecycle or cleanup path.
+- The runner owns timeline transport state, matching ADR-003.
+
+### Negative
+
+- ADR-023's original four-kind command set must be extended by a later
+  requirement, so tests around the frozen allowlist need to change when
+  PUL-F021 is implemented.
+- Seam tests can prove command delivery, but real "same point" behavior
+  is not testable until the GSAP runner exists.
+
+### Risks
+
+| Risk | Mitigation |
+|------|------------|
+| `pause` is confused with `mode=paused` | Keep `mode=paused` URL-only and first-frame-only. Live pause/resume is a `mode=present` presenter command. |
+| `pause` is implemented by aborting navigation | Forbid pause/resume from touching `AbortController`, `cleanup(ctx)`, loader handles, URL state, or history. Abort remains supersession/dispose only. |
+| A second pause command schema appears | `src/runtime/presenter.ts` is the only command schema and validator. Add `pause` / `resume` there. |
+| A stale scene keeps receiving resume | Reuse ADR-023's per-scene presenter wrapper; it aborts after cleanup and drops post-abort emissions. |
+| Resume restarts from the beginning or a beat label | The runner resumes from its current playhead position; it does not seek unless a separate command explicitly asks it to. |
+| A runner resumes playback on `advance` / `skip-*` / `hold` received while paused, or `resume` clears a prior `hold` | Only `resume` unfreezes transport; other commands update beat/playhead state the runner restores on `resume` but do not resume. `pause` / `resume` are orthogonal to `hold`. See *Cross-command precedence*. |
+| A future remote presenter protocol leaks untrusted payloads into the runner | Remote/auth policy must live before the `PresenterCommandSource`. The controller still shape-checks every emitted command before forwarding. |
+
+## Related ADRs
+
+- [ADR-003](003-gsap-timeline-engine.md) - timeline transport is GSAP
+  runner responsibility.
+- [ADR-007](007-browser-workbench.md) - `present` is the presenter
+  workbench mode and the URL is the only source of mode selection.
+- [ADR-016](016-workbench-mode-present.md) - presenter input is one
+  facet of `mode=present`.
+- [ADR-019](019-workbench-mode-paused.md) - `mode=paused` is
+  first-frame inspection, not live pause/resume.
+- [ADR-020](020-workbench-mode-scrub.md) - scrub controls are
+  timeline inspection, not pause/resume.
+- [ADR-023](023-presenter-controls.md) - presenter command source,
+  controller, validation, scoping, and cleanup seam.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -49,3 +49,4 @@ Each ADR includes:
 | [021](021-workbench-mode-screenshot.md) | Workbench Mode `screenshot` — Runner Capture-Bundle Hint at the Loader/Runner Seam | Accepted |
 | [022](022-workbench-mode-prompter.md) | Workbench Mode `prompter` — Loader-Side Lifecycle Bypass with Captions Aggregation Seam | Accepted |
 | [023](023-presenter-controls.md) | Presenter Controls — Per-Navigation Command Source at the Loader/Runner Seam | Accepted |
+| [024](024-presenter-pause-resume.md) | Presenter Pause/Resume — Runner-Owned Transport State on the Existing Presenter Command Seam | Accepted |

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -10,6 +10,11 @@ Design context for Pulsar. Source material for the ADRs in `../adrs/`.
 | [pul-f013-present-mode-preflight.md](pul-f013-present-mode-preflight.md) | Guardrails for implementing default `mode=present` behavior. |
 | [pul-f014-standalone-mode-preflight.md](pul-f014-standalone-mode-preflight.md) | Guardrails for implementing isolated `mode=standalone` behavior. |
 | [pul-f015-loop-mode-preflight.md](pul-f015-loop-mode-preflight.md) | Guardrails for implementing repeated `mode=loop` scene-timeline playback. |
+| [pul-f016-paused-mode-preflight.md](pul-f016-paused-mode-preflight.md) | Guardrails for implementing first-frame `mode=paused` behavior. |
+| [pul-f017-scrub-mode-preflight.md](pul-f017-scrub-mode-preflight.md) | Guardrails for implementing scrub-mode timeline controls and audio cue gating. |
+| [pul-f018-screenshot-mode-preflight.md](pul-f018-screenshot-mode-preflight.md) | Guardrails for implementing deterministic screenshot-mode capture. |
+| [pul-f020-presenter-controls-preflight.md](pul-f020-presenter-controls-preflight.md) | Guardrails for implementing presenter advance, hold, and skip commands. |
+| [pul-f021-pause-resume-preflight.md](pul-f021-pause-resume-preflight.md) | Guardrails for implementing presenter pause and resume commands. |
 
 Design docs are mutable. Decisions are captured as ADRs (immutable once
 accepted).

--- a/docs/design/pul-f021-pause-resume-preflight.md
+++ b/docs/design/pul-f021-pause-resume-preflight.md
@@ -1,0 +1,143 @@
+# PUL-F021 Pause and Resume Preflight
+
+PUL-F021 specifies live presenter input: pause the active timeline and
+resume from the same point. It is a presenter transport requirement
+under `mode=present`; it is not `mode=paused`, not beat hold, and not
+scrub.
+
+ADR-024 records the binding architecture decision: extend the existing
+presenter command seam from ADR-023. Do not add a pause-specific input
+surface or lifecycle path.
+
+## Boundary
+
+Pause/resume must flow through the existing runtime path:
+
+- `src/runtime/navigation.ts` owns URL grammar. PUL-F021 adds no query
+  parameter, no mode, and no URL-derived pause state.
+- `effectiveMode()` owns mode derivation. Presenter pause/resume is
+  available only under effective `present`.
+- `src/runtime/scene-loader.ts` owns per-navigation mode dispatch and
+  builds the presenter controller only when `mode=present` and the
+  workbench supplied a `presenterCommands` source.
+- `src/runtime/presenter.ts` owns command kinds, command shape
+  validation, boundary diagnostics, handler isolation, and abort-tied
+  subscription cleanup.
+- `src/runtime/scene-navigation.ts` and
+  `src/runtime/composition-resolver.ts` only forward `presenter`; they
+  do not interpret pause/resume.
+- The timeline runner owns transport behavior. For GSAP this means
+  native pause/resume from the current playhead position.
+
+Do not call `loader.handle()`, abort the navigation, invoke
+`cleanup(ctx)`, remount the scene, mutate URL/history, or persist a
+pause point to satisfy pause/resume.
+
+## Required Reuse
+
+Implementation must reuse these incumbents:
+
+- URL and mode validation: `parseNavigationSearch()`,
+  `NAVIGATION_MODES`, `effectiveMode()`, and loader-side
+  `validateModeGrammar`.
+- Presenter input schema: `PRESENTER_COMMAND_KINDS`,
+  `PresenterCommand`, `isPresenterCommand`, `PresenterCommandSource`,
+  `PresenterController`, and `createPresenterController`.
+- Presenter scoping and cleanup: `SceneLoaderOptions.presenterCommands`
+  plus the existing loader -> bridge -> resolver forwarding chain.
+- Lifecycle orchestration: `loadSceneNavigationTarget()` and
+  `resolveComposition()`. Pause/resume must not add a parallel
+  cleanup path.
+- Error handling: existing plain `Error` diagnostics through the
+  presenter controller's `onError` sink. No pause-specific exception
+  hierarchy.
+- Runner contract: ADR-003's GSAP transport API (`pause()` and
+  resumed `play()` from the current playhead). Do not hand-roll
+  timers or scene-local pause flags.
+- Test locations and shapes: `tests/runtime/presenter.test.ts` for the
+  command boundary; `scene-loader.test.ts`, `scene-navigation.test.ts`,
+  and `composition-resolver.test.ts` for seam forwarding; the future
+  GSAP runner tests for same-point behavior.
+
+## Cross-Cutting Layers
+
+| Layer | Requirement for PUL-F021 |
+|-------|--------------------------|
+| URL grammar | No new key. `mode=paused` remains first-frame inspection. Unknown URL keys stay ignored by `parseNavigationSearch()`. |
+| Mode gate | `NAVIGATION_MODES` is unchanged. The loader builds presenter control only for effective `present`. |
+| Command shape gate | Extend `PRESENTER_COMMAND_KINDS` with `pause` and `resume`. Keep `isPresenterCommand` as the only validator. |
+| Command payload safety | Commands stay flat and discriminator-based. Do not forward arbitrary objects to the runner. Freeze the emitted command copy as today. |
+| Auth surface | None in this repo. Do not add HTTP/WebSocket/remote control for PUL-F021. A future remote source must authenticate before emitting into `PresenterCommandSource`. |
+| Secret/config/env surface | None. No env vars, process argv tokens, config files, localStorage, sessionStorage, cookies, or `history.state` are involved. |
+| OS-level exposure | None. Do not put presenter tokens or pause state in process argv, URLs, files, or shell commands. |
+| Lifecycle and cleanup | `AbortSignal` still means navigation supersession/dispose. `pause` and `resume` do not abort and do not trigger cleanup. |
+| Error envelope | Invalid commands and handler exceptions use the presenter controller's existing `onError` path. Do not include raw future payloads in error text. |
+| Observability | Do not add `data-pulsar-mode-*` or pause-state stage attributes until a concrete UI/status requirement needs them. |
+
+## Guardrails
+
+- Add `pause` and `resume` to the existing command union; do not create
+  `PauseCommandSource`, `PauseController`, a second event type, or a
+  parallel validator.
+- Pause/resume is not a sticky state. If no scene runner is active
+  (for example during preload before any runner subscribed), the
+  command has no active timeline to affect. Do not queue pause for the
+  next scene unless a future requirement says so.
+- Pause while already paused and resume while already playing are
+  idempotent. They should not surface errors to presenters.
+- Navigation abort wins over pause state. After abort, presenter
+  controller cleanup drops later commands and the resolver still owns
+  exactly-once cleanup.
+- Same-point resume means the active timeline instance's current
+  playhead. It does not mean first frame, last beat, URL `beat=`, or a
+  persisted checkpoint.
+- Pause/resume composes with — does not override — the PUL-F020
+  beat-pacing commands (`hold` / `advance` / `skip-forward` /
+  `skip-backward`). `pause` snapshots beat-pacing state and freezes
+  the playhead; `resume` restores both without clearing a prior
+  `hold`. Only `resume` unfreezes transport — `advance` / `hold` /
+  `skip-*` received while paused update the state `resume` will
+  restore but never implicitly resume. ADR-024 *Cross-command
+  precedence* is the binding rule the GSAP runner and its tests must
+  honor; do not let seam-only delivery imply a particular composition
+  behavior.
+- `presenter` stays every-scene under `mode=present`; do not make it
+  head-only and do not truncate composition slices for pause/resume.
+- The placeholder runner can ignore pause/resume until the GSAP runner
+  lands. That keeps PUL-F021 DRAFT; do not claim ACTIVE on seam-only
+  delivery.
+
+## Extensibility
+
+The extension point is `PresenterCommand.kind`. If a future presenter
+command needs data, extend `PresenterCommand` as a discriminated union
+with kind-specific fields and update `isPresenterCommand` in the same
+module. Do not add a second command schema.
+
+If a future UI needs to display paused/playing state, add a separate
+runner-to-workbench status surface. Do not overload
+`PresenterCommandSource`, URL mode, or stage diagnostics as a state
+store.
+
+## Non-Goals
+
+PUL-F021 should not implement the keyboard listener, on-screen
+presenter UI, remote presenter protocol, GSAP runner, master mute,
+scrub controls, `mode=paused`, persistence, status indicators, or
+requirement status transition. It should not change scene or
+composition schemas.
+
+## Anti-Patterns
+
+- Treating `pause` as `mode=paused`.
+- Reusing the PUL-F020 `hold` command for resumable pause.
+- Treating `resume` as a `hold` release, or treating `advance` /
+  `skip-*` received while paused as an implicit `resume` — only
+  `resume` unfreezes transport (ADR-024 *Cross-command precedence*).
+- Implementing pause by aborting the navigation and later recreating
+  the scene.
+- Storing the playhead in URL/history/localStorage to support resume.
+- Adding scene-local `if (paused)` branches or raw timer gates.
+- Adding a duplicate exception hierarchy or duplicate command
+  validator.
+- Letting pause/resume commands leak into non-present modes.

--- a/src/main.ts
+++ b/src/main.ts
@@ -192,19 +192,25 @@ const buildCtx = (mode: NavigationMode): WorkbenchSceneCtx => ({ stage, mode });
 // PUL-F019 (visible captions UI + end-to-end tests).
 const renderPrompter: PrompterRenderer = () => undefined;
 
-// Presenter command source (PUL-F020 / ADR-023): intentionally
-// OMITTED here. PUL-F020 ships only the runtime-side contract
-// layer in this PR — the loader builds a per-navigation
-// `PresenterController` when `mode=present` AND
+// Presenter command source (PUL-F020 / PUL-F021 / ADR-023 /
+// ADR-024): intentionally OMITTED here. The runtime-side contract
+// layer ships the `PresenterCommandSource` / per-navigation
+// `PresenterController` seam and the `advance` / `hold` /
+// `skip-forward` / `skip-backward` (PUL-F020) plus `pause` /
+// `resume` (PUL-F021, ADR-024) command kinds — the loader builds a
+// per-navigation `PresenterController` when `mode=present` AND
 // `presenterCommands` is supplied. By omitting the field, the
 // loader gracefully degrades (runners see `input.presenter ===
 // undefined`) and the seam stays structurally inert until a real
 // presenter UI surface lands. The future workbench surface owns
 // the keyboard listener / on-screen controls and emits
 // `PresenterCommand`s through a `PresenterCommandSource`; ADR-023
-// records the DRAFT → ACTIVE bar (presenter UI module + GSAP
-// runner that translates commands to transport calls + end-to-end
-// tests).
+// (advance/hold/skip) and ADR-024 (pause/resume — including the
+// cross-command precedence the runner must honor: `pause` / `resume`
+// are a transport-freeze gate orthogonal to the beat-pacing kinds)
+// record the DRAFT → ACTIVE bar (presenter UI module + GSAP runner
+// that translates commands to transport calls — including playhead-
+// preserving pause/resume — + end-to-end tests).
 const loader = createSceneLoader({
   scenes: sceneRegistry,
   compositions: compositionRegistry,

--- a/src/runtime/composition-resolver.ts
+++ b/src/runtime/composition-resolver.ts
@@ -289,13 +289,14 @@ export interface SceneTimelineRunInput {
    */
   readonly screenshot?: 'capture';
   /**
-   * Presenter command controller (PUL-F020 / ADR-023). Forwarded to
-   * EVERY scene's run input under `mode=present` (NOT a head-only
-   * field): mode=present runs the FULL composition slice, and
-   * presenter commands act on whichever scene is currently active.
-   * Analogous to {@link signal} in shape, not to the head-only
-   * runner-input hints (`repeat` / `hold` / `cueGate` / `screenshot`
-   * — those modes are single-scene by construction).
+   * Presenter command controller (PUL-F020 / PUL-F021 / ADR-023 /
+   * ADR-024). Forwarded to EVERY scene's run input under
+   * `mode=present` (NOT a head-only field): mode=present runs the
+   * FULL composition slice, and presenter commands act on whichever
+   * scene is currently active. Analogous to {@link signal} in shape,
+   * not to the head-only runner-input hints (`repeat` / `hold` /
+   * `cueGate` / `screenshot` — those modes are single-scene by
+   * construction).
    *
    * The runner subscribes via `presenter.subscribe(handler)` to
    * receive {@link import('./presenter').PresenterCommand}s. The
@@ -306,12 +307,21 @@ export interface SceneTimelineRunInput {
    * dropped before reaching the runner).
    *
    * Translation of each command into a timeline operation
-   * (advance → play to next beat, hold → pause at current beat,
-   * skip-forward / skip-backward → seek to next/prev beat) is the
-   * runner's contract per ADR-003 (GSAP transport API). A runner
-   * that ignores `input.presenter` gracefully degrades — the
-   * placeholder runner does this today because it has no real
-   * timeline to drive.
+   * (advance → play to next beat, hold → hold at the current beat,
+   * skip-forward / skip-backward → seek to next/prev beat,
+   * pause → native pause at the current playhead, resume → resume
+   * playback from that preserved playhead — the PUL-F021 "same
+   * point" semantics, ADR-024) is the runner's contract per ADR-003
+   * (GSAP transport API). `pause` / `resume` are a transport-freeze
+   * gate orthogonal to the beat-pacing kinds (`hold` / `advance` /
+   * `skip-*`): `pause` snapshots beat-pacing state and `resume`
+   * restores it without clearing a prior `hold`, and only `resume`
+   * unfreezes transport. Duplicate pause-while-paused and
+   * resume-while-playing are idempotent no-ops at the runner. ADR-024
+   * *Cross-command precedence* is the binding rule for how the kinds
+   * compose; this seam only delivers them. A runner that ignores
+   * `input.presenter` gracefully degrades — the placeholder runner
+   * does this today because it has no real timeline to drive.
    *
    * Absent for every mode other than `present` (the loader scopes
    * delivery; the resolver does not enforce mode coherence because

--- a/src/runtime/presenter.ts
+++ b/src/runtime/presenter.ts
@@ -1,4 +1,4 @@
-// Presenter controls — PUL-F020 / ADR-023.
+// Presenter controls — PUL-F020 / PUL-F021 / ADR-023 / ADR-024.
 //
 // Defines the runtime-side contract layer for accepting presenter
 // commands under `mode=present`. The runtime does not own the input
@@ -10,36 +10,63 @@
 //
 // The runner — not this module — translates a command into a timeline
 // operation (ADR-003: GSAP `play()` / `pause()` / `seek()` /
-// `tweenTo()`). PUL-F020 stays DRAFT until a real presenter UI lands
-// AND end-to-end tests confirm advance / hold / skip-forward /
-// skip-backward actually move beat state without breaking the
-// timeline.
+// `tweenTo()`). For PUL-F021, `pause` maps to the active timeline's
+// native pause (preserving the current playhead) and `resume` maps to
+// native playback from that preserved position — the "same point"
+// semantics. `pause` / `resume` form a transport-freeze gate that is
+// orthogonal to the PUL-F020 beat-pacing commands (`hold` / `advance`
+// / `skip-forward` / `skip-backward`): `pause` snapshots beat-pacing
+// state and `resume` restores it without clearing a prior `hold`, and
+// only `resume` unfreezes transport — a beat-pacing command received
+// while paused never implicitly resumes. ADR-024 *Cross-command
+// precedence* is the binding runner contract for this composition;
+// the seam below only delivers the kinds, it does not enforce it.
+// Duplicate `pause` while already paused and duplicate `resume` while
+// already playing are idempotent no-ops at the runner. Pause/resume
+// MUST NOT abort the navigation, call `cleanup(ctx)`, remount the
+// scene, rewrite URL/history, or persist the playhead; they are
+// runner-owned transport state on the same command seam, not a new
+// mode or lifecycle path (ADR-024). PUL-F020 and PUL-F021 both stay
+// DRAFT until a real presenter UI lands AND a GSAP runner proves the
+// command-to-transport behavior end to end.
 //
 // References:
 //  - PUL-F020 — runtime SHALL accept presenter input under
 //    `mode=present` for advance / hold / skip-forward / skip-backward;
 //    beat progression SHALL be interruptible without breaking
 //    timeline state.
+//  - PUL-F021 — runtime SHALL accept presenter input to pause the
+//    active timeline and SHALL accept input to resume from the same
+//    point. Extends this seam with the `pause` / `resume` command
+//    kinds; transport behavior is the runner's contract (ADR-024).
 //  - ADR-023 — workbench presenter controls: command source +
 //    per-navigation controller seam.
+//  - ADR-024 — presenter pause/resume: runner-owned transport state
+//    on the existing presenter command seam (no new mode/source/
+//    controller/schema; `pause` / `resume` join `PRESENTER_COMMAND_KINDS`).
 //  - ADR-003 — GSAP timeline engine. The runner consumes
 //    {@link PresenterCommand} and dispatches via GSAP's transport API.
 //  - ADR-007 — workbench mode dispatch; presenter input is scoped to
 //    `mode=present`.
-//  - ADR-016 — ADR-016 names PUL-F020 as one of the four facets that
-//    gates PUL-F013 ACTIVE.
+//  - ADR-016 — names PUL-F020 / PUL-F021 / PUL-F025 as the presenter
+//    facets of `mode=present` that gate PUL-F013 ACTIVE.
 
 /**
- * The four command kinds PUL-F020 names. Centralized as a single
- * source of truth so the validator and the discriminated-union type
- * cannot drift. Frozen so a misbehaving caller cannot mutate the
- * allowlist at runtime.
+ * The presenter command kinds the runtime accepts under
+ * `mode=present`. The first four are PUL-F020 (advance / hold /
+ * skip-forward / skip-backward); `pause` and `resume` are PUL-F021
+ * (ADR-024), added to this same allowlist rather than to a separate
+ * pause-specific schema. Centralized as a single source of truth so
+ * the validator and the discriminated-union type cannot drift. Frozen
+ * so a misbehaving caller cannot mutate the allowlist at runtime.
  */
 export const PRESENTER_COMMAND_KINDS = Object.freeze([
   'advance',
   'hold',
   'skip-forward',
   'skip-backward',
+  'pause',
+  'resume',
 ] as const);
 
 /** Element type of {@link PRESENTER_COMMAND_KINDS}. */
@@ -48,7 +75,11 @@ export type PresenterCommandKind = (typeof PRESENTER_COMMAND_KINDS)[number];
 /**
  * One presenter command. Discriminated by `kind` so future extensions
  * (e.g., timed advance with duration) can add fields per-kind without
- * breaking the existing four-shape contract.
+ * breaking the existing flat-shape contract. The extension point is
+ * `kind`: a future command that needs data extends this interface
+ * into a discriminated union with kind-specific fields and updates
+ * {@link isPresenterCommand} in the same module — not a second
+ * command schema (ADR-024).
  */
 export interface PresenterCommand {
   readonly kind: PresenterCommandKind;

--- a/src/runtime/scene-loader.ts
+++ b/src/runtime/scene-loader.ts
@@ -171,7 +171,9 @@ export interface SceneLoaderOptions {
    */
   readonly renderPrompter?: PrompterRenderer;
   /**
-   * Workbench-supplied presenter command source (PUL-F020 / ADR-023).
+   * Workbench-supplied presenter command source (PUL-F020 / ADR-023;
+   * the command set is extended by PUL-F021 / ADR-024 with the
+   * `pause` / `resume` kinds — the loader-side dispatch is unchanged).
    * Lives across navigations; the loader does not own or construct
    * it. When supplied AND the per-navigation `effectiveMode(target)`
    * is `'present'`, the loader wraps it in a per-navigation

--- a/src/runtime/scene-navigation.ts
+++ b/src/runtime/scene-navigation.ts
@@ -195,7 +195,9 @@ export interface LoadSceneNavigationTargetOptions {
    */
   readonly screenshot?: 'capture';
   /**
-   * URL present-mode presenter controller (PUL-F020 / ADR-023). The
+   * URL present-mode presenter controller (PUL-F020 / ADR-023; the
+   * command set is extended by PUL-F021 / ADR-024 with the `pause` /
+   * `resume` kinds — the bridge forwarding is unchanged). The
    * loader builds a per-navigation
    * {@link import('./presenter').PresenterController} bound to its
    * `AbortController.signal` when `effectiveMode(target) === 'present'`

--- a/tests/runtime/composition-resolver.test.ts
+++ b/tests/runtime/composition-resolver.test.ts
@@ -1787,21 +1787,25 @@ describe('URL screenshot-mode runner capture-hint forwarding (PUL-F018)', () => 
   });
 });
 
-describe('URL present-mode runner presenter forwarding (PUL-F020)', () => {
+describe('URL present-mode runner presenter forwarding (PUL-F020 / PUL-F021)', () => {
   // PUL-F020: in `mode=present`, the runtime SHALL accept presenter
   // input (advance, hold, skip-forward, skip-backward); beat
   // progression SHALL be interruptible without breaking timeline
-  // state. ADR-023 places mode dispatch at the loader and the
-  // command-translation semantics (a kind → GSAP transport call) at
-  // the timeline-runner adapter. Unlike the head-only forwardings
-  // (`headBeat` / `headRepeat` / `headHold` / `headCueGate` /
-  // `headScreenshot`), `presenter` is forwarded to EVERY scene's
-  // run input because mode=present runs the FULL composition slice
-  // (no truncation) and presenter commands act on whichever scene
-  // is currently active. The shape is analogous to `signal`, not to
-  // the head-only hints. The resolver does NOT interpret the
-  // controller itself; subscribing and translating commands is the
-  // runner's contract.
+  // state. PUL-F021 (ADR-024): the runtime SHALL also accept `pause`
+  // / `resume` presenter input on this same seam — pause/resume is
+  // not a new mode, source, controller, or schema, just two more
+  // command kinds the resolver forwards to whichever scene's runner
+  // is currently active. ADR-023 places mode dispatch at the loader
+  // and the command-translation semantics (a kind → GSAP transport
+  // call) at the timeline-runner adapter. Unlike the head-only
+  // forwardings (`headBeat` / `headRepeat` / `headHold` /
+  // `headCueGate` / `headScreenshot`), `presenter` is forwarded to
+  // EVERY scene's run input because mode=present runs the FULL
+  // composition slice (no truncation) and presenter commands act on
+  // whichever scene is currently active. The shape is analogous to
+  // `signal`, not to the head-only hints. The resolver does NOT
+  // interpret the controller itself; subscribing and translating
+  // commands is the runner's contract.
 
   it('forwards a `presenter` controller to EVERY scene in a multi-scene plan (NOT head-only) — commands delegate from the navigation controller', async () => {
     // The resolver wraps the navigation-level controller in a
@@ -1845,6 +1849,50 @@ describe('URL present-mode runner presenter forwarding (PUL-F020)', () => {
       { sceneId: 'scene-a', kinds: ['advance'] },
       { sceneId: 'scene-b', kinds: ['advance'] },
       { sceneId: 'scene-c', kinds: ['advance'] },
+    ]);
+  });
+
+  it('forwards the PUL-F021 pause and resume command kinds to the active scene runner (ADR-024)', async () => {
+    // PUL-F021 (ADR-024): `pause` / `resume` flow through the same
+    // per-scene presenter wrapper as the PUL-F020 kinds. The resolver
+    // does not interpret them — translating `pause` into a GSAP
+    // `pause()`, `resume` into playhead-preserving `play()`, and how
+    // those compose with the beat-pacing kinds (ADR-024
+    // *Cross-command precedence*) is the runner's job — but it must
+    // deliver them to the run input of the scene whose timeline is
+    // currently active, which is what this test pins.
+    const sourceHandlers = new Set<
+      (cmd: import('../../src/runtime/presenter').PresenterCommand) => void
+    >();
+    const source = {
+      subscribe(handler: (cmd: import('../../src/runtime/presenter').PresenterCommand) => void) {
+        sourceHandlers.add(handler);
+        return () => {
+          sourceHandlers.delete(handler);
+        };
+      },
+    };
+    const ac = new AbortController();
+    const presenter = createPresenterController(source, ac.signal);
+
+    const runReceivedKinds: { sceneId: string; kinds: string[] }[] = [];
+    const { options } = buildHarness({
+      scenes: [{ id: 'scene-a' }, { id: 'scene-b' }],
+      manifest: ['scene-a', 'scene-b'],
+      runTimeline: (input) => {
+        const kinds: string[] = [];
+        input.presenter?.subscribe((cmd) => kinds.push(cmd.kind));
+        // Emit a pause then a resume while this scene's wrapper
+        // subscription is live.
+        for (const h of sourceHandlers) h({ kind: 'pause' });
+        for (const h of sourceHandlers) h({ kind: 'resume' });
+        runReceivedKinds.push({ sceneId: input.scene.id, kinds });
+      },
+    });
+    await resolveComposition({ ...options, presenter });
+    expect(runReceivedKinds).toEqual([
+      { sceneId: 'scene-a', kinds: ['pause', 'resume'] },
+      { sceneId: 'scene-b', kinds: ['pause', 'resume'] },
     ]);
   });
 

--- a/tests/runtime/presenter.test.ts
+++ b/tests/runtime/presenter.test.ts
@@ -1,4 +1,4 @@
-// Presenter controls — PUL-F020 / ADR-023.
+// Presenter controls — PUL-F020 / PUL-F021 / ADR-023 / ADR-024.
 //
 // Pure tests for the presenter command boundary: the discriminator
 // validator, the per-navigation controller's subscribe / unsubscribe
@@ -8,8 +8,16 @@
 // describe block.
 //
 // References:
-//  - PUL-F020 — runtime SHALL accept presenter input under mode=present.
+//  - PUL-F020 — runtime SHALL accept presenter input under mode=present
+//    (advance / hold / skip-forward / skip-backward).
+//  - PUL-F021 — runtime SHALL accept presenter input to pause the
+//    active timeline and resume from the same point. ADR-024 records
+//    that PUL-F021 extends this same command seam by adding the
+//    `pause` and `resume` kinds; "same point" playhead behavior is
+//    the future GSAP runner's contract, so PUL-F021 stays DRAFT until
+//    that runner lands.
 //  - ADR-023 — presenter command source / per-navigation controller.
+//  - ADR-024 — presenter pause/resume on the existing command seam.
 
 import { describe, expect, it, vi } from 'vitest';
 import {
@@ -41,12 +49,16 @@ const buildSource = (): {
 };
 
 describe('PRESENTER_COMMAND_KINDS', () => {
-  it('lists exactly the four kinds PUL-F020 names', () => {
+  it('lists exactly the six kinds PUL-F020 + PUL-F021 name', () => {
+    // PUL-F020: advance / hold / skip-forward / skip-backward.
+    // PUL-F021 (ADR-024): pause / resume extend the same allowlist.
     expect([...PRESENTER_COMMAND_KINDS]).toEqual([
       'advance',
       'hold',
       'skip-forward',
       'skip-backward',
+      'pause',
+      'resume',
     ]);
   });
 
@@ -55,17 +67,30 @@ describe('PRESENTER_COMMAND_KINDS', () => {
   });
 });
 
-describe('isPresenterCommand (PUL-F020 / ADR-023)', () => {
-  it('accepts every kind PUL-F020 names', () => {
+describe('isPresenterCommand (PUL-F020 / PUL-F021 / ADR-023 / ADR-024)', () => {
+  it('accepts every kind PUL-F020 + PUL-F021 name', () => {
     for (const kind of PRESENTER_COMMAND_KINDS) {
       expect(isPresenterCommand({ kind })).toBe(true);
     }
+  });
+
+  it('accepts the PUL-F021 pause and resume kinds explicitly', () => {
+    // Pin the PUL-F021 contract clause directly: the boundary admits
+    // `pause` (pause the active timeline) and `resume` (resume from
+    // the same point) so the workbench command source can deliver
+    // them to the runner. Independent of the loop above so a
+    // regression that dropped only these two kinds is caught.
+    expect(isPresenterCommand({ kind: 'pause' })).toBe(true);
+    expect(isPresenterCommand({ kind: 'resume' })).toBe(true);
   });
 
   it('rejects an unknown kind', () => {
     expect(isPresenterCommand({ kind: 'rewind' })).toBe(false);
     expect(isPresenterCommand({ kind: '' })).toBe(false);
     expect(isPresenterCommand({ kind: 'ADVANCE' })).toBe(false);
+    // `mode=paused` is a URL inspection mode (ADR-019), not a
+    // presenter command — its name must not be admitted as a kind.
+    expect(isPresenterCommand({ kind: 'paused' })).toBe(false);
   });
 
   it('rejects values that are not plain command objects', () => {
@@ -84,7 +109,7 @@ describe('isPresenterCommand (PUL-F020 / ADR-023)', () => {
   });
 });
 
-describe('createPresenterController (PUL-F020 / ADR-023)', () => {
+describe('createPresenterController (PUL-F020 / PUL-F021 / ADR-023 / ADR-024)', () => {
   it('forwards every valid command from the source to the subscribed handler', () => {
     const { source, emit } = buildSource();
     const controller = new AbortController();
@@ -94,7 +119,33 @@ describe('createPresenterController (PUL-F020 / ADR-023)', () => {
     for (const kind of PRESENTER_COMMAND_KINDS) {
       emit({ kind });
     }
-    expect(seen.map((c) => c.kind)).toEqual(['advance', 'hold', 'skip-forward', 'skip-backward']);
+    expect(seen.map((c) => c.kind)).toEqual([
+      'advance',
+      'hold',
+      'skip-forward',
+      'skip-backward',
+      'pause',
+      'resume',
+    ]);
+  });
+
+  it('forwards the PUL-F021 pause and resume commands to the runner (ADR-024)', () => {
+    // PUL-F021 contract clause at the seam: a workbench-supplied
+    // source emitting `pause` then `resume` reaches the runner's
+    // handler in order. How the runner translates them — native
+    // `pause()` / playhead-preserving `play()`, and how `pause` /
+    // `resume` compose with the beat-pacing kinds (ADR-024
+    // *Cross-command precedence*) — is the runner's contract, proved
+    // by the future GSAP runner's tests; the controller's job here is
+    // only to deliver the kinds, which is what this test pins.
+    const { source, emit } = buildSource();
+    const controller = new AbortController();
+    const ctl = createPresenterController(source, controller.signal);
+    const seen: PresenterCommand[] = [];
+    ctl.subscribe((cmd) => seen.push(cmd));
+    emit({ kind: 'pause' });
+    emit({ kind: 'resume' });
+    expect(seen.map((c) => c.kind)).toEqual(['pause', 'resume']);
   });
 
   it('returns an unsubscribe that detaches the handler from further emissions', () => {

--- a/tests/runtime/scene-loader.test.ts
+++ b/tests/runtime/scene-loader.test.ts
@@ -2137,11 +2137,21 @@ describe('createSceneLoader (PUL-F008)', () => {
     });
   });
 
-  describe('presenter-controls dispatch (PUL-F020 / ADR-023)', () => {
+  describe('presenter-controls dispatch (PUL-F020 / PUL-F021 / ADR-023 / ADR-024)', () => {
     // PUL-F020 statement: in `mode=present`, the runtime SHALL accept
     // presenter input to advance to the next beat, hold the current
     // beat, skip forward, and skip backward. Beat progression SHALL
     // be interruptible without breaking timeline state.
+    //
+    // PUL-F021 statement: the runtime SHALL accept presenter input to
+    // pause the active timeline and SHALL accept input to resume from
+    // the same point. ADR-024 records that PUL-F021 extends THIS seam
+    // (not a new mode/source/controller/schema) by adding the `pause`
+    // and `resume` command kinds; the loader-side dispatch — mode
+    // scoping, controller construction, abort-tied auto-cleanup — is
+    // unchanged. "Same point" playhead behavior is the runner's
+    // contract, so PUL-F021, like PUL-F020, stays DRAFT until a real
+    // presenter UI and a GSAP runner land with end-to-end tests.
     //
     // This block pins the loader-side dispatch — the seam by which a
     // workbench-supplied `PresenterCommandSource` reaches the
@@ -2166,8 +2176,8 @@ describe('createSceneLoader (PUL-F008)', () => {
     //   - `input.presenter` is omitted under every non-present mode.
     //   - `input.presenter` is omitted when the workbench does not
     //     supply `presenterCommands` (graceful degradation).
-    //   - Commands flow through every kind PUL-F020 names (advance,
-    //     hold, skip-forward, skip-backward).
+    //   - Commands flow through every kind PUL-F020 + PUL-F021 name
+    //     (advance, hold, skip-forward, skip-backward, pause, resume).
     //   - Aborting the navigation tears down the runner's
     //     subscription so emissions after abort do not reach it
     //     (auto-cleanup on the per-navigation AbortSignal).
@@ -2345,7 +2355,7 @@ describe('createSceneLoader (PUL-F008)', () => {
       expect(seen).toEqual([{ presenterPresent: false }]);
     });
 
-    it('delivers every command kind PUL-F020 names (advance, hold, skip-forward, skip-backward) to the runner', async () => {
+    it('delivers every command kind PUL-F020 + PUL-F021 name (advance, hold, skip-forward, skip-backward, pause, resume) to the runner', async () => {
       const sceneA = buildScene({ id: 'scene-a' });
       const stage = buildStage();
       const fake = buildFakeSource();
@@ -2383,11 +2393,21 @@ describe('createSceneLoader (PUL-F008)', () => {
       fake.emit({ kind: 'hold' });
       fake.emit({ kind: 'skip-forward' });
       fake.emit({ kind: 'skip-backward' });
+      // PUL-F021 (ADR-024): pause/resume ride the same dispatch path.
+      fake.emit({ kind: 'pause' });
+      fake.emit({ kind: 'resume' });
 
       loader.dispose();
       await loader.idle();
 
-      expect(received).toEqual(['advance', 'hold', 'skip-forward', 'skip-backward']);
+      expect(received).toEqual([
+        'advance',
+        'hold',
+        'skip-forward',
+        'skip-backward',
+        'pause',
+        'resume',
+      ]);
     });
 
     it('aborting the navigation detaches the runner subscription so post-abort emissions do not reach it', async () => {


### PR DESCRIPTION
## Summary

Extends the existing ADR-023 presenter command seam with the PUL-F021 `pause` and `resume` command kinds, per the binding decision in **ADR-024** (created during the codex architecture preflight). No new URL mode, command source, controller, event bus, cleanup path, or pause-specific schema — `pause` / `resume` join the existing `PRESENTER_COMMAND_KINDS` allowlist and flow through the unchanged validate-and-forward boundary, frozen-defensive-copy semantics, per-handler exception isolation, and abort-tied auto-cleanup. Loader mode-scoping (`mode=present` only) is unchanged.

Pause/resume *transport behavior* — `pause` → native pause at the current playhead, `resume` → playback from that preserved playhead (the "same point"), and how those compose with the PUL-F020 beat-pacing kinds (ADR-024 *Cross-command precedence*: `pause` / `resume` are a transport-freeze gate orthogonal to `hold` / `advance` / `skip-*`; only `resume` unfreezes; `resume` does not clear a prior `hold`) — is the future GSAP runner's contract. The placeholder runner ignores the new kinds as it does the other four.

**PUL-F021 stays DRAFT.** Per ADR-024 and the preflight guardrails, seam-only delivery does not transition the requirement to ACTIVE; that waits on a real presenter UI source and the GSAP runner landing with end-to-end tests proving the same-point behavior. Traceability for this PR is recorded with `DOCUMENTS` links (mirroring how PUL-F020 / ADR-023 was reconciled).

## Changes

- `docs/adrs/024-presenter-pause-resume.md` (new) — the contract decision plus the *Cross-command precedence* section and Risks table; indexed in `docs/adrs/README.md`.
- `docs/design/pul-f021-pause-resume-preflight.md` (new) — codex preflight design context; indexed in `docs/design/README.md`.
- `src/runtime/presenter.ts` — `PRESENTER_COMMAND_KINDS` gains `pause` and `resume`; module docstring records the PUL-F021 / ADR-024 contract, the cross-command precedence, and the DRAFT-until-runner gate. All exported types/functions unchanged in shape.
- `src/runtime/composition-resolver.ts` — `SceneTimelineRunInput.presenter` JSDoc records the new command → timeline-operation mappings and the cross-command precedence rule; no behavior change.
- `src/runtime/scene-loader.ts` / `src/runtime/scene-navigation.ts` / `src/main.ts` — presenter-seam comments cross-reference PUL-F021 / ADR-024 (the loader dispatch and bridge forwarding are unchanged; `src/main.ts` still omits `presenterCommands`).
- `tests/runtime/presenter.test.ts` — `PRESENTER_COMMAND_KINDS` pins the six-kind list; new assertions cover `isPresenterCommand` admitting `pause` / `resume` (and rejecting `paused`); new `createPresenterController` case pins `pause` then `resume` reaching the runner in order.
- `tests/runtime/scene-loader.test.ts` — every-kind dispatch test emits/asserts `pause` / `resume`.
- `tests/runtime/composition-resolver.test.ts` — new present-mode forwarding case pins `pause` / `resume` reaching the per-scene wrapper of the active scene's runner.
- `CHANGELOG.md` — `[Unreleased]` entries.

## Verification

- `pnpm lint && pnpm typecheck && pnpm test` — green (757 tests).
- `pre-commit run --all-files` — clean.
- Codex pre-push review (core + security) — clean after one fix cycle (the `class` finding asking for the cross-command precedence contract to be pinned; closed by the ADR-024 *Cross-command precedence* section + references). Decision recorded on the issue thread.

Closes #30