### PR TITLE
Implement PUL-F025 master mute: presenter command + loader audio handler (ADR-004 / ADR-023)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Presenter master mute — PUL-F025 / ADR-004 — in `src/runtime/presenter.ts`
+  and `src/runtime/scene-loader.ts`: the presenter command allowlist gains
+  one new kind, `'toggle-master-mute'`, and the loader's `buildLoad`
+  subscribes a per-navigation audio handler on the existing
+  `PresenterController` that, on receipt, calls
+  `audio.mute(!audio.isMuted())`. The handler lives where both the
+  controller and the per-navigation `AudioService` are in scope; it never
+  imports Howler, touches the master timeline, aborts the navigation,
+  calls `cleanup(ctx)`, or mutates URL / history. Master mute remains
+  engine-level runtime state, so the flip survives scene cleanup and
+  navigation completion (the existing `AudioService.stopAll()` does not
+  reset it — pinned by `audio.test.ts`). The subscription auto-detaches
+  on the navigation's `AbortSignal` via the controller's existing
+  `tearDownAll`. The runner still receives every command kind on its own
+  `input.presenter.subscribe(...)` — the loader handler is additive, not
+  a filter. The command is a *fact* ("presenter pressed mute"), not a
+  target state: a future `set-master-mute` kind with a boolean payload
+  would be a discriminated-union extension on the same seam. The
+  command is scoped to `mode=present` only (the controller is never built
+  for other modes); unknown / misspelled kinds (`mute`, `master-mute`,
+  `unmute`) are dropped at the controller boundary with an `onError`
+  diagnostic and never reach the audio service. No URL parameter, no new
+  mode, no localStorage / sessionStorage / cookie / history state, no
+  `MuteCommandSource` / `MuteController` / second command schema.
+  PUL-F025 remains DRAFT — the runtime-side contract is complete here,
+  but ACTIVE requires a presenter UI surface (keyboard / on-screen / remote
+  protocol) that emits `'toggle-master-mute'` through
+  `PresenterCommandSource`. `src/main.ts` still omits `presenterCommands`,
+  so production reaches the graceful-degradation path (mirrors PUL-F020 /
+  PUL-F021).
 - Audio orchestration — PUL-F024 / ADR-004 — in `src/runtime/audio.ts`:
   the runtime now provides an audio service exposed to scenes as
   `ctx.audio`. `createHowlerAudioEngine()` wraps Howler.js behind the

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -18,6 +18,7 @@ Design context for Pulsar. Source material for the ADRs in `../adrs/`.
 | [pul-f022-timeline-orchestration-preflight.md](pul-f022-timeline-orchestration-preflight.md) | Guardrails for implementing GSAP-backed master timeline orchestration. |
 | [pul-f023-named-timeline-beats-preflight.md](pul-f023-named-timeline-beats-preflight.md) | Guardrails for implementing named timeline beats. |
 | [pul-f024-audio-orchestration-preflight.md](pul-f024-audio-orchestration-preflight.md) | Guardrails for implementing runtime-owned audio orchestration. |
+| [pul-f025-master-mute-preflight.md](pul-f025-master-mute-preflight.md) | Guardrails for implementing presenter master mute. |
 
 Design docs are mutable. Decisions are captured as ADRs (immutable once
 accepted).

--- a/docs/design/pul-f025-master-mute-preflight.md
+++ b/docs/design/pul-f025-master-mute-preflight.md
@@ -1,0 +1,141 @@
+# PUL-F025 Master Mute Preflight
+
+PUL-F025 specifies presenter input that toggles master mute. Master
+mute silences audio without changing timeline state.
+
+No new ADR is needed for this preflight. ADR-004 already owns master
+mute as runtime audio-engine state, and ADR-023 / ADR-024 already own
+the presenter command source, validation, mode scoping, and abort-tied
+subscription cleanup. PUL-F025 composes those two incumbents.
+
+## Boundary
+
+Master mute must stay on the existing runtime path:
+
+- `src/runtime/presenter.ts` owns presenter command kinds, command
+  shape validation, handler isolation, and abort-tied cleanup. Add the
+  master-mute command there; do not create an audio-specific command
+  bus, validator, controller, or event type.
+- `src/runtime/scene-loader.ts` is the only runtime seam that has both
+  the per-navigation `PresenterController` and the per-navigation
+  `AudioService`. It is the correct place to bind accepted presenter
+  mute input to `audio.mute(!audio.isMuted())`.
+- `src/runtime/audio.ts` owns master mute. The implementation must call
+  `AudioService.mute()` / `isMuted()` and let the service delegate to
+  `AudioEngine.setMasterMute()`. Do not import Howler or call
+  `Howler.mute()` outside the audio boundary.
+- `src/runtime/timeline.ts` owns timeline transport. Master mute must
+  not pause, seek, repeat, kill, rebuild, or otherwise mutate the
+  master timeline.
+- `src/runtime/navigation.ts` owns URL grammar. PUL-F025 adds no query
+  parameter, no mode, no persisted mute state, and no history mutation.
+- `src/runtime/scene-navigation.ts` and
+  `src/runtime/composition-resolver.ts` remain lifecycle/pass-through
+  layers. They should not learn audio mute semantics.
+
+The intended command kind is `toggle-master-mute`: a presenter command
+is an input fact, not timeline state. The runtime audio handler toggles
+the engine's current master-mute state at command receipt time.
+
+## Required Reuse
+
+Use these canonical incumbents:
+
+- Presenter input schema: `PRESENTER_COMMAND_KINDS`,
+  `PresenterCommand`, `isPresenterCommand`,
+  `PresenterCommandSource`, `PresenterController`, and
+  `createPresenterController`.
+- Presenter mode gate: `effectiveMode()`,
+  `SceneLoaderOptions.presenterCommands`, and the loader's existing
+  `mode === 'present'` controller construction.
+- Audio service: `AudioService.mute()`, `AudioService.isMuted()`,
+  `AudioEngine.setMasterMute()`, `AudioEngine.isMasterMuted()`,
+  `createHowlerAudioEngine()`, and `noopAudioEngine`.
+- Lifecycle and cleanup: the existing per-navigation
+  `AbortController.signal`. The mute subscription must be tied to the
+  same controller cleanup as every other presenter subscription.
+- Error handling: the presenter controller's existing handler
+  try/catch and loader `onError` diagnostic sink. Do not add a mute
+  exception hierarchy or navigation failure envelope.
+- Tests: the existing presenter boundary tests, scene-loader presenter
+  seam tests, and audio service / engine tests. Keep mute behavior
+  covered at the seam where it lives.
+
+## Cross-Cutting Layers
+
+| Layer | Requirement for PUL-F025 |
+|-------|--------------------------|
+| URL grammar / mode validation | `NAVIGATION_MODES`, `parseNavigationSearch()`, `effectiveMode()`, and loader-side mode validation remain unchanged. Presenter mute is active only when the loader builds presenter controls for effective `present`. |
+| Presenter command shape | Extend the existing command allowlist with `toggle-master-mute`. Keep `isPresenterCommand` as the only boundary validator and keep emitted commands flat/frozen. |
+| Auth / remote input | No auth surface exists in this repo. A future remote presenter protocol must authenticate/authorize before emitting into `PresenterCommandSource`; the controller still shape-checks every emitted command. |
+| Audio boundary | The handler calls `AudioService.mute()` / `isMuted()`. Howler remains hidden behind `createHowlerAudioEngine()` in `audio.ts`. |
+| Timeline state | The handler must not touch `MasterTimeline`, runner hints, URL beat, pause/resume state, `AbortController`, or `cleanup(ctx)`. Existing playback continues silently while muted and continues audibly when unmuted. |
+| Lifecycle / cleanup | Presenter subscriptions auto-detach on navigation abort. Master mute state is engine-level runtime state and is not reset by per-navigation `stopAll()` or scene cleanup. |
+| Error envelopes | Malformed commands are dropped at the presenter controller and reported through `onError`. A mute-handler exception is non-fatal and must not become `composition resolution failed:` or unmount the scene. Do not include raw future remote payloads in diagnostics. |
+| Config / env / OS exposure | No env vars, config files, process argv tokens, URLs, cookies, localStorage, sessionStorage, files, or shell commands are needed. Do not persist mute state or presenter secrets. |
+| Observability | Reuse `onError` for diagnostics. Do not add stage attributes, analytics, or per-command logs for mute state until a concrete UI/status requirement needs them. |
+
+## Guardrails
+
+- Master mute is audio-owned runtime state, not a scene flag, URL mode,
+  timeline label, composition behavior override, or transport command.
+- Toggle semantics read the current engine state at receipt time. Do
+  not keep a second boolean in the loader, runner, UI, scene, or
+  browser storage.
+- Presenter input remains scoped to `mode=present`. Do not let mute
+  commands leak into standalone, loop, paused, scrub, screenshot, or
+  prompter navigations.
+- The command is accepted even before any sound has been registered.
+  `noopAudioEngine` must round-trip the mute state the same way the
+  Howler engine does.
+- The timeline runner may ignore audio-owned commands. It must not
+  interpret `toggle-master-mute` as pause, hold, cue gating, speed,
+  seek, or scene navigation.
+- Do not add visible mute indicators, keyboard listeners, remote
+  protocols, or workbench chrome in PUL-F025 unless a separate
+  requirement supplies that surface.
+
+## Extensibility
+
+The extension seam is `PresenterCommand.kind` plus the audio service
+target. Future presenter audio controls should extend the same command
+schema in `src/runtime/presenter.ts` and dispatch to `AudioService`,
+not add a second input bus.
+
+If a future command needs data, extend `PresenterCommand` as a
+discriminated union with kind-specific fields and update
+`isPresenterCommand` in the same module. Examples: explicit
+`set-master-mute` with a `muted` boolean, bus volume, ducking, or
+rehearsal cue logging. The parameter belongs on the command payload
+and the behavior belongs behind `AudioService`; it must not leak
+Howler handles or timeline internals.
+
+If a future UI needs mute status, add a separate status/read surface
+from audio/workbench state. Do not overload `PresenterCommandSource`,
+URL grammar, stage error diagnostics, or timeline labels as a state
+store.
+
+## Non-Goals
+
+PUL-F025 should not implement keyboard listeners, on-screen controls,
+remote presenter protocol, auth, telemetry, persistence, mute UI
+status, per-scene volume, ducking, bus volume, scrub cue gating,
+export mixdown, or requirement status transition. It should not change
+scene schemas, composition schemas, URL grammar, asset preload rules,
+or the resolver lifecycle.
+
+## Anti-Patterns
+
+- Adding `mute=true` / `muted` URL parameters, storage keys, cookies,
+  config flags, or history state.
+- Importing Howler outside `src/runtime/audio.ts`.
+- Adding scene-local mute booleans, hidden `<audio>` controls, or raw
+  Web Audio mute code for ordinary scenes.
+- Implementing mute by pausing or killing the timeline.
+- Implementing mute by aborting navigation, remounting scenes, or
+  calling `cleanup(ctx)`.
+- Duplicating presenter command validation or adding
+  `MuteCommandSource` / `MuteController`.
+- Reusing `hold`, `pause`, `mode=paused`, `headCueGate`, or
+  screenshot silence semantics for master mute.
+- Resetting master mute on scene cleanup or navigation completion.

--- a/src/runtime/presenter.ts
+++ b/src/runtime/presenter.ts
@@ -1,4 +1,4 @@
-// Presenter controls — PUL-F020 / PUL-F021 / ADR-023 / ADR-024.
+// Presenter controls — PUL-F020 / PUL-F021 / PUL-F025 / ADR-023 / ADR-024.
 //
 // Defines the runtime-side contract layer for accepting presenter
 // commands under `mode=present`. The runtime does not own the input
@@ -30,6 +30,22 @@
 // DRAFT until a real presenter UI lands AND a GSAP runner proves the
 // command-to-transport behavior end to end.
 //
