### PR TITLE
Implement PUL-F026 rehearsal mode (ADR-004)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Rehearsal mode — PUL-F026 / ADR-004 — in `src/runtime/navigation.ts`,
+  `src/runtime/audio.ts`, and `src/runtime/scene-loader.ts`: a new
+  workbench mode `mode=rehearsal` in which the runtime preserves every
+  timeline-state transition the equivalent non-rehearsal navigation
+  would run (same composition slice, same head-entry overrides, same
+  master timeline, no head-only `repeat` / `hold` / `cueGate` /
+  `screenshot` runner-input hint, no slice truncation) while the
+  per-navigation audio service is built `'log-cues'`: every accepted
+  audio operation (`play` / `fade` / `stop` / `stopGroup`) is emitted
+  as a frozen `AudioCueLogEntry` (semantic ids only — sound id,
+  sprite, group, operation, numeric envelope parameters, per-service
+  monotonic sequence; NEVER source URLs, Howler handles, asset paths,
+  or raw scene objects) to the workbench's optional `onAudioCue`
+  sink, and sounds are constructed muted at the engine so no audible
+  output reaches the listener. The rehearsal contract lives entirely
+  on the audio-service seam — there is no head-only runner-input
+  field, no slice transform, no new resolver semantics, no
+  presenter-command extension. The output policy is a literal-typed
+  `AudioOutputPolicy = 'audible' | 'silent' | 'log-cues'` on
+  `AudioServiceOptions`: `'silent'` is the existing screenshot /
+  paused build (audible playback suppressed — ADR-019 / ADR-021);
+  `'log-cues'` is rehearsal (muted + emitted); `'audible'` is the
+  default for every other mode. The previous `silent: boolean` field
+  is replaced by the union (one field, three values, future-extensible
+  to silent-rehearsal / export-silence / ducking variants on the same
+  seam). `load` and `mute` are NOT cues (registration is bookkeeping
+  and master mute is engine-level persistent state); validation
+  throws never emit; post-dispose calls never emit; a throwing
+  `onCue` sink is swallowed so a workbench-side log-surface bug does
+  not break scene playback. Master mute survives the rehearsal-mode
+  flip (engine-level state). The runtime-driven per-scene audio
+  teardown (`onSceneCleaned` → `audio.stopGroup(sceneId)`) is itself
+  an accepted audio operation and therefore part of the rehearsal
+  cue stream — pinned by `scene-loader-audio.test.ts`. PUL-F026
+  transitions DRAFT → ACTIVE with this PR: the runtime materially
+  delivers both halves of the requirement statement ("audio is
+  silenced OR logged as cues without altering timeline state") via
+  the policy + the no-slice-truncation / no-head-hint structural
+  defense.
 - Presenter master mute — PUL-F025 / ADR-004 — in `src/runtime/presenter.ts`
   and `src/runtime/scene-loader.ts`: the presenter command allowlist gains
   one new kind, `'toggle-master-mute'`, and the loader's `buildLoad`

--- a/docs/adrs/002-scene-registry-and-compositions.md
+++ b/docs/adrs/002-scene-registry-and-compositions.md
@@ -126,7 +126,7 @@ parameters follow that model:
   composition (compatibility shim).
 - `?scene=<scene-id>&beat=<label>` — jump to a labeled point inside a
   scene timeline (see [ADR-003](003-gsap-timeline-engine.md)).
-- `?...&mode=<present|standalone|loop|paused|scrub|screenshot|prompter>`
+- `?...&mode=<present|standalone|loop|paused|scrub|screenshot|prompter|rehearsal>`
   — select a workbench mode (see [ADR-007](007-browser-workbench.md)).
 
 Numeric / positional navigation, if exposed, is a compatibility shim

--- a/docs/adrs/004-howler-audio-engine.md
+++ b/docs/adrs/004-howler-audio-engine.md
@@ -135,8 +135,28 @@ PUL-F024 lands the runtime side in `src/runtime/audio.ts`:
   documented resolver follow-up — the same one that would let a
   composition slice repeat a scene id.
 - Master mute is held on the engine (persistent runtime state), not as a
-  per-scene checkbox. `mode=screenshot` / `mode=paused` build the
-  service `silent` (audible playback suppressed — ADR-019 / ADR-021).
+  per-scene checkbox. The per-navigation audio output policy is a
+  literal-typed `AudioOutputPolicy` on `AudioServiceOptions` (default
+  `'audible'`): `mode=screenshot` / `mode=paused` build the service
+  `'silent'` (audible playback suppressed — ADR-019 / ADR-021);
+  `mode=rehearsal` (PUL-F026) builds it `'log-cues'` — also muted at
+  engine construction, with each accepted audio operation (`play` /
+  `fade` / `stop` / `stopGroup`) emitted as a semantic
+  `AudioCueLogEntry` to the workbench's optional `onAudioCue` sink.
+  `'audible'` is the default for every other mode. Future variations
+  (export silence, ducking, bus volume, an audio-status UI) extend
+  this same union rather than scattering branches across the runtime.
+- Rehearsal (PUL-F026) lives entirely on this audio-service seam — not
+  as a head-only timeline-runner hint, not as a slice truncation, not
+  as a presenter command. Rehearsal preserves the same composition
+  slice and the same master timeline progression as the equivalent
+  non-rehearsal navigation; only audio output changes. The cue log
+  carries semantic ids only (sound id, sprite, group, operation,
+  monotonic sequence, numeric envelope parameters) — never source
+  URLs, Howler handles, absolute paths, or raw scene objects. `load`
+  and `mute` are NOT cues (registration and engine-level state).
+  Validation throws never emit. Post-dispose calls never emit. A
+  throwing sink is swallowed.
 - Browser autoplay policy is centralized by Howler's default Web Audio
   mode + `Howler.autoUnlock`: a `play()` made before the first user
   gesture is deferred (the suspended `AudioContext` blocks playback) and

--- a/docs/adrs/007-browser-workbench.md
+++ b/docs/adrs/007-browser-workbench.md
@@ -79,6 +79,7 @@ The runtime supports the following modes:
 | `scrub` | Timeline controls are visible. For inspecting timing, easing, and beat alignment. |
 | `screenshot` | Deterministic state, fixed seed for any randomness, no animation. For visual regression checks and exported stills. |
 | `prompter` | Script/caption view for the selected scene or composition, regardless of visual rendering. |
+| `rehearsal` | Author rehearsal — audio is silenced or logged as cues (PUL-F026 / ADR-004's `AudioOutputPolicy: 'log-cues'`). Timeline state, master timeline, and composition slice are unchanged from the equivalent non-rehearsal navigation. |
 
 Modes are explicit, addressable, and orthogonal to navigation: any
 scene + beat target works in any mode that makes sense for that target.

--- a/docs/adrs/016-workbench-mode-present.md
+++ b/docs/adrs/016-workbench-mode-present.md
@@ -15,13 +15,15 @@ PUL-F013 specifies `mode=present` behavior:
 > In `mode=present`, the runtime SHALL render full chrome, audio, and
 > inter-scene transitions, and SHALL respond to presenter input.
 
-`present` is one of the seven workbench modes ADR-007 defines, and it
+`present` is one of the eight workbench modes ADR-007 defines, and it
 is the default selected by `effectiveMode()` when the URL omits
 `mode=`. Other modes (`standalone`, `loop`, `paused`, `scrub`,
-`screenshot`, `prompter`) suppress some subset of the four facets
-PUL-F013 names — for example, `standalone` suppresses chrome,
-inter-scene transitions, and the audio bed (PUL-F014); `screenshot`
-suppresses audio and animation (PUL-F018).
+`screenshot`, `prompter`, `rehearsal`) suppress some subset of the
+four facets PUL-F013 names — for example, `standalone` suppresses
+chrome, inter-scene transitions, and the audio bed (PUL-F014);
+`screenshot` suppresses audio and animation (PUL-F018); `rehearsal`
+suppresses audible playback (silenced or logged as cues —
+PUL-F026 / ADR-004).
 
 Each of the four facets PUL-F013 names depends on a surface that has
 not yet landed in this repo:
@@ -185,7 +187,7 @@ traceability/status mismatch.
   input flow.
 - [ADR-004](004-howler-audio-engine.md) — `ctx.audio` is the seam
   through which audio rendering will flow.
-- [ADR-007](007-browser-workbench.md) — defines the seven workbench
+- [ADR-007](007-browser-workbench.md) — defines the eight workbench
   modes and the URL-only-source invariant for mode selection.
 - [ADR-008](008-agent-native-authoring.md) — manifests-over-flow-
   control underpins the no-mode-suppression-in-resolver constraint.

--- a/docs/adrs/017-workbench-mode-standalone.md
+++ b/docs/adrs/017-workbench-mode-standalone.md
@@ -10,8 +10,8 @@ Accepted
 
 ## Context
 
-ADR-007 names seven workbench modes: `present`, `standalone`, `loop`,
-`paused`, `scrub`, `screenshot`, `prompter`. ADR-013 fixes the URL
+ADR-007 names eight workbench modes: `present`, `standalone`, `loop`,
+`paused`, `scrub`, `screenshot`, `prompter`, `rehearsal`. ADR-013 fixes the URL
 grammar boundary that carries `mode=` to the runtime. ADR-014 fixes
 the scene navigation dispatch layer that turns a `NavigationTarget`
 into a runnable scene/slice. ADR-015 fixes URL beat positioning.
@@ -233,7 +233,7 @@ to inspect — fully supported.
   through which audio rendering will flow; the surrounding-audio-bed
   suppression clause maps onto a future audio surface reading
   `ctx.mode === 'standalone'`.
-- [ADR-007](007-browser-workbench.md) — defines the seven workbench
+- [ADR-007](007-browser-workbench.md) — defines the eight workbench
   modes and the URL-only-source invariant for mode selection.
 - [ADR-008](008-agent-native-authoring.md) — manifests-over-flow-
   control underpins the slice-drop-not-manifest-mutation choice.

--- a/docs/adrs/018-workbench-mode-loop.md
+++ b/docs/adrs/018-workbench-mode-loop.md
@@ -10,8 +10,8 @@ Accepted
 
 ## Context
 
-ADR-007 names seven workbench modes: `present`, `standalone`, `loop`,
-`paused`, `scrub`, `screenshot`, `prompter`. ADR-013 fixes the URL
+ADR-007 names eight workbench modes: `present`, `standalone`, `loop`,
+`paused`, `scrub`, `screenshot`, `prompter`, `rehearsal`. ADR-013 fixes the URL
 grammar boundary that carries `mode=` to the runtime. ADR-014 fixes the
 scene navigation dispatch layer. ADR-015 fixes URL beat positioning.
 ADR-016 establishes the precedent for landing a mode's contract while
@@ -295,7 +295,7 @@ satisfying PUL-F015 would be a traceability/status mismatch.
   the seam through which restart-on-completion will flow when the
   GSAP runner lands. Today the runner is a placeholder, so loop
   behavior is structurally vacuous.
-- [ADR-007](007-browser-workbench.md) — defines the seven workbench
+- [ADR-007](007-browser-workbench.md) — defines the eight workbench
   modes and the URL-only-source invariant for mode selection.
 - [ADR-008](008-agent-native-authoring.md) — manifests-over-flow-
   control underpins the no-mode-suppression-in-resolver constraint.

--- a/docs/adrs/019-workbench-mode-paused.md
+++ b/docs/adrs/019-workbench-mode-paused.md
@@ -10,8 +10,8 @@ Accepted
 
 ## Context
 
-ADR-007 names seven workbench modes: `present`, `standalone`, `loop`,
-`paused`, `scrub`, `screenshot`, `prompter`. ADR-013 fixes the URL
+ADR-007 names eight workbench modes: `present`, `standalone`, `loop`,
+`paused`, `scrub`, `screenshot`, `prompter`, `rehearsal`. ADR-013 fixes the URL
 grammar boundary that carries `mode=` to the runtime. ADR-014 fixes
 the scene navigation dispatch layer. ADR-015 fixes URL beat
 positioning. ADR-016 (`mode=present`), ADR-017 (`mode=standalone`),
@@ -387,7 +387,7 @@ mismatch.
   the seam through which hold-at-first-frame will flow when the
   GSAP runner lands. Today the runner is a placeholder, so paused
   behavior is structurally vacuous.
-- [ADR-007](007-browser-workbench.md) — defines the seven workbench
+- [ADR-007](007-browser-workbench.md) — defines the eight workbench
   modes and the URL-only-source invariant for mode selection.
 - [ADR-008](008-agent-native-authoring.md) — manifests-over-flow-
   control underpins the no-mode-suppression-in-resolver constraint.

--- a/docs/adrs/020-workbench-mode-scrub.md
+++ b/docs/adrs/020-workbench-mode-scrub.md
@@ -10,8 +10,8 @@ Accepted
 
 ## Context
 
-ADR-007 names seven workbench modes: `present`, `standalone`, `loop`,
-`paused`, `scrub`, `screenshot`, `prompter`. ADR-013 fixes the URL
+ADR-007 names eight workbench modes: `present`, `standalone`, `loop`,
+`paused`, `scrub`, `screenshot`, `prompter`, `rehearsal`. ADR-013 fixes the URL
 grammar boundary that carries `mode=` to the runtime. ADR-014 fixes
 the scene navigation dispatch layer. ADR-015 fixes URL beat
 positioning. ADR-016 (`mode=present`), ADR-017 (`mode=standalone`),
@@ -477,7 +477,7 @@ PR as satisfying PUL-F017 would be a traceability/status mismatch.
 - [ADR-004](004-howler-audio-engine.md) — audio cues are the
   consumer of the cue gate. Today there is no audio engine, so the
   gate has no consumer.
-- [ADR-007](007-browser-workbench.md) — defines the seven workbench
+- [ADR-007](007-browser-workbench.md) — defines the eight workbench
   modes and the URL-only-source invariant for mode selection.
   Specifically references `mode=scrub` as the timing/beat-alignment
   inspection mode.

--- a/docs/adrs/021-workbench-mode-screenshot.md
+++ b/docs/adrs/021-workbench-mode-screenshot.md
@@ -10,8 +10,8 @@ Accepted
 
 ## Context
 
-ADR-007 names seven workbench modes: `present`, `standalone`, `loop`,
-`paused`, `scrub`, `screenshot`, `prompter`. ADR-013 fixes the URL
+ADR-007 names eight workbench modes: `present`, `standalone`, `loop`,
+`paused`, `scrub`, `screenshot`, `prompter`, `rehearsal`. ADR-013 fixes the URL
 grammar boundary that carries `mode=` to the runtime. ADR-014 fixes
 the scene navigation dispatch layer. ADR-015 fixes URL beat
 positioning. ADR-016 (`mode=present`), ADR-017 (`mode=standalone`),
@@ -546,7 +546,7 @@ a traceability/status mismatch.
 - [ADR-004](004-howler-audio-engine.md) — audio output is the
   consumer of the suppression. Today there is no audio engine, so
   the suppression has no consumer.
-- [ADR-007](007-browser-workbench.md) — defines the seven workbench
+- [ADR-007](007-browser-workbench.md) — defines the eight workbench
   modes and the URL-only-source invariant for mode selection.
   Specifically references `mode=screenshot` as the
   visual-regression hook for agents and reviewers.

--- a/docs/adrs/022-workbench-mode-prompter.md
+++ b/docs/adrs/022-workbench-mode-prompter.md
@@ -10,8 +10,8 @@ Accepted
 
 ## Context
 
-ADR-007 names seven workbench modes: `present`, `standalone`, `loop`,
-`paused`, `scrub`, `screenshot`, `prompter`. ADR-013 fixes the URL
+ADR-007 names eight workbench modes: `present`, `standalone`, `loop`,
+`paused`, `scrub`, `screenshot`, `prompter`, `rehearsal`. ADR-013 fixes the URL
 grammar boundary that carries `mode=` to the runtime. ADR-014 fixes
 the scene navigation dispatch layer. ADR-015 fixes URL beat
 positioning. ADR-016 (`mode=present`), ADR-017 (`mode=standalone`),
@@ -104,7 +104,7 @@ extension.
 
 `mode=prompter` is dispatched at the loader
 (`src/runtime/scene-loader.ts`) on a separate code path from the
-other six lifecycle-running modes. When `effectiveMode(target) ===
+other seven lifecycle-running modes. When `effectiveMode(target) ===
 'prompter'`:
 
 1. The loader still validates the navigation target via the existing
@@ -442,7 +442,7 @@ mismatch.
 
 - [ADR-002](002-scene-registry-and-compositions.md) — defines the
   `Caption = { at: ms, text }` shape this ADR aggregates.
-- [ADR-007](007-browser-workbench.md) — defines the seven workbench
+- [ADR-007](007-browser-workbench.md) — defines the eight workbench
   modes; specifically references `mode=prompter` as the
   script/caption review mode.
 - [ADR-008](008-agent-native-authoring.md) — manifests-over-flow-

--- a/docs/adrs/023-presenter-controls.md
+++ b/docs/adrs/023-presenter-controls.md
@@ -10,8 +10,8 @@ Accepted
 
 ## Context
 
-ADR-007 names seven workbench modes: `present`, `standalone`, `loop`,
-`paused`, `scrub`, `screenshot`, `prompter`. ADR-013 fixes the URL
+ADR-007 names eight workbench modes: `present`, `standalone`, `loop`,
+`paused`, `scrub`, `screenshot`, `prompter`, `rehearsal`. ADR-013 fixes the URL
 grammar boundary that carries `mode=` to the runtime. ADR-016
 (`mode=present`) records the present-mode contract boundary and names
 PUL-F020 as one of the four facets that gates PUL-F013 ACTIVE
@@ -460,7 +460,7 @@ satisfying PUL-F020 would be a traceability/status mismatch.
 - [ADR-004](004-howler-audio-engine.md) — `ctx.audio` is the seam
   through which audio cleanup will flow on presenter-driven scene
   exits when the audio service lands.
-- [ADR-007](007-browser-workbench.md) — defines the seven workbench
+- [ADR-007](007-browser-workbench.md) — defines the eight workbench
   modes and the URL-only-source invariant for mode selection.
   Presenter input is scoped to `mode=present` here per ADR-007's
   mode dispatch.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -19,6 +19,7 @@ Design context for Pulsar. Source material for the ADRs in `../adrs/`.
 | [pul-f023-named-timeline-beats-preflight.md](pul-f023-named-timeline-beats-preflight.md) | Guardrails for implementing named timeline beats. |
 | [pul-f024-audio-orchestration-preflight.md](pul-f024-audio-orchestration-preflight.md) | Guardrails for implementing runtime-owned audio orchestration. |
 | [pul-f025-master-mute-preflight.md](pul-f025-master-mute-preflight.md) | Guardrails for implementing presenter master mute. |
+| [pul-f026-rehearsal-mode-preflight.md](pul-f026-rehearsal-mode-preflight.md) | Guardrails for implementing rehearsal audio suppression or cue logging without timeline-state changes. |
 
 Design docs are mutable. Decisions are captured as ADRs (immutable once
 accepted).

--- a/docs/design/pul-f026-rehearsal-mode-preflight.md
+++ b/docs/design/pul-f026-rehearsal-mode-preflight.md
@@ -1,0 +1,173 @@
+# PUL-F026 Rehearsal Mode Preflight
+
+PUL-F026 specifies a rehearsal mode in which runtime audio is silenced
+or logged as cues without altering timeline state. This is an
+audio-output policy for author rehearsal. It is not master mute,
+paused mode, scrub cue gating, screenshot capture, presenter input,
+or a new timeline lifecycle.
+
+ADR-004 already owns rehearsal as an audio-service capability. The
+implementation should add the smallest workbench-mode contract needed
+to select it and keep all audio behavior behind `ctx.audio`.
+
+## Boundary
+
+Rehearsal must stay on the existing runtime path:
+
+- `src/runtime/navigation.ts` owns URL mode grammar. If rehearsal is
+  URL-addressable, add `mode=rehearsal` to `NAVIGATION_MODES` and let
+  `parseNavigationSearch()` / `effectiveMode()` remain the only mode
+  parser/defaulting path.
+- `src/runtime/scene-loader.ts` owns mode dispatch and per-navigation
+  `ctx` construction. It is the correct place to map effective
+  `rehearsal` to an audio output policy when calling
+  `createAudioService()`.
+- `src/runtime/audio.ts` owns audible playback, silent playback, and
+  cue logging. Rehearsal must be implemented in `AudioService` /
+  `AudioServiceOptions`, not by importing Howler elsewhere, muting the
+  engine globally, or adding scene-local audio code.
+- `src/runtime/timeline.ts` owns master timeline transport. Rehearsal
+  must not pause, seek, repeat, kill, retime, or rebuild the master.
+  It should run through the same timeline state transitions the
+  equivalent non-rehearsal navigation would run.
+- `src/runtime/scene-navigation.ts` and
+  `src/runtime/composition-resolver.ts` remain mode-opaque lifecycle
+  layers. They should not learn rehearsal semantics or add a
+  rehearsal-specific lifecycle branch.
+- `src/runtime/presenter.ts` is not the selector for rehearsal. Do not
+  model rehearsal as a presenter command or by reusing
+  `toggle-master-mute`.
+
+Rehearsal should not use the single-scene truncation path unless a
+separate requirement says so. For a composition target, it should
+preserve the same scene slice and timeline progression as normal
+playback from that target; only audio output changes.
+
+## Required Reuse
+
+Implementation must reuse these canonical incumbents:
+
+- URL grammar and mode validation: `NAVIGATION_MODES`,
+  `parseNavigationSearch()`, `effectiveMode()`, and the loader's
+  `validateModeGrammar()` defense-in-depth check.
+- Scene/composition contracts: `SceneModule`, `assertSceneModule()`,
+  `createSceneRegistry()`, `assertCompositionManifest()`, and
+  `createCompositionRegistry()`.
+- Navigation and lifecycle: `resolveSceneNavigation()`,
+  `loadSceneNavigationTarget()`, `resolveComposition()`, one
+  per-navigation `AbortController.signal`, and resolver-owned cleanup.
+- Timeline state: `createGsapCompositionTimeline()`,
+  `MasterTimeline`, `composeMasterTimeline()`, and the existing normal
+  run path. Rehearsal adds no `headHold`, `headRepeat`, `headCueGate`,
+  or `headScreenshot` hint.
+- Audio boundary: `AudioService`, `createAudioService()`,
+  `AudioServiceOptions`, `AudioEngine`, `createHowlerAudioEngine()`,
+  and `noopAudioEngine`. Keep Howler hidden in `audio.ts`.
+- Audio validation: `assertSoundDefinition()`, `assertPlayOptions()`,
+  `isKebabIdentifier()`, `KEBAB_IDENTIFIER_FORM`, range checks,
+  sprite checks, group validation, and `allowedSources`.
+- Asset security: `scene.assets`, `collectAudioSources()`,
+  `createAssetPreloader()`, `resolveAssetUrl()`,
+  `DEFAULT_ALLOWED_SCHEMES`, redirect re-checks, `baseUrl`, and fetch
+  `AbortSignal` wiring.
+- Error and observability: `describeError()`, loader `onError`, and
+  `data-pulsar-navigation-error`. Cue logging must use an explicit
+  bounded sink, not ad hoc `console.log` calls scattered through the
+  timeline or scenes.
+- Tests: extend existing navigation mode tests, scene-loader mode
+  seam tests, audio service tests, and timeline non-mutation tests.
+  Do not create a parallel rehearsal harness.
+
+## Cross-Cutting Layers
+
+| Layer | Guardrail |
+|-------|-----------|
+| URL grammar / mode validation | `mode=rehearsal` must be accepted only through `NAVIGATION_MODES` and rejected everywhere the existing parser/loader rejects unknown modes. No `rehearsal=true`, `audio=silent`, or duplicate parser. |
+| Programmatic navigation | Loader-side `validateModeGrammar()` must reject hand-built targets with unknown modes before `buildCtx` receives them. |
+| Scene and composition schemas | No new scene field, composition behavior key, cue schema, or manifest override is needed. Existing scene assets and timeline callbacks remain the source of audio cue calls. |
+| Asset security | Rehearsal audio sources still must be declared in `scene.assets`, pass `resolveAssetUrl()` scheme checks, and belong to `allowedSources`. Cue logs must not include raw source URLs, credentials, cookies, or request headers. Log semantic ids only. |
+| Audio shape validation | `ctx.audio.load()` / `play()` / `fade()` / `stop()` keep the existing sound id, sprite, group, volume, and range checks. Log only after the same boundary validation that audible playback uses. |
+| Audio output policy | Rehearsal is per-navigation audio-service state. Do not implement it by calling `AudioService.mute(true)`, `Howler.mute(true)`, changing engine master mute, or resetting master mute on completion. |
+| Timeline state | The master timeline should see the same run mode as non-rehearsal playback for the same target. No rehearsal-specific seek, pause, repeat, speed, label, cleanup, or abort behavior. |
+| Lifecycle / cleanup | Audio services remain bound to the navigation `AbortSignal`; `stopGroup(sceneId)` and `stopAll()` keep their existing cleanup guarantees. Cue logging must stop when the service is disposed. |
+| Error envelopes | Synchronous audio contract violations keep existing `AudioError` subclasses and resolver wrapping. Non-fatal async audio failures still route through `onError`. Do not add a rehearsal exception hierarchy or leak raw cue payloads in errors. |
+| Auth / remote input | No auth surface exists in this repo for rehearsal. If future remote rehearsal controls arrive, authenticate before emitting into existing command/workbench seams; keep local shape validation at the boundary. |
+| Config / env / OS exposure | No env vars, process argv tokens, CLI flags, files, cookies, localStorage, sessionStorage, or history state are needed. Do not expose rehearsal choices through process arguments or persisted browser state. |
+| Observability | Cue logging must be explicit, bounded, and low-volume. Avoid per-frame logs; audio cue logs should represent accepted audio operations such as `play`/sprite cue attempts. |
+
+## Rehearsal Contract
+
+Rehearsal mode means: resolve the addressed target through the
+existing URL/registry/composition path, preload declared assets, run
+normal `create(ctx)` and `timeline(ctx)`, and drive the master timeline
+as normal while the audio service suppresses audible output or records
+accepted cue attempts.
+
+- A direct `scene` target rehearses that scene.
+- A `composition` target rehearses the normal composition slice from
+  the beginning.
+- A `composition+scene` or `composition+index` target rehearses the
+  resolved slice from the addressed head scene onward, preserving the
+  head entry's `range` / `behavior` overrides.
+- `beat=<label>` under rehearsal should reuse the existing
+  `headBeat` / `onBeatMissing` path if rehearsal supports beat
+  positioning. The beat seek is existing navigation positioning, not a
+  rehearsal-specific timeline mutation.
+
+## Extensibility
+
+The required extension point is an audio output policy on the existing
+audio-service seam. Prefer one small parameter owned by `audio.ts`,
+for example a policy equivalent to `audible` / `silent` /
+`log-cues`, plus an optional cue-log sink supplied by the loader or
+workbench bootstrap. Keep `silent` screenshot/paused behavior and
+rehearsal behavior expressed through that same audio-service policy
+instead of adding mode-specific branches throughout the runtime.
+
+Cue-log entries should be semantic and stable: sound id, sprite name
+when present, group when present, operation, and a monotonic sequence
+or timestamp if needed. They should not expose Howler handles, source
+URLs, absolute paths, request headers, or raw scene objects.
+
+Future variations such as "silent rehearsal" vs "cue-log rehearsal",
+export silence, ducking, bus volume, or audio status UI should extend
+the same `AudioServiceOptions` / `AudioService` seam. They should not
+create a second URL grammar, scene schema, timeline hint family,
+exception hierarchy, or presenter command bus.
+
+## Gotchas And Anti-Patterns
+
+- Do not conflate rehearsal with master mute. Master mute is
+  engine-level persistent state; rehearsal is per-navigation output
+  policy.
+- Do not conflate rehearsal with `mode=paused`, `mode=scrub`, or
+  `mode=screenshot`. Those modes change playhead behavior or capture
+  semantics; rehearsal must not.
+- Do not implement rehearsal by pausing audio cues in timeline
+  callbacks. Scenes should keep calling `ctx.audio`; the service
+  decides whether the cue is audible or logged.
+- Do not log cue attempts before validating the sound id, sprite,
+  group, and option shape. Rehearsal logs should represent accepted
+  runtime cues, not malformed inputs.
+- Do not log every animation frame, playhead tick, label crossing, or
+  pointer event. Rehearsal cue logs are audio-operation logs.
+- Do not add `data-pulsar-mode-*` suppression attributes, hidden
+  storage keys, or mode state outside the URL parser/loader path.
+- Do not add raw `<audio>` elements, Web Audio nodes, or Howler
+  imports in scenes to work around rehearsal.
+- Do not swallow lifecycle failures because rehearsal is "only" an
+  authoring mode. Preload, create, timeline, and cleanup failures
+  retain the same envelopes as normal playback.
+
+## Non-Goals
+
+PUL-F026 should not implement keyboard listeners, presenter controls,
+remote rehearsal protocols, auth, persistence, analytics streams,
+audio waveform UI, cue editing, scene schema changes, composition
+schema changes, export mixdown, deterministic screenshot behavior,
+scrub controls, master-mute UI, or requirement status transition.
+
+It should not add a new resolver, timeline runner, cue scheduler,
+asset inventory, validation library, logging framework, exception
+hierarchy, repository, workflow controller, env binding, or
+process-level configuration surface.

--- a/src/runtime/audio.ts
+++ b/src/runtime/audio.ts
@@ -57,7 +57,7 @@ import { Howl, Howler, type SoundSpriteDefinitions } from 'howler';
 import { DEFAULT_ALLOWED_SCHEMES, resolveAssetUrl } from './asset-preloader';
 import { describeError } from './error';
 import { KEBAB_IDENTIFIER_FORM, isKebabIdentifier } from './identifier';
-import { isPlainRecord } from './object';
+import { deepFreeze, isPlainRecord } from './object';
 
 /* ------------------------------------------------------------------ *
  *  Errors
@@ -285,6 +285,126 @@ export interface PlayOptions {
   readonly group?: string;
 }
 
+/**
+ * Public allowlist of audio output policies (PUL-F024 / PUL-F026 /
+ * ADR-004). Frozen so consumers cannot mutate the public set, and
+ * mirrored by {@link AudioOutputPolicy} so the type and the runtime
+ * check share one source of truth — same pattern
+ * {@link import('./navigation').NAVIGATION_MODES} uses. Adding a value
+ * here automatically widens the type, the validation, and any
+ * `(AUDIO_OUTPUT_POLICIES as readonly string[]).includes(...)`
+ * defense-in-depth check at the loader.
+ */
+export const AUDIO_OUTPUT_POLICIES = Object.freeze(['audible', 'silent', 'log-cues'] as const);
+
+/**
+ * Output policy for the audio service (PUL-F024 / PUL-F026 / ADR-004).
+ *
+ * The policy is held on the per-navigation service rather than the
+ * engine because rehearsal vs screenshot vs paused vs present is a
+ * per-navigation contract — the engine is a process singleton.
+ *
+ *  - `'audible'` (default) — sounds are constructed unmuted; cue
+ *    requests reach the engine and produce audio. The historical
+ *    default for `mode=present` / `mode=standalone` / `mode=loop` /
+ *    `mode=scrub`.
+ *  - `'silent'` — sounds are constructed muted at the engine. The
+ *    workbench-mode capture / paused-inspection contract: `mode=
+ *    screenshot` / `mode=paused` build the service silent because
+ *    audible playback is suppressed (ADR-019 / ADR-021).
+ *  - `'log-cues'` — sounds are constructed muted AND each accepted
+ *    audio operation (post-validation, post-engine-call) emits a
+ *    semantic {@link AudioCueLogEntry} to the optional
+ *    {@link AudioServiceOptions.onCue} sink. The PUL-F026 / ADR-004
+ *    rehearsal-mode contract: "audio is silenced OR logged as cues
+ *    without altering timeline state." With no sink wired the policy
+ *    is effectively silent (the workbench has not yet attached a cue
+ *    UI / log surface).
+ *
+ * Future variations (silent rehearsal as a distinct mode, export
+ * silence, ducking, bus volume, an audio-status UI) extend this same
+ * union rather than adding scattered branches across the runtime.
+ */
+export type AudioOutputPolicy = (typeof AUDIO_OUTPUT_POLICIES)[number];
+
+/**
+ * Common fields shared by every {@link AudioCueLogEntry} variant.
+ * Factored out so a consumer that does not narrow by `operation` can
+ * still read `sequence` and `operation` without branching.
+ */
+interface AudioCueLogBase {
+  /**
+   * Per-service monotonic sequence number. Starts at `1` for the
+   * first emitted cue and increments by one per emitted cue. A
+   * service that emits no cues never assigns a sequence.
+   */
+  readonly sequence: number;
+}
+
+/** A `play` cue (PUL-F026 / ADR-004). `soundId` is always present. */
+export interface AudioCueLogPlay extends AudioCueLogBase {
+  readonly operation: 'play';
+  readonly soundId: string;
+  readonly sprite?: string;
+  readonly group?: string;
+  readonly volume?: number;
+  readonly loop?: boolean;
+}
+
+/** A `fade` cue (PUL-F026 / ADR-004). `soundId` and `fade` are always present. */
+export interface AudioCueLogFade extends AudioCueLogBase {
+  readonly operation: 'fade';
+  readonly soundId: string;
+  readonly fade: { readonly from: number; readonly to: number; readonly durationMs: number };
+}
+
+/** A `stop` cue (PUL-F026 / ADR-004). `soundId` is always present. */
+export interface AudioCueLogStop extends AudioCueLogBase {
+  readonly operation: 'stop';
+  readonly soundId: string;
+}
+
+/** A `stop-group` cue (PUL-F026 / ADR-004). `group` is present; `soundId` is forbidden (the call targets a group, not a sound). */
+export interface AudioCueLogStopGroup extends AudioCueLogBase {
+  readonly operation: 'stop-group';
+  readonly group: string;
+}
+
+/**
+ * One entry in the rehearsal cue log (PUL-F026 / ADR-004). Emitted by
+ * `outputPolicy: 'log-cues'` after the audio service has accepted an
+ * operation (sound id / sprite / group / range validation all passed
+ * and the engine call has returned). The entry is **semantic only**:
+ * sound ids, sprite names, group names, numeric envelope parameters,
+ * a `sequence` monotonic across the service's lifetime, and the
+ * `operation` name. It does NOT carry source URLs, Howler handles,
+ * absolute paths, request headers, scene objects, or asset payload
+ * — the preflight (`docs/design/pul-f026-rehearsal-mode-preflight.md`)
+ * names this explicitly: "log semantic ids only."
+ *
+ * `load` and `mute` are NOT cues: registration is bookkeeping and
+ * master mute is engine-level persistent state. Operations that fail
+ * the boundary validation do NOT emit (the cue log represents
+ * accepted operations, not rejected ones). Operations made after the
+ * service is disposed do NOT emit (the cue log stops when the
+ * navigation ends, parallel to `stopAll()`).
+ *
+ * Modeled as a discriminated union over `operation` so a consumer can
+ * narrow with `if (entry.operation === 'fade') ...` and have the
+ * compiler guarantee `entry.fade` is defined. Impossible shapes
+ * (`{ operation: 'play' }` without `soundId`,
+ * `{ operation: 'stop-group', soundId: 'bed' }`, etc.) are rejected
+ * at the type level rather than left to runtime invariant.
+ *
+ * Entries are returned deep-frozen so a consumer cannot mutate the
+ * log (or any nested payload such as `fade`) in place.
+ */
+export type AudioCueLogEntry =
+  | AudioCueLogPlay
+  | AudioCueLogFade
+  | AudioCueLogStop
+  | AudioCueLogStopGroup;
+
 /** Construction options for {@link createAudioService}. */
 export interface AudioServiceOptions {
   /**
@@ -294,8 +414,24 @@ export interface AudioServiceOptions {
    * An already-aborted signal disposes the service immediately.
    */
   readonly signal: AbortSignal;
-  /** Construct every sound muted (screenshot / paused modes — audible playback is suppressed). */
-  readonly silent?: boolean;
+  /**
+   * Per-navigation audio output policy (PUL-F024 / PUL-F026 / ADR-004).
+   * Defaults to `'audible'`. `'silent'` mutes at engine construction
+   * time (screenshot / paused). `'log-cues'` mutes AND emits a
+   * semantic {@link AudioCueLogEntry} to {@link onCue} for every
+   * accepted audio operation (rehearsal).
+   */
+  readonly outputPolicy?: AudioOutputPolicy;
+  /**
+   * Cue-log sink for {@link AudioOutputPolicy} `'log-cues'`. Receives
+   * a frozen {@link AudioCueLogEntry} per accepted audio operation
+   * (post-validation, post-engine-call). Non-fatal: a throwing sink is
+   * swallowed so a workbench-side log surface bug does not break
+   * scene playback. Inert under any policy other than `'log-cues'`
+   * even when supplied — the policy decides whether cues are emitted,
+   * not the presence of the sink. Inert post-dispose.
+   */
+  readonly onCue?: (entry: AudioCueLogEntry) => void;
   /**
    * The source URLs scenes may register. Every {@link SoundDefinition.src}
    * URL must be in this set (ADR-008 #5 — audio is declared in
@@ -495,17 +631,130 @@ const assertSpriteMap = (soundId: string, sprite: unknown): void => {
 };
 
 /** Build the per-navigation {@link AudioService} over `engine`. */
+/**
+ * Render an unknown value for the boundary-validation error message.
+ * `JSON.stringify` throws on BigInt and silently drops Symbols, so a
+ * plain-JS misuse that passes `1n` would surface as a `TypeError`
+ * instead of {@link AudioError} (codex review, cycle 2). This helper
+ * falls back to a `typeof` + `String()` rendering for values
+ * `JSON.stringify` cannot encode, so every primitive / object value
+ * produces a readable, safe diagnostic.
+ */
+function describeRawOption(value: unknown): string {
+  try {
+    const json = JSON.stringify(value);
+    if (json !== undefined) return json;
+  } catch {
+    // Fall through to the typeof path for BigInt / cyclic / etc.
+  }
+  return `${typeof value}(${String(value)})`;
+}
+
 export function createAudioService(
   engine: AudioEngine,
   options: AudioServiceOptions,
 ): AudioService {
-  const silent = options.silent === true;
+  // Reject the legacy `silent: boolean` key loudly (codex review,
+  // cycle 3). The previous public option was `silent?: boolean`; the
+  // new public option is the more general `outputPolicy`. A
+  // plain-JS / downstream caller that still passes `{ silent: true }`
+  // would have the key silently ignored and produce audible playback
+  // — the worst possible migration failure for an audio-suppression
+  // option. Fail loud at the boundary instead.
+  if ('silent' in options) {
+    throw new AudioError(
+      "audio 'silent' option was replaced by outputPolicy in PUL-F026 / ADR-004 — pass outputPolicy: 'silent' / 'log-cues' / 'audible' instead",
+    );
+  }
+  // Runtime boundary (codex review, cycles 1 + 2): a plain-JS caller
+  // (or a direct caller that casts past the literal-typed union) could
+  // pass a misspelled policy like `'log-cue'`, or pass `null`/`true`/
+  // `1n` / a Symbol / etc., and silently get a muted, no-cues service
+  // instead of `'audible'`. Validate at construction so the misuse
+  // fails loud rather than producing dead-air playback. `undefined` →
+  // default `'audible'`; every other value goes through the allowlist
+  // check (so `null`, `true`, an empty string, and misspelled
+  // policies all fail loud rather than coalescing to the default via
+  // `??`). The allowlist is the same frozen tuple
+  // {@link AUDIO_OUTPUT_POLICIES} the type derives from, so the type
+  // and the runtime check cannot drift.
+  const rawPolicy = options.outputPolicy === undefined ? 'audible' : options.outputPolicy;
+  if (!(AUDIO_OUTPUT_POLICIES as readonly unknown[]).includes(rawPolicy)) {
+    throw new AudioError(
+      `audio outputPolicy must be one of ${AUDIO_OUTPUT_POLICIES.map((p) => `'${p}'`).join(' / ')}; got ${describeRawOption(rawPolicy)}`,
+    );
+  }
+  const outputPolicy: AudioOutputPolicy = rawPolicy;
+  // Same boundary discipline (codex review, cycle 2): `onCue` is a
+  // workbench-supplied function (kept across navigations in
+  // `SceneLoaderOptions.onAudioCue`), so a JS caller / a test
+  // harness / a misconfigured bootstrap could pass a non-function
+  // (`true`, `{}`, a number). Validating at construction surfaces
+  // the misuse via the loader's existing rollback-then-surfaceError
+  // path instead of silently swallowing a `TypeError` inside the
+  // non-fatal `emitCue` try/catch — which would leave rehearsal with
+  // an empty cue stream and no diagnostic.
+  if (options.onCue !== undefined && typeof options.onCue !== 'function') {
+    throw new AudioError(
+      `audio onCue must be a function or omitted; got ${describeRawOption(options.onCue)}`,
+    );
+  }
+  // Engine sounds are constructed muted under both 'silent' and
+  // 'log-cues' — they share the no-audible-output structural defense.
+  // 'log-cues' adds an extra logging layer on top.
+  const muted = outputPolicy !== 'audible';
   const onError = options.onError ?? ((): void => undefined);
+  const onCue = options.onCue;
   const allowed = options.allowedSources === undefined ? null : new Set(options.allowedSources);
 
   const sounds = new Map<string, RegisteredSound>();
   const groups = new Map<string, GroupedPlay[]>();
   let disposed = false;
+  // Per-service monotonic sequence for `AudioCueLogEntry.sequence`.
+  // Only incremented when a cue is actually emitted (policy is
+  // `log-cues` AND a sink is wired), so non-log-cues services pay
+  // zero cost.
+  let cueSequence = 0;
+
+  /**
+   * Emit a cue log entry to the optional `onCue` sink (PUL-F026 /
+   * ADR-004). Inert when:
+   *  - the policy is not `'log-cues'`, OR
+   *  - no sink was supplied, OR
+   *  - the service has been disposed (the cue logger stops with the
+   *    navigation, parallel to `stopAll()`).
+   *
+   * A throwing sink is swallowed: the diagnostic surface must not
+   * propagate exceptions back through `play` / `fade` / `stop` /
+   * `stopGroup` and break scene playback.
+   */
+  // Per-variant `Omit<…, 'sequence'>` so emitting code can hand in
+  // each operation's exact shape and TypeScript narrows correctly.
+  // `Omit<AudioCueLogEntry, 'sequence'>` on the union would collapse
+  // the variant-specific required fields (`group` on `stop-group`,
+  // `fade` on `fade`) into optional ones, defeating the
+  // discriminated-union guarantee.
+  type CueInput =
+    | Omit<AudioCueLogPlay, 'sequence'>
+    | Omit<AudioCueLogFade, 'sequence'>
+    | Omit<AudioCueLogStop, 'sequence'>
+    | Omit<AudioCueLogStopGroup, 'sequence'>;
+  const emitCue = (entry: CueInput): void => {
+    if (outputPolicy !== 'log-cues' || onCue === undefined || disposed) return;
+    cueSequence += 1;
+    // Deep-freeze (codex review, cycle 1): the contract says the cue
+    // log is read-only. `Object.freeze` alone would leave nested
+    // payloads (e.g. `fade: { from, to, durationMs }`) writable, so a
+    // consumer could mutate `cue.fade.to` after receiving the entry.
+    // `deepFreeze` walks every plain object/array reachable from the
+    // entry.
+    const frozen = deepFreeze({ sequence: cueSequence, ...entry } as AudioCueLogEntry);
+    try {
+      onCue(frozen);
+    } catch {
+      // Intentionally empty: the cue-log sink is non-fatal.
+    }
+  };
 
   const assertSoundId = (soundId: string): void => {
     if (!isKebabIdentifier(soundId)) {
@@ -639,7 +888,7 @@ export function createAudioService(
       const handle = engine.createSound({
         src,
         ...(definition.sprite === undefined ? {} : { sprite: definition.sprite }),
-        muted: silent,
+        muted,
         onError: (err) => {
           // Howler's async load failures can arrive after the navigation
           // ended (abort / supersession / completion). A disposed
@@ -677,6 +926,19 @@ export function createAudioService(
         if (list === undefined) groups.set(opts.group, [{ handle: sound.handle, playId }]);
         else list.push({ handle: sound.handle, playId });
       }
+      // Rehearsal cue log (PUL-F026): emitted only when `outputPolicy
+      // === 'log-cues'` AND `onCue` is set (the `emitCue` helper
+      // short-circuits otherwise so non-log-cues services pay no
+      // per-op cost). Captures every play option the scene supplied,
+      // with NO source URL.
+      emitCue({
+        operation: 'play',
+        soundId,
+        ...(opts.sprite === undefined ? {} : { sprite: opts.sprite }),
+        ...(opts.group === undefined ? {} : { group: opts.group }),
+        ...(opts.volume === undefined ? {} : { volume: opts.volume }),
+        ...(opts.loop === undefined ? {} : { loop: opts.loop }),
+      });
     },
 
     fade(soundId, from, to, durationMs) {
@@ -690,32 +952,47 @@ export function createAudioService(
         );
       }
       sound.handle.fade(from, to, durationMs);
