### PR TITLE
Implement PUL-F027 caption metadata and prompter content (ADR-027)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Caption metadata `at` widened — PUL-F027 / ADR-002 / ADR-008 — in
+  `src/runtime/scene.ts`: `Caption.at` now accepts either a finite
+  non-negative integer (millisecond offset, as before) OR a
+  kebab-case beat label string sharing the existing ADR-008 #1
+  identifier grammar. The scene-schema gate (`assertSceneModule`)
+  tightens the numeric branch at the same boundary so floats,
+  negatives, `NaN`, ±`Infinity`, empty strings, and non-kebab
+  labels are all rejected at validation time. Caption beat labels
+  use the same kebab-case predicate the runtime already uses for
+  scene ids, composition ids, timeline labels, and URL `beat=`
+  parameters — caption labels do NOT carry a stricter sub-grammar.
+  Caption validation errors now identify the caption index and
+  failing field (`captions[2].at must be ...`) rather than
+  collapsing to a generic per-array message. The prompter
+  (`buildPrompterScript`) already derives the caption view from
+  `scene.captions` and copies each entry structurally with
+  `{ ...c }`, so the widened `at` flows through the prompter
+  script unchanged — single source of truth. No URL parameter,
+  composition override, prompter-only caption schema, or new
+  exception hierarchy.
+
 ### Added
 
 - Rehearsal mode — PUL-F026 / ADR-004 — in `src/runtime/navigation.ts`,

