### PR TITLE
Implement PUL-F024 audio orchestration: ctx.audio + Howler boundary (ADR-004)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Audio orchestration — PUL-F024 / ADR-004 — in `src/runtime/audio.ts`:
+  the runtime now provides an audio service exposed to scenes as
+  `ctx.audio`. `createHowlerAudioEngine()` wraps Howler.js behind the
+  small `AudioEngine` port (the one `import ... from 'howler'` site,
+  parallel to `createTimelineEngine()` wrapping GSAP); `noopAudioEngine`
+  is the silent fallback the scene loader uses when no backend is wired
+  (the same inert-seam pattern `renderPrompter` / `presenterCommands`
+  follow). `createAudioService(engine, opts)` is the per-navigation
+  service: `load(soundId, { src, sprite? })` registers a sound,
+  `play(soundId, { sprite?, loop?, volume?, group? })` plays it,
+  `fade(soundId, from, to, durationMs)` cross-fades, `stop(soundId)` /
+  `stopGroup(group)` stop instances (named groups are kebab-case audio
+  routing/cleanup scopes — not scene/composition/timeline ids), and
+  `mute(b)` / `isMuted()` toggle master mute (persistent runtime state
+  held on the engine). The service is bound to the navigation's
+  `AbortSignal` and `stopAll()`-ed on supersession / dispose /
+  completion, so fades, loops, sprites, and muted state never survive
+  scene cleanup (ADR-004's runtime-guaranteed per-scene cleanup);
+  `mode=screenshot` / `mode=paused` build it `silent` (audible playback
+  suppressed — ADR-019 / ADR-021). Source URLs reuse PUL-F005's
+  `resolveAssetUrl` scheme resolver (now exported from
+  `src/runtime/asset-preloader.ts` — no copied scheme rules) and must be
+  declared in the active slice's `scene.assets` (ADR-008 #5 — the
+  preloader warms them); sound ids and group names obey the ADR-008 #1
+  kebab-case rule. Errors are an `AudioError` family —
+  `AudioSoundError` / `AudioGroupError` / `AudioSourceError` /
+  `AudioRangeError`. `WorkbenchSceneCtx` gains `audio`; `SceneLoaderOptions`
+  gains an optional `audioEngine`; `buildCtx` now receives the
+  per-navigation `AudioService` as its second argument. Adds `howler`
+  as a runtime dependency (`@types/howler` dev). Scenes reach audio only
+  through `ctx.audio` — never by importing Howler or constructing
+  `<audio>`. Per-scene audio teardown is runtime-driven, not author
+  discipline: a scene scopes a sound to itself with
+  `play(id, { group: <its-scene-id> })` and the new
+  `ResolveCompositionOptions.onSceneCleaned` resolver hook (wired by the
+  loader to `ctx.audio.stopGroup(sceneId)`) stops that group when the
+  scene's `cleanup(ctx)` runs. Re-registering the same sound id with the
+  same definition is idempotent (a shared transition SFX two scenes
+  both `load`); a different definition is an `AudioSoundError`. Sprite
+  maps are validated at the runtime boundary (offsets and durations
+  finite + non-negative; loop flag boolean; non-empty names). (Scrub's
+  `headCueGate`→audio cue gating is a documented follow-up; the
+  timeline adapter does not yet fire audio cues.)
 - Named timeline beats — PUL-F023 / ADR-026 — in `src/runtime/timeline.ts`:
   a scene's GSAP timeline labels *are* its beats, and `assertSceneTimeline`
   now validates every authored label is a kebab-case identifier (the same

--- a/docs/adrs/004-howler-audio-engine.md
+++ b/docs/adrs/004-howler-audio-engine.md
@@ -94,9 +94,68 @@ the runtime so the lifecycle is preserved.
 | Heavy assets bloat first-load times | Declare audio in scene metadata and preload only what the active composition needs. |
 | Scenes bypass the service to use raw `<audio>` | Treat raw `<audio>` in scene code as a smell; route through `ctx.audio` unless the scene has a documented reason. |
 
+## Implementation
+
+PUL-F024 lands the runtime side in `src/runtime/audio.ts`:
+
+- `createHowlerAudioEngine()` is the only Howler import site; `ctx.audio`
+  is a per-navigation `AudioService` (`load` / `play` / `fade` / `stop` /
+  `stopGroup` / `mute`) the scene loader builds over that engine, bound
+  to the navigation's `AbortSignal` so every sound is stopped + unloaded
+  on supersession / dispose / completion. A workbench with no audio
+  backend wired falls back to a silent no-op engine.
+- Sound ids are registered against URLs the scene already declared in
+  `scene.assets` via `ctx.audio.load(id, { src, sprite? })` at mount
+  time — there is no separate `audio:` field on `SceneModule` (ADR-008
+  #5: the only asset inventory is `scene.assets`, which the PUL-F005
+  preloader warms before `create(ctx)`). Sound ids and group names obey
+  the kebab-case rule (ADR-008 #1); source URLs pass the same scheme
+  allowlist as other assets (PUL-F005).
+- The service is per-navigation: under single-scene workbench modes that
+  is one scene; under `mode=present` it is shared across the whole
+  composition slice (the resolver mounts the slice with one ctx and
+  forbids it repeating a scene id). The sound-id namespace and the
+  source allowlist are therefore composition-slice-scoped, not per-scene
+  — multi-scene compositions pick distinct sound ids (the same
+  stable-identity discipline scene ids obey), and re-registering an id
+  with the same definition is idempotent (a shared transition SFX).
+- Per-scene audio teardown is runtime-driven, not author discipline:
+  a scene scopes a sound to itself with `play(id, { group: <its-scene-id> })`,
+  and the resolver's per-scene post-`cleanup(ctx)` hook
+  (`ResolveCompositionOptions.onSceneCleaned`, wired by the loader to
+  `ctx.audio.stopGroup(sceneId)`) stops that group when that scene's
+  `cleanup` runs — so "when a scene's `cleanup()` runs, its audio group
+  is stopped" is enforced by the runtime. Sounds not scoped to a scene
+  group are torn down when the navigation's cleanup phase completes
+  (`stopAll()` — every sound stopped + unloaded), which in the ADR-025
+  mount-all model is when every scene's `cleanup()` has run. Finer
+  granularity (a per-entry container/handle threaded through `create` /
+  `timeline` / `cleanup` so each scene gets its own `ctx.audio` facade
+  and `play()`s are attributed without the `group` convention) is a
+  documented resolver follow-up — the same one that would let a
+  composition slice repeat a scene id.
+- Master mute is held on the engine (persistent runtime state), not as a
+  per-scene checkbox. `mode=screenshot` / `mode=paused` build the
+  service `silent` (audible playback suppressed — ADR-019 / ADR-021).
+- Browser autoplay policy is centralized by Howler's default Web Audio
+  mode + `Howler.autoUnlock`: a `play()` made before the first user
+  gesture is deferred (the suspended `AudioContext` blocks playback) and
+  replayed when the first gesture resumes the context — no cue is lost,
+  and the runtime does not re-implement the unlock dance per scene.
+  `onloaderror` (a source that fails to fetch / decode) is the one async
+  failure that surfaces; it routes to the service's non-fatal `onError`
+  sink and is suppressed once the service is disposed (so a stale scene
+  cannot write over the active navigation's error state).
+- `headCueGate` (PUL-F017 / ADR-020) is plumbed to the timeline adapter
+  but does not yet gate audio cues; scenes hang `ctx.audio` cues off
+  their own timeline callbacks. Wiring scrub's monotonic-forward cue
+  gate to the audio service is a follow-up that extends `AudioService`.
+
 ## Related ADRs
 
 - [ADR-002](002-scene-registry-and-compositions.md) — defines where
   audio assets and cues are declared.
 - [ADR-003](003-gsap-timeline-engine.md) — timeline callbacks are how
   most audio cues fire.
+- [ADR-008](008-agent-native-authoring.md) — #1 kebab ids, #5 the only
+  asset inventory is `scene.assets`.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -17,6 +17,7 @@ Design context for Pulsar. Source material for the ADRs in `../adrs/`.
 | [pul-f021-pause-resume-preflight.md](pul-f021-pause-resume-preflight.md) | Guardrails for implementing presenter pause and resume commands. |
 | [pul-f022-timeline-orchestration-preflight.md](pul-f022-timeline-orchestration-preflight.md) | Guardrails for implementing GSAP-backed master timeline orchestration. |
 | [pul-f023-named-timeline-beats-preflight.md](pul-f023-named-timeline-beats-preflight.md) | Guardrails for implementing named timeline beats. |
+| [pul-f024-audio-orchestration-preflight.md](pul-f024-audio-orchestration-preflight.md) | Guardrails for implementing runtime-owned audio orchestration. |
 
 Design docs are mutable. Decisions are captured as ADRs (immutable once
 accepted).

--- a/docs/design/pul-f024-audio-orchestration-preflight.md
+++ b/docs/design/pul-f024-audio-orchestration-preflight.md
@@ -1,0 +1,125 @@
+# PUL-F024 Audio Orchestration Preflight
+
+PUL-F024 makes ADR-004 concrete: audio is a runtime service, not
+scene-owned Howler code. Scenes access audio through `ctx.audio`;
+the runtime owns engine construction, per-scene scoping, cleanup,
+autoplay unlock state, master mute, fades, sprites, looping, and
+named groups.
+
+## Boundary
+
+Implementation must stay on the existing runtime path:
+
+- `src/runtime/scene-loader.ts` builds a fresh per-navigation scene
+  context. `ctx.audio` belongs beside `ctx.gsap` and `ctx.mode`; scenes
+  must not import Howler or read global audio state.
+- `src/runtime/composition-resolver.ts` owns preload -> create ->
+  timeline -> cleanup ordering and error envelopes. Audio cleanup must
+  run through this lifecycle, not through a second scene runner.
+- `src/runtime/timeline.ts` remains the timing surface. Audio cues
+  should be fired from GSAP timeline callbacks / transport state; do
+  not add a parallel cue scheduler.
+- `src/runtime/asset-preloader.ts` remains the network validation and
+  preload boundary for scene-declared assets. Audio URLs are assets,
+  not a second fetch inventory.
+- `src/runtime/scene.ts` remains the scene schema gate. If PUL-F024
+  needs typed audio declarations, extend `SceneModule` and
+  `assertSceneModule()` once; do not add a parallel audio-scene
+  schema.
+- `src/runtime/navigation.ts` and workbench modes remain URL-owned.
+  Audio mute/unlock/group state is runtime state, not new URL grammar.
+
+## Required Reuse
+
+Use these canonical incumbents:
+
+- Scene shape: `SceneModule`, `assertSceneModule()`,
+  `createSceneRegistry()`.
+- Lifecycle and cleanup: `createSceneLoader()`,
+  `loadSceneNavigationTarget()`, `resolveComposition()`, and the
+  per-navigation `AbortSignal`.
+- Timeline cues: `ctx.gsap`, `MasterTimeline`, and
+  `createGsapCompositionTimeline()`.
+- Asset validation: `scene.assets`, `createAssetPreloader()`,
+  `DEFAULT_ALLOWED_SCHEMES`, redirect re-checks, `baseUrl`, and
+  fetch `AbortSignal` wiring. If Howler-side URL validation needs the
+  same resolver, extract the existing helper; do not copy the rules.
+- Identifier rules for named groups / sound ids:
+  `isKebabIdentifier()` and `KEBAB_IDENTIFIER_FORM`.
+- Error and observability: `describeError()`, existing stage attrs
+  (`data-pulsar-scene-target`, `data-pulsar-composition-target`,
+  `data-pulsar-navigation-error`), and the loader `onError` sink.
+- Tests: Vitest seam tests under `tests/runtime/*`, split across
+  service, loader context, resolver cleanup, and timeline-cue behavior.
+
+## Cross-Cutting Layers
+
+| Layer | Guardrail |
+|-------|-----------|
+| Dependency / supply chain | Add Howler through `package.json` and `pnpm-lock.yaml`. Import it only inside the runtime audio boundary; scenes must consume `ctx.audio`. |
+| Browser autoplay policy | Centralize unlock / mute state in the audio service or workbench bootstrap. Scenes must not attach their own unlock gesture handlers or construct hidden `<audio>` elements. |
+| Scene schema gate | `assertSceneModule()` remains the only scene-shape validator. Any audio declaration extension must reuse `scene.assets` for URLs and validate sound / group ids with `isKebabIdentifier()`. |
+| Asset security | Audio sources must be declared before use and pass the same scheme / redirect validation as other assets. Do not let `ctx.audio.play(url)` fetch arbitrary scene-provided strings. |
+| Lifecycle / cleanup | Every handle created through `ctx.audio` is scoped to the active scene by default and stopped on scene cleanup / navigation abort. Named groups are service-managed scopes, not lifecycle owners. |
+| Timeline integration | Cue firing belongs in timeline callbacks or active transport state. `headCueGate: 'monotonic-forward'`, screenshot, scrub, paused, and loop modes must influence whether cues fire; they must not fork the resolver lifecycle. |
+| Error envelope | Audio setup or playback failures surfaced through lifecycle keep `composition resolution failed:` wrapping. Non-fatal cue/playback diagnostics use `onError` / stage diagnostics without unmounting unless lifecycle invariants are broken. |
+| Config / env / OS | No env vars, process argv tokens, shell commands, persisted browser storage, cookies, or credentials are needed for PUL-F024. Do not put audio source secrets or unlock state in URLs. |
+| Observability | Use the existing `onError` sink. Cue logging for rehearsal mode must be bounded and explicit; no per-frame logs or analytics until a telemetry policy exists. |
+
+## Guardrails
+
+- The service API should expose semantic ids (`play`, `fade`, `stop`,
+  `stopGroup`, sprite names, loop flags), not raw Howler instances.
+- Group names are audio routing / cleanup scopes. Do not conflate them
+  with scene ids, composition ids, timeline labels, presenter commands,
+  or asset URLs.
+- Per-scene cleanup is automatic. A scene may stop a group explicitly,
+  but it must not be responsible for final teardown.
+- Fades and looping should be idempotent under repeated calls and
+  navigation abort. A fade started by a superseded scene must not keep
+  changing volume after cleanup.
+- Screenshot and paused modes must suppress audible playback. Scrub
+  mode must honor monotonic-forward cue gating once cues exist.
+- Master mute and future ducking are runtime state. Do not add
+  per-scene mute booleans or duplicate presenter command buses.
+- Raw Web Audio escape hatches require explicit cleanup registration
+  with the runtime; ordinary scenes use `ctx.audio` only.
+
+## Extensibility
+
+The extension seam is a small `AudioService` exposed through
+`WorkbenchSceneCtx.audio`, backed by one runtime-owned Howler engine
+adapter. The necessary parameter is the scene activation scope:
+construct or bind the context audio facade with the active scene id /
+activation token so the service can stop all sounds from that scene
+without relying on author discipline.
+
+Named groups should be parameters on service calls and service-owned
+state, not schema branches. Future variations such as ducking, bus
+volume, rehearsal cue logging, spatial panning, or export-mode silence
+extend the service facade and runtime adapter; they do not change
+scene lifecycle, URL grammar, or composition manifest semantics.
+
+## Non-Goals
+
+- No new URL parameters, storage keys, cookies, env vars, CLI flags,
+  remote protocol, analytics stream, or persistence format.
+- No replacement for `createAssetPreloader()` and no duplicate audio
+  asset inventory separate from scene-declared assets.
+- No new resolver, scene registry, exception hierarchy, or workflow
+  state machine.
+- No authoring UI, waveform editor, DAW-style scheduler, export audio
+  mixdown, or requirement status transition during this preflight.
+
+## Anti-Patterns
+
+- Importing Howler, constructing `<audio>`, or using raw Web Audio in
+  ordinary scene modules.
+- Passing arbitrary URLs to playback APIs.
+- Duplicating identifier regexes, asset validators, error envelopes, or
+  cleanup queues.
+- Treating audio groups as composition flow control or timeline labels.
+- Letting fades, loops, sprites, or muted state survive scene cleanup
+  unless they are explicitly global service state.
+- Adding scene-local unlock buttons, keyboard listeners, or presenter
+  command handling for audio.

--- a/package.json
+++ b/package.json
@@ -23,12 +23,14 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
+    "@types/howler": "^2.2.12",
     "@vitest/coverage-v8": "^3.0.0",
     "typescript": "^5.7.2",
     "vite": "^6.0.0",
     "vitest": "^3.0.0"
   },
   "dependencies": {
-    "gsap": "^3.15.0"
+    "gsap": "^3.15.0",
+    "howler": "^2.2.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,10 +11,16 @@ importers:
       gsap:
         specifier: ^3.15.0
         version: 3.15.0
+      howler:
+        specifier: ^2.2.4
+        version: 2.2.4
     devDependencies:
       '@biomejs/biome':
         specifier: ^1.9.4
         version: 1.9.4
+      '@types/howler':
+        specifier: ^2.2.12
+        version: 2.2.12
       '@vitest/coverage-v8':
         specifier: ^3.0.0
         version: 3.2.4(vitest@3.2.4)
@@ -423,6 +429,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/howler@2.2.12':
+    resolution: {integrity: sha512-hy769UICzOSdK0Kn1FBk4gN+lswcj1EKRkmiDtMkUGvFfYJzgaDXmVXkSShS2m89ERAatGIPnTUlp2HhfkVo5g==}
+
   '@vitest/coverage-v8@3.2.4':
     resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
     peerDependencies:
@@ -587,6 +596,9 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  howler@2.2.4:
+    resolution: {integrity: sha512-iARIBPgcQrwtEr+tALF+rapJ8qSc+Set2GJQl7xT1MQzWaVkFebdJhR3alVlSiUf5U7nAANKuj3aWpwerocD5w==}
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
@@ -1115,6 +1127,8 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/howler@2.2.12': {}
+
   '@vitest/coverage-v8@3.2.4(vitest@3.2.4)':
     dependencies:
       '@ampproject/remapping': 2.3.0
@@ -1303,6 +1317,8 @@ snapshots:
   gsap@3.15.0: {}
 
   has-flag@4.0.0: {}
+
+  howler@2.2.4: {}
 
   html-escaper@2.0.2: {}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,6 +25,7 @@
 
 import { DEFAULT_COMPOSITION_ID, defaultComposition } from './compositions/default';
 import { createAssetPreloader } from './runtime/asset-preloader';
+import { type AudioService, createHowlerAudioEngine } from './runtime/audio';
 import { createCompositionRegistry } from './runtime/composition-registry';
 import {
   type NavigationMode,
@@ -52,6 +53,14 @@ const compositionRegistry = createCompositionRegistry([
 // scene timelines into a master timeline (see `./runtime/timeline.ts`).
 const timelineEngine = createTimelineEngine();
 
+// PUL-F024 / ADR-004: the Howler audio engine — a process singleton.
+// The loader builds a fresh per-navigation `AudioService` over it
+// (scoped to the navigation's `AbortSignal`) and threads it into
+// `ctx.audio`; scenes call `ctx.audio.play(...)` / `fade(...)` etc.
+// rather than importing Howler. Howler auto-handles the browser
+// autoplay-unlock gesture, so the workbench does not.
+const audioEngine = createHowlerAudioEngine();
+
 // PUL-F005 asset preloader. The placeholder scene declares no assets,
 // so the preloader is a structural no-op today; once scenes start
 // declaring URLs the same wire-up validates schemes, fetches, and
@@ -69,10 +78,12 @@ const createPreloader = (signal: AbortSignal): ReturnType<typeof createAssetPrel
 // timeline (`composeMasterTimeline` — namespaced labels, sequential
 // nesting), applies the URL/runner-input head hints (`beat` seek with
 // the `onBeatMissing` fallback, `mode=loop` repeat, `mode=paused` hold,
-// `mode=screenshot` freeze-at-beat; `cueGate` is a no-op until the
-// audio engine lands per PUL-F024), plays the master, and resolves on
-// its natural completion (the resolver then tears every scene down) or
-// on the per-navigation `AbortSignal`. Per-entry `range` overrides
+// `mode=screenshot` freeze-at-beat; the audio engine lands with
+// PUL-F024, but `cueGate`→audio cue gating is a separate follow-up —
+// scenes hang `ctx.audio` cues off their own timeline callbacks today),
+// plays the master, and resolves on its natural completion (the
+// resolver then tears every scene down) or on the per-navigation
+// `AbortSignal`. Per-entry `range` overrides
 // (PUL-F003) and the presenter command controller (PUL-F020 / PUL-F021)
 // are not interpreted here yet — both land on this adapter's
 // `MasterTimeline` transport seam when their requirements are
@@ -80,20 +91,24 @@ const createPreloader = (signal: AbortSignal): ReturnType<typeof createAssetPrel
 const timeline = createGsapCompositionTimeline({ engine: timelineEngine });
 
 // Scene context carries the stage handle, the per-navigation effective
-// workbench mode (PUL-F012 / ADR-007), and the GSAP instance scenes
-// build their timeline with (PUL-F022 / ADR-003). The loader calls this
-// builder once per navigation that produces a runnable target, passing
-// the effective mode it derived from the URL via `effectiveMode`.
-// Constructing ctx per navigation enforces ADR-007's "URL is the only
-// source of mode" rule by construction — there is no long-lived ctx
-// slot for a previous mode to linger in. ADR-008 #2 (explicit
-// dependencies over ambient globals) is satisfied by passing `stage`
-// and `gsap` through ctx rather than reaching for `document` or
-// importing GSAP directly in scene modules.
-const buildCtx = (mode: NavigationMode): WorkbenchSceneCtx => ({
+// workbench mode (PUL-F012 / ADR-007), the GSAP instance scenes build
+// their timeline with (PUL-F022 / ADR-003), and the per-navigation
+// audio service (PUL-F024 / ADR-004). The loader calls this builder
+// once per navigation that produces a runnable target, passing the
+// effective mode it derived from the URL via `effectiveMode` and the
+// audio service it built over `audioEngine`. Constructing ctx per
+// navigation enforces ADR-007's "URL is the only source of mode" rule
+// by construction — there is no long-lived ctx slot for a previous
+// mode to linger in — and makes "audio survives the scene that started
+// it" impossible. ADR-008 #2 (explicit dependencies over ambient
+// globals) is satisfied by passing `stage`, `gsap`, and `audio` through
+// ctx rather than reaching for `document`, importing GSAP, or importing
+// Howler directly in scene modules.
+const buildCtx = (mode: NavigationMode, audio: AudioService): WorkbenchSceneCtx => ({
   stage,
   mode,
   gsap: timelineEngine.gsap,
+  audio,
 });
 
 // Prompter renderer placeholder (PUL-F019 / ADR-022). Under
@@ -141,6 +156,7 @@ const loader = createSceneLoader({
   buildCtx,
   createPreloader,
   timeline,
+  audioEngine,
   renderPrompter,
 });
 

--- a/src/runtime/asset-preloader.ts
+++ b/src/runtime/asset-preloader.ts
@@ -228,8 +228,13 @@ export function createAssetPreloader(
  *  - `baseUrl` not provided, asset is a relative path: pass through.
  *    The browser resolves against `document.baseURI` (same-origin by
  *    default).
+ *
+ * Also reused by the audio service (PUL-F024) to scheme-validate
+ * `ctx.audio.load()` sources with the same allowlist — one rule, not
+ * two copies (per the codex preflight: "extract the existing helper;
+ * do not copy the rules").
  */
-function resolveAssetUrl(
+export function resolveAssetUrl(
   asset: string,
   baseUrl: string | undefined,
   allowedSchemes: readonly string[],

--- a/src/runtime/audio.ts
+++ b/src/runtime/audio.ts
@@ -387,12 +387,8 @@ const sameSpriteMap = (a: AudioSpriteMap | undefined, b: AudioSpriteMap | undefi
   return aKeys.every((key) => {
     const av = a[key];
     const bv = b[key];
-    return (
-      bv !== undefined &&
-      av !== undefined &&
-      av.length === bv.length &&
-      av.every((v, i) => v === bv[i])
-    );
+    if (av === undefined || bv === undefined || av.length !== bv.length) return false;
+    return av.every((v, i) => v === bv[i]);
   });
 };
 

--- a/src/runtime/audio.ts
+++ b/src/runtime/audio.ts
@@ -379,17 +379,22 @@ const isFiniteNumber = (value: unknown): value is number =>
 const sameSourceList = (a: readonly string[], b: readonly string[]): boolean =>
   a.length === b.length && a.every((url, i) => url === b[i]);
 
+/** Element-wise equality of two sprite tuples (`[start, duration]` or `[start, duration, loop]`). */
+const sameSpriteTuple = (
+  av: readonly [number, number] | readonly [number, number, boolean] | undefined,
+  bv: readonly [number, number] | readonly [number, number, boolean] | undefined,
+): boolean => {
+  if (av?.length !== bv?.length) return false;
+  if (av === undefined || bv === undefined) return true;
+  return av.every((v, i) => v === bv[i]);
+};
+
 /** Equality of two optional sprite maps (same keys, each tuple element-wise equal). */
 const sameSpriteMap = (a: AudioSpriteMap | undefined, b: AudioSpriteMap | undefined): boolean => {
   if (a === undefined || b === undefined) return a === b;
   const aKeys = Object.keys(a);
   if (aKeys.length !== Object.keys(b).length) return false;
-  return aKeys.every((key) => {
-    const av = a[key];
-    const bv = b[key];
-    if (av === undefined || bv === undefined || av.length !== bv.length) return false;
-    return av.every((v, i) => v === bv[i]);
-  });
+  return aKeys.every((key) => sameSpriteTuple(a[key], b[key]));
 };
 
 /**

--- a/src/runtime/audio.ts
+++ b/src/runtime/audio.ts
@@ -1,0 +1,770 @@
+// Audio orchestration — PUL-F024 / ADR-004. The runtime's audio service.
+//
+// ADR-004 picks Howler.js as the audio engine and mandates that scenes
+// reach audio through the runtime context, never by importing Howler or
+// touching `<audio>` directly. This module is that boundary:
+//
+//  - `createHowlerAudioEngine()` wraps Howler behind the small
+//    {@link AudioEngine} port — parallel to `createTimelineEngine()`
+//    wrapping GSAP (ADR-003). It is the only `import ... from 'howler'`
+//    site. `noopAudioEngine` is the silent fallback (mirrors Howler's
+//    own `noAudio` graceful degradation) the scene loader uses when no
+//    engine is wired — the same inert-seam pattern `renderPrompter` /
+//    `presenterCommands` follow.
+//  - `createAudioService(engine, opts)` is the per-navigation service
+//    scenes see as `ctx.audio`. It exposes per-scene playback (`play` /
+//    `stop`), fades (`fade`), sprites ({@link SoundDefinition.sprite} +
+//    `play({ sprite })`), looping (`play({ loop })`), and named groups
+//    (`play({ group })` + `stopGroup`), plus master mute (`mute` /
+//    `isMuted` — persistent runtime state held by the engine, not a
+//    per-scene checkbox). It is bound to the navigation's `AbortSignal`:
+//    when the navigation is superseded / disposed / completes the
+//    service `stopAll()`s — every sound it created is stopped and
+//    unloaded, so fades, loops, sprites, and muted state never survive
+//    scene cleanup (PUL-P001 / ADR-004). One service is shared across a
+//    composition's slice (the resolver already forbids a slice repeating
+//    a scene id), so the sound-id namespace and the source allowlist are
+//    composition-slice-scoped: multi-scene compositions pick distinct
+//    sound ids — the same stable-identity discipline scene ids obey
+//    (ADR-008 #1) — and registering an id twice with the same definition
+//    is idempotent (a shared transition SFX). A scene scopes a sound to
+//    itself with `play(id, { group: <its-scene-id> })`; the resolver's
+//    per-scene post-`cleanup(ctx)` hook stops that group when the scene
+//    cleans up (runtime-driven, not author discipline). True per-scene
+//    activation contexts (one `ctx.audio` facade per scene entry) are a
+//    documented resolver follow-up (see `composition-resolver.ts`'s
+//    `buildPlan`).
+//
+// Source URLs reuse PUL-F005's `resolveAssetUrl` scheme resolver — no
+// copied scheme rules — and every registered source must be in the
+// active composition slice's declared `scene.assets` (ADR-008 #5: the
+// only audio inventory is `scene.assets`; there is no `audio:` field on
+// `SceneModule`). The preloader (PUL-F005) warms those URLs before
+// `create(ctx)` runs. Sound ids and group names obey the kebab-case
+// rule every other Pulsar identifier obeys (ADR-008 #1).
+//
+// References:
+//  - ADR-004 — Howler as the audio engine, exposed through `ctx.audio`;
+//    runtime-guaranteed per-scene cleanup; master mute.
+//  - ADR-003 — timeline callbacks are how most audio cues fire (scenes
+//    hang `ctx.audio.play(...)` off their `ctx.gsap` timeline).
+//  - ADR-008 — agent-native authoring; #1 kebab ids, #5 the only asset
+//    inventory is `scene.assets`.
+//  - PUL-F005 / ADR-012 — the asset preloader whose URL resolver this
+//    module reuses; declared audio sources are warmed before mount.
+
+import { Howl, Howler, type SoundSpriteDefinitions } from 'howler';
+import { DEFAULT_ALLOWED_SCHEMES, resolveAssetUrl } from './asset-preloader';
+import { describeError } from './error';
+import { KEBAB_IDENTIFIER_FORM, isKebabIdentifier } from './identifier';
+import { isPlainRecord } from './object';
+
+/* ------------------------------------------------------------------ *
+ *  Errors
+ * ------------------------------------------------------------------ */
+
+/** Base class for every error the audio service raises. */
+export class AudioError extends Error {}
+
+/**
+ * A sound id is malformed, refers to a sound that was never registered,
+ * is being registered twice, or names a sprite the sound does not have.
+ */
+export class AudioSoundError extends AudioError {}
+
+/** A group name is not a valid kebab-case identifier. */
+export class AudioGroupError extends AudioError {}
+
+/**
+ * A sound source URL has a disallowed scheme, is malformed, or was not
+ * declared in `scene.assets` (so the preloader never warmed it).
+ */
+export class AudioSourceError extends AudioError {}
+
+/** A volume, fade endpoint, or duration is outside its allowed numeric range. */
+export class AudioRangeError extends AudioError {}
+
+/* ------------------------------------------------------------------ *
+ *  Engine port — the Howler boundary
+ * ------------------------------------------------------------------ */
+
+/**
+ * Sprite definitions: name → `[startMs, durationMs]` or
+ * `[startMs, durationMs, loop]` (matching Howler's sprite shape). The
+ * record is the runtime's own type so `ctx.audio` callers never depend
+ * on `howler`'s types.
+ */
+export type AudioSpriteMap = Readonly<
+  Record<string, readonly [number, number] | readonly [number, number, boolean]>
+>;
+
+/** What an {@link AudioEngine} needs to construct one sound. */
+export interface AudioSoundConfig {
+  /** Source URL(s), in codec-preference order (like Howler's `src`). Non-empty. */
+  readonly src: readonly string[];
+  /** Optional sprite definitions. */
+  readonly sprite?: AudioSpriteMap;
+  /** Construct the sound muted (used by `silent` services — screenshot / paused modes). */
+  readonly muted: boolean;
+  /** Non-fatal sink for this sound's async load / play failures. */
+  readonly onError: (err: unknown) => void;
+}
+
+/**
+ * One sound produced by an {@link AudioEngine}. The methods mirror the
+ * slice of Howler's `Howl` the service drives; `playId` is the per-play
+ * handle `play()` returns — a plain number, not a Howler object — so a
+ * group stop targets exactly the instances it tagged.
+ */
+export interface AudioSoundHandle {
+  /** Start playback (optionally of a named sprite); returns the per-play id. */
+  play(sprite?: string): number;
+  /** Stop one play instance, or every instance when `playId` is omitted. */
+  stop(playId?: number): void;
+  /** Fade one (or every) instance from `from` to `to` over `durationMs`. */
+  fade(from: number, to: number, durationMs: number, playId?: number): void;
+  /** Set the loop flag on one (or every) instance. */
+  loop(enabled: boolean, playId?: number): void;
+  /** Set the volume of one (or every) instance, 0..1. */
+  volume(value: number, playId?: number): void;
+  /** Free this sound's buffers. Idempotent. */
+  unload(): void;
+}
+
+/**
+ * The audio engine: a sound factory plus master-mute state. A process
+ * singleton in production (`createHowlerAudioEngine()` — Howler's global
+ * is itself a singleton), like {@link import('./timeline').TimelineEngine}.
+ */
+export interface AudioEngine {
+  /** Build a sound from `config`. */
+  createSound(config: AudioSoundConfig): AudioSoundHandle;
+  /** Mute / unmute every sound the engine produces (persistent runtime state). */
+  setMasterMute(muted: boolean): void;
+  /** Whether the engine is currently master-muted. */
+  isMasterMuted(): boolean;
+}
+
+/* ------------------------------------------------------------------ *
+ *  Howler-backed engine
+ * ------------------------------------------------------------------ */
+
+function wrapHowl(howl: Howl): AudioSoundHandle {
+  return {
+    play: (sprite) => (sprite === undefined ? howl.play() : howl.play(sprite)),
+    stop: (playId) => {
+      howl.stop(playId);
+    },
+    fade: (from, to, durationMs, playId) => {
+      howl.fade(from, to, durationMs, playId);
+    },
+    loop: (enabled, playId) => {
+      howl.loop(enabled, playId);
+    },
+    volume: (value, playId) => {
+      if (playId === undefined) howl.volume(value);
+      else howl.volume(value, playId);
+    },
+    unload: () => {
+      // Howler's `unload()` dereferences a sound node that its no-audio
+      // fallback never creates, throwing a TypeError. In a browser
+      // (where the runtime actually runs) `unload()` is the right call;
+      // under Node's no-audio Howler, stopping is all that is needed.
+      if (Howler.noAudio) {
+        howl.stop();
+        return;
+      }
+      howl.unload();
+    },
+  };
+}
+
+/**
+ * Build the production {@link AudioEngine} backed by Howler. Call once
+ * — Howler's global is a process singleton, so master mute is global.
+ *
+ * Browser autoplay policy is centralized by Howler's default Web Audio
+ * mode and `Howler.autoUnlock` (ADR-004 "the audio service centralizes
+ * the unlock dance; scenes do not each implement it"): a `play()` made
+ * before the first user gesture is deferred (`AudioContext` suspended →
+ * Howler waits on its `resume` event) and replayed when the first
+ * gesture resumes the context. So no first cue is lost and the runtime
+ * does not re-implement the unlock dance. Both async failure events
+ * Howler exposes — `loaderror` (a source that fails to fetch / decode)
+ * and `playerror` (a playback failure; not emitted by Web Audio mode,
+ * but the HTML5 fallback path can) — route to the service's non-fatal
+ * `onError` sink.
+ */
+export function createHowlerAudioEngine(): AudioEngine {
+  let masterMuted = false;
+  return {
+    createSound(config) {
+      const howl = new Howl({
+        src: [...config.src],
+        // The runtime's `AudioSpriteMap` widens to Howler's mutable
+        // `SoundSpriteDefinitions` at this one boundary; Howler reads it
+        // at construction. Scenes pass the readonly shape.
+        ...(config.sprite === undefined ? {} : { sprite: config.sprite as SoundSpriteDefinitions }),
+        ...(config.muted ? { mute: true } : {}),
+        onloaderror: (_id, err) => {
+          config.onError(err);
+        },
+        onplayerror: (_id, err) => {
+          config.onError(err);
+        },
+      });
+      return wrapHowl(howl);
+    },
+    setMasterMute(muted) {
+      masterMuted = muted;
+      Howler.mute(muted);
+    },
+    isMasterMuted() {
+      return masterMuted;
+    },
+  };
+}
+
+/**
+ * A silent {@link AudioEngine}: every sound it produces is a no-op
+ * handle. Mirrors Howler's own `noAudio` graceful degradation — the
+ * scene loader uses it when no engine is wired so `ctx.audio` is always
+ * a working (if mute) service, and Node-side / test callers get a
+ * deterministic engine. Master mute is still tracked so `mute` /
+ * `isMuted` round-trip.
+ */
+export const noopAudioEngine: AudioEngine = (() => {
+  let masterMuted = false;
+  const handle: AudioSoundHandle = {
+    play: () => 0,
+    stop: () => undefined,
+    fade: () => undefined,
+    loop: () => undefined,
+    volume: () => undefined,
+    unload: () => undefined,
+  };
+  return {
+    createSound: () => handle,
+    setMasterMute: (muted) => {
+      masterMuted = muted;
+    },
+    isMasterMuted: () => masterMuted,
+  };
+})();
+
+/* ------------------------------------------------------------------ *
+ *  The audio service (`ctx.audio`)
+ * ------------------------------------------------------------------ */
+
+/** What a scene passes to {@link AudioService.load} to register one sound. */
+export interface SoundDefinition {
+  /**
+   * Source URL, or URLs in codec-preference order. Every URL must be
+   * declared in the active composition slice's `scene.assets` so the
+   * preloader warms it (ADR-008 #5) and must pass the asset scheme
+   * allowlist ({@link import('./asset-preloader').DEFAULT_ALLOWED_SCHEMES}).
+   * Re-registering an id with the same definition (same `src` list,
+   * same `sprite` map) is idempotent — e.g. a shared transition SFX two
+   * scenes both `load`; re-registering it with a different definition
+   * is an {@link AudioSoundError}.
+   */
+  readonly src: string | readonly string[];
+  /** Optional sprite definitions (offsets/durations in ms; optional third element marks a sprite looping). */
+  readonly sprite?: AudioSpriteMap;
+}
+
+/** Per-play options for {@link AudioService.play}. */
+export interface PlayOptions {
+  /** Play a named sprite of the sound instead of the whole file. */
+  readonly sprite?: string;
+  /** Loop this play instance until it is stopped. */
+  readonly loop?: boolean;
+  /** Volume for this play instance, 0..1 (master mute / `silent` still override). */
+  readonly volume?: number;
+  /** Tag this play with a named group (kebab-case) so `stopGroup` can stop it. */
+  readonly group?: string;
+}
+
+/** Construction options for {@link createAudioService}. */
+export interface AudioServiceOptions {
+  /**
+   * Navigation lifecycle signal. When it aborts the service `stopAll()`s
+   * (every sound stopped + unloaded, groups cleared, the service marked
+   * disposed) — so audio never survives the navigation that started it.
+   * An already-aborted signal disposes the service immediately.
+   */
+  readonly signal: AbortSignal;
+  /** Construct every sound muted (screenshot / paused modes — audible playback is suppressed). */
+  readonly silent?: boolean;
+  /**
+   * The source URLs scenes may register. Every {@link SoundDefinition.src}
+   * URL must be in this set (ADR-008 #5 — audio is declared in
+   * `scene.assets`, which the preloader warms). Omit to skip the
+   * membership check (non-composition / test callers); scheme
+   * validation still applies.
+   */
+  readonly allowedSources?: Iterable<string>;
+  /** Sink for non-fatal async audio errors (load / play failure). Defaults to a no-op. */
+  readonly onError?: (err: unknown) => void;
+}
+
+/**
+ * The audio service scenes see as `ctx.audio` (ADR-004). Per-navigation;
+ * one instance is shared across a composition's slice — named groups
+ * give per-scene grouping inside that. Every mutating method is inert
+ * after the service is disposed (navigation end) so a stale callback
+ * from a superseded scene cannot make sound.
+ */
+export interface AudioService {
+  /**
+   * Register a sound under `soundId` (kebab-case). Throws
+   * {@link AudioSoundError} on a malformed or already-used id and
+   * {@link AudioSourceError} when a `src` URL has a disallowed scheme,
+   * is malformed, or is not in `allowedSources`.
+   */
+  load(soundId: string, definition: SoundDefinition): void;
+  /**
+   * Play a registered sound. Throws {@link AudioSoundError} on an
+   * unknown sound id or sprite name, {@link AudioGroupError} on a
+   * malformed group name, {@link AudioRangeError} on an out-of-range
+   * volume.
+   */
+  play(soundId: string, options?: PlayOptions): void;
+  /**
+   * Fade every playing instance of `soundId` from `from` to `to` over
+   * `durationMs` milliseconds. Throws {@link AudioSoundError} on an
+   * unknown sound and {@link AudioRangeError} on an out-of-range
+   * endpoint or duration.
+   */
+  fade(soundId: string, from: number, to: number, durationMs: number): void;
+  /** Stop every playing instance of `soundId`. Throws {@link AudioSoundError} on an unknown sound. */
+  stop(soundId: string): void;
+  /**
+   * Stop every play instance tagged with `group`. Throws
+   * {@link AudioGroupError} on a malformed group name; an unknown or
+   * already-emptied group is a no-op.
+   */
+  stopGroup(group: string): void;
+  /** Set master mute (persistent runtime state on the engine). */
+  mute(muted: boolean): void;
+  /** Whether the engine is currently master-muted. */
+  isMuted(): boolean;
+  /** Stop and unload every registered sound; clear groups; mark the service disposed. Idempotent. */
+  stopAll(): void;
+  /** Whether the service has been torn down (navigation ended). */
+  isDisposed(): boolean;
+}
+
+const GAIN_MIN = 0;
+const GAIN_MAX = 1;
+
+interface RegisteredSound {
+  readonly handle: AudioSoundHandle;
+  readonly spriteNames: ReadonlySet<string>;
+  /** Normalized source list, kept so a re-`load` of the same id can verify the definition matches. */
+  readonly src: readonly string[];
+  /** Sprite map, kept for the same definition-equality check. */
+  readonly sprite: AudioSpriteMap | undefined;
+}
+
+interface GroupedPlay {
+  readonly handle: AudioSoundHandle;
+  readonly playId: number;
+}
+
+const isFiniteNumber = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value);
+
+/** Element-wise equality of two source lists. */
+const sameSourceList = (a: readonly string[], b: readonly string[]): boolean =>
+  a.length === b.length && a.every((url, i) => url === b[i]);
+
+/** Equality of two optional sprite maps (same keys, each tuple element-wise equal). */
+const sameSpriteMap = (a: AudioSpriteMap | undefined, b: AudioSpriteMap | undefined): boolean => {
+  if (a === undefined || b === undefined) return a === b;
+  const aKeys = Object.keys(a);
+  if (aKeys.length !== Object.keys(b).length) return false;
+  return aKeys.every((key) => {
+    const av = a[key];
+    const bv = b[key];
+    return (
+      bv !== undefined &&
+      av !== undefined &&
+      av.length === bv.length &&
+      av.every((v, i) => v === bv[i])
+    );
+  });
+};
+
+/**
+ * Validate the {@link SoundDefinition} payload shape at the runtime
+ * boundary — scenes can be plain JS, so the static type does not hold.
+ * `src` must be a string or array; `sprite` (if set) is validated by
+ * {@link assertSpriteMap}.
+ */
+function assertSoundDefinition(
+  soundId: string,
+  definition: unknown,
+): asserts definition is SoundDefinition {
+  if (!isPlainRecord(definition)) {
+    throw new AudioSoundError(
+      `audio sound "${soundId}" definition must be an object with at least a "src" field`,
+    );
+  }
+  const src = (definition as { src?: unknown }).src;
+  if (typeof src !== 'string' && !Array.isArray(src)) {
+    throw new AudioSourceError(
+      `audio sound "${soundId}" "src" must be a string or array of strings`,
+    );
+  }
+}
+
+/**
+ * Validate the {@link PlayOptions} payload shape at the runtime
+ * boundary — scenes can be plain JS, so the static type does not hold.
+ * Each option is type-checked before the play is attempted; volume is
+ * also range-checked later by `assertGain` inside the service.
+ */
+function assertPlayOptions(
+  soundId: string,
+  options: unknown,
+): asserts options is PlayOptions | undefined {
+  if (options === undefined) return;
+  if (!isPlainRecord(options)) {
+    throw new AudioSoundError(`audio sound "${soundId}" play options must be an object or omitted`);
+  }
+  const opts = options as { sprite?: unknown; loop?: unknown; volume?: unknown; group?: unknown };
+  if (opts.sprite !== undefined && typeof opts.sprite !== 'string') {
+    throw new AudioSoundError(
+      `audio sound "${soundId}" play option "sprite" must be a string; got ${typeof opts.sprite}`,
+    );
+  }
+  if (opts.loop !== undefined && typeof opts.loop !== 'boolean') {
+    throw new AudioSoundError(
+      `audio sound "${soundId}" play option "loop" must be a boolean; got ${typeof opts.loop}`,
+    );
+  }
+  if (opts.group !== undefined && typeof opts.group !== 'string') {
+    throw new AudioGroupError(
+      `audio sound "${soundId}" play option "group" must be a string; got ${typeof opts.group}`,
+    );
+  }
+  if (opts.volume !== undefined && typeof opts.volume !== 'number') {
+    throw new AudioRangeError(
+      `audio sound "${soundId}" play option "volume" must be a number; got ${typeof opts.volume}`,
+    );
+  }
+}
+
+/**
+ * Validate a sprite map at the runtime boundary — scene modules can be
+ * plain JS, so the {@link AudioSpriteMap} type guarantee does not hold.
+ * Each entry must be `name → [startMs, durationMs]` or
+ * `[startMs, durationMs, loop]` with finite, non-negative offsets and a
+ * boolean loop flag. Throws {@link AudioSoundError} for a malformed
+ * shape or name and {@link AudioRangeError} for an out-of-range offset
+ * or duration.
+ */
+const assertSpriteMap = (soundId: string, sprite: unknown): void => {
+  if (!isPlainRecord(sprite)) {
+    throw new AudioSoundError(
+      `audio sound "${soundId}" sprite map must be an object of name → [startMs, durationMs] or [startMs, durationMs, loop]`,
+    );
+  }
+  for (const [name, def] of Object.entries(sprite)) {
+    if (name === '') {
+      throw new AudioSoundError(`audio sound "${soundId}" has a sprite with an empty name`);
+    }
+    if (!Array.isArray(def) || (def.length !== 2 && def.length !== 3)) {
+      throw new AudioSoundError(
+        `audio sound "${soundId}" sprite "${name}" must be [startMs, durationMs] or [startMs, durationMs, loop]`,
+      );
+    }
+    if (!isFiniteNumber(def[0]) || def[0] < 0 || !isFiniteNumber(def[1]) || def[1] < 0) {
+      throw new AudioRangeError(
+        `audio sound "${soundId}" sprite "${name}" offset and duration must be finite, non-negative milliseconds; got [${def[0]}, ${def[1]}]`,
+      );
+    }
+    if (def.length === 3 && typeof def[2] !== 'boolean') {
+      throw new AudioSoundError(
+        `audio sound "${soundId}" sprite "${name}" loop flag must be a boolean; got ${typeof def[2]}`,
+      );
+    }
+  }
+};
+
+/** Build the per-navigation {@link AudioService} over `engine`. */
+export function createAudioService(
+  engine: AudioEngine,
+  options: AudioServiceOptions,
+): AudioService {
+  const silent = options.silent === true;
+  const onError = options.onError ?? ((): void => undefined);
+  const allowed = options.allowedSources === undefined ? null : new Set(options.allowedSources);
+
+  const sounds = new Map<string, RegisteredSound>();
+  const groups = new Map<string, GroupedPlay[]>();
+  let disposed = false;
+
+  const assertSoundId = (soundId: string): void => {
+    if (!isKebabIdentifier(soundId)) {
+      throw new AudioSoundError(
+        `audio sound id "${soundId}" is invalid: sound ids must be lowercase kebab-case identifiers (${KEBAB_IDENTIFIER_FORM})`,
+      );
+    }
+  };
+
+  const assertGroupName = (group: string): void => {
+    if (!isKebabIdentifier(group)) {
+      throw new AudioGroupError(
+        `audio group name "${group}" is invalid: group names must be lowercase kebab-case identifiers (${KEBAB_IDENTIFIER_FORM})`,
+      );
+    }
+  };
+
+  const assertGain = (value: number, what: string): void => {
+    if (!isFiniteNumber(value) || value < GAIN_MIN || value > GAIN_MAX) {
+      throw new AudioRangeError(
+        `audio ${what} must be a finite number in [${GAIN_MIN}, ${GAIN_MAX}]; got ${value}`,
+      );
+    }
+  };
+
+  const requireSound = (soundId: string): RegisteredSound => {
+    assertSoundId(soundId);
+    const sound = sounds.get(soundId);
+    if (sound === undefined) {
+      throw new AudioSoundError(
+        `audio sound "${soundId}" is not registered — call ctx.audio.load("${soundId}", ...) first`,
+      );
+    }
+    return sound;
+  };
+
+  /**
+   * Route an engine-side cleanup failure (a throwing `stop()` / `unload()`
+   * during `stopGroup` / `stopAll`) through the non-fatal `onError`
+   * sink, swallowing any further throw the sink itself produces. The
+   * cleanup loops keep iterating after this returns so per-item
+   * isolation holds.
+   */
+  const reportCleanupError = (where: string, target: string, cause: unknown): void => {
+    try {
+      onError(
+        new AudioError(`audio ${where}("${target}") failed: ${describeError(cause)}`, { cause }),
+      );
+    } catch {
+      // Intentionally empty: the diagnostic sink is non-fatal.
+    }
+  };
+
+  const normalizeSources = (soundId: string, src: string | readonly string[]): string[] => {
+    const list = typeof src === 'string' ? [src] : [...src];
+    if (list.length === 0) {
+      throw new AudioSourceError(
+        `audio sound "${soundId}" has no source — provide at least one URL`,
+      );
+    }
+    for (const url of list) {
+      if (typeof url !== 'string' || url === '') {
+        throw new AudioSourceError(
+          `audio sound "${soundId}" source must be a non-empty URL string`,
+        );
+      }
+      // Defense-in-depth (codex review, cycle 3): even when
+      // `allowedSources` is provided (the slice's declared
+      // `scene.assets`, which the preloader warmed), the audio service
+      // also runs the same default scheme allowlist the preloader uses
+      // by default — so a no-op or weak preloader cannot let `file:` /
+      // `//host` URLs through. Threading the preloader's exact
+      // `baseUrl` / `allowedSchemes` policy into the audio service is a
+      // documented follow-up; for now the service is at least as
+      // restrictive as `DEFAULT_ALLOWED_SCHEMES`.
+      try {
+        resolveAssetUrl(url, undefined, DEFAULT_ALLOWED_SCHEMES);
+      } catch (cause) {
+        throw new AudioSourceError(
+          `audio sound "${soundId}" source "${url}" is invalid: ${describeError(cause)}`,
+          { cause },
+        );
+      }
+      if (allowed !== null && !allowed.has(url)) {
+        // ADR-008 #5: the only audio inventory is `scene.assets`. A URL
+        // outside the slice's declared assets is not preloader-warmed
+        // and is rejected here regardless of scheme.
+        throw new AudioSourceError(
+          `audio sound "${soundId}" source "${url}" is not a declared asset — list it in scene.assets so the preloader warms it (ADR-008 #5)`,
+        );
+      }
+    }
+    return list;
+  };
+
+  const unknownSpriteMessage = (
+    soundId: string,
+    sprite: string,
+    names: ReadonlySet<string>,
+  ): string => {
+    const known = names.size === 0 ? '' : ` — known sprites: ${[...names].join(', ')}`;
+    return `audio sound "${soundId}" has no sprite "${sprite}"${known}`;
+  };
+
+  const service: AudioService = {
+    load(soundId, definition) {
+      if (disposed) return;
+      assertSoundId(soundId);
+      assertSoundDefinition(soundId, definition);
+      const src = normalizeSources(soundId, definition.src);
+      if (definition.sprite !== undefined) assertSpriteMap(soundId, definition.sprite);
+      const existing = sounds.get(soundId);
+      if (existing !== undefined) {
+        // Idempotent re-registration of the same sound (e.g. a shared
+        // transition SFX two scenes both `load` — the sound-id namespace
+        // is composition-slice-scoped); a different definition is a
+        // genuine conflict.
+        if (
+          sameSourceList(existing.src, src) &&
+          sameSpriteMap(existing.sprite, definition.sprite)
+        ) {
+          return;
+        }
+        throw new AudioSoundError(
+          `audio sound "${soundId}" is already registered with a different definition`,
+        );
+      }
+      const spriteNames: ReadonlySet<string> = new Set(
+        definition.sprite === undefined ? [] : Object.keys(definition.sprite),
+      );
+      const handle = engine.createSound({
+        src,
+        ...(definition.sprite === undefined ? {} : { sprite: definition.sprite }),
+        muted: silent,
+        onError: (err) => {
+          // Howler's async load failures can arrive after the navigation
+          // ended (abort / supersession / completion). A disposed
+          // service must not write a stale diagnostic over the active
+          // navigation, and this non-fatal sink must not throw back
+          // through Howler's callback.
+          if (disposed) return;
+          try {
+            onError(
+              new AudioError(`audio sound "${soundId}": ${describeError(err)}`, { cause: err }),
+            );
+          } catch {
+            // Intentionally empty: the diagnostic sink is non-fatal.
+          }
+        },
+      });
+      sounds.set(soundId, { handle, spriteNames, src, sprite: definition.sprite });
+    },
+
+    play(soundId, options) {
+      if (disposed) return;
+      assertPlayOptions(soundId, options);
+      const sound = requireSound(soundId);
+      const opts = options ?? {};
+      if (opts.sprite !== undefined && !sound.spriteNames.has(opts.sprite)) {
+        throw new AudioSoundError(unknownSpriteMessage(soundId, opts.sprite, sound.spriteNames));
+      }
+      if (opts.group !== undefined) assertGroupName(opts.group);
+      if (opts.volume !== undefined) assertGain(opts.volume, 'volume');
+      const playId = sound.handle.play(opts.sprite);
+      if (opts.loop === true) sound.handle.loop(true, playId);
+      if (opts.volume !== undefined) sound.handle.volume(opts.volume, playId);
+      if (opts.group !== undefined) {
+        const list = groups.get(opts.group);
+        if (list === undefined) groups.set(opts.group, [{ handle: sound.handle, playId }]);
+        else list.push({ handle: sound.handle, playId });
+      }
+    },
+
+    fade(soundId, from, to, durationMs) {
+      if (disposed) return;
+      const sound = requireSound(soundId);
+      assertGain(from, 'fade start volume');
+      assertGain(to, 'fade end volume');
+      if (!isFiniteNumber(durationMs) || durationMs < 0) {
+        throw new AudioRangeError(
+          `audio fade duration must be a finite, non-negative number of milliseconds; got ${durationMs}`,
+        );
+      }
+      sound.handle.fade(from, to, durationMs);
+    },
+
+    stop(soundId) {
+      if (disposed) return;
+      const sound = requireSound(soundId);
+      sound.handle.stop();
+    },
+
+    stopGroup(group) {
+      if (disposed) return;
+      assertGroupName(group);
+      const list = groups.get(group);
+      if (list === undefined) return;
+      // Per-play error isolation (codex review, cycle 3): a throwing
+      // engine `stop()` must not prevent later plays in the group from
+      // being stopped. Failures route through the non-fatal `onError`
+      // sink — the cleanup contract is "every play in the group is
+      // attempted to be stopped," not "all-or-nothing."
+      for (const play of list) {
+        try {
+          play.handle.stop(play.playId);
+        } catch (err) {
+          reportCleanupError('stopGroup', group, err);
+        }
+      }
+      groups.delete(group);
+    },
+
+    mute(muted) {
+      if (disposed) return;
+      // Runtime boundary: scenes can be plain JS, so the boolean type
+      // does not hold (codex review, cycle 4).
+      if (typeof muted !== 'boolean') {
+        throw new AudioError(`audio mute argument must be a boolean; got ${typeof muted}`);
+      }
+      engine.setMasterMute(muted);
+    },
+
+    isMuted() {
+      return engine.isMasterMuted();
+    },
+
+    stopAll() {
+      if (disposed) return;
+      disposed = true;
+      // Per-sound error isolation (codex review, cycle 3): a throwing
+      // engine `stop()` / `unload()` must not prevent later sounds from
+      // being torn down. Each call is wrapped; failures route through
+      // the non-fatal `onError` sink. Bookkeeping is cleared
+      // unconditionally so the disposed service is in a known state.
+      for (const [soundId, sound] of sounds) {
+        try {
+          sound.handle.stop();
+        } catch (err) {
+          reportCleanupError('stopAll', soundId, err);
+        }
+        try {
+          sound.handle.unload();
+        } catch (err) {
+          reportCleanupError('stopAll', soundId, err);
+        }
+      }
+      sounds.clear();
+      groups.clear();
+    },
+
+    isDisposed() {
+      return disposed;
+    },
+  };
+
+  if (options.signal.aborted) {
+    service.stopAll();
+  } else {
+    options.signal.addEventListener('abort', () => service.stopAll(), { once: true });
+  }
+
+  return service;
+}

--- a/src/runtime/composition-resolver.ts
+++ b/src/runtime/composition-resolver.ts
@@ -140,8 +140,11 @@ export interface CompositionTimelineRunOptions {
    */
   readonly headHold?: 'first-frame';
   /**
-   * URL scrub hint (PUL-F017 / ADR-020): no effect until the audio
-   * engine lands (PUL-F024) — there are no cues to gate yet.
+   * URL scrub hint (PUL-F017 / ADR-020): forwarded, but the timeline
+   * adapter does not yet gate audio cues against it — the PUL-F024 audio
+   * service exists, but timeline-callback cue gating is a follow-up;
+   * scenes fire their own `ctx.audio` cues from their timeline callbacks
+   * today.
    */
   readonly headCueGate?: 'monotonic-forward';
   /**
@@ -216,6 +219,17 @@ export interface ResolveCompositionOptions {
   readonly presenter?: PresenterController;
   /** Diagnostic sink paired with {@link presenter}. */
   readonly onPresenterError?: (err: unknown) => void;
+  /**
+   * Per-scene post-cleanup hook (PUL-F024 / ADR-004). Invoked after each
+   * scene's `cleanup(ctx)` completes during the cleanup phase, in the
+   * same reverse-mount order. The scene loader wires this so the runtime
+   * stops the audio group a scene scoped to itself (`group: <sceneId>`)
+   * when that scene's `cleanup` runs — runtime-guaranteed per-scene
+   * audio teardown rather than author discipline. The resolver itself
+   * does not interpret the id; it just forwards it. A throw from the
+   * hook is treated like a cleanup failure (collected, not swallowed).
+   */
+  readonly onSceneCleaned?: (sceneId: string) => void;
 }
 
 /**
@@ -363,9 +377,15 @@ function composeSegments(mounted: readonly PlanStep[], ctx: unknown): SceneTimel
  * order (last in, first out — symmetric with the mount phase). Each
  * scene's cleanup runs even if a previous one threw; the wrapped thrown
  * values are collected and returned (the caller decides whether to
- * re-raise them). Never throws.
+ * re-raise them). `onSceneCleaned` (PUL-F024 / ADR-004 — the audio
+ * group teardown hook) runs after each scene's `cleanup(ctx)`; a throw
+ * from it is collected like a cleanup failure. Never throws.
  */
-async function cleanupAll(mounted: readonly PlanStep[], ctx: unknown): Promise<readonly unknown[]> {
+async function cleanupAll(
+  mounted: readonly PlanStep[],
+  ctx: unknown,
+  onSceneCleaned?: (sceneId: string) => void,
+): Promise<readonly unknown[]> {
   const errors: unknown[] = [];
   for (const step of [...mounted].reverse()) {
     try {
@@ -373,6 +393,13 @@ async function cleanupAll(mounted: readonly PlanStep[], ctx: unknown): Promise<r
     } catch (err) {
       errors.push(
         fail(`scene ${quoteId(step.scene.id)} cleanup threw: ${describeError(err)}`, err),
+      );
+    }
+    try {
+      onSceneCleaned?.(step.scene.id);
+    } catch (err) {
+      errors.push(
+        fail(`scene ${quoteId(step.scene.id)} onSceneCleaned threw: ${describeError(err)}`, err),
       );
     }
   }
@@ -483,7 +510,7 @@ export async function resolveComposition(options: ResolveCompositionOptions): Pr
   } catch (phaseError) {
     // Mandatory cleanup: tear down every mounted scene (reverse order),
     // then re-raise — aggregating cleanup errors if any.
-    const cleanupErrors = await cleanupAll(mounted, ctx);
+    const cleanupErrors = await cleanupAll(mounted, ctx, options.onSceneCleaned);
     if (cleanupErrors.length > 0) {
       throw failAggregate(
         `composition aborted with ${cleanupErrors.length} cleanup failure(s) after: ${describeError(phaseError)}`,
@@ -497,7 +524,7 @@ export async function resolveComposition(options: ResolveCompositionOptions): Pr
   // adapter resolved without throwing). Tear every scene down, then
   // surface an abort error if the signal fired (so the loader's
   // pure-abort suppression applies) or aggregate any cleanup failures.
-  const cleanupErrors = await cleanupAll(mounted, ctx);
+  const cleanupErrors = await cleanupAll(mounted, ctx, options.onSceneCleaned);
   if (signal?.aborted === true) {
     if (cleanupErrors.length > 0) {
       throw failAggregate(

--- a/src/runtime/scene-loader.ts
+++ b/src/runtime/scene-loader.ts
@@ -29,6 +29,7 @@
 //  - ADR-007 — runtime parses URL parameters at startup AND popstate.
 //  - ADR-013 — URL navigation grammar boundary; F007 owns parsing.
 
+import { type AudioEngine, type AudioService, createAudioService, noopAudioEngine } from './audio';
 import type { CompositionRegistry } from './composition-registry';
 import type { AssetPreloader, CompositionTimelineAdapter } from './composition-resolver';
 import { describeError } from './error';
@@ -77,8 +78,8 @@ export interface StageElement {
  * mode detection. Per ADR-007 the runtime core is the dispatch
  * point; the field is set per navigation by {@link createSceneLoader}.
  *
- * Per ADR-003 the timeline engine (`gsap`) arrives here; the audio
- * engine (`audio`) will follow per ADR-004. The runtime resolver
+ * Per ADR-003 the timeline engine (`gsap`) arrives here; per ADR-004
+ * the audio service (`audio`) does too (PUL-F024). The runtime resolver
  * itself never inspects ctx — it is purely a scene-to-environment
  * carrier.
  */
@@ -101,6 +102,33 @@ export interface WorkbenchSceneCtx {
    * {@link import('./timeline').composeMasterTimeline}).
    */
   readonly gsap: TimelineEngine['gsap'];
+  /**
+   * The per-navigation audio service (PUL-F024 / ADR-004). Scenes call
+   * `ctx.audio.load(...)` / `play(...)` / `fade(...)` / `stop(...)` /
+   * `stopGroup(...)` (and `mute(...)` for master mute) rather than
+   * importing Howler or constructing `<audio>`, so the audio engine
+   * stays a single swappable runtime dependency and every sound is
+   * stopped + unloaded on navigation end. Built by the loader from
+   * {@link SceneLoaderOptions.audioEngine}, bound to the navigation's
+   * `AbortSignal`, and `silent` under `mode=screenshot` / `mode=paused`
+   * (audible playback suppressed — ADR-019 / ADR-021).
+   *
+   * One service per navigation: under single-scene modes that is the
+   * one scene; under `mode=present` it is shared across the whole
+   * composition slice (the resolver mounts the slice with one ctx and
+   * forbids it repeating a scene id). The sound-id namespace and the
+   * source allowlist (the slice's declared `scene.assets`) are therefore
+   * slice-scoped — multi-scene compositions pick distinct sound ids, the
+   * same stable-identity discipline scene ids obey (ADR-008 #1), and
+   * registering an id twice with the same definition is idempotent. A
+   * scene scopes a sound to itself with `play(id, { group: <its-scene-id> })`;
+   * the loader wires the resolver's per-scene post-`cleanup(ctx)` hook
+   * to `stopGroup(sceneId)`, so the runtime (not the author) stops a
+   * scene's group when that scene's `cleanup` runs. True per-scene
+   * activation contexts (one `ctx.audio` facade per scene entry) are a
+   * documented resolver follow-up.
+   */
+  readonly audio: AudioService;
 }
 
 /**
@@ -118,27 +146,45 @@ export interface SceneLoaderOptions {
    * Per-navigation scene context builder. The loader calls this once
    * per navigation that produces a runnable target, passing the
    * effective workbench mode derived from the URL via
-   * {@link effectiveMode} (PUL-F012 / ADR-007). The returned value is
-   * forwarded opaquely to every lifecycle hook (`create` / `timeline`
-   * / `cleanup`); the resolver never inspects it.
+   * {@link effectiveMode} (PUL-F012 / ADR-007) and the per-navigation
+   * audio service (PUL-F024 / ADR-004) the loader built from
+   * {@link audioEngine}. The returned value is forwarded opaquely to
+   * every lifecycle hook (`create` / `timeline` / `cleanup`); the
+   * resolver never inspects it.
    *
    * Returns {@link WorkbenchSceneCtx} so the production contract
-   * "scenes receive `ctx.mode`" is enforced at this boundary rather
-   * than relying on a single workbench bootstrap annotation. Mode
-   * dispatch lives at this seam per ADR-007 ("Mode is dispatched in
-   * the runtime core, not per scene"): the workbench supplies the
-   * stage and any other long-lived ctx members through a closure, the
-   * loader contributes the per-navigation `mode`, and the combined
-   * value is what scenes see as `ctx`. Constructing a fresh ctx per
-   * navigation also blocks any "previous mode leaks into a `mode`-less
-   * URL" regression — every navigation re-derives mode from its own
-   * target.
+   * "scenes receive `ctx.mode` / `ctx.audio`" is enforced at this
+   * boundary rather than relying on a single workbench bootstrap
+   * annotation. Mode dispatch lives at this seam per ADR-007 ("Mode is
+   * dispatched in the runtime core, not per scene"): the workbench
+   * supplies the stage and any other long-lived ctx members through a
+   * closure, the loader contributes the per-navigation `mode` and
+   * `audio`, and the combined value is what scenes see as `ctx`.
+   * Constructing a fresh ctx per navigation also blocks any "previous
+   * mode leaks into a `mode`-less URL" regression — every navigation
+   * re-derives mode from its own target — and a fresh audio service
+   * per navigation makes "audio survives the scene that started it"
+   * structurally impossible.
    *
    * Not invoked when the locator is `kind: 'none'` (no scene mounts)
    * or when the navigation event is a parse-error event, because
    * those paths run no lifecycle.
    */
-  readonly buildCtx: (mode: NavigationMode) => WorkbenchSceneCtx;
+  readonly buildCtx: (mode: NavigationMode, audio: AudioService) => WorkbenchSceneCtx;
+  /**
+   * The audio engine (PUL-F024 / ADR-004) — a process singleton, like
+   * the timeline engine (ADR-003). The loader builds a fresh
+   * `createAudioService(audioEngine, ...)` per navigation, scoped to
+   * that navigation's `AbortSignal` and threaded into `ctx.audio`, so
+   * per-scene audio is stopped + unloaded on supersession / dispose /
+   * completion. Optional: a workbench bootstrap that has not wired a
+   * real audio backend yet omits it and the loader falls back to
+   * {@link import('./audio').noopAudioEngine} (a silent engine —
+   * `ctx.audio` still works, it just makes no sound), the same
+   * inert-seam pattern {@link renderPrompter} / {@link presenterCommands}
+   * follow.
+   */
+  readonly audioEngine?: AudioEngine;
   /**
    * Build a per-navigation asset preloader bound to that
    * navigation's abort signal. The loader calls this once per
@@ -271,16 +317,38 @@ function isPureAbort(err: unknown, signal: AbortSignal): boolean {
 }
 
 /**
+ * The audio source URLs the resolved (possibly head-truncated) slice
+ * declared — every scene's `assets` in the slice (just the head scene's
+ * for a bare `kind: 'scene'` target, the full composition slice's for
+ * `mode=present`). The per-navigation audio service uses this so
+ * `ctx.audio.load()` can only register a URL the preloader (PUL-F005)
+ * already warmed — ADR-008 #5: the only audio inventory is
+ * `scene.assets`. Pure function (no closure captures), hoisted to
+ * module scope so the loader factory does not recreate it per instance.
+ */
+function collectAudioSources(target: SceneNavigationTarget): readonly string[] {
+  return target.composition === undefined
+    ? target.scene.assets
+    : target.composition.sceneSlice.flatMap((scene) => scene.assets);
+}
+
+/**
  * One in-flight load: the abort signal that cancels it, the promise
- * that settles when the lifecycle ends (or rejects on abort), and the
+ * that settles when the lifecycle ends (or rejects on abort), the
  * abort-detection flag used to suppress the "rejection is an error"
- * branch when the rejection was an intentional abort.
+ * branch when the rejection was an intentional abort, and the
+ * navigation's audio service (PUL-F024) so the loader can `stopAll()`
+ * it once the lifecycle settles — the signal binding already covers
+ * supersession / dispose; this covers happy-path completion. `null`
+ * for a `mode=prompter` load (no resolver lifecycle, no `ctx.audio`).
  */
 interface InFlightLoad {
   readonly controller: AbortController;
   readonly settled: Promise<void>;
   /** Set when `dispose()` aborted the load — suppresses error UI on dispose. */
   silent: boolean;
+  /** The navigation's audio service, or `null` for a prompter load. */
+  readonly audio: AudioService | null;
 }
 
 /**
@@ -298,6 +366,11 @@ type NavigationEvent =
 export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
   const { stage } = options;
   const onError = options.onError ?? ((err) => console.error(err));
+  // PUL-F024 / ADR-004: the audio engine. A workbench that has not
+  // wired a real backend gets the silent no-op engine so `ctx.audio`
+  // still works (just makes no sound) — the inert-seam pattern the
+  // prompter / presenter options also use.
+  const audioEngine = options.audioEngine ?? noopAudioEngine;
   let inFlight: InFlightLoad | null = null;
   let disposed = false;
   // Latest-event generation. Every enqueue bumps this counter; queued
@@ -465,6 +538,15 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
     target: NavigationTarget,
   ): InFlightLoad | null => {
     const controller = new AbortController();
+    // PUL-F012 / ADR-007: mode dispatch lives at the runtime-core seam.
+    // The loader derives the effective mode from the parsed target via
+    // `effectiveMode` (URL-only — no localStorage, sessionStorage,
+    // cookies, history.state, or cached state); every navigation
+    // re-derives from its own target, so a previous non-`present` mode
+    // cannot leak into a subsequent `mode`-less URL. The mode also
+    // selects whether the audio service is `silent` (screenshot /
+    // paused suppress audible playback — ADR-019 / ADR-021).
+    const mode = effectiveMode(target);
     let preloadAssets: AssetPreloader;
     try {
       preloadAssets = options.createPreloader(controller.signal);
@@ -478,29 +560,33 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
       surfaceError(err);
       return null;
     }
-    // PUL-F012 / ADR-007: mode dispatch lives at the runtime-core
-    // seam. The loader derives the effective mode from the parsed
-    // target via `effectiveMode` (URL-only — no localStorage,
-    // sessionStorage, cookies, history.state, or cached state) and
-    // hands the workbench's `buildCtx` that mode so the per-navigation
-    // ctx carries `mode`. Every navigation re-derives from its own
-    // target, so a previous non-`present` mode cannot leak into a
-    // subsequent `mode`-less URL.
-    //
-    // Built AFTER the preloader so a preloader-factory failure does
-    // not waste any builder-side allocations, and wrapped in the same
-    // rollback-then-surfaceError pattern so a throwing builder does
-    // not leave stale stage attrs or skip the queue's error sink.
+    // PUL-F024 / ADR-004: the per-navigation audio service. Built over
+    // `audioEngine`, scoped to `controller.signal` (abort ⇒ every sound
+    // stopped + unloaded), restricted to the URLs the slice declared in
+    // `scene.assets` (ADR-008 #5 — the preloader warmed them), and
+    // `silent` under screenshot / paused. Threaded into `ctx.audio` via
+    // `buildCtx`, alongside `mode` (PUL-F012). Built AFTER the preloader
+    // so a preloader-factory failure does not waste allocations, and
+    // wrapped in the same rollback-then-surfaceError pattern so a
+    // throwing builder does not leave stale stage attrs or skip the
+    // queue's error sink.
     let ctx: unknown;
+    let audio: AudioService;
     try {
-      ctx = options.buildCtx(effectiveMode(target));
+      audio = createAudioService(audioEngine, {
+        signal: controller.signal,
+        silent: mode === 'screenshot' || mode === 'paused',
+        allowedSources: collectAudioSources(resolved),
+        onError,
+      });
+      ctx = options.buildCtx(mode, audio);
     } catch (err) {
       // Abort the freshly-created controller before bailing so any
-      // signal-tied resource the preloader factory may have wired
-      // (e.g. a fetch listener registered on `controller.signal`)
-      // observes cancellation and releases. Without this, the signal
-      // is GC'd in the never-aborted state and any abort-keyed
-      // listener runs at GC time (or never).
+      // signal-tied resource (the preloader factory's fetch listener,
+      // the audio service's stop-on-abort hook) observes cancellation
+      // and releases. Without this, the signal is GC'd in the
+      // never-aborted state and any abort-keyed listener runs at GC
+      // time (or never).
       controller.abort();
       resetStageAttrs();
       surfaceError(err);
@@ -518,7 +604,6 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
     // head's timeline never naturally completes. Use a literal
     // `undefined` sentinel so the spread below cleanly omits the key
     // for non-loop modes (parity with the `beat` plumbing).
-    const mode = effectiveMode(target);
     const repeat: 'until-aborted' | undefined = mode === 'loop' ? 'until-aborted' : undefined;
     // PUL-F016 / ADR-019: under `mode=paused` the runner mounts the
     // addressed scene and holds its timeline at the first frame.
@@ -605,8 +690,15 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
         // through the same diagnostic channel as every other
         // navigation-level error (codex review, cycle 2).
         ...(presenter === undefined ? {} : { presenter, onPresenterError: onError }),
+        // PUL-F024 / ADR-004: the runtime stops the audio group a scene
+        // scoped to itself (`group: <its-scene-id>`) when that scene's
+        // `cleanup(ctx)` runs — runtime-guaranteed per-scene teardown,
+        // not author discipline. (`stopGroup` is a no-op when the group
+        // is empty or the service is already disposed.)
+        onSceneCleaned: (sceneId) => audio.stopGroup(sceneId),
       }),
       silent: false,
+      audio,
     };
   };
 
@@ -764,14 +856,18 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
   const buildPrompterLoad = (resolved: SceneNavigationTarget): InFlightLoad => {
     const controller = new AbortController();
     const renderer = options.renderPrompter;
+    // `mode=prompter` bypasses the resolver lifecycle entirely — no
+    // scene mounts, so there is no `ctx.audio` consumer and no audio
+    // service to build (`audio: null`).
     if (renderer === undefined) {
-      return { controller, settled: Promise.resolve(), silent: false };
+      return { controller, settled: Promise.resolve(), silent: false, audio: null };
     }
     const script = buildPrompterScript(resolved);
     return {
       controller,
       settled: dispatchPrompter(renderer, script, controller.signal),
       silent: false,
+      audio: null,
     };
   };
 
@@ -836,6 +932,13 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
         surfaceError(err);
       }
     } finally {
+      // PUL-F024 / ADR-004: the navigation is over — stop + unload
+      // every sound it created. On supersession / dispose the signal
+      // binding already disposed the service, so this is the
+      // happy-path-completion path (the resolver ran every scene's
+      // `cleanup(ctx)`, then `load.settled` resolved); `stopAll()` is
+      // idempotent so the double-call on the abort paths is harmless.
+      load.audio?.stopAll();
       if (inFlight === load) inFlight = null;
     }
   };

--- a/src/runtime/scene-navigation.ts
+++ b/src/runtime/scene-navigation.ts
@@ -234,6 +234,13 @@ export interface LoadSceneNavigationTargetOptions {
    * Absent: the per-scene wrapper drops diagnostics silently.
    */
   readonly onPresenterError?: (err: unknown) => void;
+  /**
+   * Per-scene post-cleanup hook (PUL-F024 / ADR-004). Forwarded to
+   * {@link resolveComposition} as `onSceneCleaned`; the loader wires it
+   * to stop the audio group a scene scoped to itself when that scene's
+   * `cleanup(ctx)` runs. Absent for callers that do not need it.
+   */
+  readonly onSceneCleaned?: (sceneId: string) => void;
 }
 
 const NAV_FAIL_PREFIX = 'scene navigation failed:';
@@ -645,5 +652,9 @@ export async function loadSceneNavigationTarget(
     ...(options.presenter === undefined || options.onPresenterError === undefined
       ? {}
       : { onPresenterError: options.onPresenterError }),
+    // `onSceneCleaned` (PUL-F024 / ADR-004 — the audio group teardown
+    // hook) is forwarded as-is; the loader supplies it on every
+    // navigation that runs the resolver lifecycle.
+    ...(options.onSceneCleaned === undefined ? {} : { onSceneCleaned: options.onSceneCleaned }),
   });
 }

--- a/src/runtime/timeline.ts
+++ b/src/runtime/timeline.ts
@@ -547,7 +547,9 @@ type MasterRunMode = 'hold' | 'loop' | 'play';
  *  - `headRepeat: 'until-aborted'` (PUL-F015 / ADR-018): loop the master
  *    forever. → `'loop'`.
  *  - `headCueGate: 'monotonic-forward'` (PUL-F017 / ADR-020): no effect
- *    here — no audio engine to gate cues against yet (PUL-F024).
+ *    here yet — the PUL-F024 audio service exists (`ctx.audio`), but
+ *    timeline-callback cue gating is a separate follow-up; scenes fire
+ *    their own `ctx.audio` cues from their timeline callbacks today.
  *  - default: → `'play'`.
  */
 function positionMaster(

--- a/tests/runtime/audio-engine.test.ts
+++ b/tests/runtime/audio-engine.test.ts
@@ -1,0 +1,82 @@
+// Smoke tests for the Howler-backed audio engine — PUL-F024 / ADR-004.
+//
+// `audio.test.ts` exercises the service against a fake engine; this file
+// exercises the real Howler boundary (`createHowlerAudioEngine`) so the
+// `import ... from 'howler'` path, the `Howl` construction, and the
+// method forwarding are covered. Howler runs in its `noAudio` fallback
+// under the `node` test environment (no `AudioContext` / `Audio`), so
+// these assert "does not throw / round-trips" rather than audible
+// behavior — which is the right contract for a headless environment and
+// mirrors how Pulsar itself degrades when audio is unavailable.
+
+import { describe, expect, it } from 'vitest';
+import {
+  type AudioSoundConfig,
+  createAudioService,
+  createHowlerAudioEngine,
+} from '../../src/runtime/audio';
+
+// A tiny silent WAV — valid bytes so Howler does not choke on the URL
+// shape even in the no-audio path.
+const SILENT_WAV =
+  'data:audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAAABAAEARKwAAIhYAQACABAAZGF0YQAAAAA=';
+
+const config = (over: Partial<AudioSoundConfig> = {}): AudioSoundConfig => ({
+  src: [SILENT_WAV],
+  muted: false,
+  onError: () => undefined,
+  ...over,
+});
+
+describe('createHowlerAudioEngine (Howler boundary)', () => {
+  it('constructs a sound and forwards every handle method without throwing', () => {
+    const engine = createHowlerAudioEngine();
+    const handle = engine.createSound(config());
+    expect(() => {
+      const playId = handle.play();
+      handle.volume(0.5, playId);
+      handle.loop(true, playId);
+      handle.fade(1, 0, 10, playId);
+      handle.fade(0.5, 0.2, 10);
+      handle.volume(0.3);
+      handle.stop(playId);
+      handle.stop();
+      handle.unload();
+    }).not.toThrow();
+  });
+
+  it('supports a muted sound and a sprite map', () => {
+    const engine = createHowlerAudioEngine();
+    const handle = engine.createSound(
+      config({ muted: true, sprite: { hit: [0, 100], cheer: [200, 300, true] } }),
+    );
+    expect(() => {
+      handle.play('hit');
+      handle.stop();
+      handle.unload();
+    }).not.toThrow();
+  });
+
+  it('round-trips master mute', () => {
+    const engine = createHowlerAudioEngine();
+    expect(engine.isMasterMuted()).toBe(false);
+    engine.setMasterMute(true);
+    expect(engine.isMasterMuted()).toBe(true);
+    engine.setMasterMute(false);
+    expect(engine.isMasterMuted()).toBe(false);
+  });
+
+  it('drives a full AudioService end-to-end over the real engine', () => {
+    const engine = createHowlerAudioEngine();
+    const service = createAudioService(engine, { signal: new AbortController().signal });
+    expect(() => {
+      service.load('bed', { src: SILENT_WAV });
+      service.play('bed', { loop: true, volume: 0.4, group: 'scene-a' });
+      service.fade('bed', 0.4, 0, 20);
+      service.stopGroup('scene-a');
+      service.mute(true);
+      service.stopAll();
+    }).not.toThrow();
+    expect(service.isDisposed()).toBe(true);
+  });
+});

--- a/tests/runtime/audio.test.ts
+++ b/tests/runtime/audio.test.ts
@@ -20,6 +20,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   type AudioEngine,
+  AudioError,
   AudioGroupError,
   AudioRangeError,
   type AudioSoundConfig,
@@ -502,9 +503,9 @@ describe('createAudioService — master mute (ADR-004)', () => {
   it('rejects a non-boolean mute argument at the runtime boundary', () => {
     const { service } = buildService();
     const muteUnchecked = service.mute as (value: unknown) => void;
-    expect(() => muteUnchecked('on')).toThrow();
-    expect(() => muteUnchecked(1)).toThrow();
-    expect(() => muteUnchecked(undefined)).toThrow();
+    expect(() => muteUnchecked('on')).toThrow(AudioError);
+    expect(() => muteUnchecked(1)).toThrow(AudioError);
+    expect(() => muteUnchecked(undefined)).toThrow(AudioError);
   });
 
   it('persists master mute across services backed by the same engine', () => {

--- a/tests/runtime/audio.test.ts
+++ b/tests/runtime/audio.test.ts
@@ -1,0 +1,694 @@
+// Tests for the runtime audio service — PUL-F024 / ADR-004.
+//
+// Coverage map (requirement clauses):
+//  - C1 "the runtime SHALL provide an audio service": `createAudioService`.
+//  - C2 "per-scene playback": `load` registers a sound, `play` / `stop`
+//    drive it; the service is per-navigation (signal-bound `stopAll`).
+//  - C3 "fades": `fade`.
+//  - C4 "sprites": `SoundDefinition.sprite` + `play({ sprite })`.
+//  - C5 "looping": `play({ loop: true })`.
+//  - C6 "named groups": `play({ group })` + `stopGroup` (kebab-only,
+//    audio routing/cleanup scope — not a scene/composition/timeline id).
+//  - ADR-004 extras: master mute (`mute` / `isMuted`, persistent on the
+//    engine), runtime-guaranteed cleanup (signal abort ⇒ `stopAll`),
+//    screenshot/paused suppression (`silent`).
+//
+// The Howler boundary is exercised separately (`audio-engine.test.ts`);
+// here the engine is a deterministic in-process fake so every code
+// path of the service is asserted without a browser audio context.
+
+import { describe, expect, it } from 'vitest';
+import {
+  type AudioEngine,
+  AudioGroupError,
+  AudioRangeError,
+  type AudioSoundConfig,
+  AudioSoundError,
+  type AudioSoundHandle,
+  AudioSourceError,
+  type SoundDefinition,
+  createAudioService,
+  noopAudioEngine,
+} from '../../src/runtime/audio';
+
+/* -------------------------------------------------------------------- *
+ *  Fake engine — records every call so tests can assert delegation.
+ * -------------------------------------------------------------------- */
+
+interface HandleCall {
+  readonly sound: string;
+  readonly method: 'play' | 'stop' | 'fade' | 'loop' | 'volume' | 'unload';
+  readonly args: readonly unknown[];
+}
+
+interface FakeEngine {
+  readonly engine: AudioEngine;
+  readonly created: AudioSoundConfig[];
+  readonly calls: HandleCall[];
+  /** Invoke the recorded `onError` for the most recently created sound (or by index). */
+  emitError(err: unknown, soundIndex?: number): void;
+  masterMuted(): boolean;
+}
+
+const fakeEngine = (): FakeEngine => {
+  const created: AudioSoundConfig[] = [];
+  const calls: HandleCall[] = [];
+  let masterMuted = false;
+  let playCounter = 0;
+  return {
+    created,
+    calls,
+    emitError(err, soundIndex) {
+      const idx = soundIndex ?? created.length - 1;
+      const cfg = created[idx];
+      if (cfg === undefined) throw new Error(`no sound created at index ${idx}`);
+      cfg.onError(err);
+    },
+    masterMuted: () => masterMuted,
+    engine: {
+      createSound(config) {
+        const id = `sound#${created.length}`;
+        created.push(config);
+        const record =
+          (method: HandleCall['method']) =>
+          (...args: unknown[]): void => {
+            calls.push({ sound: id, method, args });
+          };
+        const handle: AudioSoundHandle = {
+          play: (sprite) => {
+            calls.push({ sound: id, method: 'play', args: [sprite] });
+            return ++playCounter;
+          },
+          stop: record('stop'),
+          fade: record('fade'),
+          loop: record('loop'),
+          volume: record('volume'),
+          unload: record('unload'),
+        };
+        return handle;
+      },
+      setMasterMute(muted) {
+        masterMuted = muted;
+      },
+      isMasterMuted: () => masterMuted,
+    },
+  };
+};
+
+const liveSignal = (): AbortSignal => new AbortController().signal;
+
+const buildService = (overrides: Partial<Parameters<typeof createAudioService>[1]> = {}) => {
+  const fake = fakeEngine();
+  const controller = new AbortController();
+  const service = createAudioService(fake.engine, {
+    signal: controller.signal,
+    ...overrides,
+  });
+  return { fake, controller, service };
+};
+
+/* -------------------------------------------------------------------- *
+ *  Registration — `load`
+ * -------------------------------------------------------------------- */
+
+describe('createAudioService — load (C2 register a sound)', () => {
+  it('registers a sound and forwards its sources to the engine', () => {
+    const { fake, service } = buildService();
+    service.load('stinger', { src: '/audio/stinger.mp3' });
+    expect(fake.created).toHaveLength(1);
+    expect(fake.created[0]?.src).toEqual(['/audio/stinger.mp3']);
+    expect(fake.created[0]?.muted).toBe(false);
+  });
+
+  it('accepts an array of source URLs (codec preference order)', () => {
+    const { fake, service } = buildService();
+    service.load('bed', { src: ['/audio/bed.webm', '/audio/bed.mp3'] });
+    expect(fake.created[0]?.src).toEqual(['/audio/bed.webm', '/audio/bed.mp3']);
+  });
+
+  it('forwards sprite definitions to the engine', () => {
+    const { fake, service } = buildService();
+    service.load('fx', {
+      src: '/audio/fx.webm',
+      sprite: { laugh: [0, 1000], cheer: [1500, 2000], hum: [3000, 1000, true] },
+    });
+    expect(fake.created[0]?.sprite).toEqual({
+      laugh: [0, 1000],
+      cheer: [1500, 2000],
+      hum: [3000, 1000, true],
+    });
+  });
+
+  it('validates sprite definitions at the runtime boundary', () => {
+    const { service } = buildService();
+    // A JS-authored scene can pass garbage here; build it through a
+    // double-cast so the test exercises the runtime guard.
+    const withSprite = (id: string, sprite: unknown): SoundDefinition =>
+      ({ src: `/${id}.webm`, sprite }) as unknown as SoundDefinition;
+    // Malformed shape: not an object / wrong tuple length / empty name.
+    expect(() => service.load('a', withSprite('a', 'oops'))).toThrow(AudioSoundError);
+    expect(() => service.load('b', withSprite('b', { x: [0] }))).toThrow(AudioSoundError);
+    expect(() => service.load('c', withSprite('c', { x: [0, 1, 2, 3] }))).toThrow(AudioSoundError);
+    expect(() => service.load('d', { src: '/d.webm', sprite: { '': [0, 100] } })).toThrow(
+      AudioSoundError,
+    );
+    // Out-of-range offsets / durations.
+    expect(() => service.load('e', { src: '/e.webm', sprite: { x: [-1, 100] } })).toThrow(
+      AudioRangeError,
+    );
+    expect(() =>
+      service.load('f', { src: '/f.webm', sprite: { x: [0, Number.POSITIVE_INFINITY] } }),
+    ).toThrow(AudioRangeError);
+    // Non-boolean loop flag.
+    expect(() => service.load('g', withSprite('g', { x: [0, 100, 'yes'] }))).toThrow(
+      AudioSoundError,
+    );
+  });
+
+  it('rejects a non-kebab sound id with AudioSoundError', () => {
+    const { service } = buildService();
+    expect(() => service.load('Stinger', { src: '/a.mp3' })).toThrow(AudioSoundError);
+    expect(() => service.load('two words', { src: '/a.mp3' })).toThrow(AudioSoundError);
+    expect(() => service.load('', { src: '/a.mp3' })).toThrow(AudioSoundError);
+  });
+
+  it('validates the SoundDefinition payload shape at the runtime boundary', () => {
+    const { service } = buildService();
+    // A plain-JS scene can pass garbage where TypeScript would catch
+    // the error; the service throws the documented audio-error family.
+    const passDef =
+      (id: string, def: unknown): (() => void) =>
+      () =>
+        service.load(id, def as unknown as SoundDefinition);
+    expect(passDef('a', null)).toThrow(AudioSoundError);
+    expect(passDef('b', 'not-an-object')).toThrow(AudioSoundError);
+    expect(passDef('c', {})).toThrow(AudioSourceError); // missing src
+    expect(passDef('d', { src: 42 })).toThrow(AudioSourceError); // src wrong type
+    expect(passDef('e', { src: { not: 'array' } })).toThrow(AudioSourceError); // src wrong type
+  });
+
+  it('rejects re-registering an id with a different definition', () => {
+    const { service } = buildService();
+    service.load('bed', { src: '/audio/bed.mp3' });
+    expect(() => service.load('bed', { src: '/audio/bed2.mp3' })).toThrow(AudioSoundError);
+    service.load('fx', { src: '/audio/fx.webm', sprite: { laugh: [0, 1000] } });
+    expect(() =>
+      service.load('fx', { src: '/audio/fx.webm', sprite: { laugh: [0, 999] } }),
+    ).toThrow(AudioSoundError);
+  });
+
+  it('is idempotent when re-registering an id with the same definition (shared SFX)', () => {
+    const { fake, service } = buildService();
+    service.load('whoosh', { src: ['/audio/whoosh.webm', '/audio/whoosh.mp3'] });
+    service.load('whoosh', { src: ['/audio/whoosh.webm', '/audio/whoosh.mp3'] });
+    service.load('fx', {
+      src: '/audio/fx.webm',
+      sprite: { hit: [0, 100], cheer: [200, 300, true] },
+    });
+    service.load('fx', {
+      src: '/audio/fx.webm',
+      sprite: { hit: [0, 100], cheer: [200, 300, true] },
+    });
+    expect(fake.created).toHaveLength(2); // one per distinct id, not per call
+    expect(() => service.play('whoosh')).not.toThrow();
+    expect(() => service.play('fx', { sprite: 'hit' })).not.toThrow();
+  });
+
+  it('rejects an empty source list', () => {
+    const { service } = buildService();
+    expect(() => service.load('bed', { src: [] })).toThrow(AudioSourceError);
+  });
+
+  it('rejects an empty / non-string source URL', () => {
+    const { service } = buildService();
+    expect(() => service.load('a', { src: '' })).toThrow(AudioSourceError);
+    expect(() => service.load('b', { src: ['/ok.mp3', ''] })).toThrow(AudioSourceError);
+  });
+
+  it('rejects a disallowed source scheme when no slice allowlist is supplied', () => {
+    const { service } = buildService();
+    expect(() => service.load('bed', { src: 'file:///etc/passwd.mp3' })).toThrow(AudioSourceError);
+    expect(() => service.load('bed', { src: '//cdn.example.com/bed.mp3' })).toThrow(
+      AudioSourceError,
+    );
+  });
+
+  it('allows http(s) / data / blob and relative source URLs', () => {
+    const { service } = buildService();
+    expect(() => service.load('a', { src: 'https://cdn.example.com/a.mp3' })).not.toThrow();
+    expect(() => service.load('b', { src: '/audio/b.mp3' })).not.toThrow();
+    expect(() => service.load('c', { src: 'audio/c.mp3' })).not.toThrow();
+    expect(() => service.load('d', { src: 'data:audio/wav;base64,AAAA' })).not.toThrow();
+  });
+
+  describe('allowedSources — ADR-008 #5 (audio is declared in scene.assets)', () => {
+    it('rejects a source not in allowedSources', () => {
+      const { service } = buildService({ allowedSources: ['/audio/bed.mp3'] });
+      expect(() => service.load('bed', { src: '/audio/bed.mp3' })).not.toThrow();
+      expect(() => service.load('typo', { src: '/audio/typo.mp3' })).toThrow(AudioSourceError);
+    });
+
+    it('rejects when one URL of a multi-source sound is undeclared', () => {
+      const { service } = buildService({ allowedSources: ['/audio/bed.webm'] });
+      expect(() => service.load('bed', { src: ['/audio/bed.webm', '/audio/bed.mp3'] })).toThrow(
+        AudioSourceError,
+      );
+    });
+
+    it('still applies the default scheme allowlist even when in allowedSources (defense-in-depth)', () => {
+      // A weak / no-op preloader could declare a non-default-scheme URL
+      // in `scene.assets`; audio refuses it regardless because the
+      // audio service runs its own scheme check on top of membership.
+      const { service } = buildService({ allowedSources: ['file:///etc/passwd.mp3'] });
+      expect(() => service.load('x', { src: 'file:///etc/passwd.mp3' })).toThrow(AudioSourceError);
+    });
+
+    it('skips the membership check when allowedSources is omitted', () => {
+      const { service } = buildService();
+      expect(() => service.load('anything', { src: '/whatever.mp3' })).not.toThrow();
+    });
+  });
+
+  it('builds every sound muted when the service is silent', () => {
+    const { fake, service } = buildService({ silent: true });
+    service.load('bed', { src: '/audio/bed.mp3' });
+    expect(fake.created[0]?.muted).toBe(true);
+  });
+
+  it("routes a sound's async load/play error through onError (non-fatal)", () => {
+    const seen: unknown[] = [];
+    const { fake, service } = buildService({ onError: (err) => seen.push(err) });
+    service.load('bed', { src: '/audio/bed.mp3' });
+    fake.emitError(new Error('decode failed'));
+    expect(seen).toHaveLength(1);
+    expect(String(seen[0])).toContain('audio sound "bed"');
+    expect(String(seen[0])).toContain('decode failed');
+  });
+
+  it('suppresses a sound error that arrives after the service is disposed', () => {
+    const seen: unknown[] = [];
+    const { fake, service } = buildService({ onError: (err) => seen.push(err) });
+    service.load('bed', { src: '/audio/bed.mp3' });
+    service.stopAll();
+    fake.emitError(new Error('late decode failure')); // arrives after the navigation ended
+    expect(seen).toEqual([]);
+  });
+
+  it('does not let a throwing onError sink escape through the async callback', () => {
+    const { fake, service } = buildService({
+      onError: () => {
+        throw new Error('logger blew up');
+      },
+    });
+    service.load('bed', { src: '/audio/bed.mp3' });
+    expect(() => fake.emitError(new Error('decode failed'))).not.toThrow();
+  });
+});
+
+/* -------------------------------------------------------------------- *
+ *  Playback — `play`
+ * -------------------------------------------------------------------- */
+
+describe('createAudioService — play (C2 playback, C4 sprites, C5 looping)', () => {
+  it('plays a registered sound', () => {
+    const { fake, service } = buildService();
+    service.load('bed', { src: '/audio/bed.mp3' });
+    service.play('bed');
+    expect(fake.calls).toContainEqual({ sound: 'sound#0', method: 'play', args: [undefined] });
+  });
+
+  it('rejects playing an unregistered sound', () => {
+    const { service } = buildService();
+    expect(() => service.play('ghost')).toThrow(AudioSoundError);
+  });
+
+  it('rejects playing with a non-kebab sound id', () => {
+    const { service } = buildService();
+    expect(() => service.play('Bad Id')).toThrow(AudioSoundError);
+  });
+
+  it('plays a named sprite (C4)', () => {
+    const { fake, service } = buildService();
+    service.load('fx', { src: '/audio/fx.webm', sprite: { laugh: [0, 1000] } });
+    service.play('fx', { sprite: 'laugh' });
+    expect(fake.calls).toContainEqual({ sound: 'sound#0', method: 'play', args: ['laugh'] });
+  });
+
+  it('rejects an unknown sprite name', () => {
+    const { service } = buildService();
+    service.load('fx', { src: '/audio/fx.webm', sprite: { laugh: [0, 1000] } });
+    expect(() => service.play('fx', { sprite: 'sob' })).toThrow(AudioSoundError);
+  });
+
+  it('rejects any sprite name on a sound with no sprites', () => {
+    const { service } = buildService();
+    service.load('bed', { src: '/audio/bed.mp3' });
+    expect(() => service.play('bed', { sprite: 'laugh' })).toThrow(AudioSoundError);
+  });
+
+  it('sets the loop flag on the play instance when loop is requested (C5)', () => {
+    const { fake, service } = buildService();
+    service.load('bed', { src: '/audio/bed.mp3' });
+    service.play('bed', { loop: true });
+    const loopCall = fake.calls.find((c) => c.method === 'loop');
+    expect(loopCall).toBeDefined();
+    expect(loopCall?.args[0]).toBe(true);
+    // loop is keyed to the playId play() returned
+    expect(loopCall?.args[1]).toBe(1);
+  });
+
+  it('does not set loop when loop is absent or false', () => {
+    const { fake, service } = buildService();
+    service.load('bed', { src: '/audio/bed.mp3' });
+    service.play('bed');
+    service.play('bed', { loop: false });
+    expect(fake.calls.some((c) => c.method === 'loop')).toBe(false);
+  });
+
+  it('applies a per-play volume override to the play instance', () => {
+    const { fake, service } = buildService();
+    service.load('bed', { src: '/audio/bed.mp3' });
+    service.play('bed', { volume: 0.25 });
+    expect(fake.calls).toContainEqual({ sound: 'sound#0', method: 'volume', args: [0.25, 1] });
+  });
+
+  it('rejects an out-of-range per-play volume', () => {
+    const { service } = buildService();
+    service.load('bed', { src: '/audio/bed.mp3' });
+    expect(() => service.play('bed', { volume: -0.1 })).toThrow(AudioRangeError);
+    expect(() => service.play('bed', { volume: 1.5 })).toThrow(AudioRangeError);
+    expect(() => service.play('bed', { volume: Number.NaN })).toThrow(AudioRangeError);
+  });
+
+  it('validates the PlayOptions payload shape at the runtime boundary', () => {
+    const { service } = buildService();
+    service.load('bed', { src: '/audio/bed.mp3' });
+    const passOpts =
+      (opts: unknown): (() => void) =>
+      () =>
+        service.play('bed', opts as Parameters<typeof service.play>[1]);
+    expect(passOpts('not-an-object')).toThrow(AudioSoundError);
+    expect(passOpts({ sprite: 42 })).toThrow(AudioSoundError);
+    expect(passOpts({ loop: 'true' })).toThrow(AudioSoundError);
+    expect(passOpts({ group: 99 })).toThrow(AudioGroupError);
+    expect(passOpts({ volume: 'loud' })).toThrow(AudioRangeError);
+  });
+});
+
+/* -------------------------------------------------------------------- *
+ *  Fades — `fade`
+ * -------------------------------------------------------------------- */
+
+describe('createAudioService — fade (C3)', () => {
+  it('fades a registered sound through the engine', () => {
+    const { fake, service } = buildService();
+    service.load('bed', { src: '/audio/bed.mp3' });
+    service.fade('bed', 0.8, 0.15, 1200);
+    expect(fake.calls).toContainEqual({
+      sound: 'sound#0',
+      method: 'fade',
+      args: [0.8, 0.15, 1200],
+    });
+  });
+
+  it('rejects fading an unregistered sound', () => {
+    const { service } = buildService();
+    expect(() => service.fade('ghost', 1, 0, 100)).toThrow(AudioSoundError);
+  });
+
+  it('rejects out-of-range fade endpoints', () => {
+    const { service } = buildService();
+    service.load('bed', { src: '/audio/bed.mp3' });
+    expect(() => service.fade('bed', 1.2, 0, 100)).toThrow(AudioRangeError);
+    expect(() => service.fade('bed', 1, -0.5, 100)).toThrow(AudioRangeError);
+  });
+
+  it('rejects a negative or non-finite fade duration', () => {
+    const { service } = buildService();
+    service.load('bed', { src: '/audio/bed.mp3' });
+    expect(() => service.fade('bed', 1, 0, -10)).toThrow(AudioRangeError);
+    expect(() => service.fade('bed', 1, 0, Number.POSITIVE_INFINITY)).toThrow(AudioRangeError);
+  });
+});
+
+/* -------------------------------------------------------------------- *
+ *  stop / stopGroup — named groups (C6)
+ * -------------------------------------------------------------------- */
+
+describe('createAudioService — stop / stopGroup (C6 named groups)', () => {
+  it('stops every instance of a sound via stop()', () => {
+    const { fake, service } = buildService();
+    service.load('bed', { src: '/audio/bed.mp3' });
+    service.play('bed');
+    service.stop('bed');
+    expect(fake.calls).toContainEqual({ sound: 'sound#0', method: 'stop', args: [] });
+  });
+
+  it('rejects stopping an unregistered sound', () => {
+    const { service } = buildService();
+    expect(() => service.stop('ghost')).toThrow(AudioSoundError);
+  });
+
+  it('rejects a non-kebab group name on play and on stopGroup', () => {
+    const { service } = buildService();
+    service.load('bed', { src: '/audio/bed.mp3' });
+    expect(() => service.play('bed', { group: 'Scene A' })).toThrow(AudioGroupError);
+    expect(() => service.stopGroup('Scene A')).toThrow(AudioGroupError);
+  });
+
+  it('stopGroup stops only the play instances tagged with that group', () => {
+    const { fake, service } = buildService();
+    service.load('bed', { src: '/audio/bed.mp3' });
+    service.load('stinger', { src: '/audio/stinger.mp3' });
+    service.play('bed', { group: 'scene-a' }); // playId 1
+    service.play('stinger', { group: 'scene-a' }); // playId 2
+    service.play('bed', { group: 'scene-b' }); // playId 3
+    service.play('bed'); // playId 4 — ungrouped
+    fake.calls.length = 0;
+    service.stopGroup('scene-a');
+    expect(fake.calls).toEqual([
+      { sound: 'sound#0', method: 'stop', args: [1] },
+      { sound: 'sound#1', method: 'stop', args: [2] },
+    ]);
+  });
+
+  it('stopGroup on an unknown or already-emptied group is a no-op', () => {
+    const { fake, service } = buildService();
+    service.load('bed', { src: '/audio/bed.mp3' });
+    service.play('bed', { group: 'scene-a' });
+    service.stopGroup('scene-a');
+    fake.calls.length = 0;
+    expect(() => service.stopGroup('scene-a')).not.toThrow();
+    expect(() => service.stopGroup('never-used')).not.toThrow();
+    expect(fake.calls).toEqual([]);
+  });
+});
+
+/* -------------------------------------------------------------------- *
+ *  Master mute — ADR-004
+ * -------------------------------------------------------------------- */
+
+describe('createAudioService — master mute (ADR-004)', () => {
+  it('delegates mute / isMuted to the engine', () => {
+    const { fake, service } = buildService();
+    expect(service.isMuted()).toBe(false);
+    service.mute(true);
+    expect(fake.masterMuted()).toBe(true);
+    expect(service.isMuted()).toBe(true);
+    service.mute(false);
+    expect(service.isMuted()).toBe(false);
+  });
+
+  it('rejects a non-boolean mute argument at the runtime boundary', () => {
+    const { service } = buildService();
+    const muteUnchecked = service.mute as (value: unknown) => void;
+    expect(() => muteUnchecked('on')).toThrow();
+    expect(() => muteUnchecked(1)).toThrow();
+    expect(() => muteUnchecked(undefined)).toThrow();
+  });
+
+  it('persists master mute across services backed by the same engine', () => {
+    const fake = fakeEngine();
+    const a = createAudioService(fake.engine, { signal: liveSignal() });
+    a.mute(true);
+    const b = createAudioService(fake.engine, { signal: liveSignal() });
+    expect(b.isMuted()).toBe(true);
+  });
+
+  it('stopAll does not reset master mute (it is persistent runtime state)', () => {
+    const { service } = buildService();
+    service.mute(true);
+    service.stopAll();
+    expect(service.isMuted()).toBe(true);
+  });
+});
+
+/* -------------------------------------------------------------------- *
+ *  Lifecycle — stopAll + signal binding (ADR-004 runtime cleanup)
+ * -------------------------------------------------------------------- */
+
+describe('createAudioService — lifecycle / cleanup (ADR-004)', () => {
+  it('stopAll stops and unloads every registered sound and clears groups', () => {
+    const { fake, service } = buildService();
+    service.load('bed', { src: '/audio/bed.mp3' });
+    service.load('stinger', { src: '/audio/stinger.mp3' });
+    service.play('bed', { group: 'scene-a' });
+    fake.calls.length = 0;
+    service.stopAll();
+    expect(service.isDisposed()).toBe(true);
+    expect(fake.calls).toEqual([
+      { sound: 'sound#0', method: 'stop', args: [] },
+      { sound: 'sound#0', method: 'unload', args: [] },
+      { sound: 'sound#1', method: 'stop', args: [] },
+      { sound: 'sound#1', method: 'unload', args: [] },
+    ]);
+  });
+
+  it('stopAll is idempotent', () => {
+    const { fake, service } = buildService();
+    service.load('bed', { src: '/audio/bed.mp3' });
+    service.stopAll();
+    fake.calls.length = 0;
+    service.stopAll();
+    expect(fake.calls).toEqual([]);
+  });
+
+  it('mutating methods are inert after dispose; introspectors still work', () => {
+    const { fake, service } = buildService();
+    service.load('bed', { src: '/audio/bed.mp3' });
+    service.stopAll();
+    fake.calls.length = 0;
+    // None of these throw and none reach the engine.
+    service.load('late', { src: '/x.mp3' });
+    service.play('bed');
+    service.fade('bed', 1, 0, 10);
+    service.stop('bed');
+    service.stopGroup('scene-a');
+    service.mute(true);
+    expect(fake.calls).toEqual([]);
+    expect(fake.created).toHaveLength(1);
+    expect(service.isDisposed()).toBe(true);
+  });
+
+  it('aborting the navigation signal disposes the service (stopAll)', () => {
+    const { service, controller } = buildService();
+    service.load('bed', { src: '/audio/bed.mp3' });
+    service.play('bed', { loop: true });
+    expect(service.isDisposed()).toBe(false);
+    controller.abort();
+    expect(service.isDisposed()).toBe(true);
+  });
+
+  it('an already-aborted signal disposes the service immediately', () => {
+    const fake = fakeEngine();
+    const controller = new AbortController();
+    controller.abort();
+    const service = createAudioService(fake.engine, { signal: controller.signal });
+    expect(service.isDisposed()).toBe(true);
+  });
+
+  it('isolates per-item failures in stopAll: every sound is still torn down', () => {
+    const seen: unknown[] = [];
+    const fake = fakeEngine();
+    // Inject a throwing handle for sound#0; sound#1 stays well-behaved.
+    const original = fake.engine.createSound;
+    let firstSoundCreated = false;
+    fake.engine.createSound = ((config) => {
+      const handle = original.call(fake.engine, config);
+      if (!firstSoundCreated) {
+        firstSoundCreated = true;
+        return {
+          ...handle,
+          stop: () => {
+            throw new Error('stop kaboom');
+          },
+          unload: () => {
+            throw new Error('unload kaboom');
+          },
+        };
+      }
+      return handle;
+    }) as typeof fake.engine.createSound;
+    const service = createAudioService(fake.engine, {
+      signal: new AbortController().signal,
+      onError: (err) => seen.push(err),
+    });
+    service.load('a', { src: '/audio/a.mp3' });
+    service.load('b', { src: '/audio/b.mp3' });
+    expect(() => service.stopAll()).not.toThrow();
+    expect(service.isDisposed()).toBe(true);
+    // sound#1 (`b`) still got stop+unload despite sound#0 (`a`) throwing.
+    expect(fake.calls).toContainEqual({ sound: 'sound#1', method: 'stop', args: [] });
+    expect(fake.calls).toContainEqual({ sound: 'sound#1', method: 'unload', args: [] });
+    // The two failures from sound#0 routed through onError (non-fatal).
+    expect(seen).toHaveLength(2);
+    expect(String(seen[0])).toContain('stop kaboom');
+    expect(String(seen[1])).toContain('unload kaboom');
+  });
+
+  it('isolates per-play failures in stopGroup: every play in the group is still stopped', () => {
+    const seen: unknown[] = [];
+    const fake = fakeEngine();
+    const original = fake.engine.createSound;
+    let playCount = 0;
+    let throwingPlayId: number | null = null;
+    fake.engine.createSound = ((config) => {
+      const handle = original.call(fake.engine, config);
+      return {
+        ...handle,
+        play: (sprite) => {
+          playCount += 1;
+          const id = handle.play(sprite);
+          if (playCount === 2) throwingPlayId = id;
+          return id;
+        },
+        stop: (playId) => {
+          if (playId === throwingPlayId) {
+            throw new Error('per-play stop kaboom');
+          }
+          handle.stop(playId);
+        },
+      };
+    }) as typeof fake.engine.createSound;
+    const service = createAudioService(fake.engine, {
+      signal: new AbortController().signal,
+      onError: (err) => seen.push(err),
+    });
+    service.load('bed', { src: '/audio/bed.mp3' });
+    service.play('bed', { group: 'g' }); // playId 1, well-behaved
+    service.play('bed', { group: 'g' }); // playId 2, throws on stop
+    expect(() => service.stopGroup('g')).not.toThrow();
+    // The first play's stop went through; the second's threw and was
+    // routed through onError. Both calls were attempted (per-play
+    // isolation), and the recording engine recorded the first stop.
+    expect(fake.calls).toContainEqual({ sound: 'sound#0', method: 'stop', args: [1] });
+    expect(seen).toHaveLength(1);
+    expect(String(seen[0])).toContain('per-play stop kaboom');
+  });
+});
+
+/* -------------------------------------------------------------------- *
+ *  noopAudioEngine — the silent fallback
+ * -------------------------------------------------------------------- */
+
+describe('noopAudioEngine', () => {
+  it('produces handles whose methods do not throw and back a working service', () => {
+    const service = createAudioService(noopAudioEngine, { signal: liveSignal() });
+    service.load('bed', { src: '/audio/bed.mp3', sprite: { hit: [0, 100] } });
+    expect(() => {
+      service.play('bed', { sprite: 'hit', loop: true, volume: 0.5, group: 'scene-a' });
+      service.fade('bed', 1, 0, 50);
+      service.stopGroup('scene-a');
+      service.stop('bed');
+      service.stopAll();
+    }).not.toThrow();
+  });
+
+  it('round-trips master mute', () => {
+    const service = createAudioService(noopAudioEngine, { signal: liveSignal() });
+    service.mute(true);
+    expect(service.isMuted()).toBe(true);
+    service.mute(false);
+    expect(service.isMuted()).toBe(false);
+  });
+});

--- a/tests/runtime/composition-resolver.test.ts
+++ b/tests/runtime/composition-resolver.test.ts
@@ -120,6 +120,7 @@ interface ResolveArgs {
   readonly headHold?: 'first-frame';
   readonly headCueGate?: 'monotonic-forward';
   readonly headScreenshot?: 'capture';
+  readonly onSceneCleaned?: (sceneId: string) => void;
 }
 
 const run = (args: ResolveArgs): Promise<void> =>
@@ -136,6 +137,7 @@ const run = (args: ResolveArgs): Promise<void> =>
     ...(args.headHold === undefined ? {} : { headHold: args.headHold }),
     ...(args.headCueGate === undefined ? {} : { headCueGate: args.headCueGate }),
     ...(args.headScreenshot === undefined ? {} : { headScreenshot: args.headScreenshot }),
+    ...(args.onSceneCleaned === undefined ? {} : { onSceneCleaned: args.onSceneCleaned }),
   });
 
 const aborted = (reason?: unknown): AbortSignal => {
@@ -600,5 +602,58 @@ describe('resolveComposition — cleanup phase', () => {
       signal: aborted(),
     }).catch(() => undefined);
     expect(log).toEqual([]);
+  });
+
+  it('invokes onSceneCleaned after each scene cleanup, in reverse mount order (PUL-F024)', async () => {
+    const log: string[] = [];
+    const recordCleaned = (id: string): void => {
+      log.push(`cleaned:${id}`);
+    };
+    await run({
+      scenes: [recordingScene('a', log), recordingScene('b', log), recordingScene('c', log)],
+      manifest: ['a', 'b', 'c'],
+      onSceneCleaned: recordCleaned,
+    });
+    expect(log.slice(-6)).toEqual([
+      'cleanup:c',
+      'cleaned:c',
+      'cleanup:b',
+      'cleaned:b',
+      'cleanup:a',
+      'cleaned:a',
+    ]);
+  });
+
+  it('still invokes onSceneCleaned for a scene whose cleanup threw, and aggregates an onSceneCleaned throw', async () => {
+    const log: string[] = [];
+    let caught: unknown;
+    await run({
+      scenes: [
+        recordingScene('a', log),
+        recordingScene('b', log, {
+          cleanup: () => {
+            log.push('cleanup:b');
+            throw new Error('cleanup-b kaboom');
+          },
+        }),
+      ],
+      manifest: ['a', 'b'],
+      onSceneCleaned: (id) => {
+        log.push(`cleaned:${id}`);
+        if (id === 'a') throw new Error('hook-a kaboom');
+      },
+    }).catch((err: unknown) => {
+      caught = err;
+    });
+    // b cleaned (threw) → hook(b) → a cleaned → hook(a) (threw).
+    expect(log.slice(-4)).toEqual(['cleanup:b', 'cleaned:b', 'cleanup:a', 'cleaned:a']);
+    expect(caught).toBeInstanceOf(AggregateError);
+    const messages = (caught as AggregateError).errors.map((e) => (e as Error).message);
+    expect(messages).toContain(
+      'composition resolution failed: scene "b" cleanup threw: cleanup-b kaboom',
+    );
+    expect(messages).toContain(
+      'composition resolution failed: scene "a" onSceneCleaned threw: hook-a kaboom',
+    );
   });
 });

--- a/tests/runtime/scene-loader-audio.test.ts
+++ b/tests/runtime/scene-loader-audio.test.ts
@@ -1,0 +1,384 @@
+// Loader ↔ audio-service integration — PUL-F024 / ADR-004.
+//
+// `audio.test.ts` covers `createAudioService` in isolation; this file
+// covers the scene loader's wiring of it:
+//  - the per-navigation `AudioService` is threaded into `ctx.audio`
+//    so scenes reach audio only through the runtime context (clause:
+//    "Each scene SHALL access audio only via the runtime context");
+//  - it is bound to the navigation's `AbortSignal` (supersession /
+//    dispose) AND `stopAll()`-ed when a navigation completes — so
+//    fades / loops / sprites never survive scene cleanup (ADR-004:
+//    "per-scene cleanup is guaranteed by the runtime");
+//  - it is restricted to the URLs the active slice declared in
+//    `scene.assets` (ADR-008 #5);
+//  - it is `silent` under `mode=screenshot` / `mode=paused`
+//    (audible playback suppressed — ADR-019 / ADR-021);
+//  - `mode=prompter` bypasses it (no scene mounts, no `ctx.audio`);
+//  - a workbench that omits `audioEngine` still gives scenes a
+//    working (silent) `ctx.audio` via the no-op engine.
+
+import { describe, expect, it } from 'vitest';
+import type {
+  AudioEngine,
+  AudioService,
+  AudioSoundConfig,
+  AudioSoundHandle,
+} from '../../src/runtime/audio';
+import {
+  type NavigationTarget,
+  buildScene,
+  buildStage,
+  compositionTarget,
+  createCompositionRegistry,
+  createSceneLoader,
+  createSceneRegistry,
+  noopTimeline,
+  recordingTimeline,
+  sceneTarget,
+  stubCtx,
+} from './scene-loader.helpers';
+
+/* -------------------------------------------------------------------- *
+ *  Recording audio engine — records every sound it builds and every
+ *  handle call so tests can assert the loader's wiring + teardown.
+ * -------------------------------------------------------------------- */
+
+interface HandleCall {
+  readonly sound: number;
+  readonly method: 'play' | 'stop' | 'fade' | 'loop' | 'volume' | 'unload';
+}
+
+interface RecordingEngine {
+  readonly engine: AudioEngine;
+  readonly created: AudioSoundConfig[];
+  readonly calls: HandleCall[];
+}
+
+const recordingAudioEngine = (): RecordingEngine => {
+  const created: AudioSoundConfig[] = [];
+  const calls: HandleCall[] = [];
+  let masterMuted = false;
+  let playCounter = 0;
+  return {
+    created,
+    calls,
+    engine: {
+      createSound(config) {
+        const index = created.length;
+        created.push(config);
+        const record = (method: HandleCall['method']) => (): void => {
+          calls.push({ sound: index, method });
+        };
+        const handle: AudioSoundHandle = {
+          play: () => {
+            calls.push({ sound: index, method: 'play' });
+            return ++playCounter;
+          },
+          stop: record('stop'),
+          fade: record('fade'),
+          loop: record('loop'),
+          volume: record('volume'),
+          unload: record('unload'),
+        };
+        return handle;
+      },
+      setMasterMute(muted) {
+        masterMuted = muted;
+      },
+      isMasterMuted: () => masterMuted,
+    },
+  };
+};
+
+const targetWithMode = (scene: string, mode: NavigationTarget['mode']): NavigationTarget => ({
+  locator: { kind: 'scene', scene },
+  ...(mode === undefined ? {} : { mode }),
+});
+
+/* -------------------------------------------------------------------- */
+
+describe('scene loader — audio service wiring (PUL-F024 / ADR-004)', () => {
+  it('threads a working ctx.audio into every lifecycle hook', async () => {
+    const seen: Array<{ phase: string; audio: AudioService | undefined }> = [];
+    const audio = recordingAudioEngine();
+    const scene = buildScene({
+      id: 'a',
+      assets: ['/audio/bed.mp3'],
+      create: (ctx) => {
+        const a = (ctx as { audio?: AudioService }).audio;
+        seen.push({ phase: 'create', audio: a });
+        a?.load('bed', { src: '/audio/bed.mp3' });
+        a?.play('bed', { loop: true });
+      },
+      timeline: (ctx) => {
+        seen.push({ phase: 'timeline', audio: (ctx as { audio?: AudioService }).audio });
+        return null;
+      },
+      cleanup: (ctx) => {
+        seen.push({ phase: 'cleanup', audio: (ctx as { audio?: AudioService }).audio });
+      },
+    });
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([scene]),
+      compositions: createCompositionRegistry([]),
+      stage: null,
+      buildCtx: stubCtx,
+      createPreloader: () => () => Promise.resolve(),
+      timeline: noopTimeline,
+      audioEngine: audio.engine,
+    });
+    await loader.handle(sceneTarget('a'));
+    await loader.idle();
+    expect(seen.map((s) => s.phase)).toEqual(['create', 'timeline', 'cleanup']);
+    for (const s of seen) expect(s.audio).toBeDefined();
+    // create() registered + played + looped the bed.
+    expect(audio.created).toHaveLength(1);
+    expect(audio.calls).toContainEqual({ sound: 0, method: 'play' });
+    expect(audio.calls).toContainEqual({ sound: 0, method: 'loop' });
+    // The navigation completed → the loader stopped + unloaded it.
+    expect(audio.calls).toContainEqual({ sound: 0, method: 'stop' });
+    expect(audio.calls).toContainEqual({ sound: 0, method: 'unload' });
+  });
+
+  it('disposes the audio service when a navigation is superseded', async () => {
+    let captured: AudioService | undefined;
+    let mounted: () => void = () => undefined;
+    const mountedP = new Promise<void>((resolve) => {
+      mounted = resolve;
+    });
+    const audio = recordingAudioEngine();
+    const long = buildScene({
+      id: 'long',
+      assets: ['/audio/bed.mp3'],
+      create: (ctx) => {
+        captured = (ctx as { audio: AudioService }).audio;
+        captured.load('bed', { src: '/audio/bed.mp3' });
+        captured.play('bed', { loop: true });
+        mounted();
+      },
+    });
+    const next = buildScene({ id: 'next' });
+    const { adapter: parking } = recordingTimeline(true); // parks until the navigation aborts
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([long, next]),
+      compositions: createCompositionRegistry([]),
+      stage: null,
+      buildCtx: stubCtx,
+      createPreloader: () => () => Promise.resolve(),
+      timeline: parking,
+      audioEngine: audio.engine,
+    });
+    void loader.handle(sceneTarget('long'));
+    await mountedP; // `long` mounted and is parked in the timeline adapter
+    expect(captured?.isDisposed()).toBe(false);
+    void loader.handle(sceneTarget('next')); // synchronously aborts `long`'s controller
+    expect(captured?.isDisposed()).toBe(true);
+    loader.dispose();
+    await loader.idle();
+    expect(audio.calls).toContainEqual({ sound: 0, method: 'unload' });
+  });
+
+  it('disposes the audio service on loader dispose()', async () => {
+    let captured: AudioService | undefined;
+    let mounted: () => void = () => undefined;
+    const mountedP = new Promise<void>((resolve) => {
+      mounted = resolve;
+    });
+    const audio = recordingAudioEngine();
+    const scene = buildScene({
+      id: 'a',
+      create: (ctx) => {
+        captured = (ctx as { audio: AudioService }).audio;
+        mounted();
+      },
+    });
+    const { adapter: parking } = recordingTimeline(true);
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([scene]),
+      compositions: createCompositionRegistry([]),
+      stage: null,
+      buildCtx: stubCtx,
+      createPreloader: () => () => Promise.resolve(),
+      timeline: parking,
+      audioEngine: audio.engine,
+    });
+    void loader.handle(sceneTarget('a'));
+    await mountedP;
+    expect(captured?.isDisposed()).toBe(false);
+    loader.dispose();
+    expect(captured?.isDisposed()).toBe(true);
+    await loader.idle();
+  });
+
+  it('builds the audio service silent under mode=screenshot and mode=paused', async () => {
+    for (const mode of ['screenshot', 'paused'] as const) {
+      const audio = recordingAudioEngine();
+      const scene = buildScene({
+        id: 'a',
+        assets: ['/audio/bed.mp3'],
+        create: (ctx) => {
+          (ctx as { audio: AudioService }).audio.load('bed', { src: '/audio/bed.mp3' });
+        },
+      });
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([scene]),
+        compositions: createCompositionRegistry([]),
+        stage: null,
+        buildCtx: stubCtx,
+        createPreloader: () => () => Promise.resolve(),
+        timeline: noopTimeline,
+        audioEngine: audio.engine,
+      });
+      await loader.handle(targetWithMode('a', mode));
+      await loader.idle();
+      expect(audio.created).toHaveLength(1);
+      expect(audio.created[0]?.muted).toBe(true);
+    }
+  });
+
+  it('builds the audio service audible under mode=present', async () => {
+    const audio = recordingAudioEngine();
+    const scene = buildScene({
+      id: 'a',
+      assets: ['/audio/bed.mp3'],
+      create: (ctx) => {
+        (ctx as { audio: AudioService }).audio.load('bed', { src: '/audio/bed.mp3' });
+      },
+    });
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([scene]),
+      compositions: createCompositionRegistry([]),
+      stage: null,
+      buildCtx: stubCtx,
+      createPreloader: () => () => Promise.resolve(),
+      timeline: noopTimeline,
+      audioEngine: audio.engine,
+    });
+    await loader.handle(targetWithMode('a', 'present'));
+    await loader.idle();
+    expect(audio.created[0]?.muted).toBe(false);
+  });
+
+  it('restricts ctx.audio.load() to URLs the slice declared in scene.assets', async () => {
+    const stage = buildStage();
+    const audio = recordingAudioEngine();
+    const scene = buildScene({
+      id: 'a',
+      assets: ['/audio/bed.mp3'],
+      create: (ctx) => {
+        // Not in scene.assets — the per-navigation service rejects it.
+        (ctx as { audio: AudioService }).audio.load('typo', { src: '/audio/typo.mp3' });
+      },
+      cleanup: () => {
+        stage.attrs.set('data-cleanup-ran', 'yes');
+      },
+    });
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([scene]),
+      compositions: createCompositionRegistry([]),
+      stage: stage.element,
+      buildCtx: stubCtx,
+      createPreloader: () => () => Promise.resolve(),
+      timeline: noopTimeline,
+      audioEngine: audio.engine,
+      onError: () => undefined,
+    });
+    await loader.handle(sceneTarget('a'));
+    await loader.idle();
+    const err = stage.attrs.get('data-pulsar-navigation-error');
+    expect(err).toBeDefined();
+    expect(err).toContain('typo');
+    // The resolver still tore the scene down (create-attempted ⇒ cleanup).
+    expect(stage.attrs.get('data-cleanup-ran')).toBe('yes');
+  });
+
+  it('exposes every declared composition-slice asset to ctx.audio under mode=present', async () => {
+    const audio = recordingAudioEngine();
+    const a = buildScene({
+      id: 'scene-a',
+      assets: ['/audio/a.mp3'],
+      create: (ctx) => {
+        (ctx as { audio: AudioService }).audio.load('a-bed', { src: '/audio/a.mp3' });
+      },
+    });
+    const b = buildScene({
+      id: 'scene-b',
+      assets: ['/audio/b.mp3'],
+      create: (ctx) => {
+        // `scene-b` may register `scene-a`'s declared URL too — the
+        // slice's declared assets are the union (preloader warmed all).
+        (ctx as { audio: AudioService }).audio.load('a-from-b', { src: '/audio/a.mp3' });
+        (ctx as { audio: AudioService }).audio.load('b-bed', { src: '/audio/b.mp3' });
+      },
+    });
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([a, b]),
+      compositions: createCompositionRegistry([{ id: 'pair', manifest: ['scene-a', 'scene-b'] }]),
+      stage: null,
+      buildCtx: stubCtx,
+      createPreloader: () => () => Promise.resolve(),
+      timeline: noopTimeline,
+      audioEngine: audio.engine,
+    });
+    await loader.handle(compositionTarget('pair'));
+    await loader.idle();
+    expect(audio.created).toHaveLength(3);
+  });
+
+  it('does not build an audio service under mode=prompter (no scene mounts)', async () => {
+    const audio = recordingAudioEngine();
+    const head = buildScene({
+      id: 'head',
+      assets: ['/audio/head.mp3'],
+      create: (ctx) => {
+        // Would register a sound — but prompter never mounts the scene.
+        (ctx as { audio: AudioService }).audio.load('head-bed', { src: '/audio/head.mp3' });
+      },
+    });
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([head]),
+      compositions: createCompositionRegistry([{ id: 'talk', manifest: ['head'] }]),
+      stage: null,
+      buildCtx: stubCtx,
+      createPreloader: () => () => Promise.resolve(),
+      timeline: noopTimeline,
+      audioEngine: audio.engine,
+    });
+    await loader.handle({
+      locator: { kind: 'composition', composition: 'talk' },
+      mode: 'prompter',
+    });
+    await loader.idle();
+    expect(audio.created).toHaveLength(0);
+  });
+
+  it('falls back to a silent (no-op) audio engine when audioEngine is omitted', async () => {
+    let captured: AudioService | undefined;
+    const scene = buildScene({
+      id: 'a',
+      assets: ['/audio/bed.mp3'],
+      create: (ctx) => {
+        captured = (ctx as { audio: AudioService }).audio;
+        // The no-op engine still backs a working service.
+        captured.load('bed', { src: '/audio/bed.mp3', sprite: { hit: [0, 100] } });
+        captured.play('bed', { sprite: 'hit', loop: true, volume: 0.5, group: 'scene-a' });
+        captured.fade('bed', 0.5, 0, 25);
+        captured.stopGroup('scene-a');
+        captured.mute(true);
+      },
+    });
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([scene]),
+      compositions: createCompositionRegistry([]),
+      stage: null,
+      buildCtx: stubCtx,
+      createPreloader: () => () => Promise.resolve(),
+      timeline: noopTimeline,
+    });
+    await expect(loader.handle(sceneTarget('a'))).resolves.toBeUndefined();
+    await loader.idle();
+    expect(captured).toBeDefined();
+    expect(captured?.isMuted()).toBe(true);
+    expect(captured?.isDisposed()).toBe(true);
+  });
+});