+      emitCue({
+        operation: 'fade',
+        soundId,
+        fade: { from, to, durationMs },
+      });
     },
 
     stop(soundId) {
       if (disposed) return;
       const sound = requireSound(soundId);
       sound.handle.stop();
+      emitCue({ operation: 'stop', soundId });
     },
 
     stopGroup(group) {
       if (disposed) return;
       assertGroupName(group);
       const list = groups.get(group);
-      if (list === undefined) return;
-      // Per-play error isolation (codex review, cycle 3): a throwing
-      // engine `stop()` must not prevent later plays in the group from
-      // being stopped. Failures route through the non-fatal `onError`
-      // sink — the cleanup contract is "every play in the group is
-      // attempted to be stopped," not "all-or-nothing."
-      for (const play of list) {
-        try {
-          play.handle.stop(play.playId);
-        } catch (err) {
-          reportCleanupError('stopGroup', group, err);
+      if (list !== undefined) {
+        // Per-play error isolation (codex review, cycle 3): a throwing
+        // engine `stop()` must not prevent later plays in the group from
+        // being stopped. Failures route through the non-fatal `onError`
+        // sink — the cleanup contract is "every play in the group is
+        // attempted to be stopped," not "all-or-nothing."
+        for (const play of list) {
+          try {
+            play.handle.stop(play.playId);
+          } catch (err) {
+            reportCleanupError('stopGroup', group, err);
+          }
         }
+        groups.delete(group);
       }
-      groups.delete(group);
+      // PUL-F026 (codex review, cycle 1): emit AFTER the engine
+      // stop loop and the bookkeeping delete (parity with `play` /
+      // `fade` / `stop`, which all emit after the engine call
+      // returns). An accepted stop-group of an empty group is still
+      // recorded as an audio operation the scene requested — same
+      // semantics `stop` of a never-played sound has — but the cue
+      // is published only after the state transition it represents.
+      emitCue({ operation: 'stop-group', group });
     },
 
     mute(muted) {

--- a/src/runtime/audio.ts
+++ b/src/runtime/audio.ts
@@ -678,13 +678,22 @@ export function createAudioService(
   // `??`). The allowlist is the same frozen tuple
   // {@link AUDIO_OUTPUT_POLICIES} the type derives from, so the type
   // and the runtime check cannot drift.
-  const rawPolicy = options.outputPolicy === undefined ? 'audible' : options.outputPolicy;
-  if (!(AUDIO_OUTPUT_POLICIES as readonly unknown[]).includes(rawPolicy)) {
+  // Validate the supplied value (if any) against the allowlist FIRST,
+  // then default `undefined` to `'audible'`. Doing the default with
+  // `??` BEFORE validation would coalesce `null` to `'audible'` and
+  // skip the boundary check; explicit `=== undefined` keeps the two
+  // concerns ordered correctly.
+  const policyArg: unknown = options.outputPolicy;
+  if (
+    policyArg !== undefined &&
+    !(AUDIO_OUTPUT_POLICIES as readonly unknown[]).includes(policyArg)
+  ) {
+    const quotedPolicies = AUDIO_OUTPUT_POLICIES.map((p) => `'${p}'`).join(' / ');
     throw new AudioError(
-      `audio outputPolicy must be one of ${AUDIO_OUTPUT_POLICIES.map((p) => `'${p}'`).join(' / ')}; got ${describeRawOption(rawPolicy)}`,
+      `audio outputPolicy must be one of ${quotedPolicies}; got ${describeRawOption(policyArg)}`,
     );
   }
-  const outputPolicy: AudioOutputPolicy = rawPolicy;
+  const outputPolicy: AudioOutputPolicy = (policyArg ?? 'audible') as AudioOutputPolicy;
   // Same boundary discipline (codex review, cycle 2): `onCue` is a
   // workbench-supplied function (kept across navigations in
   // `SceneLoaderOptions.onAudioCue`), so a JS caller / a test
@@ -748,7 +757,7 @@ export function createAudioService(
     // consumer could mutate `cue.fade.to` after receiving the entry.
     // `deepFreeze` walks every plain object/array reachable from the
     // entry.
-    const frozen = deepFreeze({ sequence: cueSequence, ...entry } as AudioCueLogEntry);
+    const frozen = deepFreeze({ sequence: cueSequence, ...entry });
     try {
       onCue(frozen);
     } catch {

--- a/src/runtime/navigation.ts
+++ b/src/runtime/navigation.ts
@@ -40,9 +40,14 @@
 import { KEBAB_IDENTIFIER_FORM, isKebabIdentifier } from './identifier';
 
 /**
- * Workbench mode set per ADR-007. The seven modes are the only values
+ * Workbench mode set per ADR-007. The eight modes are the only values
  * accepted for `mode=` URL parameters. Frozen so consumers cannot
  * mutate the public allowlist in place.
+ *
+ * `rehearsal` (PUL-F026 / ADR-004) is the only mode whose contract
+ * lives entirely on the per-navigation audio service rather than at
+ * a head-only timeline-runner seam — see `audio.ts` `outputPolicy`
+ * and `scene-loader.ts` `buildLoad`.
  */
 export const NAVIGATION_MODES = Object.freeze([
   'present',
@@ -52,10 +57,11 @@ export const NAVIGATION_MODES = Object.freeze([
   'scrub',
   'screenshot',
   'prompter',
+  'rehearsal',
 ] as const);
 
 /**
- * One of the seven {@link NAVIGATION_MODES} values.
+ * One of the eight {@link NAVIGATION_MODES} values.
  */
 export type NavigationMode = (typeof NAVIGATION_MODES)[number];
 

--- a/src/runtime/scene-loader.ts
+++ b/src/runtime/scene-loader.ts
@@ -29,7 +29,14 @@
 //  - ADR-007 — runtime parses URL parameters at startup AND popstate.
 //  - ADR-013 — URL navigation grammar boundary; F007 owns parsing.
 
-import { type AudioEngine, type AudioService, createAudioService, noopAudioEngine } from './audio';
+import {
+  type AudioCueLogEntry,
+  type AudioEngine,
+  type AudioOutputPolicy,
+  type AudioService,
+  createAudioService,
+  noopAudioEngine,
+} from './audio';
 import type { CompositionRegistry } from './composition-registry';
 import type { AssetPreloader, CompositionTimelineAdapter } from './composition-resolver';
 import { describeError } from './error';
@@ -185,6 +192,20 @@ export interface SceneLoaderOptions {
    * follow.
    */
   readonly audioEngine?: AudioEngine;
+  /**
+   * Workbench-supplied cue-log sink (PUL-F026 / ADR-004). When set,
+   * the loader threads it through to every per-navigation
+   * {@link AudioService} as `onCue`. The per-navigation
+   * {@link AudioOutputPolicy} decides whether cues are emitted — the
+   * loader supplies `'log-cues'` under `mode=rehearsal` and `'silent'`
+   * under `mode=screenshot` / `mode=paused`, so a workbench that
+   * always wires a cue-log surface only sees entries during
+   * rehearsal navigations. Optional: a workbench that has not wired
+   * a cue UI yet omits the field and rehearsal navigations are
+   * effectively silent — the audio is still muted at the engine
+   * level (PUL-F026: "audio is silenced OR logged as cues").
+   */
+  readonly onAudioCue?: (entry: AudioCueLogEntry) => void;
   /**
    * Build a per-navigation asset preloader bound to that
    * navigation's abort signal. The loader calls this once per
@@ -641,24 +662,49 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
       surfaceError(err);
       return null;
     }
-    // PUL-F024 / ADR-004: the per-navigation audio service. Built over
-    // `audioEngine`, scoped to `controller.signal` (abort ⇒ every sound
-    // stopped + unloaded), restricted to the URLs the slice declared in
-    // `scene.assets` (ADR-008 #5 — the preloader warmed them), and
-    // `silent` under screenshot / paused. Threaded into `ctx.audio` via
-    // `buildCtx`, alongside `mode` (PUL-F012). Built AFTER the preloader
-    // so a preloader-factory failure does not waste allocations, and
-    // wrapped in the same rollback-then-surfaceError pattern so a
-    // throwing builder does not leave stale stage attrs or skip the
-    // queue's error sink.
+    // PUL-F024 / PUL-F026 / ADR-004: the per-navigation audio service.
+    // Built over `audioEngine`, scoped to `controller.signal` (abort ⇒
+    // every sound stopped + unloaded), restricted to the URLs the slice
+    // declared in `scene.assets` (ADR-008 #5 — the preloader warmed
+    // them), and with a per-mode `AudioOutputPolicy`:
+    //  - `'silent'`   under `mode=screenshot` / `mode=paused` (audible
+    //                 playback suppressed — ADR-019 / ADR-021).
+    //  - `'log-cues'` under `mode=rehearsal` (audible playback
+    //                 suppressed AND every accepted audio operation
+    //                 is emitted to the workbench's optional
+    //                 `onAudioCue` sink — PUL-F026 / ADR-004).
+    //  - `'audible'`  otherwise (`present` / `standalone` / `loop` /
+    //                 `scrub`).
+    //
+    // The rehearsal policy lives entirely on this audio-service seam
+    // — there is no head-only runner-input hint, no slice truncation,
+    // no resolver semantics — so "without altering timeline state"
+    // (PUL-F026) is the structural invariant. The optional
+    // `onAudioCue` sink is threaded through unconditionally; the
+    // policy decides whether cues are emitted, so a non-rehearsal
+    // navigation pays no per-op cost even when the workbench wired a
+    // cue surface.
+    //
+    // Threaded into `ctx.audio` via `buildCtx`, alongside `mode`
+    // (PUL-F012). Built AFTER the preloader so a preloader-factory
+    // failure does not waste allocations, and wrapped in the same
+    // rollback-then-surfaceError pattern so a throwing builder does
+    // not leave stale stage attrs or skip the queue's error sink.
+    const outputPolicy: AudioOutputPolicy =
+      mode === 'rehearsal'
+        ? 'log-cues'
+        : mode === 'screenshot' || mode === 'paused'
+          ? 'silent'
+          : 'audible';
     let ctx: unknown;
     let audio: AudioService;
     try {
       audio = createAudioService(audioEngine, {
         signal: controller.signal,
-        silent: mode === 'screenshot' || mode === 'paused',
+        outputPolicy,
         allowedSources: collectAudioSources(resolved),
         onError,
+        ...(options.onAudioCue === undefined ? {} : { onCue: options.onAudioCue }),
       });
       ctx = options.buildCtx(mode, audio);
     } catch (err) {

--- a/src/runtime/scene-loader.ts
+++ b/src/runtime/scene-loader.ts
@@ -354,6 +354,24 @@ function collectAudioSources(target: SceneNavigationTarget): readonly string[] {
 }
 
 /**
+ * Map the effective workbench mode to the per-navigation
+ * {@link AudioOutputPolicy} (PUL-F024 / PUL-F026 / ADR-004):
+ *
+ *  - `'rehearsal'`                       → `'log-cues'`
+ *  - `'screenshot'` / `'paused'`         → `'silent'`
+ *  - every other lifecycle-running mode  → `'audible'`
+ *
+ * Pure function (no closure captures), hoisted to module scope so the
+ * loader's `buildLoad` stays within Sonar's cognitive-complexity
+ * budget and the mode→policy table lives in one place.
+ */
+function audioOutputPolicyFor(mode: NavigationMode): AudioOutputPolicy {
+  if (mode === 'rehearsal') return 'log-cues';
+  if (mode === 'screenshot' || mode === 'paused') return 'silent';
+  return 'audible';
+}
+
+/**
  * One in-flight load: the abort signal that cancels it, the promise
  * that settles when the lifecycle ends (or rejects on abort), the
  * abort-detection flag used to suppress the "rejection is an error"
@@ -690,12 +708,7 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
     // failure does not waste allocations, and wrapped in the same
     // rollback-then-surfaceError pattern so a throwing builder does
     // not leave stale stage attrs or skip the queue's error sink.
-    const outputPolicy: AudioOutputPolicy =
-      mode === 'rehearsal'
-        ? 'log-cues'
-        : mode === 'screenshot' || mode === 'paused'
-          ? 'silent'
-          : 'audible';
+    const outputPolicy = audioOutputPolicyFor(mode);
     let ctx: unknown;
     let audio: AudioService;
     try {

--- a/tests/runtime/audio.test.ts
+++ b/tests/runtime/audio.test.ts
@@ -19,6 +19,8 @@
 
 import { describe, expect, it } from 'vitest';
 import {
+  type AudioCueLogEntry,
+  type AudioCueLogStopGroup,
   type AudioEngine,
   AudioError,
   AudioGroupError,
@@ -270,8 +272,20 @@ describe('createAudioService — load (C2 register a sound)', () => {
     });
   });
 
-  it('builds every sound muted when the service is silent', () => {
-    const { fake, service } = buildService({ silent: true });
+  it('builds every sound audible by default (outputPolicy: audible)', () => {
+    const { fake, service } = buildService();
+    service.load('bed', { src: '/audio/bed.mp3' });
+    expect(fake.created[0]?.muted).toBe(false);
+  });
+
+  it('builds every sound muted when outputPolicy is silent', () => {
+    const { fake, service } = buildService({ outputPolicy: 'silent' });
+    service.load('bed', { src: '/audio/bed.mp3' });
+    expect(fake.created[0]?.muted).toBe(true);
+  });
+
+  it('builds every sound muted when outputPolicy is log-cues (rehearsal)', () => {
+    const { fake, service } = buildService({ outputPolicy: 'log-cues' });
     service.load('bed', { src: '/audio/bed.mp3' });
     expect(fake.created[0]?.muted).toBe(true);
   });
@@ -691,5 +705,396 @@ describe('noopAudioEngine', () => {
     expect(service.isMuted()).toBe(true);
     service.mute(false);
     expect(service.isMuted()).toBe(false);
+  });
+});
+
+/* -------------------------------------------------------------------- *
+ *  Output policy `log-cues` — PUL-F026 / ADR-004 rehearsal mode
+ *
+ *  The cue log is the runtime-visible half of "audio is silenced or
+ *  logged as cues" (PUL-F026). Engine sounds are still constructed
+ *  muted (the `silent` parity check lives above), and every ACCEPTED
+ *  audio operation (post-validation, post-engine-call) emits a
+ *  semantic `AudioCueLogEntry` to `onCue`. Entries carry sound id,
+ *  sprite, group, volume, loop, fade endpoints, operation, and a
+ *  monotonic sequence — NO source URLs, Howler handles, raw scene
+ *  objects, or asset paths (preflight: "log semantic ids only").
+ *  `load` and `mute` are NOT cues; validation throws never emit;
+ *  post-dispose calls never emit; a throwing sink is swallowed.
+ * -------------------------------------------------------------------- */
+
+describe('createAudioService — outputPolicy log-cues (PUL-F026 / ADR-004)', () => {
+  const buildLogCues = (
+    options: Partial<Parameters<typeof createAudioService>[1]> = {},
+  ): {
+    fake: FakeEngine;
+    controller: AbortController;
+    service: ReturnType<typeof createAudioService>;
+    cues: AudioCueLogEntry[];
+  } => {
+    const cues: AudioCueLogEntry[] = [];
+    const fake = fakeEngine();
+    const controller = new AbortController();
+    const service = createAudioService(fake.engine, {
+      signal: controller.signal,
+      outputPolicy: 'log-cues',
+      onCue: (entry) => cues.push(entry),
+      ...options,
+    });
+    return { fake, controller, service, cues };
+  };
+
+  it('emits a cue entry for an accepted play (sound id, monotonic sequence)', () => {
+    const { service, cues } = buildLogCues();
+    service.load('bed', { src: '/audio/bed.mp3' });
+    service.play('bed');
+    expect(cues).toHaveLength(1);
+    const cue = cues[0];
+    expect(cue?.operation).toBe('play');
+    if (cue?.operation === 'play') {
+      expect(cue.soundId).toBe('bed');
+      expect(cue.sequence).toBe(1);
+    }
+  });
+
+  it('captures sprite, group, volume, and loop on the play cue', () => {
+    const { service, cues } = buildLogCues();
+    service.load('fx', { src: '/audio/fx.webm', sprite: { laugh: [0, 1000] } });
+    service.play('fx', { sprite: 'laugh', group: 'scene-a', volume: 0.5, loop: true });
+    expect(cues).toEqual([
+      {
+        sequence: 1,
+        operation: 'play',
+        soundId: 'fx',
+        sprite: 'laugh',
+        group: 'scene-a',
+        volume: 0.5,
+        loop: true,
+      },
+    ]);
+  });
+
+  it('omits optional fields from the play cue when not supplied', () => {
+    const { service, cues } = buildLogCues();
+    service.load('bed', { src: '/audio/bed.mp3' });
+    service.play('bed');
+    const cue = cues[0];
+    expect(cue?.operation).toBe('play');
+    if (cue?.operation !== 'play') return;
+    expect(cue.sprite).toBeUndefined();
+    expect(cue.group).toBeUndefined();
+    expect(cue.volume).toBeUndefined();
+    expect(cue.loop).toBeUndefined();
+  });
+
+  it('emits a fade cue with from / to / durationMs', () => {
+    const { service, cues } = buildLogCues();
+    service.load('bed', { src: '/audio/bed.mp3' });
+    service.fade('bed', 0.8, 0.15, 1200);
+    expect(cues).toEqual([
+      {
+        sequence: 1,
+        operation: 'fade',
+        soundId: 'bed',
+        fade: { from: 0.8, to: 0.15, durationMs: 1200 },
+      },
+    ]);
+  });
+
+  it('emits a stop cue with sound id', () => {
+    const { service, cues } = buildLogCues();
+    service.load('bed', { src: '/audio/bed.mp3' });
+    service.play('bed');
+    service.stop('bed');
+    const stops = cues.filter((c) => c.operation === 'stop');
+    expect(stops).toEqual([{ sequence: 2, operation: 'stop', soundId: 'bed' }]);
+  });
+
+  it('emits a stop-group cue with group only (no sound id)', () => {
+    const { service, cues } = buildLogCues();
+    service.load('bed', { src: '/audio/bed.mp3' });
+    service.play('bed', { group: 'scene-a' });
+    service.stopGroup('scene-a');
+    const groupStops = cues.filter((c): c is AudioCueLogStopGroup => c.operation === 'stop-group');
+    expect(groupStops).toEqual([{ sequence: 2, operation: 'stop-group', group: 'scene-a' }]);
+    // The discriminated-union type already guarantees `soundId` is
+    // absent on `stop-group` cues — assert at runtime too.
+    const entry = groupStops[0];
+    expect(entry).toBeDefined();
+    expect(entry !== undefined && 'soundId' in entry).toBe(false);
+  });
+
+  it('emits a stop-group cue even when the group has no plays (audible call vs effect)', () => {
+    const { service, cues } = buildLogCues();
+    service.stopGroup('scene-a');
+    expect(cues).toEqual([{ sequence: 1, operation: 'stop-group', group: 'scene-a' }]);
+  });
+
+  it('does NOT emit cues for load (registration is not a cue)', () => {
+    const { service, cues } = buildLogCues();
+    service.load('bed', { src: '/audio/bed.mp3', sprite: { hit: [0, 100] } });
+    service.load('whoosh', { src: ['/audio/whoosh.webm', '/audio/whoosh.mp3'] });
+    expect(cues).toEqual([]);
+  });
+
+  it('does NOT emit cues for master mute (engine state, not a cue)', () => {
+    const { service, cues } = buildLogCues();
+    service.mute(true);
+    service.mute(false);
+    expect(cues).toEqual([]);
+  });
+
+  it('does NOT emit a cue when validation rejects an operation', () => {
+    const { service, cues } = buildLogCues();
+    service.load('bed', { src: '/audio/bed.mp3' });
+    expect(() => service.play('ghost')).toThrow(AudioSoundError);
+    expect(() => service.play('bed', { volume: 5 })).toThrow(AudioRangeError);
+    expect(() => service.fade('bed', -0.1, 1, 100)).toThrow(AudioRangeError);
+    expect(() => service.stop('ghost')).toThrow(AudioSoundError);
+    expect(() => service.stopGroup('Bad Group')).toThrow(AudioGroupError);
+    expect(cues).toEqual([]);
+  });
+
+  it('sequence is monotonic across operations', () => {
+    const { service, cues } = buildLogCues();
+    service.load('bed', { src: '/audio/bed.mp3' });
+    service.play('bed', { group: 'scene-a' });
+    service.fade('bed', 1, 0, 100);
+    service.stop('bed');
+    service.stopGroup('scene-a');
+    expect(cues.map((c) => c.sequence)).toEqual([1, 2, 3, 4]);
+  });
+
+  it('never includes source URLs in cue entries', () => {
+    const { service, cues } = buildLogCues();
+    service.load('bed', { src: '/audio/super-secret-asset.mp3' });
+    service.play('bed', { group: 'scene-a' });
+    service.fade('bed', 1, 0, 100);
+    service.stop('bed');
+    service.stopGroup('scene-a');
+    const blob = JSON.stringify(cues);
+    expect(blob).not.toContain('super-secret-asset.mp3');
+    expect(blob).not.toContain('/audio/');
+    expect(blob).not.toContain('mp3');
+  });
+
+  it('does NOT emit cues after the service is disposed', () => {
+    const { service, controller, cues } = buildLogCues();
+    service.load('bed', { src: '/audio/bed.mp3' });
+    service.play('bed');
+    cues.length = 0;
+    controller.abort();
+    service.play('bed');
+    service.fade('bed', 1, 0, 100);
+    service.stop('bed');
+    service.stopGroup('scene-a');
+    expect(cues).toEqual([]);
+  });
+
+  it('does not let a throwing onCue sink escape through play / fade / stop / stopGroup', () => {
+    const fake = fakeEngine();
+    const service = createAudioService(fake.engine, {
+      signal: liveSignal(),
+      outputPolicy: 'log-cues',
+      onCue: () => {
+        throw new Error('cue sink blew up');
+      },
+    });
+    service.load('bed', { src: '/audio/bed.mp3' });
+    expect(() => service.play('bed', { group: 'g' })).not.toThrow();
+    expect(() => service.fade('bed', 1, 0, 100)).not.toThrow();
+    expect(() => service.stop('bed')).not.toThrow();
+    expect(() => service.stopGroup('g')).not.toThrow();
+  });
+
+  it('emits cues only under outputPolicy log-cues (not silent, not audible)', () => {
+    for (const policy of ['audible', 'silent'] as const) {
+      const cues: AudioCueLogEntry[] = [];
+      const fake = fakeEngine();
+      const service = createAudioService(fake.engine, {
+        signal: liveSignal(),
+        outputPolicy: policy,
+        onCue: (e) => cues.push(e),
+      });
+      service.load('bed', { src: '/audio/bed.mp3' });
+      service.play('bed');
+      service.fade('bed', 1, 0, 100);
+      service.stop('bed');
+      expect(cues).toEqual([]);
+    }
+  });
+
+  it('log-cues without an onCue sink still mutes audio (silent rehearsal)', () => {
+    const fake = fakeEngine();
+    const service = createAudioService(fake.engine, {
+      signal: liveSignal(),
+      outputPolicy: 'log-cues',
+      // onCue intentionally omitted — workbench has not wired a cue UI
+    });
+    service.load('bed', { src: '/audio/bed.mp3' });
+    expect(fake.created[0]?.muted).toBe(true);
+    expect(() => service.play('bed')).not.toThrow();
+  });
+
+  it('cue entries are frozen so consumers cannot mutate them in place', () => {
+    const { service, cues } = buildLogCues();
+    service.load('bed', { src: '/audio/bed.mp3' });
+    service.play('bed');
+    expect(Object.isFrozen(cues[0])).toBe(true);
+  });
+
+  it('fade cues are deep-frozen — nested fade payload is also immutable', () => {
+    const { service, cues } = buildLogCues();
+    service.load('bed', { src: '/audio/bed.mp3' });
+    service.fade('bed', 1, 0, 100);
+    const cue = cues[0];
+    expect(cue?.operation).toBe('fade');
+    if (cue?.operation !== 'fade') return;
+    expect(Object.isFrozen(cue.fade)).toBe(true);
+  });
+
+  it('emits the stop-group cue AFTER the engine stop loop and bookkeeping delete', () => {
+    // Contract parity with `play` / `fade` / `stop`: a cue is published
+    // only after the state transition it represents. A consumer must
+    // not observe a stop-group cue before its grouped handles have
+    // been stopped.
+    const fake = fakeEngine();
+    const cues: AudioCueLogEntry[] = [];
+    let stoppedPlays = 0;
+    const original = fake.engine.createSound;
+    fake.engine.createSound = ((config) => {
+      const handle = original.call(fake.engine, config);
+      return {
+        ...handle,
+        stop: (playId) => {
+          stoppedPlays += 1;
+          handle.stop(playId);
+        },
+      };
+    }) as typeof fake.engine.createSound;
+    const service = createAudioService(fake.engine, {
+      signal: liveSignal(),
+      outputPolicy: 'log-cues',
+      onCue: (entry) => {
+        if (entry.operation === 'stop-group') {
+          // Observed at cue-emit time: every play in the group has
+          // already been stopped (the engine `stop()` calls ran
+          // before the cue published).
+          expect(stoppedPlays).toBe(2);
+        }
+        cues.push(entry);
+      },
+    });
+    service.load('bed', { src: '/audio/bed.mp3' });
+    service.play('bed', { group: 'scene-a' });
+    service.play('bed', { group: 'scene-a' });
+    service.stopGroup('scene-a');
+    expect(cues.map((c) => c.operation)).toEqual(['play', 'play', 'stop-group']);
+  });
+});
+
+describe('createAudioService — legacy silent option rejection (codex review, cycle 3)', () => {
+  type Opts = Parameters<typeof createAudioService>[1];
+
+  it('rejects the legacy `silent: true` key loudly instead of failing open to audible playback', () => {
+    // The previous public option was `silent?: boolean`; PUL-F026
+    // replaces it with the general `outputPolicy` union. A JS caller
+    // that still passes `{ silent: true }` would have the key silently
+    // ignored and produce AUDIBLE playback — the worst migration
+    // failure for an audio-suppression option. The boundary throws
+    // `AudioError` instead.
+    const fake = fakeEngine();
+    const buildWithSilent =
+      (silentValue: unknown): (() => void) =>
+      () => {
+        const opts = { signal: liveSignal(), silent: silentValue } as unknown as Opts;
+        createAudioService(fake.engine, opts);
+      };
+    expect(buildWithSilent(true)).toThrow(AudioError);
+    expect(buildWithSilent(false)).toThrow(AudioError);
+    expect(buildWithSilent(undefined)).toThrow(AudioError);
+  });
+});
+
+describe('createAudioService — outputPolicy runtime validation', () => {
+  type Opts = Parameters<typeof createAudioService>[1];
+  // Cast the bad value through `unknown` and into the parameter type
+  // so the test exercises the runtime guard (a plain-JS / direct
+  // caller can supply garbage that the literal-typed union would
+  // not).
+  const buildBadPolicy =
+    (fake: FakeEngine, policy: unknown): (() => void) =>
+    () => {
+      const opts = { signal: liveSignal(), outputPolicy: policy } as unknown as Opts;
+      createAudioService(fake.engine, opts);
+    };
+
+  it('rejects an unknown outputPolicy value at construction', () => {
+    const fake = fakeEngine();
+    expect(buildBadPolicy(fake, 'log-cue')).toThrow(AudioError);
+    expect(buildBadPolicy(fake, 'SILENT')).toThrow(AudioError);
+    expect(buildBadPolicy(fake, '')).toThrow(AudioError);
+    expect(buildBadPolicy(fake, true)).toThrow(AudioError);
+    expect(buildBadPolicy(fake, null)).toThrow(AudioError);
+  });
+
+  it('does NOT throw a TypeError on values JSON.stringify cannot encode (codex review, cycle 2)', () => {
+    // A plain-JS caller passing `1n` or a Symbol used to surface as a
+    // `TypeError` from `JSON.stringify` inside the audio-error
+    // construction itself — the documented `AudioError` envelope
+    // never reached the loader's rollback path. The safe describer
+    // turns these into a typeof+String rendering so the construction
+    // throws `AudioError` instead.
+    const fake = fakeEngine();
+    expect(buildBadPolicy(fake, 1n)).toThrow(AudioError);
+    expect(buildBadPolicy(fake, 1n)).not.toThrow(TypeError);
+    expect(buildBadPolicy(fake, Symbol('x'))).toThrow(AudioError);
+    expect(buildBadPolicy(fake, Symbol('x'))).not.toThrow(TypeError);
+  });
+
+  it('accepts each of the three valid policies', () => {
+    const fake = fakeEngine();
+    for (const policy of ['audible', 'silent', 'log-cues'] as const) {
+      expect(() =>
+        createAudioService(fake.engine, { signal: liveSignal(), outputPolicy: policy }),
+      ).not.toThrow();
+    }
+  });
+});
+
+describe('createAudioService — onCue runtime validation (codex review, cycle 2)', () => {
+  type Opts = Parameters<typeof createAudioService>[1];
+  const buildBadOnCue =
+    (fake: FakeEngine, onCue: unknown): (() => void) =>
+    () => {
+      const opts = {
+        signal: liveSignal(),
+        outputPolicy: 'log-cues' as const,
+        onCue,
+      } as unknown as Opts;
+      createAudioService(fake.engine, opts);
+    };
+
+  it('rejects a non-function onCue at construction so misconfiguration fails loud', () => {
+    const fake = fakeEngine();
+    // A plain-JS caller or a misconfigured loader could pass garbage
+    // here; without boundary validation, the misuse would be silently
+    // swallowed inside the non-fatal `emitCue` try/catch and rehearsal
+    // would see an empty cue stream.
+    expect(buildBadOnCue(fake, true)).toThrow(AudioError);
+    expect(buildBadOnCue(fake, 42)).toThrow(AudioError);
+    expect(buildBadOnCue(fake, {})).toThrow(AudioError);
+    expect(buildBadOnCue(fake, 'cue-log')).toThrow(AudioError);
+    expect(buildBadOnCue(fake, null)).toThrow(AudioError);
+  });
+
+  it('accepts an omitted onCue (workbench without a cue UI)', () => {
+    const fake = fakeEngine();
+    expect(() =>
+      createAudioService(fake.engine, {
+        signal: liveSignal(),
+        outputPolicy: 'log-cues',
+      }),
+    ).not.toThrow();
   });
 });

--- a/tests/runtime/navigation.test.ts
+++ b/tests/runtime/navigation.test.ts
@@ -39,6 +39,7 @@ const ALL_MODES: readonly NavigationMode[] = [
   'scrub',
   'screenshot',
   'prompter',
+  'rehearsal',
 ];
 
 describe('parseNavigationSearch — clause 1: accepts the five grammar keys', () => {

--- a/tests/runtime/scene-loader-audio.test.ts
+++ b/tests/runtime/scene-loader-audio.test.ts
@@ -19,6 +19,7 @@
 
 import { describe, expect, it } from 'vitest';
 import type {
+  AudioCueLogEntry,
   AudioEngine,
   AudioService,
   AudioSoundConfig,
@@ -232,6 +233,9 @@ describe('scene loader — audio service wiring (PUL-F024 / ADR-004)', () => {
       await loader.handle(targetWithMode('a', mode));
       await loader.idle();
       expect(audio.created).toHaveLength(1);
+      // outputPolicy === 'silent' constructs every sound muted at the
+      // engine (PUL-F024 / ADR-019 / ADR-021). The cue log stays
+      // silent because the policy is not 'log-cues'.
       expect(audio.created[0]?.muted).toBe(true);
     }
   });
@@ -352,6 +356,34 @@ describe('scene loader — audio service wiring (PUL-F024 / ADR-004)', () => {
     expect(audio.created).toHaveLength(0);
   });
 
+  it('threads onAudioCue through ctx.audio under mode=present but emits no cues (policy: audible)', async () => {
+    const cues: AudioCueLogEntry[] = [];
+    const audio = recordingAudioEngine();
+    const scene = buildScene({
+      id: 'a',
+      assets: ['/audio/bed.mp3'],
+      create: (ctx) => {
+        (ctx as { audio: AudioService }).audio.load('bed', { src: '/audio/bed.mp3' });
+        (ctx as { audio: AudioService }).audio.play('bed');
+      },
+    });
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([scene]),
+      compositions: createCompositionRegistry([]),
+      stage: null,
+      buildCtx: stubCtx,
+      createPreloader: () => () => Promise.resolve(),
+      timeline: noopTimeline,
+      audioEngine: audio.engine,
+      onAudioCue: (entry) => cues.push(entry),
+    });
+    await loader.handle(targetWithMode('a', 'present'));
+    await loader.idle();
+    // Audible policy => audio.created[0].muted is false; no cues emitted.
+    expect(audio.created[0]?.muted).toBe(false);
+    expect(cues).toEqual([]);
+  });
+
   it('falls back to a silent (no-op) audio engine when audioEngine is omitted', async () => {
     let captured: AudioService | undefined;
     const scene = buildScene({
@@ -382,3 +414,278 @@ describe('scene loader — audio service wiring (PUL-F024 / ADR-004)', () => {
     expect(captured?.isDisposed()).toBe(true);
   });
 });
+
+/* -------------------------------------------------------------------- *
+ *  mode=rehearsal — PUL-F026 / ADR-004
+ *
+ *  Rehearsal is an audio-output policy, not a timeline-state mode. The
+ *  loader's responsibility:
+ *
+ *  - Build the per-navigation `AudioService` with
+ *    `outputPolicy: 'log-cues'` (audio muted at engine level AND
+ *    every accepted audio operation emitted to the workbench's
+ *    optional `onAudioCue` sink).
+ *  - Thread `onAudioCue` through to `onCue` regardless of mode (the
+ *    policy decides whether cues are emitted).
+ *  - Reach `ctx.mode === 'rehearsal'` (PUL-F012 seam) on every
+ *    lifecycle hook.
+ *  - NOT truncate the composition slice (rehearsal preserves "the
+ *    same scene slice and timeline progression as normal playback
+ *    from that target" — preflight).
+ *  - Preserve head-entry `range` / `behavior` overrides for composition
+ *    + scene / composition + index rehearsal targets.
+ * -------------------------------------------------------------------- */
+
+describe('scene loader — mode=rehearsal (PUL-F026 / ADR-004)', () => {
+  it('builds the audio service with outputPolicy log-cues (sounds muted at the engine)', async () => {
+    const audio = recordingAudioEngine();
+    const scene = buildScene({
+      id: 'a',
+      assets: ['/audio/bed.mp3'],
+      create: (ctx) => {
+        (ctx as { audio: AudioService }).audio.load('bed', { src: '/audio/bed.mp3' });
+      },
+    });
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([scene]),
+      compositions: createCompositionRegistry([]),
+      stage: null,
+      buildCtx: stubCtx,
+      createPreloader: () => () => Promise.resolve(),
+      timeline: noopTimeline,
+      audioEngine: audio.engine,
+    });
+    await loader.handle(targetWithMode('a', 'rehearsal'));
+    await loader.idle();
+    expect(audio.created).toHaveLength(1);
+    expect(audio.created[0]?.muted).toBe(true);
+  });
+
+  it('emits cues through onAudioCue when scenes play audio under mode=rehearsal', async () => {
+    const cues: AudioCueLogEntry[] = [];
+    const audio = recordingAudioEngine();
+    // Scope the scene's audio to its own group (`scene.id`) so the
+    // loader's per-scene post-cleanup hook (`onSceneCleaned` →
+    // `audio.stopGroup(sceneId)`) emits the same group's stop-group
+    // cue at teardown — the runtime-guaranteed audio-group teardown
+    // (ADR-004) is itself an accepted audio operation and therefore
+    // part of the rehearsal cue stream.
+    const scene = buildScene({
+      id: 'a',
+      assets: ['/audio/bed.mp3'],
+      create: (ctx) => {
+        const x = (ctx as { audio: AudioService }).audio;
+        x.load('bed', { src: '/audio/bed.mp3' });
+        x.play('bed', { group: 'a' });
+        x.fade('bed', 1, 0, 100);
+      },
+    });
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([scene]),
+      compositions: createCompositionRegistry([]),
+      stage: null,
+      buildCtx: stubCtx,
+      createPreloader: () => () => Promise.resolve(),
+      timeline: noopTimeline,
+      audioEngine: audio.engine,
+      onAudioCue: (entry) => cues.push(entry),
+    });
+    await loader.handle(targetWithMode('a', 'rehearsal'));
+    await loader.idle();
+    expect(cues.map((c) => c.operation)).toEqual(['play', 'fade', 'stop-group']);
+    expect(cues[0]).toMatchObject({ operation: 'play', soundId: 'bed', group: 'a' });
+    expect(cues[1]).toMatchObject({ operation: 'fade', soundId: 'bed' });
+    // The final stop-group cue is the runtime-fired teardown of the
+    // scene's audio group on `cleanup(ctx)` (PUL-F024 / ADR-004).
+    expect(cues[2]).toMatchObject({ operation: 'stop-group', group: 'a' });
+    // Engine-level mute is independent of the cue log.
+    expect(audio.created[0]?.muted).toBe(true);
+  });
+
+  it('rehearses a composition target through the FULL slice — no slice truncation', async () => {
+    // Distinguishes rehearsal from standalone/loop/paused/scrub/screenshot:
+    // those modes truncate the slice to the head; rehearsal preserves it.
+    const a = buildScene({ id: 'scene-a' });
+    const b = buildScene({ id: 'scene-b' });
+    const c = buildScene({ id: 'scene-c' });
+    const { adapter, calls } = recordingTimeline();
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([a, b, c]),
+      compositions: createCompositionRegistry([
+        { id: 'talk', manifest: ['scene-a', 'scene-b', 'scene-c'] },
+      ]),
+      stage: null,
+      buildCtx: stubCtx,
+      createPreloader: () => () => Promise.resolve(),
+      timeline: adapter,
+    });
+    await loader.handle({
+      locator: { kind: 'composition', composition: 'talk' },
+      mode: 'rehearsal',
+    });
+    await loader.idle();
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.segments.map((s) => s.id)).toEqual(['scene-a', 'scene-b', 'scene-c']);
+  });
+
+  it('rehearses a composition+scene target from the addressed head onward (slice preserved)', async () => {
+    const a = buildScene({ id: 'scene-a' });
+    const b = buildScene({ id: 'scene-b' });
+    const c = buildScene({ id: 'scene-c' });
+    const { adapter, calls } = recordingTimeline();
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([a, b, c]),
+      compositions: createCompositionRegistry([
+        { id: 'talk', manifest: ['scene-a', 'scene-b', 'scene-c'] },
+      ]),
+      stage: null,
+      buildCtx: stubCtx,
+      createPreloader: () => () => Promise.resolve(),
+      timeline: adapter,
+    });
+    await loader.handle({
+      locator: { kind: 'composition-scene', composition: 'talk', scene: 'scene-b' },
+      mode: 'rehearsal',
+    });
+    await loader.idle();
+    // Slice from scene-b onward — full progression, no truncation to head.
+    expect(calls[0]?.segments.map((s) => s.id)).toEqual(['scene-b', 'scene-c']);
+  });
+
+  it('rehearses a composition+index target preserving the head entry’s `range` / `behavior` overrides', async () => {
+    const a = buildScene({ id: 'scene-a' });
+    const b = buildScene({ id: 'scene-b' });
+    const { adapter, calls } = recordingTimeline();
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([a, b]),
+      compositions: createCompositionRegistry([
+        {
+          id: 'talk',
+          manifest: [
+            'scene-a',
+            // Object-form entry with range + behavior so we can verify
+            // they reach the runner unchanged under rehearsal. The
+            // entry shape is `{ id, range?, behavior? }` per PUL-F003;
+            // `range` is a `[start, end]` tuple of kebab-case beat
+            // labels (or a single kebab string).
+            { id: 'scene-b', range: ['a-beat', 'z-beat'], behavior: { x: 1 } },
+          ],
+        },
+      ]),
+      stage: null,
+      buildCtx: stubCtx,
+      createPreloader: () => () => Promise.resolve(),
+      timeline: adapter,
+    });
+    await loader.handle({
+      locator: { kind: 'composition-index', composition: 'talk', index: 1 },
+      mode: 'rehearsal',
+    });
+    await loader.idle();
+    const segment = calls[0]?.segments[0];
+    expect(segment?.id).toBe('scene-b');
+    expect(segment?.range).toEqual(['a-beat', 'z-beat']);
+    expect(segment?.behavior).toEqual({ x: 1 });
+  });
+
+  it('reaches ctx.mode === "rehearsal" in every lifecycle hook of every scene in the slice', async () => {
+    const seen: Array<{ id: string; phase: string; mode: string | undefined }> = [];
+    const a = buildScene({
+      id: 'scene-a',
+      create: (ctx) => {
+        seen.push({ id: 'scene-a', phase: 'create', mode: (ctx as WorkbenchSceneCtxLike).mode });
+      },
+      timeline: (ctx) => {
+        seen.push({ id: 'scene-a', phase: 'timeline', mode: (ctx as WorkbenchSceneCtxLike).mode });
+        return null;
+      },
+      cleanup: (ctx) => {
+        seen.push({ id: 'scene-a', phase: 'cleanup', mode: (ctx as WorkbenchSceneCtxLike).mode });
+      },
+    });
+    const b = buildScene({
+      id: 'scene-b',
+      create: (ctx) => {
+        seen.push({ id: 'scene-b', phase: 'create', mode: (ctx as WorkbenchSceneCtxLike).mode });
+      },
+    });
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([a, b]),
+      compositions: createCompositionRegistry([{ id: 'talk', manifest: ['scene-a', 'scene-b'] }]),
+      stage: null,
+      buildCtx: stubCtx,
+      createPreloader: () => () => Promise.resolve(),
+      timeline: noopTimeline,
+    });
+    await loader.handle({
+      locator: { kind: 'composition', composition: 'talk' },
+      mode: 'rehearsal',
+    });
+    await loader.idle();
+    expect(seen.every((s) => s.mode === 'rehearsal')).toBe(true);
+    // Both scenes mounted (full slice — no truncation).
+    expect(seen.some((s) => s.id === 'scene-a')).toBe(true);
+    expect(seen.some((s) => s.id === 'scene-b')).toBe(true);
+  });
+
+  it('exposes every declared composition-slice asset to ctx.audio under mode=rehearsal', async () => {
+    // Rehearsal preserves the full slice, so the audio service's
+    // allowedSources is the union of every scene's `scene.assets` —
+    // same invariant as `mode=present`. A scene further down the slice
+    // can register a sibling scene's declared URL.
+    const a = buildScene({
+      id: 'scene-a',
+      assets: ['/audio/a.mp3'],
+      create: (ctx) => {
+        (ctx as { audio: AudioService }).audio.load('a-bed', { src: '/audio/a.mp3' });
+      },
+    });
+    const b = buildScene({
+      id: 'scene-b',
+      assets: ['/audio/b.mp3'],
+      create: (ctx) => {
+        (ctx as { audio: AudioService }).audio.load('a-from-b', { src: '/audio/a.mp3' });
+        (ctx as { audio: AudioService }).audio.load('b-bed', { src: '/audio/b.mp3' });
+      },
+    });
+    const audio = recordingAudioEngine();
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([a, b]),
+      compositions: createCompositionRegistry([{ id: 'pair', manifest: ['scene-a', 'scene-b'] }]),
+      stage: null,
+      buildCtx: stubCtx,
+      createPreloader: () => () => Promise.resolve(),
+      timeline: noopTimeline,
+      audioEngine: audio.engine,
+    });
+    await loader.handle({
+      locator: { kind: 'composition', composition: 'pair' },
+      mode: 'rehearsal',
+    });
+    await loader.idle();
+    expect(audio.created).toHaveLength(3);
+    expect(audio.created.every((c) => c.muted)).toBe(true);
+  });
+
+  it('preserves head-only timeline-runner contracts under mode=rehearsal (no `repeat` / `hold` / `cueGate` / `screenshot`)', async () => {
+    const a = buildScene({ id: 'scene-a' });
+    const { adapter, calls } = recordingTimeline();
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([a]),
+      compositions: createCompositionRegistry([]),
+      stage: null,
+      buildCtx: stubCtx,
+      createPreloader: () => () => Promise.resolve(),
+      timeline: adapter,
+    });
+    await loader.handle(targetWithMode('scene-a', 'rehearsal'));
+    await loader.idle();
+    const opts = calls[0]?.opts;
+    expect(opts?.headRepeat).toBeUndefined();
+    expect(opts?.headHold).toBeUndefined();
+    expect(opts?.headCueGate).toBeUndefined();
+    expect(opts?.headScreenshot).toBeUndefined();
+  });
+});
+
+type WorkbenchSceneCtxLike = { readonly mode?: string };


