### PR TITLE
Implement PUL-F023 named timeline beats: kebab validation + beat-query surface (ADR-026)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Named timeline beats — PUL-F023 / ADR-026 — in `src/runtime/timeline.ts`:
+  a scene's GSAP timeline labels *are* its beats, and `assertSceneTimeline`
+  now validates every authored label is a kebab-case identifier (the same
+  `isKebabIdentifier` rule scenes, compositions, and assets obey — ADR-008
+  #1) sitting at a finite, non-negative time no later than the scene
+  timeline's duration, throwing the new `SceneTimelineLabelError` (a leaf
+  of the existing `TimelineError` hierarchy) naming the scene id, the
+  offending label, and (for a bad position) the time and the duration;
+  `composeMasterTimeline` runs this over every segment before it builds the
+  master, so a bad beat is rejected before any timeline is constructed —
+  killing every GSAP timeline the adapter was already handed so a
+  default-playing or repeating scene timeline cannot keep ticking after the
+  resolver unmounts the scenes — and surfaces through the composition
+  resolver's `composition timeline failed:` envelope with mandatory cleanup
+  (a scene-contract failure — distinct from ADR-015's non-fatal "unknown
+  URL beat" diagnostic). `MasterTimeline` is
+  now the canonical beat-query surface every runtime subsystem references
+  beats through: alongside `labels` / `hasLabel` / `seek` / `labelFor` it
+  gains `beats(): readonly MasterBeat[]` — the scene-authored beats in
+  playhead order (each `{ scene, occurrence, label, name, time }`; the
+  automatic segment-start anchors are transport anchors, not beats, and are
+  excluded), a fresh caller-owned array each call. New `parseSceneTimelineLabel`
+  is the single inverse of `sceneTimelineLabel` — decomposing a namespaced
+  master label into `{ scene, occurrence, label }` or `null` for a bare
+  anchor / malformed name — so no subsystem reparses the `:` / `#` namespace
+  grammar locally. URL `beat=` (PUL-F011 / ADR-015), presenter input
+  (PUL-F020 / ADR-023 / ADR-024), and scrub controls (PUL-F017 / ADR-020)
+  reference beats through this surface; they do not own beat parsing,
+  validation, or storage.
+- `docs/adrs/026-named-timeline-beats.md` — records the PUL-F023 decision:
+  beats are scene-local kebab GSAP labels (no `beats` field on `SceneModule`
+  — ADR-015); validated at compose time by `assertSceneTimeline`; namespaced
+  into the master per ADR-025; the canonical beat-query surface is
+  `MasterTimeline` (`labels` / `hasLabel` / `seek` / `labelFor` / `beats`)
+  plus `sceneTimelineLabel` / `parseSceneTimelineLabel`; URL / presenter /
+  scrub consumers reference beats through that surface rather than
+  re-implementing label handling. Indexed in `docs/adrs/README.md`.
 - `src/runtime/timeline.ts` — the GSAP timeline adapter (PUL-F022 /
   ADR-003 / ADR-025), the runtime's single GSAP boundary:
   `createTimelineEngine()` returns the `gsap` handle scenes receive as

--- a/docs/adrs/026-named-timeline-beats.md
+++ b/docs/adrs/026-named-timeline-beats.md
@@ -1,0 +1,191 @@
+# ADR-026: Named Timeline Beats — Scene-Local Kebab Labels, Validated at Compose Time, Referenced Through the Master
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-10
+
+## Context
+
+[ADR-008](008-agent-native-authoring.md) names *named timeline beats*
+(versus raw millisecond offsets) as one of the things that make the
+human/agent loop tractable: "so the agent and the human refer to the
+same moment." [ADR-003](003-gsap-timeline-engine.md) decided that the
+GSAP timeline's first-class **labels** are how those beats are
+expressed, and that trailer-friendly subranges and presenter beats are
+labels inside a scene's timeline. [ADR-015](015-url-beat-positioning.md)
+established that the URL `beat=<label>` parameter is timeline-runner
+state — label existence and seeking belong to the timeline boundary,
+not to URL parsing, the scene registry, or composition-manifest
+validation — and that scene metadata must **not** carry a parallel
+`beats` list that could drift from the timeline.
+
+PUL-F022 / [ADR-025](025-timeline-adapter-boundary.md) then shipped the
+GSAP timeline adapter (`src/runtime/timeline.ts`). It already nests the
+active composition slice's scene timelines into one master GSAP
+timeline, copies each scene's labels into the master under a
+deterministic namespace (`<scene>:<label>`, disambiguated to
+`<scene>#<n>:<label>` when a composition reuses a scene id — ADR-002
+permits repeated entries), exposes the master through a `MasterTimeline`
+transport surface (`labels`, `hasLabel`, `seek`, `labelFor`, …), and
+resolves the URL `beat=` head hint against it with the non-fatal
+`onBeatMissing` fallback PUL-F011 / ADR-015 require.
+
+PUL-F023 is the requirement that *names and finalizes* that contract:
+
+> Scene timelines SHALL support named labels (beats) referenceable by
+> URL, presenter input, and other runtime subsystems.
+
+Two things were still loose:
+
+1. **A scene-authored timeline label was not validated as a beat.**
+   ADR-008 #1 makes kebab-case binding on scenes, compositions, **beats**,
+   and assets; the runtime validates scene ids, composition entry ids,
+   and asset URLs and rejects loudly, but `composeMasterTimeline` copied
+   *any* GSAP label string into the master. A scene that did
+   `tl.addLabel('My Beat')` produced a master label that the kebab-only
+   URL `beat=` grammar can never address — a silent dead end in exactly
+   the agent loop ADR-008 is about.
+2. **There was no canonical way to enumerate or parse beats.** A
+   subsystem holding a master label name had only `master.labels` (every
+   label, including the automatic segment-start anchors) and would have
+   to re-derive the `:` / `#` namespace grammar itself. Future scrub
+   controls (PUL-F017 — "scrub … to named beats"), a presenter HUD
+   (PUL-F020), beat pickers, and automation each reinventing that
+   parsing is the failure this requirement exists to prevent.
+
+## Decision
+
+**A scene's GSAP timeline labels *are* its beats.** There is no `beats`
+or `labels` field on `SceneModule` (ADR-015) and there will not be one
+unless a future ADR supersedes this — the labels in the timeline
+returned by `timeline(ctx)` are the single source of truth.
+
+**A beat must be a well-formed, reachable moment.** Each scene-authored
+label must (a) be a kebab-case identifier — the same `isKebabIdentifier`
+rule scenes, compositions, and assets obey (ADR-008 #1), because the URL
+`beat=` grammar is kebab-only and a name it cannot express could never be
+addressed — and (b) sit at a finite, non-negative time no later than the
+scene timeline's own duration — a beat past or outside the scene's
+content is not a usable moment, and `beats()` / label-based `seek` would
+otherwise expose a clamped or out-of-range position as canonical. Both
+are enforced by `assertSceneTimeline` when a scene timeline first enters
+the runtime: `composeMasterTimeline` runs it over every segment before it
+builds the master, so a non-conforming beat fails *before any timeline is
+constructed* (and, on rejection, every GSAP timeline the adapter was
+already handed is killed, so a default-playing or repeating scene
+timeline cannot keep ticking after the resolver unmounts the scenes).
+The failure is a `SceneTimelineLabelError` (a leaf of the existing
+`TimelineError` hierarchy — no new exception family) whose message names
+the scene id, the offending label, and (for a bad position) the time and
+the duration (PUL-Q006). It is a **scene-contract violation**, surfaced
+through the composition resolver's `composition timeline failed:`
+envelope with mandatory cleanup of every mounted scene (ADR-025) — *not*
+the non-fatal positioning diagnostic reserved for an *unknown URL beat*
+(ADR-015): an authored beat that cannot be addressed is a bug in the
+scene, not a navigation miss.
+
+**Beats are namespaced into the master per ADR-025.** A scene-local
+label `hook` on a scene `intro` appears on the master as `intro:hook`
+(or `intro#1:hook` for the second `intro` in a composition). The
+automatic per-segment start labels (`intro`, `intro#1`) are **transport
+anchors**, not authored beats; they exist for sequencing, not as
+agent-addressable moments, and are not surfaced as beats unless a future
+requirement asks for scene-entry anchors explicitly.
+
+**`MasterTimeline` is the canonical beat-query surface** every runtime
+subsystem references beats through:
+
+- `labels` — every master label (anchors + namespaced beats), names → times.
+- `hasLabel(name)` — existence check.
+- `seek(time | name)` — positioning; an unknown label or non-finite time throws.
+- `labelFor(scene, label, occurrence?)` — the master name for a
+  scene-local beat (a thin alias of `sceneTimelineLabel`).
+- `beats()` — just the scene-authored beats, in playhead order, each as a
+  `MasterBeat` (`{ scene, occurrence, label, name, time }`); a fresh,
+  caller-owned array.
+
+`sceneTimelineLabel(scene, label, occurrence?)` builds a namespaced
+master beat name; `parseSceneTimelineLabel(name)` is the **one inverse**
+— it returns `{ scene, occurrence, label }` for a namespaced beat or
+`null` for a bare anchor / malformed name. No subsystem reparses the
+`:` / `#` grammar locally.
+
+**Consumers reference beats through this surface; they do not
+re-implement label handling.** URL `beat=` (PUL-F011 / ADR-015) resolves
+its head-scoped beat to `sceneTimelineLabel(headScene, beat)` and seeks
+it via the master, with `onBeatMissing` for an unknown label. Presenter
+input (PUL-F020 / ADR-023 / ADR-024) that targets a beat resolves it
+against the active master through `hasLabel` / `labelFor` / `seek`; a
+future presenter command that carries an explicit beat target extends
+the `PresenterCommand` discriminated union in `src/runtime/presenter.ts`
+and validates the beat payload there with `isKebabIdentifier` (no second
+presenter event schema). Scrub controls (PUL-F017 / ADR-020) enumerate
+`master.beats()` for their "scrub to named beats" affordance. None of
+these own beat parsing, validation, or storage — `src/runtime/timeline.ts`
+does.
+
+## Consequences
+
+### Positive
+
+- A non-kebab beat label fails loudly at compose time with a scoped
+  message, instead of silently producing an unaddressable label —
+  closing the agent-loop footgun ADR-008 cares about.
+- Beat handling stays in one module. URL, presenter, and scrub
+  consumers share `MasterTimeline` + `sceneTimelineLabel` /
+  `parseSceneTimelineLabel`; none re-derive the `:` / `#` grammar, so it
+  cannot drift between subsystems.
+- `beats()` gives future scrub / presenter-HUD / beat-picker / automation
+  consumers a ready, ordered, parsed view — they do not filter
+  `master.labels` by hand.
+- Reuses the existing `isKebabIdentifier` / `KEBAB_IDENTIFIER_FORM`
+  predicate, the existing `assertSceneTimeline` boundary, the existing
+  `TimelineError` hierarchy, and the resolver's existing
+  rejection-wrapping path. No new module, no scene-schema change, no
+  duplicate regex.
+
+### Negative
+
+- Scenes that (today, with only the placeholder scene authoring no
+  timeline) start using labels must pick kebab-case names. That is the
+  same rule already in force for scene ids, composition entries, and
+  assets, so the constraint is consistent, not new — but it is now
+  enforced where before any string would have been silently accepted.
+- `parseSceneTimelineLabel` and `beats()` add a small amount of surface
+  to `timeline.ts` ahead of the first consumer (scrub / presenter are
+  still DRAFT). The alternative — each consumer reinventing label
+  parsing — is the named anti-pattern; the cost is one short parser plus
+  one derived view.
+
+### Risks
+
+| Risk | Mitigation |
+|------|------------|
+| A scene author adds a parallel `beats` metadata list | Labels in the returned timeline are the single source of truth; `SceneModule` has no `beats` field and nothing in the runtime reads one, so a metadata list would be inert and drift-prone. ADR-015's risk table already records this. |
+| A subsystem parses namespaced label strings its own way | `parseSceneTimelineLabel` is the one inverse of `sceneTimelineLabel`; `beats()` is the one enumeration. Code review keeps `:` / `#` string-splitting out of consumers. |
+| The automatic segment-start anchors get treated as authored beats | `parseSceneTimelineLabel` returns `null` for a bare anchor, so `beats()` excludes them; the namespaced form (`scene:label`) is the only thing that parses as a beat. |
+| A bad beat is reported like an unknown URL beat (non-fatal) and the scene stays mounted with a broken label | A non-kebab authored label throws `SceneTimelineLabelError` through the resolver's `composition timeline failed:` envelope with mandatory cleanup — it is a scene-contract failure, distinct from ADR-015's non-fatal "URL named a label that doesn't exist" path. |
+
+## Related ADRs
+
+- [ADR-003](003-gsap-timeline-engine.md) — GSAP labels + seeking are the
+  beat mechanism; `ctx.gsap`.
+- [ADR-008](008-agent-native-authoring.md) — named beats as an
+  agent-native ergonomic; #1 makes kebab-case binding on scenes,
+  compositions, beats, and assets.
+- [ADR-015](015-url-beat-positioning.md) — URL `beat=` is
+  timeline-runner state; an *unknown* URL beat is a non-fatal positioning
+  diagnostic (distinct from the *malformed authored beat* this ADR
+  rejects); no parallel `beats` metadata.
+- [ADR-025](025-timeline-adapter-boundary.md) — the timeline adapter,
+  the composition master, and the namespaced master labels this ADR's
+  beat-query surface is built on.
+- [ADR-002](002-scene-registry-and-compositions.md) — compositions may
+  reuse a scene id; that is why beats carry an occurrence.
+- [ADR-020](020-workbench-mode-scrub.md) / [ADR-023](023-presenter-controls.md)
+  / [ADR-024](024-presenter-pause-resume.md) — scrub and presenter
+  consume the beat-query surface; they do not own beat handling.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -51,3 +51,4 @@ Each ADR includes:
 | [023](023-presenter-controls.md) | Presenter Controls — Per-Navigation Command Source at the Loader/Runner Seam | Accepted |
 | [024](024-presenter-pause-resume.md) | Presenter Pause/Resume — Runner-Owned Transport State on the Existing Presenter Command Seam | Accepted |
 | [025](025-timeline-adapter-boundary.md) | Timeline Adapter and Composition Master — Revising the Resolution Lifecycle | Accepted (supersedes ADR-002 §Resolution + ADR-011 ordering) |
+| [026](026-named-timeline-beats.md) | Named Timeline Beats — Scene-Local Kebab Labels, Validated at Compose Time, Referenced Through the Master | Accepted |

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -16,6 +16,7 @@ Design context for Pulsar. Source material for the ADRs in `../adrs/`.
 | [pul-f020-presenter-controls-preflight.md](pul-f020-presenter-controls-preflight.md) | Guardrails for implementing presenter advance, hold, and skip commands. |
 | [pul-f021-pause-resume-preflight.md](pul-f021-pause-resume-preflight.md) | Guardrails for implementing presenter pause and resume commands. |
 | [pul-f022-timeline-orchestration-preflight.md](pul-f022-timeline-orchestration-preflight.md) | Guardrails for implementing GSAP-backed master timeline orchestration. |
+| [pul-f023-named-timeline-beats-preflight.md](pul-f023-named-timeline-beats-preflight.md) | Guardrails for implementing named timeline beats. |
 
 Design docs are mutable. Decisions are captured as ADRs (immutable once
 accepted).

--- a/docs/design/pul-f023-named-timeline-beats-preflight.md
+++ b/docs/design/pul-f023-named-timeline-beats-preflight.md
@@ -1,0 +1,147 @@
+# PUL-F023 Named Timeline Beats Preflight
+
+PUL-F023 names the shared time grammar: scene timelines support named
+labels (beats) referenceable by URL, presenter input, and other runtime
+subsystems. Existing ADRs already decide the core boundary: GSAP labels
+are the canonical beat source (ADR-003, ADR-008), URL `beat=` is
+timeline-runner state (ADR-015), and the GSAP adapter owns the master
+timeline label surface (ADR-025).
+
+## Boundary
+
+Implementation must keep beats on the existing navigation / lifecycle /
+timeline path:
+
+- `src/runtime/navigation.ts` owns URL grammar shape. It validates
+  `beat=` as a kebab identifier and valid parameter combination only.
+  It must not inspect scene modules, GSAP timelines, registries, or
+  master labels.
+- `src/runtime/scene-loader.ts` owns defensive grammar checks for
+  hand-built `NavigationTarget` values, stage diagnostics, `onError`,
+  per-navigation abort, and mode dispatch. Missing URL beats remain
+  non-fatal positioning diagnostics.
+- `src/runtime/scene-navigation.ts` owns scene/composition target
+  resolution and snapshotting. It forwards beat input without label
+  lookup.
+- `src/runtime/composition-resolver.ts` owns lifecycle ordering,
+  cleanup, and error envelopes. It forwards `headBeat` /
+  `onBeatMissing` to the timeline adapter; resolver rejection remains
+  reserved for lifecycle or adapter failures.
+- `src/runtime/timeline.ts` is the canonical beat-resolution boundary.
+  Scene-local GSAP labels are copied to the master under deterministic
+  namespaced labels with `sceneTimelineLabel()` / `labelFor()`. Runtime
+  subsystems consume the `MasterTimeline.labels` snapshot, `hasLabel()`,
+  `seek()`, and `labelFor()` rather than reaching into GSAP directly.
+- `src/runtime/presenter.ts` owns presenter command shape validation.
+  Presenter commands that need an explicit beat target must extend the
+  existing `PresenterCommand` discriminator and validate any beat
+  payload at this same boundary; do not add a second presenter event
+  schema.
+
+## Required Reuse
+
+Use the canonical incumbents:
+
+- Identifier rule: `isKebabIdentifier()` and `KEBAB_IDENTIFIER_FORM`.
+- URL grammar: `parseNavigationSearch()`, `NavigationTarget.beat`,
+  loader-side `validateBeatGrammar`, `NAVIGATION_MODES`,
+  `effectiveMode()`.
+- Scene schema: `SceneModule`, `assertSceneModule()`,
+  `createSceneRegistry()`. Do not add scene metadata solely to list
+  beats.
+- Composition schema: `SubRange`, `assertCompositionManifest()`,
+  `entryId()`, `findUnregisteredEntries()`,
+  `createCompositionRegistry()`. `range` stays label-shaped metadata;
+  label existence is adapter/runtime state, not manifest validation.
+- Timeline adapter: `createTimelineEngine()`, `assertSceneTimeline()`,
+  `composeMasterTimeline()`, `MasterTimeline`, `sceneSegmentLabel()`,
+  `sceneTimelineLabel()`, `createGsapCompositionTimeline()`.
+- Presenter seam: `PRESENTER_COMMAND_KINDS`,
+  `isPresenterCommand()`, `createPresenterController()`,
+  loader-scoped `presenterCommands`.
+- Error and observability: `describeError()`, existing stage attrs
+  (`data-pulsar-scene-target`, `data-pulsar-composition-target`,
+  `data-pulsar-navigation-error`), and the loader `onError` sink.
+- Tests: Vitest seam tests under `tests/runtime/*`, split by boundary
+  when coverage grows. Keep URL/loader/bridge/resolver/timeline tests
+  distinct.
+
+## Cross-Cutting Layers
+
+| Layer | Guardrail |
+|-------|-----------|
+| URL input | `beat=` is an identifier, not a path, module name, resource URL, or script. Repeated grammar keys and invalid combinations stay rejected before lifecycle side effects. |
+| Presenter input | Workbench or remote presenter code emits through `PresenterCommandSource`; the controller shape-checks before the runner sees commands. If a future command carries a beat, validate it with `isKebabIdentifier()` in `presenter.ts`. Remote auth/policy belongs before the source. |
+| Scene validation | `assertSceneModule()` remains the only scene-shape gate. Beats live in the returned GSAP timeline labels, not a duplicate `beats` field. |
+| Composition validation | `assertCompositionManifest()` validates `range` shape only. It must not build timelines or prove label existence. |
+| Timeline validation | `assertSceneTimeline()` rejects non-GSAP returns; `MasterTimeline.seek()` rejects unknown labels/non-finite times; missing URL beats use `onBeatMissing`, not adapter rejection. |
+| Asset/security | Beats must not trigger undeclared fetches, dynamic imports, or asset discovery. Asset loading remains `scene.assets` through `createAssetPreloader()` with scheme and redirect checks. |
+| Error envelopes | Navigation errors keep `scene navigation failed:` / grammar prefixes. Lifecycle failures keep `composition resolution failed:` with causes. Missing URL beat diagnostics stay non-fatal and use the stage error attr plus `onError`. |
+| Config/env/OS | No env vars, config files, process argv flags, browser storage, cookies, or history state are needed for beat state. Do not persist current beat or presenter target outside the active runtime unless a future requirement says so. |
+| Observability | Use stage diagnostics and `onError`; do not add per-frame or per-command label logging without a telemetry policy. |
+
+## Guardrails
+
+- Treat authored beats as scene-local GSAP labels. Master labels are
+  runtime namespaced labels; use helper functions instead of string
+  concatenation.
+- Keep URL `beat` head-scoped per ADR-015. It does not search later
+  composition entries and does not rewrite the composition slice.
+- Do not expose automatic segment-start labels (`scene-a`,
+  `scene-a#1`) as authored beats unless a future requirement
+  explicitly asks for scene-entry anchors. They are transport anchors.
+- If a subsystem needs an ordered or filtered beat list, derive it in
+  `src/runtime/timeline.ts` from the master labels and namespace
+  helpers. Do not make every subsystem parse label strings locally.
+- Presenter advance / hold / skip / pause / resume remain transport
+  commands. Translation to `MasterTimeline.play()`, `pause()`,
+  `seek()`, or GSAP `tweenTo()` belongs in the timeline adapter /
+  runner, not in the controller, loader, scene, or URL parser.
+- Missing URL beat: surface one non-fatal diagnostic, stay at frame 0,
+  keep the scene mounted until normal completion or abort.
+- Invalid command payload or malformed beat from a presenter source:
+  drop at the controller boundary and report through `onError`; do not
+  unmount the scene to report input validation.
+- Repeated scene ids require occurrence-aware labels
+  (`sceneTimelineLabel(scene, beat, occurrence)`). Do not assume the
+  first occurrence if future repeated-entry activation support lands.
+
+## Extensibility
+
+The extension seam is `MasterTimeline` plus the optional `onMaster`
+observer in `createGsapCompositionTimeline()`. Future scrub controls,
+presenter HUDs, beat pickers, or automation should consume a
+runtime-derived beat view from that seam. If the runtime needs a
+first-class beat-list helper, it belongs in `src/runtime/timeline.ts`
+and should be parameterized by scene id / occurrence so repeated
+entries and head-scoped URL beats stay unambiguous.
+
+Future presenter commands that target a specific beat extend
+`PresenterCommand` as a discriminated union in `src/runtime/presenter.ts`
+and validate the beat payload there. The runner resolves the validated
+payload against the active `MasterTimeline`; the loader only decides
+whether presenter input is present for the navigation.
+
+## Non-Goals
+
+- No new URL query key beyond existing `beat=`.
+- No `beats`, `labels`, cue, or marker list on `SceneModule`.
+- No new registry, manifest schema, persistence format, or authoring UI.
+- No label-existence validation in URL parsing, scene registries, or
+  composition manifest validation.
+- No new exception hierarchy for beats.
+- No remote-presenter protocol, auth model, analytics, or telemetry.
+- No requirement status transition or traceability changes during this
+  preflight.
+
+## Anti-Patterns
+
+- Duplicating the kebab-case regex or beat validators.
+- Importing `gsap` directly from scenes or presenter/workbench UI.
+- Treating `range`, URL `beat`, presenter `skip`, scrub selection, and
+  segment-start labels as interchangeable concepts.
+- Throwing through `resolveComposition()` for a missing URL beat.
+- Persisting current beat in localStorage/sessionStorage/cookies or
+  recovering it from `history.state`.
+- Building a scene-side keyboard listener or command pump for beats.
+- Letting each subsystem parse namespaced label strings differently.

--- a/src/runtime/timeline.ts
+++ b/src/runtime/timeline.ts
@@ -218,7 +218,7 @@ export function parseSceneTimelineLabel(name: string): ParsedSceneTimelineLabel 
   if (!isKebabIdentifier(scene)) return null;
   // Occurrence 0 is the bare segment label (no `#` suffix), so a valid
   // suffix is a positive integer with no leading zero.
-  if (!/^[1-9][0-9]*$/.test(occurrenceText)) return null;
+  if (!/^[1-9]\d*$/.test(occurrenceText)) return null;
   return { scene, occurrence: Number(occurrenceText), label };
 }
 

--- a/src/runtime/timeline.ts
+++ b/src/runtime/timeline.ts
@@ -1,10 +1,22 @@
-// Timeline orchestration — PUL-F022. The GSAP timeline adapter.
+// Timeline orchestration — PUL-F022 / PUL-F023. The GSAP timeline adapter.
 //
-// This module is the GSAP boundary for the runtime (ADR-003, ADR-025):
+// This module is the GSAP boundary for the runtime (ADR-003, ADR-025)
+// and the canonical home of the named-beat grammar (ADR-008 #1, ADR-026):
 //
 //  - Scenes receive the GSAP instance as `ctx.gsap` (via
 //    `createTimelineEngine`) and construct their own timeline in
 //    `timeline(ctx)`; they do not import GSAP directly.
+//  - A scene's GSAP timeline labels ARE its beats (PUL-F023 / ADR-026):
+//    the agent-friendly time grammar from ADR-008. An authored beat must
+//    be a kebab-case identifier (the same rule scenes, compositions, and
+//    assets obey — ADR-008 #1; the kebab-only URL `beat=` grammar could
+//    never address anything else) at a finite, non-negative time no
+//    later than the scene timeline's duration (a beat outside the
+//    scene's content is not a usable moment). `assertSceneTimeline`
+//    enforces both when a scene timeline first enters the runtime, so a
+//    bad beat fails loudly instead of silently. There is no `beats`
+//    field on `SceneModule` — the labels in the returned timeline are
+//    the single source of truth (ADR-015).
 //  - `composeMasterTimeline` nests the scene timelines of an active
 //    composition slice into a single master GSAP timeline, copying each
 //    scene's labels into the master under a deterministic namespace so a
@@ -13,7 +25,13 @@
 //  - `MasterTimeline` is the transport surface PUL-F022 mandates: play,
 //    pause, seek (by time or named label), speed change (a validated
 //    positive multiplier — zero / negative / NaN / Infinity / non-number
-//    are rejected), named labels.
+//    are rejected), named labels. It is also the canonical beat-query
+//    surface PUL-F023 requires every runtime subsystem to reference
+//    beats through: `labels` (every master label), `hasLabel`, `seek`,
+//    `labelFor` (the master name for a scene-local beat), and `beats`
+//    (just the scene-authored beats, in playhead order). `labelFor` /
+//    `sceneTimelineLabel` build a master beat name; `parseSceneTimelineLabel`
+//    is the one inverse — no subsystem reparses namespaced label strings.
 //  - `createGsapCompositionTimeline` is the composition-level timeline
 //    adapter the workbench wires onto the composition resolver (ADR-011
 //    + ADR-025): the resolver mounts every scene in the slice, hands the
@@ -27,12 +45,18 @@
 // zero-duration segment rather than rejecting it.
 //
 // References:
-//  - ADR-003 — GSAP as the timeline engine; `ctx.gsap`.
+//  - ADR-003 — GSAP as the timeline engine; `ctx.gsap`; labels + seeking.
+//  - ADR-008 — agent-native authoring; #1 makes kebab-case binding on
+//    scenes, compositions, beats, and assets.
 //  - ADR-011 — composition resolver as a pure orchestrator with an
 //    injected timeline adapter; this module is that adapter.
 //  - ADR-025 — timeline adapter + composition master + the revised
 //    resolution lifecycle (mount-all → compose-master → play →
 //    cleanup-all) superseding ADR-002 §Resolution / ADR-011 ordering.
+//  - ADR-026 — named timeline beats: beats are scene-local kebab GSAP
+//    labels, validated at compose time, namespaced into the master, and
+//    referenced by URL / presenter / scrub through the `MasterTimeline`
+//    beat-query surface.
 //  - ADR-002 — the composition the master is built for.
 //  - ADR-015 / ADR-018 / ADR-019 / ADR-021 — the URL beat / loop /
 //    paused / screenshot head hints the adapter honors via the master's
@@ -44,6 +68,7 @@ import type {
   CompositionTimelineRunOptions,
   SceneTimelineSegment,
 } from './composition-resolver';
+import { KEBAB_IDENTIFIER_FORM, isKebabIdentifier } from './identifier';
 
 type GsapTimeline = InstanceType<typeof gsap.core.Timeline>;
 
@@ -68,6 +93,15 @@ export class TimelineError extends Error {}
 /** A scene's `timeline(ctx)` returned something that is not a GSAP timeline. */
 export class SceneTimelineTypeError extends TimelineError {}
 
+/**
+ * A scene timeline carries a label that is not a valid beat identifier.
+ * Beats share the kebab-case rule with every other Pulsar identifier
+ * (ADR-008 #1); a label that does not match it could never be addressed
+ * by the kebab-only URL `beat=` grammar, so it is a scene-contract
+ * violation rather than a silent dead end.
+ */
+export class SceneTimelineLabelError extends TimelineError {}
+
 /** A speed multiplier or repeat count handed to the master was out of range. */
 export class TimelineSpeedError extends TimelineError {}
 
@@ -78,11 +112,30 @@ const isGsapTimeline = (value: unknown): value is GsapTimeline =>
   value instanceof gsap.core.Timeline;
 
 /**
- * Validate the value a scene's `timeline(ctx)` returned. `null` /
- * `undefined` are accepted as "no timeline authored yet" (the
- * placeholder scene returns `null`); any other non-timeline value is a
- * scene-contract violation and throws {@link SceneTimelineTypeError}
- * with the scene id in the message.
+ * Validate the value a scene's `timeline(ctx)` returned, including its
+ * beats. `null` / `undefined` are accepted as "no timeline authored
+ * yet" (the placeholder scene returns `null`); any other non-timeline
+ * value is a scene-contract violation and throws
+ * {@link SceneTimelineTypeError} with the scene id in the message.
+ *
+ * When the value is a GSAP timeline, every label on it is treated as a
+ * named beat (PUL-F023 / ADR-026). Each must be:
+ *  - a kebab-case identifier — the same rule scenes, compositions, and
+ *    assets obey (ADR-008 #1, via `isKebabIdentifier`) — because the URL
+ *    `beat=` grammar is kebab-only and a name it cannot express could
+ *    never be addressed; and
+ *  - at a finite, non-negative time no later than the scene timeline's
+ *    duration — a beat past (or outside) the scene's content is not a
+ *    usable moment, and `seek` / `beats()` would otherwise expose a
+ *    clamped or out-of-range position as canonical.
+ *
+ * The first non-conforming label throws {@link SceneTimelineLabelError}
+ * naming the scene id and the offending label (PUL-Q006).
+ * `composeMasterTimeline` runs this over every segment before it builds
+ * the master, so a bad beat is rejected before any timeline is
+ * constructed; the resolver wraps the throw in its
+ * `composition timeline failed:` envelope and tears every mounted scene
+ * down (ADR-025).
  */
 export function assertSceneTimeline(
   value: unknown,
@@ -93,6 +146,19 @@ export function assertSceneTimeline(
     throw new SceneTimelineTypeError(
       `scene "${sceneId}" timeline is invalid: timeline(ctx) must return a GSAP timeline or null`,
     );
+  }
+  const duration = value.duration();
+  for (const [label, time] of Object.entries(value.labels)) {
+    if (!isKebabIdentifier(label)) {
+      throw new SceneTimelineLabelError(
+        `scene "${sceneId}" timeline label "${label}" is not a valid beat: beat labels must be lowercase kebab-case identifiers (${KEBAB_IDENTIFIER_FORM})`,
+      );
+    }
+    if (!Number.isFinite(time) || time < 0 || time > duration) {
+      throw new SceneTimelineLabelError(
+        `scene "${sceneId}" timeline beat "${label}" is at an invalid time ${time}: a beat time must be a finite number between 0 and the scene timeline duration (${duration}s)`,
+      );
+    }
   }
 }
 
@@ -118,10 +184,70 @@ export function sceneTimelineLabel(sceneId: string, localLabel: string, occurren
   return `${sceneSegmentLabel(sceneId, occurrence)}${SCENE_LABEL_SEPARATOR}${localLabel}`;
 }
 
+/** A namespaced master beat name decomposed into its parts. */
+export interface ParsedSceneTimelineLabel {
+  /** The scene id the beat belongs to. */
+  readonly scene: string;
+  /** Which occurrence of `scene` in the composition (0 = first / only). */
+  readonly occurrence: number;
+  /** The scene-local label name the scene author wrote. */
+  readonly label: string;
+}
+
 /**
- * The composed master timeline's transport surface (PUL-F022 C3). All
- * methods keep GSAP behind the boundary — callers never touch the
- * underlying timeline directly.
+ * The single inverse of {@link sceneTimelineLabel}: decompose a master
+ * label name into `{ scene, occurrence, label }`, or `null` when `name`
+ * is not a namespaced scene beat — a bare segment-start anchor
+ * (`scene-a`, `scene-a#1`), a malformed occurrence suffix, or anything
+ * whose scene / label parts are not kebab-case identifiers. Runtime
+ * subsystems that hold a master label name resolve it through here
+ * rather than reparsing the `:` / `#` grammar locally (ADR-026).
+ */
+export function parseSceneTimelineLabel(name: string): ParsedSceneTimelineLabel | null {
+  const sep = name.indexOf(SCENE_LABEL_SEPARATOR);
+  if (sep < 0) return null;
+  const segment = name.slice(0, sep);
+  const label = name.slice(sep + 1);
+  if (!isKebabIdentifier(label)) return null;
+  const hash = segment.indexOf('#');
+  if (hash < 0) {
+    return isKebabIdentifier(segment) ? { scene: segment, occurrence: 0, label } : null;
+  }
+  const scene = segment.slice(0, hash);
+  const occurrenceText = segment.slice(hash + 1);
+  if (!isKebabIdentifier(scene)) return null;
+  // Occurrence 0 is the bare segment label (no `#` suffix), so a valid
+  // suffix is a positive integer with no leading zero.
+  if (!/^[1-9][0-9]*$/.test(occurrenceText)) return null;
+  return { scene, occurrence: Number(occurrenceText), label };
+}
+
+/**
+ * One scene-authored beat on the composed master timeline (PUL-F023 /
+ * ADR-026): the scene-local label, the scene segment it belongs to and
+ * which occurrence of that scene, the namespaced master label name to
+ * `seek` to, and the beat's time on the master in seconds. The
+ * automatic segment-start anchors (`scene-a`, `scene-a#1`) are
+ * transport anchors, not authored beats, and are not represented here.
+ */
+export interface MasterBeat {
+  /** The scene segment this beat belongs to. */
+  readonly scene: string;
+  /** Which occurrence of `scene` in the composition (0 = first / only). */
+  readonly occurrence: number;
+  /** The scene-local label name the scene author wrote. */
+  readonly label: string;
+  /** The namespaced master label name (`<scene>:<label>` / `<scene>#<n>:<label>`). */
+  readonly name: string;
+  /** The beat's time on the master timeline, in seconds. */
+  readonly time: number;
+}
+
+/**
+ * The composed master timeline's transport surface (PUL-F022 C3) and
+ * the canonical beat-query surface (PUL-F023 / ADR-026). All methods
+ * keep GSAP behind the boundary — callers never touch the underlying
+ * timeline directly.
  */
 export interface MasterTimeline {
   /** Resume (or start) playback from the current playhead. */
@@ -160,6 +286,13 @@ export interface MasterTimeline {
   hasLabel(name: string): boolean;
   /** The master label name for a scene-local label (see {@link sceneTimelineLabel}). */
   labelFor(sceneId: string, localLabel: string, occurrence?: number): string;
+  /**
+   * The scene-authored beats on this master, in playhead order (ties
+   * broken by master label name for determinism). Excludes the
+   * automatic segment-start anchors — see {@link MasterBeat}. A fresh
+   * array each call; mutating it does not affect the master.
+   */
+  beats(): readonly MasterBeat[];
   /**
    * Register a handler invoked whenever the master reaches its end.
    * A master with `repeat(-1)` never reaches its end, and a paused /
@@ -253,6 +386,24 @@ class GsapMasterTimeline implements MasterTimeline {
     return sceneTimelineLabel(sceneId, localLabel, occurrence);
   }
 
+  beats(): readonly MasterBeat[] {
+    const beats: MasterBeat[] = [];
+    for (const [name, time] of Object.entries(this.#tl.labels)) {
+      const parsed = parseSceneTimelineLabel(name);
+      if (parsed === null) continue;
+      beats.push({ ...parsed, name, time });
+    }
+    beats.sort((a, b) => {
+      if (a.time !== b.time) return a.time - b.time;
+      // Tie-break on the (unique) master label name so the order is
+      // deterministic for beats that land at the same time.
+      if (a.name < b.name) return -1;
+      if (a.name > b.name) return 1;
+      return 0;
+    });
+    return beats;
+  }
+
   onComplete(handler: () => void): void {
     this.#tl.eventCallback('onComplete', handler);
   }
@@ -276,44 +427,62 @@ class GsapMasterTimeline implements MasterTimeline {
  * master drives it; the master itself stays paused at time 0 —
  * positioning and playback are the caller's (the adapter's) job.
  *
- * Throws {@link SceneTimelineTypeError} (before any timeline is built)
- * if a segment's timeline value is not a GSAP timeline or `null` /
- * `undefined`.
+ * Throws {@link SceneTimelineTypeError} (a non-GSAP-timeline segment
+ * value) or {@link SceneTimelineLabelError} (a malformed beat) — in
+ * both cases before any timeline is nested. The resolver has already
+ * called every scene's `timeline(ctx)` by the time this runs, so on
+ * rejection this kills every GSAP timeline it was handed: a scene that
+ * returned a default-playing or repeating timeline must not keep
+ * ticking on the GSAP root after the resolver unmounts the scenes.
+ * (A timeline already nested into a partial master is killed redundantly
+ * — GSAP's `kill()` is idempotent.)
  */
 export function composeMasterTimeline(
   engine: TimelineEngine,
   segments: readonly SceneTimelineSegment[],
 ): MasterTimeline {
-  for (const segment of segments) {
-    assertSceneTimeline(segment.timeline, segment.id);
-  }
-  const master = engine.gsap.timeline({ paused: true });
-  const occurrences = new Map<string, number>();
-  for (const segment of segments) {
-    const occurrence = occurrences.get(segment.id) ?? 0;
-    occurrences.set(segment.id, occurrence + 1);
-    // `master.duration()` before the add is the position the segment
-    // lands at (`'>'` appends at the current end) and the offset for
-    // the segment's labels in master coordinates.
-    const start = master.duration();
-    master.addLabel(sceneSegmentLabel(segment.id, occurrence), start);
-    const child = segment.timeline;
-    if (isGsapTimeline(child)) {
-      // Normalize the scene's timeline before nesting: pause it (a scene
-      // that returned a default-playing `gsap.timeline()` has already
-      // started ticking on the root) and reset its playhead to 0, then
-      // nest it and let the master drive it. After this the master owns
-      // all playback — no scene timeline runs outside it.
-      child.pause();
-      child.seek(0);
-      master.add(child, '>');
-      child.paused(false);
-      for (const [localLabel, localTime] of Object.entries(child.labels)) {
-        master.addLabel(sceneTimelineLabel(segment.id, localLabel, occurrence), start + localTime);
+  let master: GsapTimeline | undefined;
+  try {
+    for (const segment of segments) {
+      assertSceneTimeline(segment.timeline, segment.id);
+    }
+    master = engine.gsap.timeline({ paused: true });
+    const occurrences = new Map<string, number>();
+    for (const segment of segments) {
+      const occurrence = occurrences.get(segment.id) ?? 0;
+      occurrences.set(segment.id, occurrence + 1);
+      // `master.duration()` before the add is the position the segment
+      // lands at (`'>'` appends at the current end) and the offset for
+      // the segment's labels in master coordinates.
+      const start = master.duration();
+      master.addLabel(sceneSegmentLabel(segment.id, occurrence), start);
+      const child = segment.timeline;
+      if (isGsapTimeline(child)) {
+        // Normalize the scene's timeline before nesting: pause it (a scene
+        // that returned a default-playing `gsap.timeline()` has already
+        // started ticking on the root) and reset its playhead to 0, then
+        // nest it and let the master drive it. After this the master owns
+        // all playback — no scene timeline runs outside it.
+        child.pause();
+        child.seek(0);
+        master.add(child, '>');
+        child.paused(false);
+        for (const [localLabel, localTime] of Object.entries(child.labels)) {
+          master.addLabel(
+            sceneTimelineLabel(segment.id, localLabel, occurrence),
+            start + localTime,
+          );
+        }
       }
     }
+    return new GsapMasterTimeline(master);
+  } catch (err) {
+    master?.kill();
+    for (const segment of segments) {
+      if (isGsapTimeline(segment.timeline)) segment.timeline.kill();
+    }
+    throw err;
   }
-  return new GsapMasterTimeline(master);
 }
 
 /** Construction options for {@link createGsapCompositionTimeline}. */
@@ -417,7 +586,12 @@ function positionMaster(
  *  - `'play'`: play and resolve on natural completion, regardless of
  *    whether a cancellation signal is wired (a caller without a signal
  *    still gets playback and completion — the export pipeline before it
- *    owns abort, a test harness).
+ *    owns abort, a test harness). If positioning already left the master
+ *    at (or past) its finite end — e.g. `headBeat` seeked to a beat the
+ *    scene authored at its own end and that scene is the composition's
+ *    tail — `play()` would not re-fire `onComplete`, so resolve right
+ *    away instead of parking the resolver until an abort that may never
+ *    come.
  *  - `'loop'`: start (infinite) playback; only abort resolves it. With
  *    no signal there is nothing to wait for, so resolve immediately —
  *    a loop cannot be observed without cancellation.
@@ -446,6 +620,13 @@ function runMasterUntilDone(
       signal.addEventListener('abort', finish, { once: true });
     }
     if (mode === 'play') {
+      const duration = master.duration();
+      if (Number.isFinite(duration) && duration > 0 && master.time() >= duration) {
+        // Already at the end after positioning — playing from progress 1
+        // does not re-fire `onComplete` in GSAP. Treat it as completed.
+        finish();
+        return;
+      }
       // Arm the completion handler BEFORE play() so a very short master
       // cannot complete before the waiter is installed.
       master.onComplete(finish);

--- a/tests/runtime/timeline.test.ts
+++ b/tests/runtime/timeline.test.ts
@@ -1,15 +1,24 @@
-// Tests for the GSAP timeline adapter — PUL-F022 / ADR-025.
+// Tests for the GSAP timeline adapter — PUL-F022 / ADR-025 and the
+// named-beat grammar PUL-F023 / ADR-026.
 //
 // Coverage map (requirement clauses):
-//  - C1 "Each scene SHALL produce a timeline": `createTimelineEngine`
+//  - PUL-F022 C1 "Each scene SHALL produce a timeline": `createTimelineEngine`
 //    exposes `gsap` for `ctx.gsap`; `assertSceneTimeline` validates the
 //    value a scene's `timeline(ctx)` returns.
-//  - C2 "the runtime composes into a master timeline for the active
+//  - PUL-F022 C2 "the runtime composes into a master timeline for the active
 //    composition": `composeMasterTimeline` nests scene timelines into a
 //    master with namespaced labels; `createGsapCompositionTimeline` is
 //    the composition-level adapter the resolver drives.
-//  - C3 "SHALL support play, pause, seek, speed change, and named
+//  - PUL-F022 C3 "SHALL support play, pause, seek, speed change, and named
 //    labels": the `MasterTimeline` controller.
+//  - PUL-F023 "Scene timelines SHALL support named labels (beats)":
+//    `assertSceneTimeline` enforces that authored beat labels are
+//    kebab-case identifiers (ADR-008 #1) before any timeline is built,
+//    and rejects a bad beat through `resolveComposition`'s envelope.
+//  - PUL-F023 "referenceable by URL / presenter / other runtime
+//    subsystems": the `MasterTimeline` beat-query surface — `labels`,
+//    `hasLabel`, `seek`, `labelFor`, `beats` — plus `parseSceneTimelineLabel`,
+//    the one inverse of `sceneTimelineLabel`.
 //
 // GSAP runs in the `node` test environment: timeline math, labels,
 // seeking, and timeScale need no DOM. Tests that call `play()` always
@@ -26,6 +35,7 @@ import { createSceneRegistry } from '../../src/runtime/registry';
 import type { SceneModule } from '../../src/runtime/scene';
 import {
   type MasterTimeline,
+  SceneTimelineLabelError,
   SceneTimelineTypeError,
   TimelineSeekError,
   TimelineSpeedError,
@@ -33,6 +43,7 @@ import {
   composeMasterTimeline,
   createGsapCompositionTimeline,
   createTimelineEngine,
+  parseSceneTimelineLabel,
   sceneSegmentLabel,
   sceneTimelineLabel,
 } from '../../src/runtime/timeline';
@@ -103,6 +114,56 @@ describe('assertSceneTimeline', () => {
     expect(() => assertSceneTimeline(42, 'scene-a')).toThrow(SceneTimelineTypeError);
     expect(() => assertSceneTimeline('not-a-timeline', 'scene-a')).toThrow(SceneTimelineTypeError);
   });
+
+  it('accepts kebab-case scene timeline labels (beats)', () => {
+    const tl = sceneTl(2, { hook: 0.5, 'cold-open': 0, 'beat-2': 1 });
+    expect(() => assertSceneTimeline(tl, 'intro')).not.toThrow();
+    tl.kill();
+  });
+
+  it.each([
+    ['an uppercase letter', 'My Beat'],
+    ['whitespace', 'cold open'],
+    ['an underscore', 'cold_open'],
+    ['a leading hyphen', '-hook'],
+    ['a trailing hyphen', 'hook-'],
+    ['a double hyphen', 'cold--open'],
+    ['the namespace separator', 'intro:hook'],
+    ['the occurrence marker', 'beat#1'],
+    ['an empty string', ''],
+  ])(
+    'rejects a scene timeline label containing %s with the scene id and label in the message',
+    (_why, label) => {
+      const tl = sceneTl(2, { [label]: 0.5 });
+      expect(() => assertSceneTimeline(tl, 'intro')).toThrow(SceneTimelineLabelError);
+      expect(() => assertSceneTimeline(tl, 'intro')).toThrow(/scene "intro"/);
+      expect(() => assertSceneTimeline(tl, 'intro')).toThrow(
+        new RegExp(`"${label.replace(/[.*+?^${}()|[\]\\#-]/g, '\\$&')}"`),
+      );
+      tl.kill();
+    },
+  );
+
+  it('accepts a beat at time 0 and at exactly the scene timeline duration', () => {
+    const tl = sceneTl(2, { start: 0, finish: 2 });
+    expect(() => assertSceneTimeline(tl, 'intro')).not.toThrow();
+    tl.kill();
+  });
+
+  it.each([
+    ['NaN', Number.NaN],
+    ['Infinity', Number.POSITIVE_INFINITY],
+    ['a negative time', -0.5],
+    ['a time past the scene timeline duration', 5],
+  ])('rejects a beat at %s with the scene id, beat name, and time in the message', (_why, at) => {
+    const tl = gsap.timeline({ paused: true });
+    tl.to({ v: 0 }, { v: 1, duration: 2 });
+    tl.addLabel('peak', at);
+    expect(() => assertSceneTimeline(tl, 'intro')).toThrow(SceneTimelineLabelError);
+    expect(() => assertSceneTimeline(tl, 'intro')).toThrow(/scene "intro"/);
+    expect(() => assertSceneTimeline(tl, 'intro')).toThrow(/"peak"/);
+    tl.kill();
+  });
 });
 
 describe('label namespacing helpers', () => {
@@ -113,6 +174,65 @@ describe('label namespacing helpers', () => {
     expect(sceneTimelineLabel('intro', 'hook')).toBe('intro:hook');
     expect(sceneTimelineLabel('intro', 'hook', 0)).toBe('intro:hook');
     expect(sceneTimelineLabel('intro', 'hook', 1)).toBe('intro#1:hook');
+  });
+});
+
+describe('parseSceneTimelineLabel', () => {
+  it('parses a first-occurrence namespaced label', () => {
+    expect(parseSceneTimelineLabel('intro:hook')).toEqual({
+      scene: 'intro',
+      occurrence: 0,
+      label: 'hook',
+    });
+    expect(parseSceneTimelineLabel('cold-open:beat-2')).toEqual({
+      scene: 'cold-open',
+      occurrence: 0,
+      label: 'beat-2',
+    });
+  });
+
+  it('parses a repeated-occurrence namespaced label', () => {
+    expect(parseSceneTimelineLabel('intro#1:hook')).toEqual({
+      scene: 'intro',
+      occurrence: 1,
+      label: 'hook',
+    });
+    expect(parseSceneTimelineLabel('intro#12:hook')).toEqual({
+      scene: 'intro',
+      occurrence: 12,
+      label: 'hook',
+    });
+  });
+
+  it('round-trips with sceneTimelineLabel', () => {
+    for (const [scene, label, occ] of [
+      ['intro', 'hook', 0],
+      ['intro', 'hook', 3],
+      ['cold-open', 'beat-2', 1],
+    ] as const) {
+      expect(parseSceneTimelineLabel(sceneTimelineLabel(scene, label, occ))).toEqual({
+        scene,
+        occurrence: occ,
+        label,
+      });
+    }
+  });
+
+  it.each([
+    ['a segment-start anchor (no separator)', 'intro'],
+    ['a repeated segment-start anchor', 'intro#1'],
+    ['an empty string', ''],
+    ['a name with no separator', 'no-separator'],
+    ['a trailing separator with no label', 'intro:'],
+    ['a leading separator with no scene', ':hook'],
+    ['a zero occurrence (occurrence 0 has no suffix)', 'intro#0:hook'],
+    ['a non-numeric occurrence', 'intro#x:hook'],
+    ['a negative occurrence', 'intro#-1:hook'],
+    ['a non-kebab scene segment', 'Intro:hook'],
+    ['a non-kebab local label', 'intro:Hook'],
+    ['extra separators in the label', 'intro:hook:extra'],
+  ])('returns null for %s', (_why, name) => {
+    expect(parseSceneTimelineLabel(name)).toBeNull();
   });
 });
 
@@ -188,6 +308,35 @@ describe('composeMasterTimeline', () => {
 
   it('rejects a segment whose timeline value is not a GSAP timeline', () => {
     expect(() => composeMasterTimeline(engine, [segment('a', {})])).toThrow(SceneTimelineTypeError);
+  });
+
+  it('rejects a segment whose timeline carries a non-kebab beat label, before building the master', () => {
+    // The bad label is on the SECOND segment, so a successful compose
+    // would already have added the first segment's labels to a master.
+    // The pre-pass must reject before any timeline is constructed.
+    const good = sceneTl(1, { hook: 0.5 });
+    const bad = sceneTl(1, { 'Bad Label': 0.5 });
+    let caught: unknown;
+    try {
+      composeMasterTimeline(engine, [segment('intro', good), segment('demo', bad)]);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(SceneTimelineLabelError);
+    expect((caught as Error).message).toMatch(/scene "demo"/);
+    expect((caught as Error).message).toMatch(/"Bad Label"/);
+  });
+
+  it('kills every scene timeline it was handed when compose rejects, leaking no live tickers', () => {
+    const good = sceneTl(1, { hook: 0.5 });
+    const bad = sceneTl(1, { 'Bad Label': 0.5 });
+    const goodKill = vi.spyOn(good, 'kill');
+    const badKill = vi.spyOn(bad, 'kill');
+    expect(() =>
+      composeMasterTimeline(engine, [segment('intro', good), segment('demo', bad)]),
+    ).toThrow(SceneTimelineLabelError);
+    expect(goodKill).toHaveBeenCalled();
+    expect(badKill).toHaveBeenCalled();
   });
 
   it('exposes a frozen labels snapshot that does not mutate the master', () => {
@@ -278,6 +427,67 @@ describe('MasterTimeline transport', () => {
     const master = composeMasterTimeline(engine, [segment('a', sceneTl(1))]);
     master.kill();
     expect(() => master.kill()).not.toThrow();
+  });
+});
+
+describe('MasterTimeline.beats', () => {
+  /** Drop `time` (float) so the structural shape can be compared exactly. */
+  const shape = (master: MasterTimeline) => master.beats().map(({ time: _time, ...rest }) => rest);
+
+  it('lists scene-authored beats in playhead order, excluding the segment-start anchors', () => {
+    const master = composeMasterTimeline(engine, [
+      segment('intro', sceneTl(2, { hook: 0.5, outro: 1.5 })),
+      segment('demo', sceneTl(1, { peak: 0.25 })),
+    ]);
+    expect(shape(master)).toEqual([
+      { scene: 'intro', occurrence: 0, label: 'hook', name: 'intro:hook' },
+      { scene: 'intro', occurrence: 0, label: 'outro', name: 'intro:outro' },
+      { scene: 'demo', occurrence: 0, label: 'peak', name: 'demo:peak' },
+    ]);
+    const byName = new Map(master.beats().map((b) => [b.name, b.time]));
+    expect(byName.get('intro:hook')).toBeCloseTo(0.5);
+    expect(byName.get('intro:outro')).toBeCloseTo(1.5);
+    expect(byName.get('demo:peak')).toBeCloseTo(2.25);
+    // The segment-start anchors are present as labels but are not beats.
+    expect(master.hasLabel('intro')).toBe(true);
+    expect(master.hasLabel('demo')).toBe(true);
+    expect(master.beats().some((b) => b.name === 'intro' || b.name === 'demo')).toBe(false);
+    master.kill();
+  });
+
+  it('disambiguates repeated scene entries by occurrence', () => {
+    const master = composeMasterTimeline(engine, [
+      segment('beat', sceneTl(1, { mid: 0.5 })),
+      segment('gap', sceneTl(1)),
+      segment('beat', sceneTl(1, { mid: 0.5 })),
+    ]);
+    expect(shape(master)).toEqual([
+      { scene: 'beat', occurrence: 0, label: 'mid', name: 'beat:mid' },
+      { scene: 'beat', occurrence: 1, label: 'mid', name: 'beat#1:mid' },
+    ]);
+    const byName = new Map(master.beats().map((b) => [b.name, b.time]));
+    expect(byName.get('beat:mid')).toBeCloseTo(0.5);
+    expect(byName.get('beat#1:mid')).toBeCloseTo(2.5);
+    master.kill();
+  });
+
+  it('returns an empty list when no scene authored a beat (including null timelines)', () => {
+    const master = composeMasterTimeline(engine, [
+      segment('a', sceneTl(1)),
+      segment('empty', null),
+      segment('b', sceneTl(1)),
+    ]);
+    expect(master.beats()).toEqual([]);
+    master.kill();
+  });
+
+  it('returns a fresh array each call that does not alias the master state', () => {
+    const master = composeMasterTimeline(engine, [segment('a', sceneTl(1, { mid: 0.5 }))]);
+    const first = master.beats();
+    expect(first).toHaveLength(1);
+    (first as unknown as unknown[]).push('tamper');
+    expect(master.beats()).toHaveLength(1);
+    master.kill();
   });
 });
 
@@ -462,6 +672,45 @@ describe('createGsapCompositionTimeline', () => {
     controller.abort(); // no-op: already settled.
   });
 
+  it('resolves immediately when headBeat seeks the master to a beat authored at the composition tail end', async () => {
+    // The head (and only) scene authored a beat at its own end, so the
+    // positioned master starts at progress 1. `play()` from there would
+    // never re-fire `onComplete`, so the run must resolve right away
+    // rather than park the resolver until an abort that never comes.
+    const adapter = createGsapCompositionTimeline({ engine });
+    await expect(
+      adapter.run([segment('intro', sceneTl(0.02, { 'the-end': 0.02 }))], { headBeat: 'the-end' }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('tears the scene down through resolveComposition when headBeat lands on a terminal beat', async () => {
+    // A single-scene composition whose head scene authored a beat at its
+    // own end: the URL beat (head-scoped) seeks the master to its finite
+    // end, so the run must resolve and the resolver must run cleanup —
+    // not park forever waiting on an `onComplete` that cannot re-fire.
+    const cleaned: string[] = [];
+    const onBeatMissing = vi.fn();
+    const adapter = createGsapCompositionTimeline({ engine });
+    await resolveComposition({
+      registry: createSceneRegistry([
+        stubScene('intro', {
+          timeline: () => sceneTl(0.02, { 'the-end': 0.02 }),
+          cleanup: () => {
+            cleaned.push('intro');
+          },
+        }),
+      ]),
+      manifest: ['intro'],
+      ctx: {},
+      preloadAssets: () => undefined,
+      timeline: adapter,
+      headBeat: 'the-end',
+      onBeatMissing,
+    });
+    expect(onBeatMissing).not.toHaveBeenCalled();
+    expect(cleaned).toEqual(['intro']);
+  });
+
   it('does not reject when the missing-beat sink throws', async () => {
     const controller = new AbortController();
     const { settled } = runWith([segment('intro', sceneTl(4))], {
@@ -529,6 +778,40 @@ describe('createGsapCompositionTimeline', () => {
     // scene timelines (3 × 0.005s).
     expect(composedDurations).toHaveLength(1);
     expect(composedDurations[0]).toBeCloseTo(0.015);
+  });
+
+  it('rejects through resolveComposition with the composition envelope and tears every scene down when a scene authors a bad beat label', async () => {
+    const cleaned: string[] = [];
+    const trace = (id: string, timeline: SceneModule['timeline']): SceneModule =>
+      stubScene(id, {
+        timeline,
+        cleanup: () => {
+          cleaned.push(id);
+        },
+      });
+    const adapter = createGsapCompositionTimeline({ engine });
+    let caught: unknown;
+    try {
+      await resolveComposition({
+        registry: createSceneRegistry([
+          trace('intro', () => sceneTl(0.005, { hook: 0.002 })),
+          trace('demo', () => sceneTl(0.005, { 'Bad Beat': 0.002 })),
+          trace('outro', () => sceneTl(0.005)),
+        ]),
+        manifest: ['intro', 'demo', 'outro'],
+        ctx: {},
+        preloadAssets: () => undefined,
+        timeline: adapter,
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toMatch(/composition timeline failed:/);
+    expect((caught as Error).message).toMatch(/scene "demo".*"Bad Beat"/);
+    expect((caught as { cause?: unknown }).cause).toBeInstanceOf(SceneTimelineLabelError);
+    // Mandatory cleanup ran for every mounted scene (reverse order).
+    expect(cleaned).toEqual(['outro', 'demo', 'intro']);
   });
 
   it('passes a default-playing (not `{ paused: true }`) scene timeline through, master-driven', async () => {

--- a/tests/runtime/timeline.test.ts
+++ b/tests/runtime/timeline.test.ts
@@ -328,15 +328,23 @@ describe('composeMasterTimeline', () => {
   });
 
   it('kills every scene timeline it was handed when compose rejects, leaking no live tickers', () => {
-    const good = sceneTl(1, { hook: 0.5 });
-    const bad = sceneTl(1, { 'Bad Label': 0.5 });
-    const goodKill = vi.spyOn(good, 'kill');
-    const badKill = vi.spyOn(bad, 'kill');
+    // Default-playing timelines (`gsap.timeline()`, not `{ paused: true }`)
+    // are children of the global timeline the moment they exist — i.e.
+    // already ticking. A rejected compose must detach (kill) every one it
+    // was handed so none keeps running after the resolver unmounts the scenes.
+    const liveChildren = () => gsap.globalTimeline.getChildren(false) as unknown[];
+    const live = gsap.timeline();
+    live.to({ v: 0 }, { v: 1, duration: 30 });
+    const bad = gsap.timeline();
+    bad.to({ v: 0 }, { v: 1, duration: 30 });
+    bad.addLabel('Bad Label', 0.5);
+    expect(liveChildren()).toContain(live);
+    expect(liveChildren()).toContain(bad);
     expect(() =>
-      composeMasterTimeline(engine, [segment('intro', good), segment('demo', bad)]),
+      composeMasterTimeline(engine, [segment('intro', live), segment('demo', bad)]),
     ).toThrow(SceneTimelineLabelError);
-    expect(goodKill).toHaveBeenCalled();
-    expect(badKill).toHaveBeenCalled();
+    expect(liveChildren()).not.toContain(live);
+    expect(liveChildren()).not.toContain(bad);
   });
 
   it('exposes a frozen labels snapshot that does not mutate the master', () => {


### PR DESCRIPTION
Implements **PUL-F023 — Named timeline beats** (#32):

> Scene timelines SHALL support named labels (beats) referenceable by URL, presenter input, and other runtime subsystems.

PUL-F022 / ADR-025 already shipped the master-timeline machinery (namespaced scene labels, `MasterTimeline` transport surface, URL `beat=` head-hint seeking). This PR names and finalizes the named-beat contract — the two pieces that were still loose:

- **A scene-authored timeline label is now validated as a beat.** `assertSceneTimeline` rejects any label that is not a kebab-case identifier (ADR-008 #1 — the kebab-only URL `beat=` grammar could never address anything else) or that sits at a non-finite / negative time, or past the scene timeline's duration — throwing the new `SceneTimelineLabelError` (a leaf of the existing `TimelineError` hierarchy) naming the scene, the beat, the time, and the duration (PUL-Q006). `composeMasterTimeline` runs this over every segment before it builds the master, so a bad beat is rejected before any timeline is constructed; it surfaces through the resolver's `composition timeline failed:` envelope with mandatory cleanup — a scene-contract failure, distinct from ADR-015's non-fatal "unknown URL beat" diagnostic. On rejection, `composeMasterTimeline` also kills every GSAP timeline it was handed so a default-playing or repeating scene timeline cannot keep ticking after the resolver unmounts the scenes.
- **A canonical beat-query surface.** `MasterTimeline` gains `beats(): readonly MasterBeat[]` — the scene-authored beats in playhead order (each `{ scene, occurrence, label, name, time }`; the automatic segment-start anchors are transport anchors, not beats, and are excluded) — alongside `labels` / `hasLabel` / `seek` / `labelFor`. New `parseSceneTimelineLabel` is the single inverse of `sceneTimelineLabel` (a namespaced master label → `{ scene, occurrence, label }`, or `null` for a bare anchor / malformed name), so no subsystem reparses the `:` / `#` grammar locally. URL `beat=` (PUL-F011 / ADR-015), presenter input (PUL-F020 / ADR-023 / ADR-024), and scrub controls (PUL-F017 / ADR-020) reference beats through this surface; they do not own beat handling.

Also fixed during pre-push review: `runMasterUntilDone` resolves immediately when positioning leaves a play-mode master at its finite end, so a `headBeat` seeked to a beat the scene authored at the composition's tail end no longer parks the resolver waiting on an `onComplete` GSAP cannot re-fire from progress 1.

`docs/adrs/026-named-timeline-beats.md` records the decision; `docs/design/pul-f023-named-timeline-beats-preflight.md` is the codex architecture preflight note. CHANGELOG + ADR index updated. New tests in `tests/runtime/timeline.test.ts` cover beat-shape and beat-position validation, the leak-on-rejection behavior, `parseSceneTimelineLabel`, `MasterTimeline.beats()`, the resolver `composition timeline failed:` path on a bad beat, and the terminal-beat resolve-immediately path. Full suite (782 tests) green; lint + typecheck clean.

Closes #32