--- a/tests/runtime/scene-loader-beat-mode.test.ts
+++ b/tests/runtime/scene-loader-beat-mode.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+  type AudioService,
   type Caption,
   type CompositionTimelineAdapter,
   type CompositionTimelineRunOptions,
@@ -473,16 +474,16 @@ describe('createSceneLoader — beat positioning & mode dispatch (PUL-F008)', ()
 
     interface ModeProbe {
       readonly modes: NavigationMode[];
-      readonly buildCtx: (mode: NavigationMode) => WorkbenchSceneCtx;
+      readonly buildCtx: (mode: NavigationMode, audio: AudioService) => WorkbenchSceneCtx;
     }
 
     const buildModeProbe = (): ModeProbe => {
       const modes: NavigationMode[] = [];
       return {
         modes,
-        buildCtx: vi.fn((mode: NavigationMode): WorkbenchSceneCtx => {
+        buildCtx: vi.fn((mode: NavigationMode, audio: AudioService): WorkbenchSceneCtx => {
           modes.push(mode);
-          return { stage: null, mode, gsap };
+          return { stage: null, mode, gsap, audio };
         }),
       };
     };
@@ -581,7 +582,7 @@ describe('createSceneLoader — beat positioning & mode dispatch (PUL-F008)', ()
         scenes: createSceneRegistry([intro]),
         compositions: createCompositionRegistry([]),
         stage: stage.element,
-        buildCtx: (mode) => ({ stage: stage.element, mode, gsap }),
+        buildCtx: (mode, audio: AudioService) => ({ stage: stage.element, mode, gsap, audio }),
         createPreloader: () => () => undefined,
         timeline: noopTimeline,
       });
@@ -741,12 +742,12 @@ describe('createSceneLoader — beat positioning & mode dispatch (PUL-F008)', ()
       const outro = buildScene({ id: 'outro' });
       const stage = buildStage();
       let ctxCalls = 0;
-      const buildCtx = (mode: NavigationMode): WorkbenchSceneCtx => {
+      const buildCtx = (mode: NavigationMode, audio: AudioService): WorkbenchSceneCtx => {
         ctxCalls += 1;
         if (ctxCalls === 1) {
           throw new Error('builder bug');
         }
-        return { stage: null, mode, gsap };
+        return { stage: null, mode, gsap, audio };
       };
       const loader = createSceneLoader({
         scenes: createSceneRegistry([intro, outro]),

--- a/tests/runtime/scene-loader-paused-scrub.test.ts
+++ b/tests/runtime/scene-loader-paused-scrub.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+  type AudioService,
   type Caption,
   type CompositionTimelineAdapter,
   type CompositionTimelineRunOptions,
@@ -505,7 +506,7 @@ describe('createSceneLoader — paused & scrub modes (PUL-F008)', () => {
           scenes: createSceneRegistry([makeScene(locatorKind)]),
           compositions: createCompositionRegistry([{ id: 'full-talk', manifest: [sceneId] }]),
           stage: stage.element,
-          buildCtx: (mode) => ({ stage: stage.element, mode, gsap }),
+          buildCtx: (mode, audio: AudioService) => ({ stage: stage.element, mode, gsap, audio }),
           createPreloader: () => () => undefined,
           timeline: noopTimeline,
         });
@@ -1059,7 +1060,7 @@ describe('createSceneLoader — paused & scrub modes (PUL-F008)', () => {
           scenes: createSceneRegistry([makeScene(locatorKind)]),
           compositions: createCompositionRegistry([{ id: 'full-talk', manifest: [sceneId] }]),
           stage: stage.element,
-          buildCtx: (mode) => ({ stage: stage.element, mode, gsap }),
+          buildCtx: (mode, audio: AudioService) => ({ stage: stage.element, mode, gsap, audio }),
           createPreloader: () => () => undefined,
           timeline: noopTimeline,
         });

--- a/tests/runtime/scene-loader-present.test.ts
+++ b/tests/runtime/scene-loader-present.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+  type AudioService,
   type Caption,
   type CompositionTimelineAdapter,
   type CompositionTimelineRunOptions,
@@ -226,7 +227,7 @@ describe('createSceneLoader — present-mode & presenter seams (PUL-F008)', () =
           { id: 'full-talk', manifest: ['scene-a', 'scene-b'] },
         ]),
         stage: stage.element,
-        buildCtx: (mode) => ({ stage: stage.element, mode, gsap }),
+        buildCtx: (mode, audio: AudioService) => ({ stage: stage.element, mode, gsap, audio }),
         createPreloader: () => () => undefined,
         timeline: noopTimeline,
       });

--- a/tests/runtime/scene-loader-screenshot-prompter.test.ts
+++ b/tests/runtime/scene-loader-screenshot-prompter.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+  type AudioService,
   type Caption,
   type CompositionTimelineAdapter,
   type CompositionTimelineRunOptions,
@@ -373,7 +374,7 @@ describe('createSceneLoader — screenshot & prompter modes (PUL-F008)', () => {
           scenes: createSceneRegistry([makeScene(locatorKind)]),
           compositions: createCompositionRegistry([{ id: 'full-talk', manifest: [sceneId] }]),
           stage: stage.element,
-          buildCtx: (mode) => ({ stage: stage.element, mode, gsap }),
+          buildCtx: (mode, audio: AudioService) => ({ stage: stage.element, mode, gsap, audio }),
           createPreloader: () => () => undefined,
           timeline: noopTimeline,
         });
@@ -737,7 +738,7 @@ describe('createSceneLoader — screenshot & prompter modes (PUL-F008)', () => {
       readonly probe: LifecycleProbe;
       readonly preloader: () => Promise<void>;
       readonly runner: (input: LegacyRunInput) => void;
-      readonly buildCtxFn: (mode: NavigationMode) => WorkbenchSceneCtx;
+      readonly buildCtxFn: (mode: NavigationMode, audio: AudioService) => WorkbenchSceneCtx;
       readonly scenes: readonly SceneModule[];
     };
 
@@ -771,9 +772,9 @@ describe('createSceneLoader — screenshot & prompter modes (PUL-F008)', () => {
         probe.preloaderInvocations += 1;
         return Promise.resolve();
       };
-      const buildCtxFn = (mode: NavigationMode): WorkbenchSceneCtx => {
+      const buildCtxFn = (mode: NavigationMode, audio: AudioService): WorkbenchSceneCtx => {
         probe.buildCtxInvocations += 1;
-        return { stage: null, mode, gsap };
+        return { stage: null, mode, gsap, audio };
       };
       const scenes = [
         trace('scene-a', [{ at: 0, text: 'A1' }]),

--- a/tests/runtime/scene-loader-standalone-loop.test.ts
+++ b/tests/runtime/scene-loader-standalone-loop.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+  type AudioService,
   type Caption,
   type CompositionTimelineAdapter,
   type CompositionTimelineRunOptions,
@@ -316,7 +317,7 @@ describe('createSceneLoader — standalone & loop modes (PUL-F008)', () => {
           scenes: createSceneRegistry([makeScene(locatorKind)]),
           compositions: createCompositionRegistry([{ id: 'full-talk', manifest: [sceneId] }]),
           stage: stage.element,
-          buildCtx: (mode) => ({ stage: stage.element, mode, gsap }),
+          buildCtx: (mode, audio: AudioService) => ({ stage: stage.element, mode, gsap, audio }),
           createPreloader: () => () => undefined,
           timeline: noopTimeline,
         });
@@ -823,7 +824,7 @@ describe('createSceneLoader — standalone & loop modes (PUL-F008)', () => {
           scenes: createSceneRegistry([makeScene(locatorKind)]),
           compositions: createCompositionRegistry([{ id: 'full-talk', manifest: [sceneId] }]),
           stage: stage.element,
-          buildCtx: (mode) => ({ stage: stage.element, mode, gsap }),
+          buildCtx: (mode, audio: AudioService) => ({ stage: stage.element, mode, gsap, audio }),
           createPreloader: () => () => undefined,
           timeline: noopTimeline,
         });

--- a/tests/runtime/scene-loader.helpers.ts
+++ b/tests/runtime/scene-loader.helpers.ts
@@ -6,6 +6,12 @@
 // the helpers they all use. The loader is the testable unit `main.ts`
 // drives once PUL-F007 has parsed the URL into a `NavigationTarget`.
 
+import {
+  type AudioEngine,
+  type AudioService,
+  createAudioService,
+  noopAudioEngine,
+} from '../../src/runtime/audio';
 import { createCompositionRegistry } from '../../src/runtime/composition-registry';
 import type {
   CompositionTimelineAdapter,
@@ -33,9 +39,13 @@ export {
   createSceneRegistry,
   createPresenterController,
   createSceneLoader,
+  createAudioService,
+  noopAudioEngine,
   NAVIGATION_MODES,
 };
 export type {
+  AudioEngine,
+  AudioService,
   Caption,
   CompositionTimelineAdapter,
   CompositionTimelineRunOptions,
@@ -50,17 +60,25 @@ export type {
   WorkbenchSceneCtx,
 };
 
-// PUL-F012 added `mode` and PUL-F022 added `gsap` to the ctx. The shared
-// GSAP handle is real (the timeline engine is a process singleton) so a
-// ctx-builder stub that does not care about ctx contents still satisfies
-// `WorkbenchSceneCtx`.
+// PUL-F012 added `mode`, PUL-F022 added `gsap`, and PUL-F024 added
+// `audio` to the ctx. The shared GSAP handle is real (the timeline
+// engine is a process singleton); the loader supplies the per-navigation
+// audio service as the second `buildCtx` argument, so a ctx-builder stub
+// that does not care about ctx contents still satisfies `WorkbenchSceneCtx`
+// by forwarding it.
 import { createTimelineEngine } from '../../src/runtime/timeline';
 export const { gsap } = createTimelineEngine();
-export const stubCtx = (mode: NavigationMode): WorkbenchSceneCtx => ({ stage: null, mode, gsap });
+export const stubCtx = (mode: NavigationMode, audio: AudioService): WorkbenchSceneCtx => ({
+  stage: null,
+  mode,
+  gsap,
+  audio,
+});
 
 export interface BuildSceneOpts {
   readonly id: string;
   readonly title?: string;
+  readonly assets?: readonly string[];
   readonly captions?: readonly Caption[];
   readonly create?: SceneModule['create'];
   readonly timeline?: SceneModule['timeline'];
@@ -72,7 +90,7 @@ export const buildScene = (opts: BuildSceneOpts): SceneModule => ({
   title: opts.title ?? opts.id,
   duration: 1000,
   tags: [],
-  assets: [],
+  assets: opts.assets ?? [],
   captions: opts.captions ?? [],
   defaultNext: null,
   standalone: true,


### PR DESCRIPTION
Implements PUL-F024 (audio orchestration), making ADR-004 concrete.

## What ships

A runtime audio service exposed to scenes as `ctx.audio`, in `src/runtime/audio.ts`:

- `createHowlerAudioEngine()` wraps Howler.js behind the small `AudioEngine` port — the only `import ... from 'howler'` site in the runtime, parallel to `createTimelineEngine()` wrapping GSAP (ADR-003). `noopAudioEngine` is the silent fallback for a workbench that has not wired a real backend (mirrors Howler's own `noAudio` graceful degradation).
- `createAudioService(engine, opts)` is the per-navigation service: `load(soundId, def)` registers a sound, `play(soundId, opts?)` plays it (with `sprite` / `loop` / `volume` / `group` options), `fade(id, from, to, durationMs)` cross-fades, `stop(id)` / `stopGroup(group)` stop instances, `mute(b)` / `isMuted()` toggle master mute (persistent runtime state held by the engine), `stopAll()` / `isDisposed()` cover lifecycle teardown.
- The service is bound to the navigation's `AbortSignal` and `stopAll()`-ed on supersession / dispose / completion, so fades, loops, sprites, and muted state never survive scene cleanup. Per-scene group teardown is runtime-driven via the new `ResolveCompositionOptions.onSceneCleaned` resolver hook (the loader wires it to `ctx.audio.stopGroup(sceneId)`). Cleanup loops isolate per-item failures (a throwing `stop()` / `unload()` on one sound does not block teardown of the rest).
- Source URLs always pass `DEFAULT_ALLOWED_SCHEMES` (defense-in-depth) and, when supplied by the loader, must be in the active composition slice's declared `scene.assets` (ADR-008 #5). Sound ids and group names obey kebab-case (ADR-008 #1). `mode=screenshot` / `mode=paused` build the service `silent` (audible playback suppressed — ADR-019 / ADR-021). Runtime validators (`assertSoundDefinition`, `assertPlayOptions`, `assertSpriteMap`, boolean check on `mute`) cover the scene-facing boundary so a plain-JS scene with a malformed payload gets a documented `AudioError` family error rather than a generic `TypeError`.
- `WorkbenchSceneCtx` gains `audio`; `SceneLoaderOptions` gains an optional `audioEngine` (defaults to `noopAudioEngine`); `buildCtx` now receives the per-navigation `AudioService` as its second argument. `ResolveCompositionOptions.onSceneCleaned` and `LoadSceneNavigationTargetOptions.onSceneCleaned` are new optional public APIs.
- Adds `howler` as a runtime dependency (`@types/howler` dev).

## Out of scope (documented follow-ups)

- Per-entry activation contexts in the resolver (a per-scene `ctx` factory, so each scene gets its own `ctx.audio` facade and every play is attributed to the active scene by default without scenes passing `group: <its-scene-id>`). The codebase explicitly defers this in `composition-resolver.ts`'s `buildPlan` comment. Today, scenes that want their sounds torn down by `cleanup` use the documented `group: <its-scene-id>` convention; the runtime stops that group via `onSceneCleaned`.
- Threading the asset preloader's exact `baseUrl` / `allowedSchemes` policy into the audio service (it currently uses `DEFAULT_ALLOWED_SCHEMES` plus membership in the slice's declared assets). No Pulsar deployment configures non-default schemes today.
- Wiring scrub's `headCueGate: 'monotonic-forward'` to actually gate audio cues. The audio service exists now; the timeline adapter does not yet fire audio cues from its own callbacks — scenes hang `ctx.audio` cues off their own timeline callbacks.

## Review history

Four pre-push codex review cycles (1, 2, 3, plus user-authorized cycle 4 over the hard-cap). Decisions recorded on the issue thread:
- Cycle 1 (3 findings): all fixed (class finding on sound-id namespace + slice scoping; non-fatal `onError` dispose-gating; autoplay-unlock handling via Howler's default Web Audio mode).
- Cycle 2 (4 findings): fixed `onSceneCleaned` resolver hook for runtime-driven per-scene group teardown; idempotent re-registration of shared sounds; sprite map runtime validation; documented the per-entry-context follow-up.
- Cycle 3 (3 findings): defense-in-depth scheme check on audio sources; per-item error isolation in `stopGroup` / `stopAll`. User-authorized `not-applicable` on the recurring per-scene-cleanup-author-disciplined finding (requires the deferred resolver follow-up).
- Cycle 4 (3 findings): runtime-validation gap on `load` / `play` / `mute` fixed with new module-scope validators. Per-scene-cleanup and preloader-policy-drift findings repeat earlier dispositions; user authorized push.

Closes #33