### PR DESCRIPTION
Implements PUL-F026: \"The runtime SHALL provide a rehearsal mode in which audio is silenced or logged as cues without altering timeline state.\"

Rehearsal lives entirely on the audio-service seam — no head-only timeline-runner hint, no slice truncation, no presenter command, no resolver semantics. It preserves the same composition slice and the same master timeline progression as the equivalent non-rehearsal navigation; only audio output changes.

## Key changes

- \`src/runtime/navigation.ts\` — add \`'rehearsal'\` to \`NAVIGATION_MODES\` (eighth workbench mode).
- \`src/runtime/audio.ts\` — refactor \`AudioServiceOptions.silent: boolean\` to literal-typed \`AudioOutputPolicy = 'audible' | 'silent' | 'log-cues'\`, with frozen \`AUDIO_OUTPUT_POLICIES\` as single source of truth. Add \`onCue?\` sink and the discriminated-union \`AudioCueLogEntry\` (play/fade/stop/stop-group variants). Construction-time boundary validation: rejects the legacy \`silent\` key, bad \`outputPolicy\` values (BigInt/Symbol safe), and non-function \`onCue\`.
- \`src/runtime/scene-loader.ts\` — mode → outputPolicy derivation in \`buildLoad\` (\`'log-cues'\` for rehearsal, \`'silent'\` for screenshot/paused, \`'audible'\` otherwise). Add \`onAudioCue?\` workbench seam threaded through to the per-navigation \`AudioService\`.
- ADRs swept for the new mode count: ADR-004 (output-policy subsection), ADR-007 (mode table), ADR-002/016/017/018/019/020/021/022/023 (\"eight workbench modes\" enumeration).

## Cue contract (PUL-F026 / ADR-004)

Cue entries are emitted after validation and after the engine call returns. They carry **semantic ids only** — sound id, sprite, group, monotonic sequence, numeric envelope parameters — and NEVER source URLs, Howler handles, asset paths, or raw scene objects. \`load\` and \`mute\` are not cues. Validation failures never emit. Post-dispose calls never emit. A throwing \`onCue\` is swallowed. Entries are deep-frozen.

## Test coverage

914 tests total. New coverage:
- Navigation grammar (\`mode=rehearsal\` accepted, frozen allowlist includes it).
- Audio-service cue emission per operation, policy matrix (audible/silent/log-cues), validation throws never emit, deep-freeze of fade payload, post-dispose inert, throwing sink swallowed, no URLs in entries, monotonic sequence.
- Output-policy and onCue runtime validation (BigInt/Symbol safe error formatting, legacy \`silent\` key rejected).
- Scene-loader audio-service wiring under \`mode=rehearsal\`: full slice preservation (no truncation), head-entry \`range\`/\`behavior\` overrides preserved, \`ctx.mode === 'rehearsal'\` reaches every lifecycle hook of every scene in the slice, no head-only runner-input hints set.

Plan comment: https://github.com/KeplerOps/pulsar/issues/35#issuecomment-4417079626

Closes #35