--- a/docs/adrs/002-scene-registry-and-compositions.md
+++ b/docs/adrs/002-scene-registry-and-compositions.md
@@ -59,6 +59,8 @@ export const scene = {
   tags: [],              // free-form labels (act, theme, surface kind, etc.)
   assets: [],            // images, audio, fonts, data, etc.
   captions: [],          // [{ at: ms, text }] for prompter and exporters
+                         // (refined by ADR-027: `at` may also be a
+                         // kebab-case beat label string)
   defaultNext: "string", // optional: scene id to advance to by default
   standalone: false,     // safe to launch in isolation?
   trailerSafe: false,    // safe to use in a trailer cut without context?

--- a/docs/adrs/022-workbench-mode-prompter.md
+++ b/docs/adrs/022-workbench-mode-prompter.md
@@ -33,7 +33,8 @@ The clauses decompose this way:
 
 - "Render a script/caption view derived from the captions metadata of
   the addressed scene or composition" — the runtime aggregates
-  `scene.captions` (PUL-F001 / ADR-002 — `{ at: ms, text }[]`) from
+  `scene.captions` (PUL-F001 / ADR-002, refined by ADR-027 to
+  `{ at: ms | beat-label, text }[]`) from
   the addressed target into a script structure and hands it to a
   rendering surface. For composition targets, captions span every
   scene in the resolved slice (PUL-F008 / ADR-014's snapshot from the
@@ -442,6 +443,10 @@ mismatch.
 
 - [ADR-002](002-scene-registry-and-compositions.md) — defines the
   `Caption = { at: ms, text }` shape this ADR aggregates.
+- [ADR-027](027-caption-timestamp-grammar.md) — refines `Caption.at`
+  to also accept a kebab-case beat label string. The prompter
+  aggregation seam is structurally unchanged; the widened `at` flows
+  through `buildPrompterScript()`'s `{ ...c }` spread.
 - [ADR-007](007-browser-workbench.md) — defines the eight workbench
   modes; specifically references `mode=prompter` as the
   script/caption review mode.

--- a/docs/adrs/027-caption-timestamp-grammar.md
+++ b/docs/adrs/027-caption-timestamp-grammar.md
@@ -1,0 +1,229 @@
+# ADR-027: Caption Timestamp Grammar — `at` Accepts a Millisecond Offset or a Beat Label, Validated at the Scene Schema Boundary
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-11
+
+## Context
+
+[ADR-002](002-scene-registry-and-compositions.md) §"Scene shape"
+documents the canonical scene module shape, and its illustrative
+example shows `captions: []` with the comment `[{ at: ms, text }]` —
+millisecond-only `at` values for the prompter and exporter.
+[ADR-022](022-workbench-mode-prompter.md) §"Captions data model"
+similarly cites `Caption = { at: ms, text }` as the canonical scene
+caption shape the prompter aggregates over.
+
+[ADR-008](008-agent-native-authoring.md) #1 makes one identifier
+grammar binding on scenes, compositions, beats, and assets:
+kebab-case (`[a-z0-9]+(-[a-z0-9]+)*`). [ADR-015](015-url-beat-positioning.md)
+applied that grammar to the URL `beat=` parameter, [ADR-002] /
+[ADR-011](011-composition-resolver-orchestration.md) applied it to
+composition `range` endpoints, and [ADR-026](026-named-timeline-beats.md)
+applied it to scene-authored timeline labels with the bridge-level
+`assertSceneTimeline()` gate. Wherever the runtime says "named beat"
+it means *this* grammar.
+
+PUL-F027 specifies the caption metadata shape:
+
+> Each scene SHALL declare its captions in metadata as a list of
+> `{ at, text }` entries, where `at` is a millisecond offset or a beat
+> label. The runtime SHALL derive the prompter view from this same
+> metadata.
+
+That clause widens caption `at` beyond the millisecond-only shape
+ADR-002 / ADR-022 illustrate. A caption author whose scene pins a
+moment to a named beat (an existing GSAP label) wants
+`at: 'midpoint-stinger'`, not a recomputed millisecond offset that
+goes stale every time the beat moves. That is the same affordance
+URL `beat=`, presenter `seek-to-beat`, and composition `range` give
+the same author for the same beat.
+
+The question this ADR answers is: where does the widened caption
+grammar live, what predicate validates it, and how do downstream
+consumers (the prompter, future exporter, future caption editor)
+discriminate the two cases? It also records the policy decision so
+ADR-002's `Caption = { at: ms, text }` and ADR-022's parallel claim
+are refined here rather than mutated in place.
+
+## Decision
+
+### Type
+
+`Caption.at` widens from `number` to `number | string`:
+
+- A **number** value is a non-negative integer millisecond offset
+  from the scene's start, the same shape ADR-002 / ADR-022 originally
+  documented. The runtime now also rejects floats, negatives, `NaN`,
+  and `±Infinity` at validation time (PUL-F027 is the first
+  requirement that puts a tightened gate on the numeric branch; the
+  loose `typeof v.at === 'number'` predicate predated this).
+- A **string** value is a scene-local beat label sharing the **one**
+  ADR-008 #1 kebab-case identifier grammar — the same predicate
+  `isKebabIdentifier` validates scene ids, composition ids, timeline
+  labels (ADR-026), URL `beat=` (ADR-015), composition `range`
+  endpoints (ADR-002), and asset ids. Caption labels carry **no**
+  caption-only sub-grammar; a digit-only label such as `"1000"` is
+  valid here because it is valid everywhere else the shared grammar
+  applies. A string `at` is **always** a beat label, never coerced
+  to a number — if an author wants 1000 ms they write `at: 1000`.
+
+The widened type lives at the single scene-schema boundary in
+`src/runtime/scene.ts`. Consumers that need to discriminate the two
+cases do so by `typeof at` at their own boundary; the caption schema
+does not pre-classify or normalize for them.
+
+### Validator
+
+`assertSceneModule()` in `src/runtime/scene.ts` remains the only
+runtime caption-shape check (preflight: "the registry validates scene
+modules once and freezes snapshots"). The PUL-F027 refinement is
+local to two helpers next to the `Caption` type:
+
+- `isCaptionAt(v)` — returns `true` when `v` is a finite, non-negative
+  integer OR a value satisfying `isKebabIdentifier`. Rejects every
+  other shape.
+- `describeCaptionFault(cap, index)` — returns the message the
+  schema-error envelope should report (or `null`). Identifies the
+  caption index and the failing field so a scene with twenty captions
+  surfaces the offender as `captions[14].at must be ...`, matching
+  the indexed style the composition-manifest validator
+  (`assertCompositionManifest`) already uses. Caption `text` is
+  **never** echoed in the message (preflight: avoid leaking caption
+  content through diagnostics).
+
+`assertSceneModule()` runs the array check via the existing
+`FIELD_GUARDS` pass, then iterates captions and uses
+`describeCaptionFault` for per-element diagnostics. The previous
+boolean-collapsing `isCaptionArray` is removed; an orphaned
+`isCaption` predicate that no longer routes through the indexed
+validator is removed alongside it (codex review, cycle 3 — keeping
+two caption-validation entry points weakens the single boundary).
+
+### Prompter passthrough
+
+`buildPrompterScript()` in `src/runtime/prompter.ts` already derives
+the prompter view from the registered scene module's `captions` and
+structurally copies each entry (`{ ...c }` — the spread carries any
+PUL-F001 `Caption` field forward without a parallel schema). The
+widened `at` flows through unchanged: numeric captions stay numeric,
+beat-label captions stay strings, and the prompter performs **no**
+coercion, sorting, dropping, or rewriting. The runtime SHALL-clause
+"derive the prompter view from this same metadata" is therefore a
+structural invariant pinned by the existing prompter tests plus a
+new mixed-shape passthrough test.
+
+### Boundaries
+
+- **Schema gate** owns the union and the validation. No second caption
+  schema exists in the prompter, exporter, registry, or composition
+  layer.
+- **Registry** continues to call `assertSceneModule()` once and freeze
+  snapshots; it does not introduce a registry-local caption parser.
+- **Timeline / beat boundary** owns label existence. The scene-schema
+  gate validates label *shape*, not label *existence* on the scene's
+  timeline — running `timeline(ctx)` from `assertSceneModule()` would
+  move lifecycle side effects into metadata validation. A future
+  authoring lint may cross-check caption labels against
+  `MasterTimeline.beats()` through the existing timeline seam without
+  changing this boundary.
+- **Prompter aggregation** stays a pure structural copy. It does not
+  resolve labels to milliseconds, drop labels that don't appear on the
+  master, or normalize the union — those are consumer-side decisions
+  the captions UI / exporter make with the discriminated `at` value
+  the prompter hands them.
+- **URL grammar** is unchanged. Caption metadata is not URL-addressable
+  and adds no new query key.
+- **Composition manifest** is unchanged. Caption text and `at` come
+  from the registered scene module; object-form composition entries
+  do **not** override captions (the existing `range` / `behavior`
+  overrides are runner-side timeline knobs, not caption knobs).
+
+### Relation to ADR-002 / ADR-022
+
+This ADR **refines** the caption-shape clauses in ADR-002 §"Scene
+shape" and ADR-022 §"Captions data model". The original ADRs are not
+rewritten; they continue to describe the millisecond-only shape that
+was the contract under PUL-F001 / PUL-F019. From PUL-F027 onward the
+binding caption-shape rule is the one stated above, validated at the
+single boundary named above. Future ADRs that reference caption shape
+SHOULD cite ADR-027.
+
+### What this ADR does NOT change
+
+- The `Caption.text` shape (still `string`).
+- The `captions` field placement (still on `SceneModule`, no
+  composition override).
+- The prompter contract (still structural derivation from scene
+  metadata; the mode-prompter lifecycle bypass in ADR-022 is
+  unchanged).
+- The kebab-case identifier grammar (still the one ADR-008 #1
+  predicate, used unchanged).
+- The PUL-F019 / ADR-022 captions data path (still aggregates the
+  full slice from the addressed scene onward; no caption truncation
+  by composition `range`).
+
+## Consequences
+
+### Positive
+
+- One caption-shape contract, one validator, one error envelope shape
+  with indexed faults. The boundary that already owned `Caption`
+  continues to own it.
+- One identifier grammar across captions, timelines, URL `beat=`,
+  composition `range`, and asset ids. An author who pins a caption
+  to a named beat uses the same string they would write in any other
+  beat-addressable surface.
+- Future caption consumers (caption editor UI, exporter, beat-aware
+  prompter scroll) discriminate `Caption.at` by `typeof` at their own
+  boundary. No pre-classifier; no parallel `CaptionTime` /
+  `CaptionRef` / `Cue` schema; no shared union helper landed
+  speculatively before two consumers need it.
+- The prompter contract did not have to change. The structural-copy
+  invariant `buildPrompterScript` already enforced is what carries
+  the widened `at` through unchanged.
+
+### Negative
+
+- Caption authors get a slightly larger set of valid inputs that the
+  validator MUST reject loudly. The numeric-branch tightening (no
+  floats, no NaN, no Infinity, no negatives) catches inputs the old
+  loose `typeof === 'number'` accepted. That is a correctness
+  improvement, but a caption library hand-rolled against the original
+  laxer numeric check could need a one-time cleanup pass — surface as
+  a clear `captions[N].at must be ...` error so the fix is local.
+- The scene-schema gate is now two passes (FIELD_GUARDS broad check,
+  then per-element loop). The split is the minimum required to get
+  indexed errors on captions; the composition-manifest validator
+  already uses the same two-pass pattern, so the cognitive cost is
+  shared.
+
+### Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| A consumer normalizes string `at` to milliseconds and drops the label | Prompter test pins mixed numeric + beat-label passthrough end to end. The contract is "structural copy"; a coercing consumer is a regression. |
+| Caption labels diverge from the shared grammar (caption-only stricter rule, separate predicate copy) | The scene-schema validator routes through `isKebabIdentifier` directly; there is no caption-only regex. Codex review, cycle 2 caught and rejected an earlier draft that did invent a caption-only sub-grammar. |
+| Per-element error messages echo caption text and leak script content | `describeCaptionFault` returns messages that mention only the index and the failing field. Tests pin index/field identification; no test or implementation echoes `text` in an error. |
+| A future caption editor mutates the prompter script and corrupts the source scene | `buildPrompterScript` already deep-clones each caption (`{ ...c }`) and deep-freezes the script. Adding the union to `Caption.at` does not change those invariants — pinned by existing prompter tests. |
+| Caption beat labels reference labels that don't exist on the scene's timeline | Out of scope here — beat *existence* belongs to the timeline boundary, not the schema gate. A future authoring lint may compare caption labels to `MasterTimeline.beats()` through the timeline seam without changing this ADR. |
+
+## Related ADRs
+
+- [ADR-002](002-scene-registry-and-compositions.md) — defines the
+  scene module shape including the original millisecond-only
+  `captions` example; refined here for `Caption.at`.
+- [ADR-008](008-agent-native-authoring.md) — #1 names the one
+  kebab-case identifier grammar reused for caption beat labels.
+- [ADR-015](015-url-beat-positioning.md) — applies the same grammar
+  to URL `beat=`; caption labels share that vocabulary.
+- [ADR-022](022-workbench-mode-prompter.md) — defines the prompter
+  captions data path; the structural-copy invariant is the seam this
+  ADR's widening flows through unchanged.
+- [ADR-026](026-named-timeline-beats.md) — validates scene-authored
+  timeline labels as beats using the same grammar caption beat
+  labels reuse.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -20,6 +20,7 @@ Design context for Pulsar. Source material for the ADRs in `../adrs/`.
 | [pul-f024-audio-orchestration-preflight.md](pul-f024-audio-orchestration-preflight.md) | Guardrails for implementing runtime-owned audio orchestration. |
 | [pul-f025-master-mute-preflight.md](pul-f025-master-mute-preflight.md) | Guardrails for implementing presenter master mute. |
 | [pul-f026-rehearsal-mode-preflight.md](pul-f026-rehearsal-mode-preflight.md) | Guardrails for implementing rehearsal audio suppression or cue logging without timeline-state changes. |
+| [pul-f027-caption-metadata-prompter-preflight.md](pul-f027-caption-metadata-prompter-preflight.md) | Guardrails for widening caption metadata timing and keeping prompter content single-sourced. |
 
 Design docs are mutable. Decisions are captured as ADRs (immutable once
 accepted).

--- a/docs/design/pul-f027-caption-metadata-prompter-preflight.md
+++ b/docs/design/pul-f027-caption-metadata-prompter-preflight.md
@@ -1,0 +1,135 @@
+# PUL-F027 Caption Metadata And Prompter Preflight
+
+PUL-F027 widens the caption timestamp grammar: each scene still
+declares `captions` in scene metadata, but each caption's `at` value
+may be either a non-negative integer millisecond offset or a named
+beat label. The runtime prompter view continues to derive from that
+same metadata. This is a scene-schema refinement, not a new prompter
+data source, timeline cue system, or composition override.
+
+The existing architecture already supplies the right boundaries:
+`SceneModule` metadata is canonical (ADR-002 / ADR-008), GSAP labels
+are canonical beats (ADR-026), and `buildPrompterScript()` aggregates
+scene metadata for `mode=prompter` without mounting scenes (ADR-022).
+
+## Boundary
+
+- `src/runtime/scene.ts` owns the `Caption` type and
+  `assertSceneModule()` validation. Widen `Caption.at` at this
+  boundary only; downstream consumers must reuse that type.
+- `src/runtime/registry.ts` and `src/runtime/scene-loader.ts` must
+  continue to rely on the scene-schema gate instead of duplicating a
+  caption validator.
+- `src/runtime/prompter.ts` remains a pure aggregation seam over an
+  already resolved `SceneNavigationTarget`. It must copy captions
+  structurally from scene metadata and must not invent a prompter-only
+  caption schema.
+- `src/runtime/timeline.ts` remains the canonical beat-label boundary.
+  Caption beat labels use the same kebab-case rule as timeline labels,
+  URL `beat=`, composition `range`, scenes, compositions, and assets.
+- `src/runtime/navigation.ts` is out of scope except for preserving
+  the existing URL `beat=` semantics. Caption metadata must not add a
+  URL query key or alter navigation parsing.
+- Composition manifests do not carry caption overrides. Object-form
+  entries may expose `range` / `behavior` to the prompter script as
+  entry metadata, but caption text and `at` values come from the
+  registered scene module.
+
+## Required Reuse
+
+Implementation must build on these incumbents:
+
+- Scene metadata and validation: `Caption`, `SceneModule`,
+  `assertSceneModule()`, `isSceneModule()`, `isPlainRecord()`.
+- Identifier grammar: `isKebabIdentifier()` and
+  `KEBAB_IDENTIFIER_FORM`; do not copy or loosen the regex for
+  caption beat labels.
+- Registry validation: `createSceneRegistry()` remains the scene
+  boundary that calls `assertSceneModule()`.
+- Navigation and target resolution: `parseNavigationSearch()`,
+  `NavigationTarget.beat`, `effectiveMode()`,
+  `resolveSceneNavigation()`, and `SceneNavigationTarget`.
+- Prompter aggregation: `PrompterScript`, `PrompterScriptEntry`,
+  `buildPrompterScript()`, `PrompterRenderer`, `PrompterDispose`,
+  and the loader's `renderPrompter` path.
+- Timeline beat validation and lookup: `assertSceneTimeline()`,
+  `MasterTimeline`, `MasterBeat`, `sceneTimelineLabel()`,
+  `parseSceneTimelineLabel()`, and `createGsapCompositionTimeline()`.
+- Error and diagnostics: `describeError()`, the loader `onError`
+  sink, and existing stage attrs. Validation errors should identify
+  the caption index / field and rule; avoid echoing full caption text.
+- Tests and tooling: Vitest boundary tests under `tests/runtime/*`,
+  `pnpm test`, `pnpm typecheck`, and `pnpm lint` using the existing
+  `vitest.config.ts`, `tsconfig.json`, and `biome.json`.
+
+## Cross-Cutting Layers
+
+| Layer | Guardrail |
+|-------|-----------|
+| Scene schema gate | `assertSceneModule()` is the only runtime shape-check for captions. `at` accepts finite non-negative integer milliseconds or a kebab-case beat label string. Reject floats, negative numbers, `NaN`, `Infinity`, empty strings, and non-kebab labels. A digit-only label such as `"1000"` is a *valid* beat label because the shared ADR-008 #1 kebab grammar accepts it — caption schema does not invent a stricter sub-grammar (see Gotchas). Per-caption errors must identify the caption index and the failing field (`captions[N].at must be ...`). |
+| Registry boundary | Registries continue to validate scene modules once and freeze snapshots. Do not add registry-local caption parsing or a second caption DTO. |
+| Timeline / beat boundary | Caption beat labels share the timeline label grammar, but scene-schema validation must not run timelines merely to prove label existence. A future authoring lint may compare caption labels to `MasterTimeline.beats()` through the timeline seam. |
+| Prompter data path | `buildPrompterScript()` derives directly from scene `captions` and carries `at` through unchanged. It should not sort, coerce, resolve, drop, or split captions based on whether `at` is numeric or a beat label unless a later requirement defines that view policy. |
+| DOM rendering / security | Caption `text` is user-authored content. Any visible prompter renderer must render it as text, not HTML; use `textContent` / framework text binding and never `innerHTML` from caption text. |
+| URL / auth surface | PUL-F027 adds no URL grammar, remote input, auth, cookie, localStorage, sessionStorage, or `history.state` surface. URL `beat=` remains navigation state, not caption metadata. |
+| Asset / network surface | Captions must not cause asset discovery, dynamic imports, fetches, or audio loads. Asset loading remains only `scene.assets` through `createAssetPreloader()` and audio source allowlists. |
+| Error envelope | Caption schema failures should keep the existing `scene "<id>" is invalid:` style and flow through registry / loader diagnostics. Do not introduce a caption exception hierarchy or leak full script content through errors. |
+| Config / env / OS exposure | No env vars, config files, process argv flags, shell commands, filesystem reads, or persisted browser state are needed for caption metadata. Do not expose prompter content through process arguments or logs. |
+| Observability | Reuse stage diagnostics and `onError`. Do not add per-caption console logging, analytics, or script dumps before the repo has a telemetry/redaction policy. |
+
+## Extensibility
+
+The extension seam is the `Caption.at` type in `src/runtime/scene.ts`
+plus any small caption-time classifier needed by multiple consumers.
+If more than one module needs to distinguish millisecond offsets from
+beat labels, put one helper next to `Caption` and parameterize it by
+the consumer's policy rather than letting prompter UI, exporters, and
+tests each infer the union differently.
+
+Future caption UI features such as sorting, active-line highlighting,
+beat-click seeking, caption export, speaker labels, or localized text
+must extend the scene metadata / prompter-script seam without creating
+a second caption store. Beat-aware features resolve labels through the
+timeline seam after a scene timeline exists; they do not make the URL
+parser, registry, or prompter aggregator import GSAP or inspect
+timeline internals.
+
+## Gotchas And Anti-Patterns
+
+- Do not coerce a string `Caption.at` into a number. A string `at` is
+  always a beat label, never milliseconds — even when its characters
+  happen to be all digits (`"1000"` is the label `1000`, not 1000 ms).
+  The validator MUST accept any string that satisfies the shared
+  ADR-008 #1 kebab identifier rule (`isKebabIdentifier`) — caption
+  schema does not invent a stricter sub-grammar than timeline labels,
+  URL `beat=`, composition `range`, or asset ids.
+- Do not validate caption beat existence in `assertSceneModule()` by
+  running `timeline(ctx)`. That would move lifecycle side effects into
+  metadata validation.
+- Do not add `captions` to composition entries, workbench URLs,
+  presenter commands, local storage, or a separate prompter manifest.
+- Do not normalize all captions to milliseconds in the prompter path;
+  labels are authored metadata and must remain visible to consumers.
+- Do not parse namespaced master labels in the prompter. Caption labels
+  are scene-local; master namespacing is runtime transport state.
+- Do not filter captions by composition `range` until a requirement
+  defines label-to-caption filtering semantics. Existing prompter tests
+  pin full scene captions with entry `range` / `behavior` carried as
+  optional metadata.
+- Do not render caption text as HTML, include it in error messages, or
+  dump full scripts to logs.
+- Do not create `CaptionError`, `CaptionSchema`, `PrompterCaption`, or
+  an exporter-only caption DTO unless a real second boundary appears.
+
+## Non-Goals
+
+PUL-F027 does not implement a visible prompter UI, teleprompter
+scrolling, caption editing, caption persistence, localization,
+speaker attribution, caption export, beat-click navigation, label
+existence linting, presenter overlays, audio cues, timeline authoring,
+composition caption overrides, new URL parameters, remote protocols,
+auth, analytics, or requirement status transition.
+
+It should not add a new registry, repository, workflow controller,
+configuration surface, exception hierarchy, validation library, asset
+inventory, or persistence format.

--- a/src/runtime/scene.ts
+++ b/src/runtime/scene.ts
@@ -21,12 +21,23 @@ import { KEBAB_IDENTIFIER_FORM, isKebabIdentifier } from './identifier';
 import { isPlainRecord } from './object';
 
 /**
- * Caption metadata. ADR-002 specifies `{ at: ms, text }`. The prompter,
- * the live runtime, and the export pipeline all consume this same
- * structure (PUL-A009).
+ * Caption metadata. ADR-002 / ADR-008 / PUL-F027: `{ at, text }` where
+ * `at` is EITHER a finite non-negative integer (millisecond offset
+ * from scene start) OR a kebab-case beat label sharing the same
+ * identifier grammar as scene ids, composition ids, timeline labels,
+ * and asset ids (ADR-008 #1 — `isKebabIdentifier`). The prompter, the
+ * live runtime, and the export pipeline all consume this same
+ * structure (PUL-A009 / PUL-F019).
+ *
+ * Beat-label `at` values are scene-local — they refer to a label
+ * registered on the scene's own timeline (ADR-026 named beats). The
+ * scene-schema validator does NOT walk the timeline to verify the
+ * label exists; lifecycle side effects do not belong in metadata
+ * validation. A future authoring lint MAY cross-check caption beat
+ * labels against `MasterTimeline.beats()`.
  */
 export interface Caption {
-  at: number;
+  at: number | string;
   text: string;
 }
 
@@ -93,11 +104,50 @@ const isStringArray = (v: unknown): v is readonly string[] =>
 const isValidDuration = (v: unknown): v is number | null =>
   v === null || (typeof v === 'number' && Number.isInteger(v) && Number.isFinite(v) && v >= 0);
 
-const isCaption = (v: unknown): v is Caption =>
-  isPlainRecord(v) && typeof v.at === 'number' && typeof v.text === 'string';
+/**
+ * PUL-F027: a caption's `at` field is either a millisecond offset
+ * (finite non-negative integer) OR a beat label string sharing the
+ * one identifier grammar ADR-008 #1 reserves for scenes, compositions,
+ * beats, and assets — `isKebabIdentifier`. Floats, negatives, NaN,
+ * ±Infinity, empty strings, and non-kebab labels are rejected at
+ * this boundary. A purely-digit label like `"1000"` IS valid (the
+ * shared kebab regex accepts it), the same as it is for a timeline
+ * label, a URL `beat=` parameter, and a composition `range` endpoint
+ * — caption labels do not invent a stricter sub-grammar (codex
+ * review, cycle 1).
+ *
+ * Hoisted to module scope (pure, no closure captures) so the same
+ * predicate covers `describeCaptionFault` and any future
+ * caption-time classifier the preflight reserves.
+ */
+const isCaptionAt = (v: unknown): v is number | string => {
+  if (typeof v === 'number') {
+    return Number.isInteger(v) && Number.isFinite(v) && v >= 0;
+  }
+  return isKebabIdentifier(v);
+};
 
-const isCaptionArray = (v: unknown): v is readonly Caption[] =>
-  Array.isArray(v) && v.every(isCaption);
+/**
+ * Describe why a caption is malformed, indexed by position so the
+ * scene author can find the offending entry directly (codex review,
+ * cycle 1 — adjacent composition-manifest validator does the same).
+ * Returns the message the scene-schema error envelope will report,
+ * or `null` when the caption is well-formed. Caption text is NEVER
+ * echoed in the message (preflight: avoid leaking full caption
+ * content through diagnostics).
+ */
+const describeCaptionFault = (cap: unknown, index: number): string | null => {
+  if (!isPlainRecord(cap)) {
+    return `captions[${index}] must be a {at, text} object`;
+  }
+  if (!isCaptionAt(cap.at)) {
+    return `captions[${index}].at must be a non-negative integer (ms) or a kebab-case beat label (${KEBAB_IDENTIFIER_FORM})`;
+  }
+  if (typeof cap.text !== 'string') {
+    return `captions[${index}].text must be a string`;
+  }
+  return null;
+};
 
 // Scene ids share the kebab-case rule with all other Pulsar
 // identifiers per ADR-008 #1; the predicate lives in ./identifier.ts
@@ -138,8 +188,8 @@ const FIELD_GUARDS: readonly FieldGuard[] = [
   },
   {
     field: 'captions',
-    check: (v) => isCaptionArray(v.captions),
-    condition: 'must be an array of {at: number, text: string}',
+    check: (v) => Array.isArray(v.captions),
+    condition: 'must be an array',
   },
   {
     field: 'defaultNext',
@@ -202,6 +252,22 @@ export function assertSceneModule(value: unknown): asserts value is SceneModule 
   for (const guard of FIELD_GUARDS) {
     if (!guard.check(value)) {
       fail(id, guard.field, guard.condition);
+    }
+  }
+
+  // Indexed caption validation (codex review, cycle 1): the
+  // FIELD_GUARDS pass above only verifies `captions` is an array.
+  // Per-element validation runs here so a bad caption in a
+  // multi-caption scene surfaces with its index and the failing
+  // field, matching the adjacent composition-manifest validator's
+  // `composition entry [N] is invalid: ...` envelope. Caption text
+  // is never echoed in the message (preflight: avoid leaking full
+  // caption content).
+  const idLabel = id === undefined ? '?' : `"${id}"`;
+  for (let i = 0; i < (value.captions as readonly unknown[]).length; i++) {
+    const fault = describeCaptionFault((value.captions as readonly unknown[])[i], i);
+    if (fault !== null) {
+      throw new Error(`scene ${idLabel} is invalid: ${fault}`);
     }
   }
 }

--- a/tests/runtime/prompter.test.ts
+++ b/tests/runtime/prompter.test.ts
@@ -148,6 +148,37 @@ describe('buildPrompterScript (PUL-F019 / ADR-022)', () => {
     expect(script.entries[0]?.captions).toEqual([{ at: 0, text: 'kept' }]);
   });
 
+  it('carries mixed numeric and beat-label "at" values through the script entries unchanged (PUL-F027)', () => {
+    // PUL-F027: `Caption.at` is a union of `number` (ms offset) and
+    // `string` (kebab-case beat label). The runtime SHALL derive the
+    // prompter view from this same metadata — `buildPrompterScript`
+    // does NOT coerce, sort, drop, or rewrite `at` based on its type.
+    // A regression that normalized all `at` values to milliseconds in
+    // the prompter path would lose authored beat-label semantics for
+    // consumers (caption editor, beat-aware UI, exporter) that
+    // discriminate by `typeof`.
+    const intro = buildScene({
+      id: 'intro',
+      title: 'Intro',
+      captions: [
+        { at: 0, text: 'opening' },
+        { at: 'hook', text: 'beat-labelled' },
+        { at: 4000, text: 'numeric again' },
+        { at: 'midpoint-stinger', text: 'multi-segment label' },
+      ],
+    });
+    const target: SceneNavigationTarget = { scene: intro };
+
+    const script = buildPrompterScript(target);
+
+    expect(script.entries[0]?.captions).toEqual([
+      { at: 0, text: 'opening' },
+      { at: 'hook', text: 'beat-labelled' },
+      { at: 4000, text: 'numeric again' },
+      { at: 'midpoint-stinger', text: 'multi-segment label' },
+    ]);
+  });
+
   it('preserves all Caption fields structurally (no parallel { at, text } schema)', () => {
     // PUL-F001 declares `Caption` with `at` and `text` today.
     // Future fields (e.g. a `speaker` annotation, an `id` for

--- a/tests/runtime/scene.test.ts
+++ b/tests/runtime/scene.test.ts
@@ -206,28 +206,135 @@ describe('SceneModule contract (PUL-F001)', () => {
     });
   });
 
-  describe('caption element shape', () => {
+  describe('caption element shape (PUL-F027)', () => {
+    // PUL-F027 widens `Caption.at` from `number` to `number | string`,
+    // where the string is a kebab-case beat label sharing the existing
+    // ADR-008 #1 identifier grammar. The numeric branch tightens to
+    // "finite, non-negative integer milliseconds" — the values the
+    // existing scene-module contract documents but did not gate.
     const captionScene = (caption: unknown): Record<string, unknown> =>
       withField('captions', [caption]);
 
-    it('accepts a valid caption', () => {
+    it('accepts a valid numeric caption', () => {
       const cap: Caption = { at: 1000, text: 'hello' };
       expect(() => assertSceneModule(captionScene(cap))).not.toThrow();
     });
 
-    it('accepts multiple captions', () => {
+    it('accepts at: 0 (frame zero)', () => {
+      expect(() => assertSceneModule(captionScene({ at: 0, text: 'hi' }))).not.toThrow();
+    });
+
+    it('accepts a kebab-case beat-label "at" (PUL-F027 string branch)', () => {
+      // ADR-008 #1: scenes, compositions, beats, and assets share one
+      // identifier grammar. A caption pinned to a named beat uses the
+      // same kebab-case string a timeline label uses.
+      expect(() =>
+        assertSceneModule(captionScene({ at: 'midpoint', text: 'pivotal line' })),
+      ).not.toThrow();
+    });
+
+    it('accepts mixed numeric and beat-label captions in one scene', () => {
       expect(() =>
         assertSceneModule(
           withField('captions', [
             { at: 0, text: 'opening hook' },
+            { at: 'hook', text: 'named beat caption' },
             { at: 4000, text: 'first payoff' },
+            { at: 'midpoint-stinger', text: 'multi-segment label' },
           ]),
         ),
       ).not.toThrow();
     });
 
-    it('rejects caption with non-number "at"', () => {
-      expect(() => assertSceneModule(captionScene({ at: '1000', text: 'hi' }))).toThrow(/captions/);
+    it('rejects a non-integer numeric "at"', () => {
+      expect(() => assertSceneModule(captionScene({ at: 1.5, text: 'hi' }))).toThrow(/captions/);
+    });
+
+    it('rejects a negative "at"', () => {
+      expect(() => assertSceneModule(captionScene({ at: -1, text: 'hi' }))).toThrow(/captions/);
+    });
+
+    it('rejects NaN "at"', () => {
+      expect(() => assertSceneModule(captionScene({ at: Number.NaN, text: 'hi' }))).toThrow(
+        /captions/,
+      );
+    });
+
+    it('rejects Infinity "at"', () => {
+      expect(() =>
+        assertSceneModule(captionScene({ at: Number.POSITIVE_INFINITY, text: 'hi' })),
+      ).toThrow(/captions/);
+      expect(() =>
+        assertSceneModule(captionScene({ at: Number.NEGATIVE_INFINITY, text: 'hi' })),
+      ).toThrow(/captions/);
+    });
+
+    it('rejects an empty-string "at"', () => {
+      expect(() => assertSceneModule(captionScene({ at: '', text: 'hi' }))).toThrow(/captions/);
+    });
+
+    it('rejects a non-kebab-case label "at"', () => {
+      // The preflight names every shape the kebab regex rejects.
+      expect(() => assertSceneModule(captionScene({ at: 'Bad Label', text: 'hi' }))).toThrow(
+        /captions/,
+      );
+      expect(() => assertSceneModule(captionScene({ at: 'midpoint!', text: 'hi' }))).toThrow(
+        /captions/,
+      );
+      expect(() => assertSceneModule(captionScene({ at: '--mid', text: 'hi' }))).toThrow(
+        /captions/,
+      );
+      expect(() => assertSceneModule(captionScene({ at: 'a--b', text: 'hi' }))).toThrow(/captions/);
+      expect(() => assertSceneModule(captionScene({ at: 'scene_a', text: 'hi' }))).toThrow(
+        /captions/,
+      );
+    });
+
+    it('accepts a digit-only beat-label "at" (it satisfies the shared kebab grammar)', () => {
+      // Codex review, cycle 1: caption beat labels share the ONE
+      // identifier grammar ADR-008 #1 reserves for scenes,
+      // compositions, beats, and assets. The shared kebab regex
+      // accepts purely-digit labels (`[a-z0-9]+`), and a caption
+      // label MUST NOT carry a stricter sub-grammar — a timeline
+      // label of `"1000"` is valid, a URL `beat=1000` is valid, a
+      // composition `range: ["1000", ...]` is valid, so the caption
+      // schema is consistent. A string `at` value is interpreted
+      // as a beat label, not as a coerced number; if the author
+      // wants 1000ms they write `at: 1000`.
+      expect(() => assertSceneModule(captionScene({ at: '1000', text: 'hi' }))).not.toThrow();
+    });
+
+    it('reports the offending caption index and field on a multi-caption scene (codex review, cycle 1)', () => {
+      // The validator must identify the caption index and the
+      // failing field — not collapse to a generic "captions must be
+      // an array of ..." message — so a scene author with twenty
+      // captions can find the broken one.
+      expect(() =>
+        assertSceneModule(
+          withField('captions', [
+            { at: 0, text: 'good first' },
+            { at: 'good-label', text: 'good middle' },
+            { at: -5, text: 'bad third' },
+          ]),
+        ),
+      ).toThrow(/captions\[2\]\.at/);
+    });
+
+    it('reports the offending caption index and field for a non-string text', () => {
+      expect(() =>
+        assertSceneModule(
+          withField('captions', [
+            { at: 0, text: 'good' },
+            { at: 100, text: 42 },
+          ]),
+        ),
+      ).toThrow(/captions\[1\]\.text/);
+    });
+
+    it('reports the offending caption index when the entry is not an object', () => {
+      expect(() =>
+        assertSceneModule(withField('captions', [{ at: 0, text: 'good' }, 'not-a-caption'])),
+      ).toThrow(/captions\[1\]/);
     });
 
     it('rejects caption with non-string "text"', () => {


### PR DESCRIPTION
Implements PUL-F027: \"Each scene SHALL declare its captions in metadata as a list of \`{ at, text }\` entries, where \`at\` is a millisecond offset or a beat label. The runtime SHALL derive the prompter view from this same metadata.\"

## Key changes

- \`src/runtime/scene.ts\` — widen \`Caption.at\` from \`number\` to \`number | string\` (kebab-case beat label sharing ADR-008 #1 grammar). Tighten numeric branch (reject floats, negatives, NaN, ±Infinity, empty strings). Split caption validation: \`FIELD_GUARDS\` array-only check + per-element \`describeCaptionFault()\` pass that surfaces \`captions[N].at must be ...\` indexed errors. Caption text never echoed in diagnostics.
- \`tests/runtime/scene.test.ts\` — 14 new tests covering the union (numeric + beat-label + mixed), every reject path (float, negative, NaN, ±Infinity, empty, non-kebab, etc.), digit-only labels accepted via shared grammar, indexed error format pinned on multi-caption scenes.
- \`tests/runtime/prompter.test.ts\` — passthrough test pinning that \`buildPrompterScript()\` carries mixed numeric + beat-label \`at\` values unchanged.
- \`docs/adrs/027-caption-timestamp-grammar.md\` — new ADR refining the caption clauses in ADR-002 / ADR-022 (accepted ADRs not edited in place).
- \`docs/adrs/002-scene-registry-and-compositions.md\` + \`docs/adrs/022-workbench-mode-prompter.md\` — cite ADR-027 alongside the original \`{ at: ms, text }\` notes.
- \`CHANGELOG.md\` — \`### Changed\` entry under \`## [Unreleased]\`.

## Plan + review history

Plan: https://github.com/KeplerOps/pulsar/issues/36#issuecomment-4417508040

Codex review: 3 cycles, all findings addressed (caption beat labels share the shared grammar — no caption-only sub-grammar; per-element indexed errors; preflight aligned with implementation; refining ADR created instead of editing accepted ADRs; orphaned isCaption removed).

## Verification

- \`pnpm lint && pnpm typecheck && pnpm test\` — 926/926 passing
- Pre-commit clean
- \`buildPrompterScript\` unchanged — single source of truth for prompter view derivation, structurally preserved

Closes #36