+// PUL-F025 (master mute) composes ADR-004 with this same seam by
+// adding the `toggle-master-mute` kind to the allowlist below. The
+// command is a *fact* ("presenter pressed mute"), not a target state:
+// the loader's audio handler reads the engine's current master mute
+// at command receipt time and flips it via
+// `AudioService.mute(!AudioService.isMuted())`. The handler lives
+// where both the per-navigation `PresenterController` and the
+// per-navigation `AudioService` are in scope — `src/runtime/scene-loader.ts`
+// (`buildLoad`) — and never imports Howler, touches the master
+// timeline, aborts the navigation, calls `cleanup(ctx)`, or mutates
+// URL / history. Master mute is engine-level runtime state, so it
+// survives scene cleanup and navigation completion (the existing
+// `AudioService.stopAll()` does not reset it). PUL-F025 stays DRAFT
+// until a presenter UI surface lands and emits the kind end-to-end,
+// mirroring the PUL-F020 / PUL-F021 precedent.
+//
 // References:
 //  - PUL-F020 — runtime SHALL accept presenter input under
 //    `mode=present` for advance / hold / skip-forward / skip-backward;
@@ -39,6 +55,11 @@
 //    active timeline and SHALL accept input to resume from the same
 //    point. Extends this seam with the `pause` / `resume` command
 //    kinds; transport behavior is the runner's contract (ADR-024).
+//  - PUL-F025 — runtime SHALL accept presenter input to toggle
+//    master mute. Master mute SHALL silence audio without altering
+//    timeline state. Extends this seam with the `toggle-master-mute`
+//    kind; the audio dispatch lives in `scene-loader.ts` and
+//    composes `AudioService.mute()` / `isMuted()` per ADR-004.
 //  - ADR-023 — workbench presenter controls: command source +
 //    per-navigation controller seam.
 //  - ADR-024 — presenter pause/resume: runner-owned transport state
@@ -46,6 +67,9 @@
 //    controller/schema; `pause` / `resume` join `PRESENTER_COMMAND_KINDS`).
 //  - ADR-003 — GSAP timeline engine. The runner consumes
 //    {@link PresenterCommand} and dispatches via GSAP's transport API.
+//  - ADR-004 — Howler audio engine; master mute is engine-level
+//    runtime state and the audio service exposes it via `mute()` /
+//    `isMuted()`. PUL-F025's audio handler calls those methods only.
 //  - ADR-007 — workbench mode dispatch; presenter input is scoped to
 //    `mode=present`.
 //  - ADR-016 — names PUL-F020 / PUL-F021 / PUL-F025 as the presenter
@@ -55,10 +79,11 @@
  * The presenter command kinds the runtime accepts under
  * `mode=present`. The first four are PUL-F020 (advance / hold /
  * skip-forward / skip-backward); `pause` and `resume` are PUL-F021
- * (ADR-024), added to this same allowlist rather than to a separate
- * pause-specific schema. Centralized as a single source of truth so
- * the validator and the discriminated-union type cannot drift. Frozen
- * so a misbehaving caller cannot mutate the allowlist at runtime.
+ * (ADR-024); `toggle-master-mute` is PUL-F025 (ADR-004), added to
+ * this same allowlist rather than to a separate audio-specific
+ * schema. Centralized as a single source of truth so the validator
+ * and the discriminated-union type cannot drift. Frozen so a
+ * misbehaving caller cannot mutate the allowlist at runtime.
  */
 export const PRESENTER_COMMAND_KINDS = Object.freeze([
   'advance',
@@ -67,6 +92,7 @@ export const PRESENTER_COMMAND_KINDS = Object.freeze([
   'skip-backward',
   'pause',
   'resume',
+  'toggle-master-mute',
 ] as const);
 
 /** Element type of {@link PRESENTER_COMMAND_KINDS}. */
@@ -174,22 +200,28 @@ export function createPresenterController(
   onError?: (err: unknown) => void,
 ): PresenterController {
   // One record per active subscription. `active` is the single
-  // source of truth for "this subscription is live" — both the
-  // per-subscriber unsubscribe AND the abort-driven tearDownAll
-  // check it before calling `sourceUnsub`, so a non-idempotent
-  // source receives at most one unsubscribe per registration even
-  // when both teardown paths fire (codex review: abort-then-runner-
-  // unsubscribe and per-scene-after-nav-abort are real overlapping
-  // paths). The wrapped handler also checks `active` before
-  // forwarding, so post-abort emissions cannot reach the runner
-  // even if a misbehaving source ignored or threw on its
-  // unsubscribe.
+  // source of truth for "this subscription is live" — the per-
+  // subscriber unsubscribe AND the abort-driven tearDownAll BOTH
+  // set it to false. The dispatch loop checks `active` before
+  // forwarding so post-abort or post-unsubscribe emissions from a
+  // misbehaving source whose unsubscribe ignored or threw still
+  // cannot reach the runner.
   interface Subscription {
     active: boolean;
-    sourceUnsub: () => void;
+    readonly handler: (cmd: PresenterCommand) => void;
   }
   const subscriptions: Subscription[] = [];
   let aborted = signal.aborted;
+  // The single source subscription's unsubscribe handle (codex
+  // review, post-PUL-F025: validation and onError emission MUST
+  // happen once per source event, not once per controller
+  // subscriber — otherwise adding a second runtime-owned subscriber
+  // would multiply diagnostic noise. The controller therefore
+  // registers ONE wrapped handler on the source and fans the
+  // sanitized command out to every active subscription, so adding
+  // the loader's PUL-F025 audio handler does not double up
+  // diagnostics for malformed kinds).
+  let sourceUnsub: (() => void) | null = null;
 
   const reportError = (err: unknown): void => {
     if (onError === undefined) return;
@@ -205,22 +237,44 @@ export function createPresenterController(
     }
   };
 
-  const tearDownSubscription = (sub: Subscription): void => {
-    if (!sub.active) return;
-    // Mark inactive BEFORE calling sourceUnsub so the wrapped
-    // handler's `!sub.active` guard fires for any in-flight
-    // emissions the source is still mid-iteration over (covers
-    // sources whose unsubscribe is asynchronous-leaning or whose
-    // accounting is non-idempotent).
-    sub.active = false;
-    try {
-      sub.sourceUnsub();
-    } catch (err) {
-      // A misbehaving source could throw on unsubscribe; record
-      // the diagnostic but keep tearing the rest down. Without
-      // the catch a single bad source would strand the remaining
-      // subscriptions.
-      reportError(err);
+  // Single centralized wrapper. Four guards layer here:
+  //   1. `aborted` — controller-level abort guard. Drops every
+  //      emission after the navigation aborts even if a
+  //      misbehaving source kept emitting after its unsubscribe.
+  //   2. `isPresenterCommand` — boundary validation; unknown kinds
+  //      are dropped ONCE with an `onError` diagnostic regardless
+  //      of how many subscribers are attached.
+  //   3. Frozen defensive copy of the command — one subscriber
+  //      cannot mutate `kind` and corrupt sibling subscribers'
+  //      view of the same emission. The freeze runs once here
+  //      and the same frozen object is fanned out to every
+  //      subscriber.
+  //   4. Per-handler try/catch — a buggy subscriber cannot poison
+  //      emissions for siblings; exceptions flow through
+  //      `onError`.
+  const centralWrapped = (cmd: unknown): void => {
+    if (aborted) return;
+    if (!isPresenterCommand(cmd)) {
+      reportError(
+        new Error(
+          `presenter command rejected: payload does not match the PresenterCommand shape (allowed kinds: ${PRESENTER_COMMAND_KINDS.join(', ')})`,
+        ),
+      );
+      return;
+    }
+    const safe: PresenterCommand = Object.freeze({ kind: cmd.kind });
+    // Snapshot to a local copy so a subscriber that unsubscribes
+    // (or subscribes) mid-fan-out doesn't perturb iteration.
+    const active = subscriptions.filter((s) => s.active);
+    for (const sub of active) {
+      // Re-check `active` in case a sibling handler unsubscribed
+      // this sub during this same emission's fan-out.
+      if (!sub.active) continue;
+      try {
+        sub.handler(safe);
+      } catch (err) {
+        reportError(err);
+      }
     }
   };
 
@@ -232,14 +286,46 @@ export function createPresenterController(
     // any later code path sees an empty registry.
     const drained = subscriptions.splice(0, subscriptions.length);
     for (const sub of drained) {
-      tearDownSubscription(sub);
+      sub.active = false;
+    }
+    // Detach from the source exactly once (codex review history:
+    // non-idempotent unsubscribes must run at most once).
+    if (sourceUnsub !== null) {
+      const unsub = sourceUnsub;
+      sourceUnsub = null;
+      try {
+        unsub();
+      } catch (err) {
+        // A misbehaving source could throw on unsubscribe; record
+        // the diagnostic but do not propagate — the boundary's job
+        // is to detach what it can and surface the rest.
+        reportError(err);
+      }
     }
   };
 
-  if (aborted) {
-    // Signal already fired before construction. Nothing to wire;
-    // subscribe will fall through to the aborted no-op below.
-  } else {
+  // Lazy source attachment: register the central wrapper on the
+  // source the first time a subscriber attaches. A controller with
+  // zero subscribers (e.g., the placeholder timeline runner that
+  // ignores `input.presenter`) does not pay a source registration.
+  // Subscribe-time failures from the workbench-supplied source are
+  // routed through `onError` here rather than escaping the loader's
+  // `buildLoad` (codex review, post-PUL-F025: a throwing source
+  // subscribe used to bypass the loader's stage-attr rollback and
+  // navigation error envelope; routing through `onError` keeps
+  // setup failures contained at the boundary the source owns).
+  const ensureSourceAttached = (): boolean => {
+    if (sourceUnsub !== null) return true;
+    try {
+      sourceUnsub = source.subscribe(centralWrapped);
+    } catch (err) {
+      reportError(err);
+      return false;
+    }
+    return true;
+  };
+
+  if (!aborted) {
     signal.addEventListener('abort', tearDownAll, { once: true });
   }
 
@@ -249,57 +335,28 @@ export function createPresenterController(
       // attachment, no emissions, no leak.
       return () => undefined;
     }
-    // Pre-allocate the subscription record so the wrapped handler
-    // closure can capture it. `sourceUnsub` is patched in
-    // immediately after `source.subscribe(wrapped)` returns.
-    const sub: Subscription = { active: true, sourceUnsub: () => undefined };
-    // Validate-and-forward wrapper. Five guards layer here:
-    //   1. `!sub.active` — post-abort or post-unsubscribe emission
-    //      from a misbehaving source whose own unsubscribe didn't
-    //      actually detach. Without this, a bad source could
-    //      deliver commands to a runner whose subscription was
-    //      torn down. This is the leak-prevention invariant
-    //      (codex review).
-    //   2. `aborted` — controller-level abort guard. Same defense
-    //      as `!sub.active` but cheaper to check (one bool).
-    //   3. `isPresenterCommand` — boundary validation; unknown
-    //      kinds are dropped with an `onError` diagnostic.
-    //   4. Frozen defensive copy of the command — one subscriber
-    //      cannot mutate `kind` and corrupt later subscribers'
-    //      view of the same emission (the source emits ONE
-    //      reference to every wrapped handler).
-    //   5. Per-handler try/catch — a buggy subscriber cannot
-    //      poison emissions for siblings; exceptions flow through
-    //      `onError`.
-    const wrapped = (cmd: unknown): void => {
-      if (!sub.active || aborted) return;
-      if (!isPresenterCommand(cmd)) {
-        reportError(
-          new Error(
-            `presenter command rejected: payload does not match the PresenterCommand shape (allowed kinds: ${PRESENTER_COMMAND_KINDS.join(', ')})`,
-          ),
-        );
-        return;
-      }
-      const safe: PresenterCommand = Object.freeze({ kind: cmd.kind });
-      try {
-        handler(safe);
-      } catch (err) {
-        reportError(err);
-      }
-    };
-    sub.sourceUnsub = source.subscribe(wrapped);
+    const sub: Subscription = { active: true, handler };
     subscriptions.push(sub);
-    return () => {
-      // Idempotent: re-calling does nothing because
-      // `tearDownSubscription` short-circuits on `!sub.active`.
-      // Also covers the abort-then-runner-unsubscribe race where
-      // the abort listener already drained this sub; the
-      // remove-then-tear-down sequence handles either order
-      // safely.
+    // Attach the source wrapper on the first live subscription.
+    // If the source's `subscribe` throws (a misbehaving workbench
+    // bridge, an early-failure stub), the failure is reported
+    // through `onError` and the subscription is rolled back so the
+    // caller's invariant ("subscribe returns a usable unsub") is
+    // preserved.
+    if (!ensureSourceAttached()) {
       const idx = subscriptions.indexOf(sub);
       if (idx >= 0) subscriptions.splice(idx, 1);
-      tearDownSubscription(sub);
+      sub.active = false;
+      return () => undefined;
+    }
+    return () => {
+      // Idempotent: marking inactive is enough — the next dispatch
+      // skips this sub. We remove from the registry to keep the
+      // active-count snapshot cheap for steady-state.
+      if (!sub.active) return;
+      sub.active = false;
+      const idx = subscriptions.indexOf(sub);
+      if (idx >= 0) subscriptions.splice(idx, 1);
     };
   };
 

--- a/src/runtime/scene-loader.ts
+++ b/src/runtime/scene-loader.ts
@@ -349,6 +349,23 @@ interface InFlightLoad {
   silent: boolean;
   /** The navigation's audio service, or `null` for a prompter load. */
   readonly audio: AudioService | null;
+  /**
+   * Lifecycle controller for the per-navigation
+   * {@link import('./presenter').PresenterController} (PUL-F025 /
+   * ADR-023). A separate `AbortController` from `controller` so the
+   * navigation signal stays un-aborted on the happy path (PUL-F013
+   * boundary contract): the navigation `controller` is only aborted
+   * on supersession / dispose / popstate, while `presenterAbort` is
+   * aborted on EITHER supersession (wired in `buildLoad` to the
+   * navigation signal) OR normal completion (in `runTarget`'s
+   * `finally`). That gives presenter subscriptions a deterministic
+   * teardown on every path — the workbench-supplied long-lived
+   * `PresenterCommandSource` does not accumulate stale wrappers
+   * across successful present-mode completions. `null` when no
+   * presenter controller was built (non-present mode, no
+   * `presenterCommands` supplied, or `mode=prompter` load).
+   */
+  readonly presenterAbort: AbortController | null;
 }
 
 /**
@@ -667,10 +684,75 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
     // adapters; this is the central enforcement point for "presenter
     // input only under mode=present" — no other code path builds the
     // controller.
+    // PUL-F025 / ADR-023 (codex review, post-PUL-F025): the
+    // presenter controller's lifetime is "the navigation" — which
+    // ends on supersession / dispose / popstate (the navigation
+    // signal aborts) OR on normal completion (the resolver finishes
+    // and `runTarget`'s `finally` runs). Binding to the navigation
+    // signal alone covers only the first set; we use a separate
+    // `AbortController` so the loader can also tear down on the
+    // success path. The presenter signal is fired on EITHER cause:
+    // the navigation-abort listener below propagates supersession /
+    // dispose / popstate, and `runTarget`'s `finally` aborts it on
+    // completion. Both aborts are idempotent. The navigation signal
+    // itself stays un-aborted on the success path so the PUL-F013
+    // boundary contract — "the navigation signal reaches the runner
+    // un-aborted at receive time AND stays un-aborted across a
+    // successful completion" — is preserved.
+    const presenterAbort: AbortController | null =
+      mode === 'present' && options.presenterCommands !== undefined ? new AbortController() : null;
+    if (presenterAbort !== null) {
+      // Propagate navigation abort → presenter abort. Without this
+      // wiring, a supersession-time `controller.abort()` would not
+      // tear down the presenter controller (because it's bound to
+      // `presenterAbort.signal`, not `controller.signal`).
+      const propagateAbort = (): void => {
+        presenterAbort.abort();
+      };
+      if (controller.signal.aborted) {
+        presenterAbort.abort();
+      } else {
+        controller.signal.addEventListener('abort', propagateAbort, { once: true });
+      }
+    }
     const presenter =
-      mode === 'present' && options.presenterCommands !== undefined
-        ? createPresenterController(options.presenterCommands, controller.signal, onError)
+      presenterAbort !== null && options.presenterCommands !== undefined
+        ? createPresenterController(options.presenterCommands, presenterAbort.signal, onError)
         : undefined;
+    // PUL-F025 / ADR-004: presenter master mute. The audio handler
+    // lives here because this is the only seam where both the
+    // per-navigation `PresenterController` and the per-navigation
+    // `AudioService` are in scope — the runner cannot reach `audio`
+    // and the audio service does not see presenter commands.
+    //
+    // The command is a *fact* ("presenter pressed mute"), not a
+    // target state — the handler reads the engine's current master
+    // mute at receipt time and flips it via the audio boundary.
+    // `audio.mute()` validates the boolean (PUL-F024) and is inert
+    // post-dispose; the engine owns mute as runtime state so the
+    // flip survives scene cleanup and is observable by sibling
+    // services backed by the same engine (ADR-004, pinned in
+    // `audio.test.ts`).
+    //
+    // The subscription auto-detaches on `controller.signal` abort
+    // via the presenter controller's existing `tearDownAll` — no
+    // separate teardown wiring is needed. The handler is additive,
+    // not a filter: the runner still receives every command kind
+    // on its own `input.presenter.subscribe(...)`. Other kinds
+    // fall through to no-ops here.
+    //
+    // The handler can only throw if `audio.mute()` itself does. The
+    // controller's per-handler `try/catch` (`createPresenterController`)
+    // catches and routes through the same `onError` sink the loader
+    // already supplies, so a regression that made `mute()` throw
+    // mid-toggle cannot poison sibling subscribers or abort the
+    // navigation.
+    if (presenter !== undefined) {
+      presenter.subscribe((cmd) => {
+        if (cmd.kind !== 'toggle-master-mute') return;
+        audio.mute(!audio.isMuted());
+      });
+    }
     return {
       controller,
       settled: loadSceneNavigationTarget(resolved, {
@@ -699,6 +781,7 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
       }),
       silent: false,
       audio,
+      presenterAbort,
     };
   };
 
@@ -860,7 +943,13 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
     // scene mounts, so there is no `ctx.audio` consumer and no audio
     // service to build (`audio: null`).
     if (renderer === undefined) {
-      return { controller, settled: Promise.resolve(), silent: false, audio: null };
+      return {
+        controller,
+        settled: Promise.resolve(),
+        silent: false,
+        audio: null,
+        presenterAbort: null,
+      };
     }
     const script = buildPrompterScript(resolved);
     return {
@@ -868,6 +957,7 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
       settled: dispatchPrompter(renderer, script, controller.signal),
       silent: false,
       audio: null,
+      presenterAbort: null,
     };
   };
 
@@ -939,6 +1029,21 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
       // `cleanup(ctx)`, then `load.settled` resolved); `stopAll()` is
       // idempotent so the double-call on the abort paths is harmless.
       load.audio?.stopAll();
+      // PUL-F025 / ADR-023 (codex review, post-PUL-F025): tear down
+      // the presenter controller's subscriptions on the happy path
+      // too. The presenter controller is built against a *separate*
+      // `presenterAbort` signal in `buildLoad` (NOT the navigation
+      // signal) so the navigation signal's "un-aborted on success"
+      // invariant — pinned by the PUL-F013 boundary tests — is
+      // preserved. The separate signal still fires on navigation
+      // abort (wired in `buildLoad`), and we abort it here so the
+      // long-lived `PresenterCommandSource` does not accumulate
+      // stale wrappers across successful present-mode completions
+      // (the loader's PUL-F025 mute handler, plus any runner-owned
+      // subscription that forgot to unsubscribe at scene-exit).
+      // Idempotent: a subsequent supersession-time abort of the
+      // same `presenterAbort` is a no-op.
+      load.presenterAbort?.abort();
       if (inFlight === load) inFlight = null;
     }
   };

--- a/src/runtime/scene-loader.ts
+++ b/src/runtime/scene-loader.ts
@@ -541,6 +541,70 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
   };
 
   /**
+   * Construct the per-navigation presenter pipeline:
+   *  - `presenterAbort` — a separate `AbortController` whose signal
+   *    drives the `PresenterController`'s teardown. Distinct from
+   *    the navigation `controller` so the navigation signal can
+   *    stay un-aborted across a successful completion (PUL-F013
+   *    boundary). Wired to fire on navigation abort AND aborted by
+   *    `runTarget`'s `finally` on normal completion.
+   *  - `presenter` — the `PresenterController` itself (PUL-F020 /
+   *    ADR-023), with the PUL-F025 audio handler attached.
+   *
+   * Both are `null` / `undefined` when the loader does NOT build a
+   * controller for this navigation: non-present mode OR the workbench
+   * did not supply a `presenterCommands` source. Hoisted out of
+   * `buildLoad` to keep that function within Sonar's
+   * cognitive-complexity budget.
+   *
+   * The PUL-F025 audio handler (presenter master mute / ADR-004)
+   * lives here — the only seam where both the controller and the
+   * per-navigation `AudioService` are in scope. On
+   * `'toggle-master-mute'` it reads the engine's current master
+   * mute and flips it via the audio boundary; `audio.mute()`
+   * validates the boolean (PUL-F024) and is inert post-dispose.
+   * Master mute is engine-level runtime state so the flip survives
+   * scene cleanup and is observable by sibling services backed by
+   * the same engine (pinned in `audio.test.ts`). The handler is
+   * additive — the runner still receives every kind on its own
+   * `input.presenter.subscribe(...)`. The controller's per-handler
+   * `try/catch` already routes any throw through the same `onError`.
+   */
+  const buildPresenterPipe = (
+    mode: NavigationMode,
+    controller: AbortController,
+    audio: AudioService,
+  ): {
+    readonly presenter: ReturnType<typeof createPresenterController> | undefined;
+    readonly presenterAbort: AbortController | null;
+  } => {
+    if (mode !== 'present' || options.presenterCommands === undefined) {
+      return { presenter: undefined, presenterAbort: null };
+    }
+    const presenterAbort = new AbortController();
+    // Propagate navigation abort → presenter abort. Without this
+    // wiring, supersession-time `controller.abort()` would not tear
+    // down the presenter controller (bound to `presenterAbort.signal`,
+    // not `controller.signal`).
+    if (controller.signal.aborted) {
+      presenterAbort.abort();
+    } else {
+      controller.signal.addEventListener('abort', () => presenterAbort.abort(), { once: true });
+    }
+    const presenter = createPresenterController(
+      options.presenterCommands,
+      presenterAbort.signal,
+      onError,
+    );
+    // PUL-F025 / ADR-004 audio handler — see method header.
+    presenter.subscribe((cmd) => {
+      if (cmd.kind !== 'toggle-master-mute') return;
+      audio.mute(!audio.isMuted());
+    });
+    return { presenter, presenterAbort };
+  };
+
+  /**
    * Build the in-flight load record: an `AbortController`, the
    * preloader factory's per-load preloader (a synchronous failure
    * is rolled back through `resetStageAttrs()` + `surfaceError`),
@@ -660,99 +724,7 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
     // exclusive at the URL boundary, so at most one of `repeat` /
     // `hold` / `cueGate` / `screenshot` is non-undefined here.
     const screenshot: 'capture' | undefined = mode === 'screenshot' ? 'capture' : undefined;
-    // PUL-F020 / ADR-023: under `mode=present` the loader builds a
-    // per-navigation `PresenterController` bound to this load's
-    // `controller.signal` and forwards it to every scene's run input
-    // via the bridge → resolver. Two scoping conditions: the mode
-    // must resolve to `'present'` (URL `mode=present` OR absent
-    // `mode=`, both of which `effectiveMode` collapses), AND the
-    // workbench must have supplied a `presenterCommands` source.
-    // When either condition is unmet, `presenter` is `undefined` and
-    // the spread below omits it from the bridge call so a runner
-    // that branches on `'presenter' in input` sees an absent key
-    // (parity with the `repeat` / `hold` / `cueGate` / `screenshot`
-    // / `beat` plumbing).
-    //
-    // Auto-cleanup: the controller registers `controller.signal`'s
-    // abort listener internally. When the navigation aborts (next
-    // handle, dispose, popstate, presenter-driven scene exit), every
-    // outstanding runner subscription is detached from the source.
-    // A runner that subscribes via `input.presenter.subscribe(...)`
-    // and forgets to unsubscribe cannot leak across navigations.
-    //
-    // Per ADR-007, mode dispatch lives in the runtime core, not at
-    // adapters; this is the central enforcement point for "presenter
-    // input only under mode=present" — no other code path builds the
-    // controller.
-    // PUL-F025 / ADR-023 (codex review, post-PUL-F025): the
-    // presenter controller's lifetime is "the navigation" — which
-    // ends on supersession / dispose / popstate (the navigation
-    // signal aborts) OR on normal completion (the resolver finishes
-    // and `runTarget`'s `finally` runs). Binding to the navigation
-    // signal alone covers only the first set; we use a separate
-    // `AbortController` so the loader can also tear down on the
-    // success path. The presenter signal is fired on EITHER cause:
-    // the navigation-abort listener below propagates supersession /
-    // dispose / popstate, and `runTarget`'s `finally` aborts it on
-    // completion. Both aborts are idempotent. The navigation signal
-    // itself stays un-aborted on the success path so the PUL-F013
-    // boundary contract — "the navigation signal reaches the runner
-    // un-aborted at receive time AND stays un-aborted across a
-    // successful completion" — is preserved.
-    const presenterAbort: AbortController | null =
-      mode === 'present' && options.presenterCommands !== undefined ? new AbortController() : null;
-    if (presenterAbort !== null) {
-      // Propagate navigation abort → presenter abort. Without this
-      // wiring, a supersession-time `controller.abort()` would not
-      // tear down the presenter controller (because it's bound to
-      // `presenterAbort.signal`, not `controller.signal`).
-      const propagateAbort = (): void => {
-        presenterAbort.abort();
-      };
-      if (controller.signal.aborted) {
-        presenterAbort.abort();
-      } else {
-        controller.signal.addEventListener('abort', propagateAbort, { once: true });
-      }
-    }
-    const presenter =
-      presenterAbort !== null && options.presenterCommands !== undefined
-        ? createPresenterController(options.presenterCommands, presenterAbort.signal, onError)
-        : undefined;
-    // PUL-F025 / ADR-004: presenter master mute. The audio handler
-    // lives here because this is the only seam where both the
-    // per-navigation `PresenterController` and the per-navigation
-    // `AudioService` are in scope — the runner cannot reach `audio`
-    // and the audio service does not see presenter commands.
-    //
-    // The command is a *fact* ("presenter pressed mute"), not a
-    // target state — the handler reads the engine's current master
-    // mute at receipt time and flips it via the audio boundary.
-    // `audio.mute()` validates the boolean (PUL-F024) and is inert
-    // post-dispose; the engine owns mute as runtime state so the
-    // flip survives scene cleanup and is observable by sibling
-    // services backed by the same engine (ADR-004, pinned in
-    // `audio.test.ts`).
-    //
-    // The subscription auto-detaches on `controller.signal` abort
-    // via the presenter controller's existing `tearDownAll` — no
-    // separate teardown wiring is needed. The handler is additive,
-    // not a filter: the runner still receives every command kind
-    // on its own `input.presenter.subscribe(...)`. Other kinds
-    // fall through to no-ops here.
-    //
-    // The handler can only throw if `audio.mute()` itself does. The
-    // controller's per-handler `try/catch` (`createPresenterController`)
-    // catches and routes through the same `onError` sink the loader
-    // already supplies, so a regression that made `mute()` throw
-    // mid-toggle cannot poison sibling subscribers or abort the
-    // navigation.
-    if (presenter !== undefined) {
-      presenter.subscribe((cmd) => {
-        if (cmd.kind !== 'toggle-master-mute') return;
-        audio.mute(!audio.isMuted());
-      });
-    }
+    const { presenter, presenterAbort } = buildPresenterPipe(mode, controller, audio);
     return {
       controller,
       settled: loadSceneNavigationTarget(resolved, {

--- a/tests/runtime/presenter.test.ts
+++ b/tests/runtime/presenter.test.ts
@@ -1,11 +1,11 @@
-// Presenter controls — PUL-F020 / PUL-F021 / ADR-023 / ADR-024.
+// Presenter controls — PUL-F020 / PUL-F021 / PUL-F025 / ADR-023 / ADR-024.
 //
 // Pure tests for the presenter command boundary: the discriminator
 // validator, the per-navigation controller's subscribe / unsubscribe
 // semantics, and the abort-tied auto-cleanup that prevents
 // subscriptions from leaking across navigations. The loader-side
-// dispatch tests live in `scene-loader.test.ts`'s presenter-controls
-// describe block.
+// dispatch tests (including the PUL-F025 master-mute audio handler)
+// live in `scene-loader-present.test.ts`.
 //
 // References:
 //  - PUL-F020 — runtime SHALL accept presenter input under mode=present
@@ -16,6 +16,17 @@
 //    `pause` and `resume` kinds; "same point" playhead behavior is
 //    the future GSAP runner's contract, so PUL-F021 stays DRAFT until
 //    that runner lands.
+//  - PUL-F025 — runtime SHALL accept presenter input to toggle master
+//    mute. Master mute SHALL silence audio without altering timeline
+//    state. Composes ADR-004 (master mute owned by the audio engine)
+//    with the same command seam by adding the `toggle-master-mute`
+//    kind; the engine-level mute mechanics already exist in
+//    `src/runtime/audio.ts`. The loader-side dispatch (subscribe in
+//    `buildLoad`, call `audio.mute(!audio.isMuted())`) is the
+//    PUL-F025-specific wiring and is pinned in the scene-loader
+//    suite. PUL-F025 stays DRAFT until a presenter UI surface lands
+//    and emits the kind end-to-end, mirroring the PUL-F020 / PUL-F021
+//    precedent.
 //  - ADR-023 — presenter command source / per-navigation controller.
 //  - ADR-024 — presenter pause/resume on the existing command seam.
 
@@ -49,9 +60,12 @@ const buildSource = (): {
 };
 
 describe('PRESENTER_COMMAND_KINDS', () => {
-  it('lists exactly the six kinds PUL-F020 + PUL-F021 name', () => {
+  it('lists exactly the seven kinds PUL-F020 + PUL-F021 + PUL-F025 name', () => {
     // PUL-F020: advance / hold / skip-forward / skip-backward.
     // PUL-F021 (ADR-024): pause / resume extend the same allowlist.
+    // PUL-F025: toggle-master-mute extends the same allowlist again —
+    // composes ADR-004 (engine-level master mute) without adding a
+    // second command schema, source, controller, or mode.
     expect([...PRESENTER_COMMAND_KINDS]).toEqual([
       'advance',
       'hold',
@@ -59,6 +73,7 @@ describe('PRESENTER_COMMAND_KINDS', () => {
       'skip-backward',
       'pause',
       'resume',
+      'toggle-master-mute',
     ]);
   });
 
@@ -67,8 +82,8 @@ describe('PRESENTER_COMMAND_KINDS', () => {
   });
 });
 
-describe('isPresenterCommand (PUL-F020 / PUL-F021 / ADR-023 / ADR-024)', () => {
-  it('accepts every kind PUL-F020 + PUL-F021 name', () => {
+describe('isPresenterCommand (PUL-F020 / PUL-F021 / PUL-F025 / ADR-023 / ADR-024)', () => {
+  it('accepts every kind PUL-F020 + PUL-F021 + PUL-F025 name', () => {
     for (const kind of PRESENTER_COMMAND_KINDS) {
       expect(isPresenterCommand({ kind })).toBe(true);
     }
@@ -84,6 +99,17 @@ describe('isPresenterCommand (PUL-F020 / PUL-F021 / ADR-023 / ADR-024)', () => {
     expect(isPresenterCommand({ kind: 'resume' })).toBe(true);
   });
 
+  it('accepts the PUL-F025 toggle-master-mute kind explicitly', () => {
+    // Pin the PUL-F025 contract clause directly: the boundary admits
+    // `toggle-master-mute` so the workbench command source can
+    // deliver presenter master-mute requests to the loader-side
+    // audio handler. Independent of the loop above so a regression
+    // that dropped only this kind is caught — and so a regression
+    // that drifted the kind's spelling (e.g., to `mute` or
+    // `master-mute`) is caught with a specific failure.
+    expect(isPresenterCommand({ kind: 'toggle-master-mute' })).toBe(true);
+  });
+
   it('rejects an unknown kind', () => {
     expect(isPresenterCommand({ kind: 'rewind' })).toBe(false);
     expect(isPresenterCommand({ kind: '' })).toBe(false);
@@ -91,6 +117,13 @@ describe('isPresenterCommand (PUL-F020 / PUL-F021 / ADR-023 / ADR-024)', () => {
     // `mode=paused` is a URL inspection mode (ADR-019), not a
     // presenter command — its name must not be admitted as a kind.
     expect(isPresenterCommand({ kind: 'paused' })).toBe(false);
+    // PUL-F025 spelling defense: only the full `toggle-master-mute`
+    // is admitted. Common drift candidates must remain rejected so
+    // a misspelled workbench source cannot smuggle the kind in.
+    expect(isPresenterCommand({ kind: 'mute' })).toBe(false);
+    expect(isPresenterCommand({ kind: 'master-mute' })).toBe(false);
+    expect(isPresenterCommand({ kind: 'unmute' })).toBe(false);
+    expect(isPresenterCommand({ kind: 'toggle-mute' })).toBe(false);
   });
 
   it('rejects values that are not plain command objects', () => {
@@ -109,7 +142,7 @@ describe('isPresenterCommand (PUL-F020 / PUL-F021 / ADR-023 / ADR-024)', () => {
   });
 });
 
-describe('createPresenterController (PUL-F020 / PUL-F021 / ADR-023 / ADR-024)', () => {
+describe('createPresenterController (PUL-F020 / PUL-F021 / PUL-F025 / ADR-023 / ADR-024)', () => {
   it('forwards every valid command from the source to the subscribed handler', () => {
     const { source, emit } = buildSource();
     const controller = new AbortController();
@@ -126,6 +159,7 @@ describe('createPresenterController (PUL-F020 / PUL-F021 / ADR-023 / ADR-024)', 
       'skip-backward',
       'pause',
       'resume',
+      'toggle-master-mute',
     ]);
   });
 
@@ -146,6 +180,24 @@ describe('createPresenterController (PUL-F020 / PUL-F021 / ADR-023 / ADR-024)', 
     emit({ kind: 'pause' });
     emit({ kind: 'resume' });
     expect(seen.map((c) => c.kind)).toEqual(['pause', 'resume']);
+  });
+
+  it('forwards the PUL-F025 toggle-master-mute command to the subscriber', () => {
+    // PUL-F025 contract clause at the seam: a workbench-supplied
+    // source emitting `toggle-master-mute` reaches the subscribed
+    // handler in order. The loader-side audio dispatch (call
+    // `audio.mute(!audio.isMuted())`) is pinned by the
+    // scene-loader-present suite; here we pin only that the kind
+    // crosses the command boundary unchanged, independent of any
+    // audio service.
+    const { source, emit } = buildSource();
+    const controller = new AbortController();
+    const ctl = createPresenterController(source, controller.signal);
+    const seen: PresenterCommand[] = [];
+    ctl.subscribe((cmd) => seen.push(cmd));
+    emit({ kind: 'toggle-master-mute' });
+    emit({ kind: 'toggle-master-mute' });
+    expect(seen.map((c) => c.kind)).toEqual(['toggle-master-mute', 'toggle-master-mute']);
   });
 
   it('returns an unsubscribe that detaches the handler from further emissions', () => {
@@ -222,6 +274,60 @@ describe('createPresenterController (PUL-F020 / PUL-F021 / ADR-023 / ADR-024)', 
       expect(call[0]).toBeInstanceOf(Error);
       expect((call[0] as Error).message).toMatch(/presenter/i);
     }
+  });
+
+  it('reports a rejected emission ONCE regardless of subscriber count (centralized validation)', () => {
+    // Codex review, post-PUL-F025: each PresenterController used
+    // to attach a wrapped handler PER subscriber on the underlying
+    // source. A malformed emission would therefore surface one
+    // `onError` diagnostic per subscriber — observable noise that
+    // grew quadratically with the number of runtime-owned
+    // subscribers (loader's mute handler, the runner, any future
+    // facets). The refactor centralizes validation: ONE source
+    // wrapper validates each emission and fans a sanitized command
+    // out to every subscriber, so the rejected-emission diagnostic
+    // fires exactly once regardless of subscriber count.
+    const { source, emit } = buildSource();
+    const controller = new AbortController();
+    const onError = vi.fn();
+    const ctl = createPresenterController(source, controller.signal, onError);
+    ctl.subscribe(() => undefined);
+    ctl.subscribe(() => undefined);
+    ctl.subscribe(() => undefined);
+    emit({ kind: 'rewind' });
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect((onError.mock.calls[0]?.[0] as Error).message).toMatch(/presenter/i);
+  });
+
+  it('contains a subscribe-time throw from the source and routes it through onError', () => {
+    // Codex review, post-PUL-F025: the loader's PUL-F025 audio
+    // handler subscribes during `buildLoad`, BEFORE the navigation
+    // queue runs the lifecycle. A workbench-supplied
+    // `PresenterCommandSource.subscribe` that throws on attach
+    // used to escape past the loader's stage-attr rollback /
+    // navigation-error envelope. Pin that the controller contains
+    // the throw at its own boundary: `subscribe()` does not
+    // propagate the source's error to the caller; instead the
+    // diagnostic flows through `onError` and the call returns a
+    // no-op unsubscribe so the caller's invariant ("subscribe
+    // returns a usable unsubscribe function") is preserved.
+    const throwingSource: PresenterCommandSource = {
+      subscribe() {
+        throw new Error('source subscribe failed');
+      },
+    };
+    const controller = new AbortController();
+    const onError = vi.fn();
+    const ctl = createPresenterController(throwingSource, controller.signal, onError);
+    let unsub: (() => void) | undefined;
+    expect(() => {
+      unsub = ctl.subscribe(() => undefined);
+    }).not.toThrow();
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect((onError.mock.calls[0]?.[0] as Error).message).toMatch(/source subscribe failed/);
+    // The returned unsubscribe is callable and does not throw —
+    // even though no source attachment ever happened.
+    expect(() => unsub?.()).not.toThrow();
   });
 
   it('drops unknown commands silently when no onError sink is provided', () => {

--- a/tests/runtime/scene-loader-present.test.ts
+++ b/tests/runtime/scene-loader-present.test.ts
@@ -1735,11 +1735,14 @@ describe('createSceneLoader — present-mode & presenter seams (PUL-F008)', () =
       // that let the throw escape `buildLoad` would either reject
       // the handle promise or leave stale stage attrs (the latter
       // detectable by additional tests; the former by this `await`
-      // throwing).
+      // throwing). The exact count of 1 also pins that the
+      // controller does NOT retry the source's subscribe (a
+      // regression that mistakenly looped on transient failure
+      // would surface here).
       const subscribeFailures = errors.filter(
         (e) => e instanceof Error && /subscribe failed/i.test(e.message),
       );
-      expect(subscribeFailures.length).toBeGreaterThanOrEqual(1);
+      expect(subscribeFailures).toHaveLength(1);
     });
 
     it('drops misspelled mute kinds (`mute`, `master-mute`, `unmute`) at the controller boundary — audio is never toggled', async () => {
@@ -1783,7 +1786,15 @@ describe('createSceneLoader — present-mode & presenter seams (PUL-F008)', () =
       fake.emit({ kind: 'master-mute' });
       fake.emit({ kind: 'unmute' });
       expect(engine.isMasterMuted()).toBe(false);
-      expect(errors.length).toBeGreaterThanOrEqual(3);
+      // Centralized validation surfaces exactly one diagnostic per
+      // rejected emission, regardless of subscriber count — so 3
+      // misspelled kinds yield 3 errors. A regression to per-
+      // subscriber validation would emit 3 × subscribers and fail
+      // this exact-count assertion.
+      const rejects = errors.filter(
+        (e) => e instanceof Error && /presenter/i.test(e.message),
+      );
+      expect(rejects).toHaveLength(3);
       loader.dispose();
       await loader.idle();
     });

--- a/tests/runtime/scene-loader-present.test.ts
+++ b/tests/runtime/scene-loader-present.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+  type AudioEngine,
   type AudioService,
   type Caption,
   type CompositionTimelineAdapter,
@@ -34,6 +35,32 @@ import {
   sceneTarget,
   stubCtx,
 } from './scene-loader.helpers';
+
+interface FakeSource {
+  readonly source: import('../../src/runtime/presenter').PresenterCommandSource;
+  readonly emit: (cmd: unknown) => void;
+  readonly handlerCount: () => number;
+}
+
+const buildFakeSource = (): FakeSource => {
+  const handlers = new Set<(cmd: import('../../src/runtime/presenter').PresenterCommand) => void>();
+  return {
+    source: {
+      subscribe(handler) {
+        handlers.add(handler);
+        return () => {
+          handlers.delete(handler);
+        };
+      },
+    },
+    emit(cmd) {
+      for (const h of handlers) {
+        h(cmd as import('../../src/runtime/presenter').PresenterCommand);
+      }
+    },
+    handlerCount: () => handlers.size,
+  };
+};
 
 describe('createSceneLoader — present-mode & presenter seams (PUL-F008)', () => {
   describe('present-mode adapter seams (PUL-F013 boundary, NOT a PUL-F013 implementation)', () => {
@@ -431,7 +458,7 @@ describe('createSceneLoader — present-mode & presenter seams (PUL-F008)', () =
     });
   });
 
-  describe('presenter-controls dispatch (PUL-F020 / PUL-F021 / ADR-023 / ADR-024)', () => {
+  describe('presenter-controls dispatch (PUL-F020 / PUL-F021 / PUL-F025 / ADR-023 / ADR-024)', () => {
     // PUL-F020 statement: in `mode=present`, the runtime SHALL accept
     // presenter input to advance to the next beat, hold the current
     // beat, skip forward, and skip backward. Beat progression SHALL
@@ -446,6 +473,19 @@ describe('createSceneLoader — present-mode & presenter seams (PUL-F008)', () =
     // unchanged. "Same point" playhead behavior is the runner's
     // contract, so PUL-F021, like PUL-F020, stays DRAFT until a real
     // presenter UI and a GSAP runner land with end-to-end tests.
+    //
+    // PUL-F025 statement: the runtime SHALL accept presenter input to
+    // toggle master mute, and master mute SHALL silence audio without
+    // altering timeline state. PUL-F025 also extends THIS seam by
+    // adding the `toggle-master-mute` command kind; the loader-side
+    // dispatch is the same mode scoping + controller construction +
+    // abort-tied auto-cleanup. PUL-F025-specific behavior is the
+    // loader's audio handler: on `toggle-master-mute` it calls
+    // `audio.mute(!audio.isMuted())`. The audio engine already owns
+    // master mute as runtime state per ADR-004, so PUL-F025 stays
+    // DRAFT until a real presenter UI surface lands and emits the
+    // kind end-to-end (mirroring PUL-F020 / PUL-F021). The
+    // PUL-F025-specific tests live in their own describe block below.
     //
     // This block pins the loader-side dispatch — the seam by which a
     // workbench-supplied `PresenterCommandSource` reaches the
@@ -481,33 +521,6 @@ describe('createSceneLoader — present-mode & presenter seams (PUL-F008)', () =
     //     "interruptible without breaking timeline state" clause).
     //   - Unknown command kinds are dropped at the controller
     //     boundary; the loader's `onError` sees a diagnostic.
-
-    interface FakeSource {
-      readonly source: import('../../src/runtime/presenter').PresenterCommandSource;
-      readonly emit: (cmd: unknown) => void;
-      readonly handlerCount: () => number;
-    }
-    const buildFakeSource = (): FakeSource => {
-      const handlers = new Set<
-        (cmd: import('../../src/runtime/presenter').PresenterCommand) => void
-      >();
-      return {
-        source: {
-          subscribe(handler) {
-            handlers.add(handler);
-            return () => {
-              handlers.delete(handler);
-            };
-          },
-        },
-        emit(cmd) {
-          for (const h of handlers) {
-            h(cmd as import('../../src/runtime/presenter').PresenterCommand);
-          }
-        },
-        handlerCount: () => handlers.size,
-      };
-    };
 
     it('forwards `input.presenter` to the runner under `mode=present` for a single-scene target', async () => {
       const sceneA = buildScene({ id: 'scene-a' });
@@ -651,7 +664,7 @@ describe('createSceneLoader — present-mode & presenter seams (PUL-F008)', () =
       expect(seen).toEqual([{ presenterPresent: false }]);
     });
 
-    it('delivers every command kind PUL-F020 + PUL-F021 name (advance, hold, skip-forward, skip-backward, pause, resume) to the runner', async () => {
+    it('delivers every command kind PUL-F020 + PUL-F021 + PUL-F025 name (advance, hold, skip-forward, skip-backward, pause, resume, toggle-master-mute) to the runner', async () => {
       const sceneA = buildScene({ id: 'scene-a' });
       const stage = buildStage();
       const fake = buildFakeSource();
@@ -692,6 +705,10 @@ describe('createSceneLoader — present-mode & presenter seams (PUL-F008)', () =
       // PUL-F021 (ADR-024): pause/resume ride the same dispatch path.
       fake.emit({ kind: 'pause' });
       fake.emit({ kind: 'resume' });
+      // PUL-F025 (ADR-004): toggle-master-mute rides the same
+      // dispatch path. The runner sees it too — the loader's audio
+      // handler is additive, not a filter.
+      fake.emit({ kind: 'toggle-master-mute' });
 
       loader.dispose();
       await loader.idle();
@@ -703,6 +720,7 @@ describe('createSceneLoader — present-mode & presenter seams (PUL-F008)', () =
         'skip-backward',
         'pause',
         'resume',
+        'toggle-master-mute',
       ]);
     });
 
@@ -916,6 +934,15 @@ describe('createSceneLoader — present-mode & presenter seams (PUL-F008)', () =
       await loader.idle();
 
       expect(received).toEqual(['advance']);
+      // PUL-F025 / ADR-023 (codex review, post-PUL-F025): even
+      // though PUL-F025 added a second subscriber on the navigation
+      // controller (the loader's audio handler), the controller
+      // validates each source emission ONCE — not once per
+      // subscriber — and surfaces ONE diagnostic per rejected
+      // emission regardless of how many subscribers are attached.
+      // Pin the exact count so a regression that reverted the
+      // controller to per-subscriber validation (multiplying
+      // diagnostic noise as subscribers grow) is caught here.
       expect(errors).toHaveLength(1);
       expect(errors[0]).toBeInstanceOf(Error);
       expect((errors[0] as Error).message).toMatch(/presenter/i);
@@ -945,6 +972,820 @@ describe('createSceneLoader — present-mode & presenter seams (PUL-F008)', () =
         name.startsWith('data-pulsar-mode-'),
       );
       expect(modeAttrs).toEqual([]);
+    });
+  });
+
+  describe('presenter master-mute dispatch (PUL-F025 / ADR-004)', () => {
+    // PUL-F025 statement: the runtime SHALL accept presenter input to
+    // toggle master mute. Master mute SHALL silence audio without
+    // altering timeline state.
+    //
+    // PUL-F025 composes ADR-004 (master mute as engine-level runtime
+    // state) with the existing presenter command seam (ADR-023):
+    //  - Schema: `'toggle-master-mute'` joins `PRESENTER_COMMAND_KINDS`.
+    //    No new command source, controller, validator, or mode.
+    //  - Loader-side audio handler: on `'toggle-master-mute'`,
+    //    `audio.mute(!audio.isMuted())`. The handler lives in
+    //    `buildLoad` because that is the only seam holding both the
+    //    per-navigation `PresenterController` and the per-navigation
+    //    `AudioService`. The subscription is auto-detached on the
+    //    navigation's `AbortSignal` via the controller's existing
+    //    teardown.
+    //  - Timeline state untouched: no `cleanup(ctx)`, no abort, no
+    //    URL / history / mode mutation. The runner's pending promise
+    //    stays pending while mute toggles.
+    //
+    // PUL-F025 stays DRAFT until a presenter UI surface lands and
+    // emits the kind end-to-end, mirroring the PUL-F020 / PUL-F021
+    // precedent. The runtime-side contract is delivered by this PR;
+    // the issue ↔ PUL-F025 link stays `DOCUMENTS`.
+
+    // Local fresh-engine factory: the exported `noopAudioEngine` is a
+    // process singleton with mutable master-mute state, so reusing it
+    // across tests would leak state. This mirrors `noopAudioEngine`
+    // but returns a fresh instance per test, giving each test
+    // hermetic engine state.
+    const freshAudioEngine = (): AudioEngine => {
+      let muted = false;
+      const noopHandle = {
+        play: () => 0,
+        stop: () => undefined,
+        fade: () => undefined,
+        loop: () => undefined,
+        volume: () => undefined,
+        unload: () => undefined,
+      };
+      return {
+        createSound: () => noopHandle,
+        setMasterMute: (m: boolean) => {
+          muted = m;
+        },
+        isMasterMuted: () => muted,
+      };
+    };
+
+    interface MountedPresent {
+      readonly loader: ReturnType<typeof createSceneLoader>;
+      readonly fake: ReturnType<typeof buildFakeSource>;
+      readonly capturedAudio: () => AudioService;
+      readonly captureCount: () => number;
+      readonly readyP: Promise<void>;
+    }
+
+    // Mount a single-scene `mode=present` navigation, capture
+    // `ctx.audio` from the scene's `create(ctx)` (the only lifecycle
+    // hook guaranteed to run before the runner starts), park the
+    // runner until abort, and resolve `readyP` once the scene is
+    // mounted and the runner has entered. Tests then drive presenter
+    // commands and assert on the captured audio service.
+    //
+    // The runner subscribes to `input.presenter` so the codex review
+    // can verify the loader's audio handler is additive (the runner
+    // still receives every kind). `runner.received` is exposed for
+    // tests that need it.
+    const mountPresent = (opts?: {
+      readonly noPresenterCommands?: boolean;
+      readonly mode?: NavigationMode;
+      readonly scenes?: readonly SceneModule[];
+      readonly compositionId?: string;
+      readonly compositionScenes?: readonly string[];
+      readonly engine?: AudioEngine;
+      readonly runnerReceived?: string[];
+    }): MountedPresent => {
+      const fake = buildFakeSource();
+      const engine = opts?.engine ?? freshAudioEngine();
+      let captured: AudioService | undefined;
+      let captureCount = 0;
+      const captureCtx = (ctx: unknown): void => {
+        const a = (ctx as { audio: AudioService }).audio;
+        captured = a;
+        captureCount += 1;
+      };
+      const scenes = opts?.scenes ?? [
+        buildScene({
+          id: 'scene-a',
+          create: (ctx) => captureCtx(ctx),
+        }),
+      ];
+      let runnerEntered: () => void = () => undefined;
+      const readyP = new Promise<void>((resolve) => {
+        runnerEntered = resolve;
+      });
+      const runner = (input: LegacyRunInput): Promise<void> => {
+        // Capture commands the runner sees so additive-handler tests
+        // can verify the loader's PUL-F025 dispatch did not consume
+        // the command before the runner.
+        if (opts?.runnerReceived !== undefined) {
+          input.presenter?.subscribe((cmd) => opts.runnerReceived?.push(cmd.kind));
+        }
+        runnerEntered();
+        return new Promise<void>((resolve) => {
+          input.signal?.addEventListener('abort', () => resolve(), { once: true });
+        });
+      };
+      const loaderOpts: SceneLoaderOptions = {
+        scenes: createSceneRegistry(scenes),
+        compositions: createCompositionRegistry(
+          opts?.compositionId === undefined
+            ? []
+            : [
+                {
+                  id: opts.compositionId,
+                  manifest: opts.compositionScenes ?? [scenes[0]?.id ?? ''],
+                },
+              ],
+        ),
+        stage: buildStage().element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        timeline: asTimeline(runner),
+        audioEngine: engine,
+        ...(opts?.noPresenterCommands === true ? {} : { presenterCommands: fake.source }),
+      };
+      const loader = createSceneLoader(loaderOpts);
+      const target: NavigationTarget =
+        opts?.compositionId === undefined
+          ? {
+              locator: { kind: 'scene', scene: scenes[0]?.id ?? 'scene-a' },
+              ...(opts?.mode === undefined ? {} : { mode: opts.mode }),
+            }
+          : {
+              locator: { kind: 'composition', composition: opts.compositionId },
+              ...(opts?.mode === undefined ? {} : { mode: opts.mode }),
+            };
+      void loader.handle(target);
+      return {
+        loader,
+        fake,
+        capturedAudio: () => {
+          if (captured === undefined) throw new Error('ctx.audio was never captured');
+          return captured;
+        },
+        captureCount: () => captureCount,
+        readyP,
+      };
+    };
+
+    it('flips master mute from unmuted to muted on the first `toggle-master-mute` command', async () => {
+      // Clause 1: "accept presenter input to toggle master mute."
+      // First emission must flip the engine-level mute state via
+      // the audio service.
+      const m = mountPresent({ mode: 'present' });
+      await m.readyP;
+      expect(m.capturedAudio().isMuted()).toBe(false);
+      m.fake.emit({ kind: 'toggle-master-mute' });
+      expect(m.capturedAudio().isMuted()).toBe(true);
+      m.loader.dispose();
+      await m.loader.idle();
+    });
+
+    it('round-trips master mute on repeated `toggle-master-mute` commands', async () => {
+      // The command is a *fact*, not a target state — the loader
+      // reads the engine's current mute at receipt time and flips
+      // it. Two emissions return to unmuted; a third re-mutes.
+      const m = mountPresent({ mode: 'present' });
+      await m.readyP;
+      expect(m.capturedAudio().isMuted()).toBe(false);
+      m.fake.emit({ kind: 'toggle-master-mute' });
+      m.fake.emit({ kind: 'toggle-master-mute' });
+      expect(m.capturedAudio().isMuted()).toBe(false);
+      m.fake.emit({ kind: 'toggle-master-mute' });
+      expect(m.capturedAudio().isMuted()).toBe(true);
+      m.loader.dispose();
+      await m.loader.idle();
+    });
+
+    it('does NOT alter timeline state — no `cleanup(ctx)`, no abort, runner pending stays pending across toggles', async () => {
+      // Clause 2: "Master mute SHALL silence audio without altering
+      // timeline state." The handler must not abort the navigation,
+      // call cleanup, or affect the runner's transport. We pin this
+      // by counting `cleanup(ctx)` invocations, observing
+      // `signal.aborted` from the runner side, and verifying the
+      // navigation handle stays pending while toggles fire.
+      let cleanupRan = 0;
+      let abortedAtRunner = false;
+      let capturedAudio: AudioService | undefined;
+      let runnerEntered: () => void = () => undefined;
+      const ready = new Promise<void>((resolve) => {
+        runnerEntered = resolve;
+      });
+      // One scene that captures `ctx.audio` in `create` AND counts
+      // cleanup invocations, so both invariants are pinned on the
+      // same navigation.
+      const scene = buildScene({
+        id: 'scene-a',
+        create: (ctx) => {
+          capturedAudio = (ctx as { audio: AudioService }).audio;
+        },
+        cleanup: () => {
+          cleanupRan += 1;
+        },
+      });
+      const runner = (input: LegacyRunInput): Promise<void> => {
+        // Resolve `ready` once the runner has entered so the test
+        // can assert mid-flight. `create(ctx)` already ran by this
+        // point (ADR-025: mount-all then run), so `capturedAudio`
+        // is set.
+        runnerEntered();
+        return new Promise<void>((resolve) => {
+          input.signal?.addEventListener(
+            'abort',
+            () => {
+              abortedAtRunner = true;
+              resolve();
+            },
+            { once: true },
+          );
+        });
+      };
+      const fake = buildFakeSource();
+      const engine = freshAudioEngine();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([scene]),
+        compositions: createCompositionRegistry([]),
+        stage: buildStage().element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        timeline: asTimeline(runner),
+        audioEngine: engine,
+        presenterCommands: fake.source,
+      });
+      const handle = loader.handle({
+        locator: { kind: 'scene', scene: 'scene-a' },
+        mode: 'present',
+      });
+      // Track handle settlement so we can pin "toggles do not
+      // complete the navigation."
+      let handleSettled = false;
+      void handle.then(
+        () => {
+          handleSettled = true;
+        },
+        () => {
+          handleSettled = true;
+        },
+      );
+      await ready;
+      expect(capturedAudio?.isMuted()).toBe(false);
+      fake.emit({ kind: 'toggle-master-mute' });
+      fake.emit({ kind: 'toggle-master-mute' });
+      fake.emit({ kind: 'toggle-master-mute' });
+      // Yield to the microtask queue so any spurious settle would
+      // have already happened.
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(handleSettled).toBe(false);
+      expect(cleanupRan).toBe(0);
+      expect(abortedAtRunner).toBe(false);
+      // Three toggles on a no-op engine — ends muted.
+      expect(capturedAudio?.isMuted()).toBe(true);
+      loader.dispose();
+      await loader.idle();
+      // After dispose: cleanup must run exactly once (the normal
+      // mandatory-cleanup invariant), and the runner must observe
+      // the abort. Both are existing PUL-F006 invariants; we only
+      // re-pin them to make explicit that PUL-F025's handler did
+      // NOT cause additional cleanups.
+      expect(cleanupRan).toBe(1);
+      expect(abortedAtRunner).toBe(true);
+    });
+
+    it.each(NAVIGATION_MODES.filter((m) => m !== 'present'))(
+      'does NOT toggle master mute under non-present mode `%s` even when `presenterCommands` is supplied',
+      async (mode) => {
+        // PUL-F025 mode scoping: presenter input is `mode=present`
+        // only. The controller is never built for other modes, so a
+        // workbench source that emits `'toggle-master-mute'` while a
+        // non-present navigation is active reaches NO subscriber —
+        // master mute stays untouched. Without this guard, mute
+        // would leak into screenshot / paused / loop / etc.
+        const sceneA = buildScene({ id: 'scene-a' });
+        const fake = buildFakeSource();
+        const engine = freshAudioEngine();
+        let capturedAudio: AudioService | undefined;
+        let runnerEntered: () => void = () => undefined;
+        const ready = new Promise<void>((resolve) => {
+          runnerEntered = resolve;
+        });
+        const runner = (input: LegacyRunInput): Promise<void> => {
+          runnerEntered();
+          return new Promise<void>((resolve) => {
+            input.signal?.addEventListener('abort', () => resolve(), { once: true });
+          });
+        };
+        const noopRendererForPrompter: PrompterRenderer = () => undefined;
+        const captureScene = buildScene({
+          id: 'scene-a',
+          create: (ctx) => {
+            capturedAudio = (ctx as { audio: AudioService }).audio;
+            runnerEntered();
+          },
+        });
+        const loader = createSceneLoader({
+          scenes: createSceneRegistry([captureScene]),
+          compositions: createCompositionRegistry([]),
+          stage: buildStage().element,
+          buildCtx: stubCtx,
+          createPreloader: () => () => undefined,
+          timeline: asTimeline(runner),
+          audioEngine: engine,
+          renderPrompter: noopRendererForPrompter,
+          presenterCommands: fake.source,
+        });
+        void sceneA;
+        const handle = loader.handle({
+          locator: { kind: 'scene', scene: 'scene-a' },
+          mode,
+        });
+        if (mode === 'prompter') {
+          // mode=prompter bypasses the resolver lifecycle entirely
+          // (ADR-022) so `ctx.audio` is never built. The invariant
+          // "presenter master mute does not run under non-present
+          // modes" still holds vacuously, because no subscription
+          // exists; pin it by emitting and confirming the source
+          // has zero handlers.
+          await handle;
+          fake.emit({ kind: 'toggle-master-mute' });
+          expect(fake.handlerCount()).toBe(0);
+        } else {
+          await ready;
+          expect(capturedAudio?.isMuted()).toBe(false);
+          fake.emit({ kind: 'toggle-master-mute' });
+          fake.emit({ kind: 'toggle-master-mute' });
+          fake.emit({ kind: 'toggle-master-mute' });
+          expect(capturedAudio?.isMuted()).toBe(false);
+          // The loader must not have wired a controller — the source
+          // has zero subscribed handlers.
+          expect(fake.handlerCount()).toBe(0);
+          loader.dispose();
+          await loader.idle();
+        }
+      },
+    );
+
+    it('toggles master mute under absent-mode URLs (mode defaults to present per ADR-007)', async () => {
+      // Defense in depth: a regression that branched on
+      // `target.mode === 'present'` instead of
+      // `effectiveMode(target) === 'present'` would skip the mute
+      // handler for `mode`-absent URLs even though they resolve to
+      // present.
+      const sceneA = buildScene({ id: 'scene-a' });
+      const fake = buildFakeSource();
+      const engine = freshAudioEngine();
+      let capturedAudio: AudioService | undefined;
+      let runnerEntered: () => void = () => undefined;
+      const ready = new Promise<void>((resolve) => {
+        runnerEntered = resolve;
+      });
+      const captureScene = buildScene({
+        id: 'scene-a',
+        create: (ctx) => {
+          capturedAudio = (ctx as { audio: AudioService }).audio;
+          runnerEntered();
+        },
+      });
+      const runner = (input: LegacyRunInput): Promise<void> =>
+        new Promise<void>((resolve) => {
+          input.signal?.addEventListener('abort', () => resolve(), { once: true });
+        });
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([captureScene]),
+        compositions: createCompositionRegistry([]),
+        stage: buildStage().element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        timeline: asTimeline(runner),
+        audioEngine: engine,
+        presenterCommands: fake.source,
+      });
+      void sceneA;
+      void loader.handle({ locator: { kind: 'scene', scene: 'scene-a' } });
+      await ready;
+      fake.emit({ kind: 'toggle-master-mute' });
+      expect(capturedAudio?.isMuted()).toBe(true);
+      loader.dispose();
+      await loader.idle();
+    });
+
+    it('does NOT toggle master mute when `presenterCommands` is omitted (graceful degradation)', async () => {
+      // Mirror of the PUL-F020 graceful-degradation invariant: when
+      // the workbench omits `presenterCommands` the loader builds no
+      // controller, so there is no subscriber for the audio handler.
+      // The audio service stays unmuted; no source to assert against,
+      // so we drive the test by mounting and inspecting `isMuted()`
+      // after a hypothetical out-of-band emission would have run.
+      const engine = freshAudioEngine();
+      let capturedAudio: AudioService | undefined;
+      let runnerEntered: () => void = () => undefined;
+      const ready = new Promise<void>((resolve) => {
+        runnerEntered = resolve;
+      });
+      const sceneA = buildScene({
+        id: 'scene-a',
+        create: (ctx) => {
+          capturedAudio = (ctx as { audio: AudioService }).audio;
+          runnerEntered();
+        },
+      });
+      const runner = (input: LegacyRunInput): Promise<void> =>
+        new Promise<void>((resolve) => {
+          input.signal?.addEventListener('abort', () => resolve(), { once: true });
+        });
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: buildStage().element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        timeline: asTimeline(runner),
+        audioEngine: engine,
+      });
+      void loader.handle({ locator: { kind: 'scene', scene: 'scene-a' }, mode: 'present' });
+      await ready;
+      // With no source the workbench cannot emit; the invariant is
+      // "engine stays at initial unmuted." A regression that wired
+      // master mute through some other path (e.g., a default-on
+      // listener) would flip the engine state here.
+      expect(capturedAudio?.isMuted()).toBe(false);
+      loader.dispose();
+      await loader.idle();
+    });
+
+    it('toggles master mute even when no scene has registered a sound (engine-level state, noop engine round-trip)', async () => {
+      // The preflight calls out: "The command is accepted even before
+      // any sound has been registered. `noopAudioEngine` must round-
+      // trip the mute state the same way the Howler engine does."
+      // The scene here does NOT call `ctx.audio.load(...)`, yet the
+      // toggle still mutates engine state observable via `isMuted()`.
+      const engine = freshAudioEngine();
+      const fake = buildFakeSource();
+      let capturedAudio: AudioService | undefined;
+      let runnerEntered: () => void = () => undefined;
+      const ready = new Promise<void>((resolve) => {
+        runnerEntered = resolve;
+      });
+      const sceneA = buildScene({
+        id: 'scene-a',
+        create: (ctx) => {
+          capturedAudio = (ctx as { audio: AudioService }).audio;
+          runnerEntered();
+        },
+      });
+      const runner = (input: LegacyRunInput): Promise<void> =>
+        new Promise<void>((resolve) => {
+          input.signal?.addEventListener('abort', () => resolve(), { once: true });
+        });
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: buildStage().element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        timeline: asTimeline(runner),
+        audioEngine: engine,
+        presenterCommands: fake.source,
+      });
+      void loader.handle({ locator: { kind: 'scene', scene: 'scene-a' }, mode: 'present' });
+      await ready;
+      // The engine starts unmuted; isMasterMuted() reads from the
+      // engine, not from any registered sound.
+      expect(engine.isMasterMuted()).toBe(false);
+      fake.emit({ kind: 'toggle-master-mute' });
+      expect(engine.isMasterMuted()).toBe(true);
+      expect(capturedAudio?.isMuted()).toBe(true);
+      loader.dispose();
+      await loader.idle();
+    });
+
+    it('persists master mute across scenes within a present-mode composition slice (engine-level runtime state)', async () => {
+      // A composition slice runs the full slice through one audio
+      // service shared across scenes (PUL-F024 / ADR-004), backed by
+      // a single engine. Toggling mute mid-slice must be observable
+      // by the next scene's `ctx.audio.isMuted()`; the audio service
+      // delegates to the engine, which is the single source of
+      // truth. Without engine-level persistence the second scene
+      // would see unmuted again.
+      const engine = freshAudioEngine();
+      const fake = buildFakeSource();
+      let firstAudio: AudioService | undefined;
+      let secondAudio: AudioService | undefined;
+      let firstEntered: () => void = () => undefined;
+      const firstReady = new Promise<void>((resolve) => {
+        firstEntered = resolve;
+      });
+      let secondEntered: () => void = () => undefined;
+      const secondReady = new Promise<void>((resolve) => {
+        secondEntered = resolve;
+      });
+      const sceneA = buildScene({
+        id: 'scene-a',
+        create: (ctx) => {
+          firstAudio = (ctx as { audio: AudioService }).audio;
+          firstEntered();
+        },
+      });
+      const sceneB = buildScene({
+        id: 'scene-b',
+        create: (ctx) => {
+          secondAudio = (ctx as { audio: AudioService }).audio;
+          secondEntered();
+        },
+      });
+      // The composition runs both scenes through one master timeline
+      // adapter `run` call (ADR-025). Park until aborted so we can
+      // assert mid-flight.
+      const rec = recordingTimeline(true);
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA, sceneB]),
+        compositions: createCompositionRegistry([
+          { id: 'two-scenes', manifest: ['scene-a', 'scene-b'] },
+        ]),
+        stage: buildStage().element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        timeline: rec.adapter,
+        audioEngine: engine,
+        presenterCommands: fake.source,
+      });
+      void loader.handle({
+        locator: { kind: 'composition', composition: 'two-scenes' },
+        mode: 'present',
+      });
+      await firstReady;
+      await secondReady;
+      // Both scenes mounted under the same per-navigation service —
+      // the resolver mounts every entry before `run` begins (ADR-025).
+      expect(firstAudio).toBeDefined();
+      expect(secondAudio).toBeDefined();
+      fake.emit({ kind: 'toggle-master-mute' });
+      expect(firstAudio?.isMuted()).toBe(true);
+      // Engine-level state: both services backed by the same engine
+      // observe the toggle.
+      expect(secondAudio?.isMuted()).toBe(true);
+      loader.dispose();
+      await loader.idle();
+    });
+
+    it('stops responding to `toggle-master-mute` after the navigation aborts', async () => {
+      // Auto-cleanup: the presenter controller detaches the loader's
+      // mute subscription when the per-navigation `AbortSignal`
+      // fires. Post-abort emissions reach NO subscriber. The audio
+      // service is also disposed and inert, so even if the
+      // subscription somehow stayed attached the engine state would
+      // not move — this test pins both layers.
+      const engine = freshAudioEngine();
+      const fake = buildFakeSource();
+      let capturedAudio: AudioService | undefined;
+      let runnerEntered: () => void = () => undefined;
+      const ready = new Promise<void>((resolve) => {
+        runnerEntered = resolve;
+      });
+      const sceneA = buildScene({
+        id: 'scene-a',
+        create: (ctx) => {
+          capturedAudio = (ctx as { audio: AudioService }).audio;
+          runnerEntered();
+        },
+      });
+      const runner = (input: LegacyRunInput): Promise<void> =>
+        new Promise<void>((resolve) => {
+          input.signal?.addEventListener('abort', () => resolve(), { once: true });
+        });
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: buildStage().element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        timeline: asTimeline(runner),
+        audioEngine: engine,
+        presenterCommands: fake.source,
+      });
+      void loader.handle({ locator: { kind: 'scene', scene: 'scene-a' }, mode: 'present' });
+      await ready;
+      // First toggle pre-abort flips engine state — proves the
+      // baseline subscription works.
+      fake.emit({ kind: 'toggle-master-mute' });
+      expect(engine.isMasterMuted()).toBe(true);
+      loader.dispose();
+      await loader.idle();
+      // Post-abort: the loader's subscription is detached AND the
+      // audio service is disposed (PUL-F024). Engine state stays
+      // wherever the last pre-abort toggle left it.
+      fake.emit({ kind: 'toggle-master-mute' });
+      expect(engine.isMasterMuted()).toBe(true);
+      expect(fake.handlerCount()).toBe(0);
+      // The audio service is disposed; calling mute() on it from
+      // outside the runtime now is a no-op (PUL-F024 invariant).
+      expect(capturedAudio?.isDisposed()).toBe(true);
+    });
+
+    it('still delivers `toggle-master-mute` to the runner — the loader handler is additive, not a filter', async () => {
+      // A runner that subscribes to `input.presenter` MUST still
+      // receive every command the controller forwards, including
+      // `toggle-master-mute`. The loader's audio handler is a
+      // second subscriber on the controller, not a transformation
+      // of the stream — see the existing "delivers every command
+      // kind" test, which already includes `toggle-master-mute` in
+      // the expected sequence. This focused test pins the rule in
+      // isolation so a regression that gated the runner on a kind
+      // allowlist would fail here with a single-kind failure that
+      // is easy to read in CI output.
+      const received: string[] = [];
+      const engine = freshAudioEngine();
+      const fake = buildFakeSource();
+      let runnerEntered: () => void = () => undefined;
+      const ready = new Promise<void>((resolve) => {
+        runnerEntered = resolve;
+      });
+      const sceneA = buildScene({ id: 'scene-a' });
+      const runner = (input: LegacyRunInput): Promise<void> => {
+        input.presenter?.subscribe((cmd) => received.push(cmd.kind));
+        runnerEntered();
+        return new Promise<void>((resolve) => {
+          input.signal?.addEventListener('abort', () => resolve(), { once: true });
+        });
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: buildStage().element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        timeline: asTimeline(runner),
+        audioEngine: engine,
+        presenterCommands: fake.source,
+      });
+      void loader.handle({ locator: { kind: 'scene', scene: 'scene-a' }, mode: 'present' });
+      await ready;
+      fake.emit({ kind: 'toggle-master-mute' });
+      // Engine moved AND the runner observed the kind.
+      expect(engine.isMasterMuted()).toBe(true);
+      expect(received).toEqual(['toggle-master-mute']);
+      loader.dispose();
+      await loader.idle();
+    });
+
+    it('tears down the presenter subscription when a `mode=present` navigation completes normally (no leak across successful runs)', async () => {
+      // Finding 1 from the codex review, post-PUL-F025: the
+      // presenter controller's only teardown path used to be the
+      // navigation `AbortSignal`. A `mode=present` navigation that
+      // resolved normally (the resolver finished + `load.settled`
+      // resolved) would clear `inFlight` without aborting the
+      // navigation controller, leaving the loader-owned mute
+      // subscription (and any runner-owned subscription) attached
+      // to the long-lived `PresenterCommandSource`. Across many
+      // successful navigations, stale wrappers would accumulate.
+      //
+      // Pin the fix: after a successful navigation completes, the
+      // workbench source has zero attached handlers — the loader's
+      // happy-path teardown disposed the presenter controller.
+      const engine = freshAudioEngine();
+      const fake = buildFakeSource();
+      const sceneA = buildScene({ id: 'scene-a' });
+      // Adapter resolves immediately — successful normal completion.
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: buildStage().element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        timeline: noopTimeline,
+        audioEngine: engine,
+        presenterCommands: fake.source,
+      });
+      await loader.handle({ locator: { kind: 'scene', scene: 'scene-a' }, mode: 'present' });
+      expect(fake.handlerCount()).toBe(0);
+      // A second successful navigation must also leave the source
+      // clean — a regression that only fixed the first nav would
+      // pass the assertion above and fail here as the second
+      // controller leaks.
+      await loader.handle({ locator: { kind: 'scene', scene: 'scene-a' }, mode: 'present' });
+      expect(fake.handlerCount()).toBe(0);
+    });
+
+    it('keeps the navigation `AbortSignal` un-aborted after a successful completion (the presenter teardown uses its own lifecycle signal)', async () => {
+      // Layered defense for the PUL-F013-boundary invariant: the
+      // happy-path presenter teardown MUST use a separate
+      // AbortController from the navigation `controller` so the
+      // navigation signal's "un-aborted at runner receive time AND
+      // un-aborted across a successful completion" property is
+      // preserved. A regression that aborted the navigation
+      // controller in `finally` to tear down the presenter
+      // controller would flip this invariant — the cached signal
+      // reference on the recorded run options would show
+      // `aborted: true` after navigation completes.
+      const engine = freshAudioEngine();
+      const fake = buildFakeSource();
+      const sceneA = buildScene({ id: 'scene-a' });
+      const rec = recordingTimeline();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: buildStage().element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        timeline: rec.adapter,
+        audioEngine: engine,
+        presenterCommands: fake.source,
+      });
+      await loader.handle({ locator: { kind: 'scene', scene: 'scene-a' }, mode: 'present' });
+      expect(rec.calls).toHaveLength(1);
+      // Navigation signal stays un-aborted across a successful
+      // completion. Presenter teardown happens via the separate
+      // `presenterAbort` signal in `InFlightLoad`.
+      expect(rec.calls[0]?.opts.signal?.aborted).toBe(false);
+      // And the presenter source's wrappers were nonetheless
+      // detached — proving both invariants hold simultaneously.
+      expect(fake.handlerCount()).toBe(0);
+    });
+
+    it('surfaces a subscribe-time throw from `presenterCommands.subscribe` through the loader `onError` envelope (does not escape `buildLoad`)', async () => {
+      // Finding 3 from the codex review, post-PUL-F025: the loader
+      // now subscribes a navigation-owned audio handler in
+      // `buildLoad`. A workbench source whose `subscribe` throws
+      // during registration would have escaped past the existing
+      // stage-attr rollback + `surfaceError` envelope, leaving the
+      // navigation in an inconsistent state. Pin the fix: a
+      // throwing source surfaces a diagnostic via `onError` and the
+      // navigation still settles (the resolver still runs because
+      // the loader's `buildLoad` returned without re-throwing).
+      const engine = freshAudioEngine();
+      const throwingSource: import('../../src/runtime/presenter').PresenterCommandSource = {
+        subscribe() {
+          throw new Error('source subscribe failed (test)');
+        },
+      };
+      const sceneA = buildScene({ id: 'scene-a' });
+      const errors: unknown[] = [];
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: buildStage().element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        timeline: noopTimeline,
+        audioEngine: engine,
+        presenterCommands: throwingSource,
+        onError: (err) => errors.push(err),
+      });
+      await loader.handle({ locator: { kind: 'scene', scene: 'scene-a' }, mode: 'present' });
+      // The subscribe-time throw was routed through `onError`
+      // exactly once and did NOT abort the navigation. A regression
+      // that let the throw escape `buildLoad` would either reject
+      // the handle promise or leave stale stage attrs (the latter
+      // detectable by additional tests; the former by this `await`
+      // throwing).
+      const subscribeFailures = errors.filter(
+        (e) => e instanceof Error && /subscribe failed/i.test(e.message),
+      );
+      expect(subscribeFailures.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('drops misspelled mute kinds (`mute`, `master-mute`, `unmute`) at the controller boundary — audio is never toggled', async () => {
+      // PUL-F025 spelling defense at the loader level: only the full
+      // `'toggle-master-mute'` reaches the audio handler. Common
+      // drift candidates that pass static-string checks but fail the
+      // allowlist must be dropped at `isPresenterCommand` and never
+      // touch the engine. Mirrors the unit-level coverage in
+      // `presenter.test.ts` but pinned at the integrated seam.
+      const engine = freshAudioEngine();
+      const fake = buildFakeSource();
+      const errors: unknown[] = [];
+      let runnerEntered: () => void = () => undefined;
+      const ready = new Promise<void>((resolve) => {
+        runnerEntered = resolve;
+      });
+      const sceneA = buildScene({
+        id: 'scene-a',
+        create: () => {
+          runnerEntered();
+        },
+      });
+      const runner = (input: LegacyRunInput): Promise<void> =>
+        new Promise<void>((resolve) => {
+          input.signal?.addEventListener('abort', () => resolve(), { once: true });
+        });
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: buildStage().element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        timeline: asTimeline(runner),
+        audioEngine: engine,
+        presenterCommands: fake.source,
+        onError: (err) => errors.push(err),
+      });
+      void loader.handle({ locator: { kind: 'scene', scene: 'scene-a' }, mode: 'present' });
+      await ready;
+      fake.emit({ kind: 'mute' });
+      fake.emit({ kind: 'master-mute' });
+      fake.emit({ kind: 'unmute' });
+      expect(engine.isMasterMuted()).toBe(false);
+      expect(errors.length).toBeGreaterThanOrEqual(3);
+      loader.dispose();
+      await loader.idle();
     });
   });
 });

--- a/tests/runtime/scene-loader-present.test.ts
+++ b/tests/runtime/scene-loader-present.test.ts
@@ -1791,9 +1791,7 @@ describe('createSceneLoader — present-mode & presenter seams (PUL-F008)', () =
       // misspelled kinds yield 3 errors. A regression to per-
       // subscriber validation would emit 3 × subscribers and fail
       // this exact-count assertion.
-      const rejects = errors.filter(
-        (e) => e instanceof Error && /presenter/i.test(e.message),
-      );
+      const rejects = errors.filter((e) => e instanceof Error && /presenter/i.test(e.message));
       expect(rejects).toHaveLength(3);
       loader.dispose();
       await loader.idle();


### PR DESCRIPTION
Implements presenter master mute (PUL-F025) on top of the existing
presenter command seam (ADR-023) and the existing audio engine
boundary (ADR-004). Composition only — no new ADR, no new mode, no
new command source/controller/validator.

## Summary

- `src/runtime/presenter.ts` — extends `PRESENTER_COMMAND_KINDS`
  with `'toggle-master-mute'`. Refactors `createPresenterController`
  so validation runs once per source emission and fans the
  sanitized command out to every subscriber (centralized
  validation; pre-PUL-F025 it ran once per subscriber, which would
  have multiplied diagnostic noise as runtime-owned subscribers
  grew). Contains subscribe-time throws from the workbench source
  at the controller boundary and routes them through `onError`.
- `src/runtime/scene-loader.ts` — `buildLoad` subscribes a
  navigation-owned audio handler on the per-navigation
  `PresenterController` that, on `'toggle-master-mute'`, calls
  `audio.mute(!audio.isMuted())`. The handler lives where both the
  controller and `AudioService` are in scope; it never imports
  Howler, touches the master timeline, aborts the navigation,
  calls `cleanup(ctx)`, or mutates URL/history. The presenter
  controller is built against a *separate* `presenterAbort` signal
  (not the navigation signal) so the navigation signal's
  "un-aborted at runner-receive time AND across a successful
  completion" invariant (PUL-F013 boundary) is preserved while
  presenter subscriptions still get a deterministic teardown on
  EITHER supersession or normal completion — `runTarget`'s
  `finally` aborts the presenter signal too.
- `tests/runtime/presenter.test.ts` — pins the new kind in the
  allowlist + `isPresenterCommand` accept/reject coverage,
  centralized-validation property ("one diagnostic per emission
  regardless of subscriber count"), and contained subscribe-time
  throw.
- `tests/runtime/scene-loader-present.test.ts` — pins loader-side
  dispatch: toggle from unmuted, round-trip, no timeline state
  alteration, mode scoping (negative across every non-present
  mode), absent-mode default-to-present, graceful degradation
  without `presenterCommands`, sound-free toggle (engine-level
  state via `noopAudioEngine`), cross-scene persistence in a
  composition slice, abort-time detachment, runner-additivity
  (the runner still sees `'toggle-master-mute'`), misspelled-kind
  rejection (`mute` / `master-mute` / `unmute`), presenter
  subscription teardown on normal completion, navigation-signal
  un-aborted on success, and subscribe-time-throw envelope.
- `docs/design/pul-f025-master-mute-preflight.md` — codex
  architecture preflight, kept (referenced from `docs/design/README.md`).
- `CHANGELOG.md` — `## [Unreleased] / ### Added` entry covering
  the new kind, the loader's audio handler, the cross-cutting
  refactors (centralized validation, separate presenter signal,
  subscribe-time envelope), and the PUL-F025 DRAFT note.

## Status (PUL-F025)

Stays **DRAFT** — mirrors the PUL-F020 / PUL-F021 / ADR-023 / ADR-024
precedent. The runtime-side contract ships here; the user-visible
ACTIVE bar additionally requires a presenter UI surface
(keyboard / on-screen / remote protocol) that emits
`'toggle-master-mute'` through `PresenterCommandSource`.
`src/main.ts` still omits `presenterCommands`, so production
reaches the graceful-degradation path.

## Tests

873 vitest cases pass. Pre-push codex review: cycle 1 surfaced
three `class` findings (subscription leak on normal completion,
per-subscriber duplicate diagnostics, subscribe-time throws
bypassing the envelope); all three fixed at the category level;
cycle 2 clean.

Closes #34