### PR TITLE
Implement PUL-F028 runtime validation pass (ADR-008 #7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,59 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Runtime validation pass — PUL-F028 / ADR-008 #7 — in
+  `src/runtime/validation.ts`: a new `validateRuntime(input)` function
+  that inspects the same declarative inputs the runtime consumes at
+  boot (raw scene modules + composition registrations + an optional
+  asset policy) and returns a frozen `readonly Finding[]` covering the
+  four clauses of the requirement statement — scene ids referenced in
+  compositions but not registered (`unknown-scene-reference`), assets
+  referenced in scene metadata that fail `resolveAssetUrl`
+  (`asset-unresolvable`), duplicate scene ids
+  (`duplicate-scene-id`), and scenes that do not export a
+  `cleanup` function (`scene-schema-invalid`, which is the existing
+  PUL-F001 envelope from `assertSceneModule`). A malformed composition
+  manifest emits one `composition-manifest-invalid` finding and is
+  skipped for the reference check so a bad shape never produces
+  misleading "missing scene" misses. The pass is a pure orchestrator
+  over existing contracts: `assertSceneModule`,
+  `assertCompositionManifest` + `entryId` + the same iteration
+  `findUnregisteredEntries` uses, `resolveAssetUrl` with the
+  preloader's `baseUrl` / `allowedSchemes` (defaulting to
+  `DEFAULT_ALLOWED_SCHEMES`), and the id-registry duplicate-id
+  grammar — no parallel scene/composition schema, registry, asset
+  inventory, URL parser, exception hierarchy, logging framework, or
+  config surface. Side-effect-free by construction: never calls
+  `scene.create` / `scene.timeline` / `scene.cleanup`, never `fetch`es,
+  never imports anything, never touches the DOM / history / storage
+  / audio engine / preloader / timeline adapter / navigation dispatch
+  / process argv / env vars. Findings carry only ids, indexes, asset
+  strings, and bounded diagnostic text — never raw scene objects,
+  full captions, request headers, cookies, or auth values. A thin
+  fail-loud wrapper `assertNoValidationFindings(findings)` throws an
+  `AggregateError` (`runtime validation failed: N finding(s)`) whose
+  `errors` array carries one `Error` per finding for callers that
+  want exception semantics. Validation is the agent / author
+  inspection tool that runs *before* the throwing registry /
+  resolver / preloader paths the runtime already exposes — those
+  paths stay untouched. `src/main.ts` invokes the pass at boot
+  against the same scene and composition inputs it is about to hand
+  to `createSceneRegistry` and `createCompositionRegistry`; on a
+  non-empty findings array, each finding is logged through the
+  workbench error sink (`console.error`), the `#stage` element gets a
+  `data-pulsar-validation-failed` attribute so screenshot regression
+  / agent-driven inspection can see at a glance that boot aborted
+  on structural grounds, and `assertNoValidationFindings` halts the
+  workbench before navigation, loader, preloader, or resolver
+  touch a broken graph. Empty findings → boot proceeds untouched.
+  The `createIdRegistry` helper gained an optional `onDuplicate`
+  collector hook so the validator and the runtime boot path share
+  one source of truth for duplicate-id semantics; the runtime path
+  (no callback) still throws fail-fast with the
+  `<label>: duplicate id "<id>"` grammar.
+
 ### Changed
 
 - Caption metadata `at` widened — PUL-F027 / ADR-002 / ADR-008 — in

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -21,6 +21,7 @@ Design context for Pulsar. Source material for the ADRs in `../adrs/`.
 | [pul-f025-master-mute-preflight.md](pul-f025-master-mute-preflight.md) | Guardrails for implementing presenter master mute. |
 | [pul-f026-rehearsal-mode-preflight.md](pul-f026-rehearsal-mode-preflight.md) | Guardrails for implementing rehearsal audio suppression or cue logging without timeline-state changes. |
 | [pul-f027-caption-metadata-prompter-preflight.md](pul-f027-caption-metadata-prompter-preflight.md) | Guardrails for widening caption metadata timing and keeping prompter content single-sourced. |
+| [pul-f028-validation-preflight.md](pul-f028-validation-preflight.md) | Guardrails for implementing structural runtime validation without duplicating schemas, registries, asset policy, or lifecycle logic. |
 
 Design docs are mutable. Decisions are captured as ADRs (immutable once
 accepted).

--- a/docs/design/pul-f028-validation-preflight.md
+++ b/docs/design/pul-f028-validation-preflight.md
@@ -1,0 +1,140 @@
+# PUL-F028 Validation Preflight
+
+PUL-F028 adds a runtime validation pass for structural authoring
+breakage: composition entries that reference unregistered scenes,
+asset URLs declared in scene metadata that cannot be resolved,
+duplicate scene ids, and scene modules that do not export
+`cleanup(ctx)`.
+
+This is an orchestration layer over existing contracts. It is not a
+second scene schema, second composition schema, registry replacement,
+asset preloader clone, CLI-only linter, or workflow controller. The
+validator should make the current runtime boundaries inspectable
+before lifecycle effects begin.
+
+## Boundary
+
+- `src/runtime/scene.ts` remains the scene module contract. The
+  validation pass must reuse `assertSceneModule()` for required
+  fields, including `cleanup`.
+- `src/runtime/registry.ts`, `src/runtime/composition-registry.ts`,
+  and `src/runtime/id-registry.ts` remain the canonical id-keyed
+  registry boundaries. Duplicate scene ids are detected by the same
+  `createSceneRegistry()` / `createIdRegistry()` behavior, not by a
+  parallel map with different error grammar.
+- `src/runtime/composition.ts` remains the composition-manifest format
+  and reference helper. Use `assertCompositionManifest()`,
+  `entryId()`, and `findUnregisteredEntries()` for composition
+  reference checks.
+- `src/runtime/asset-preloader.ts` remains the asset URL resolution
+  and scheme-policy boundary. Asset validation must reuse
+  `resolveAssetUrl()` and the same `allowedSchemes` / `baseUrl`
+  semantics the preloader and audio service use.
+- `src/runtime/composition-resolver.ts`, `src/runtime/scene-navigation.ts`,
+  and `src/runtime/scene-loader.ts` remain lifecycle/navigation
+  layers. Validation may run before them, but it must not move scene
+  mounting, asset fetching, timeline creation, navigation dispatch, or
+  cleanup ownership into the validation pass.
+
+## Required Reuse
+
+Implementation must build on these incumbents:
+
+- Scene schema: `SceneModule`, `assertSceneModule()`,
+  `isSceneModule()`, `isPlainRecord()`, `isKebabIdentifier()`, and
+  `KEBAB_IDENTIFIER_FORM`.
+- Registry behavior: `createSceneRegistry()`, `SceneRegistry`,
+  `createIdRegistry()`, frozen `ids()` snapshots, and existing
+  duplicate-id messages.
+- Composition schema and references: `CompositionManifest`,
+  `assertCompositionManifest()`, `entryId()`, and
+  `findUnregisteredEntries()`.
+- Asset policy: `scene.assets`, `resolveAssetUrl()`,
+  `DEFAULT_ALLOWED_SCHEMES`, `AssetPreloaderOptions.baseUrl`, and
+  `AssetPreloaderOptions.allowedSchemes`.
+- Error rendering and diagnostics: `describeError()`, existing
+  `Error` / `AggregateError` style, loader `onError`, and
+  `data-pulsar-navigation-error` where validation is surfaced through
+  the workbench.
+- Tests and tooling: Vitest suites under `tests/runtime/*`,
+  `pnpm test`, `pnpm typecheck`, and `pnpm lint`.
+
+## Cross-Cutting Layers
+
+| Layer | Guardrail |
+|-------|-----------|
+| Scene schema gate | `assertSceneModule()` is the only shape-check for scene modules. A missing or non-function `cleanup` keeps the existing `scene "<id>" is invalid: cleanup ...` grammar. Do not add `CleanupError` or a second required-field table. |
+| Scene id registry | Duplicate scene ids must use the id-registry construction path so uniqueness, insertion order, `ids()` snapshots, and frozen surfaces stay identical to normal runtime boot. |
+| Composition schema gate | Validate manifest shape with `assertCompositionManifest()` before checking references. Do not let a malformed object-form entry reach registry lookup and produce a misleading "missing scene" error. |
+| Composition reference check | Use `findUnregisteredEntries()` to aggregate every dangling scene id in declaration order. Error text should name the composition id, scene id, and entry index. |
+| Asset URL policy | Asset resolvability means resolving each `scene.assets` value through `resolveAssetUrl(asset, baseUrl, allowedSchemes)`. Honor the same protocol-relative, relative-without-`baseUrl`, invalid-URL, and scheme-allowlist semantics as the preloader. Do not copy the URL parser. |
+| Network / filesystem security | Core validation must not fetch, stream-drain, import, read arbitrary files, or probe the network just to validate metadata. If a future local-file or CDN existence check is required, add it as an injected resolver with explicit policy. |
+| Audio source policy | Audio already reuses `scene.assets` and `resolveAssetUrl()` through `audio.ts`. Do not add an `audioAssets` field or a separate audio validation inventory. |
+| Timeline / lifecycle | Validation must not call `scene.create(ctx)`, `scene.timeline(ctx)`, or `scene.cleanup(ctx)`. Timeline beat validation remains `assertSceneTimeline()` when the lifecycle creates a timeline; PUL-F028 is structural metadata validation. |
+| URL / mode / auth surface | No new URL key, workbench mode, presenter command, auth gate, cookie, localStorage, sessionStorage, or history-state rule is needed. Validation is not navigation parsing. |
+| Config and env binding | The only asset-policy parameters should mirror the existing preloader shape: `baseUrl` and `allowedSchemes`. Do not add env vars, process argv flags, hidden config files, or persistent browser state for this requirement. |
+| OS-level exposure | Asset paths, source URLs, captions, headers, tokens, and registry objects must not be passed through process argv or shell commands. Browser/runtime validation should stay in memory; any future CLI wrapper must pass options through typed config, not argv secrets. |
+| Error envelope and leakage | Diagnostics should be actionable and bounded: ids, composition ids, entry indexes, asset string, resolved URL when relevant, and rule violated. Do not dump raw scene objects, request headers, cookies, authorization values, or full captions. |
+| Observability | Surface validation failures through the same workbench error sink and stage diagnostic path when invoked from the browser. Avoid scattered `console.log` output or a new logging framework. |
+
+## Validation Contract
+
+The pass should inspect the same declarative inputs the runtime uses:
+the scene module collection, composition registry entries/manifests,
+and an optional asset URL policy. It should report structural problems
+before preload, mount, timeline composition, presenter input, audio
+playback, or cleanup side effects.
+
+The pass may choose a throwing or diagnostic-list API, but it must keep
+one canonical normalization path. If it reports multiple failures, use
+the repo's existing aggregate-error style or a small diagnostic value
+owned by the validation module; do not expose subsystem-specific
+private objects or introduce parallel exception hierarchies.
+
+## Extensibility
+
+The required seam is the asset resolver policy. Keep it parameterized
+with the same knobs the preloader already has: `baseUrl` and
+`allowedSchemes`. A future offline-export validator can add an
+injected existence resolver at that seam without changing scene
+metadata, composition manifests, registries, or the browser loader.
+
+If multiple callers need validation output in different shapes
+(browser error, CI summary, JSON report), keep collection separate
+from rendering. The canonical validation pass should produce stable
+findings; adapters format them for the workbench or CI.
+
+## Gotchas And Anti-Patterns
+
+- Do not implement validation by running the scene lifecycle. That
+  turns a structural check into rendering, network, audio, and cleanup
+  behavior.
+- Do not build new scene/composition DTOs. The runtime already has the
+  contracts and validators.
+- Do not copy the kebab-case regex, manifest entry parsing, duplicate
+  id map, or asset scheme logic.
+- Do not validate only the active URL target. PUL-F028 is about the
+  registered runtime graph, not the currently navigated scene.
+- Do not flatten object-form composition entries or drop `range` /
+  `behavior` while checking references; use `entryId()`.
+- Do not silently accept malformed composition manifests and then
+  report missing scenes from bad shapes.
+- Do not fetch assets in the core validator. Fetching belongs to the
+  preloader; validation should be deterministic and cheap.
+- Do not add an asset inventory separate from `scene.assets`.
+- Do not mark missing `cleanup` as a warning. `cleanup` is mandatory
+  scene schema and lifecycle policy.
+- Do not create a new logging, exception, config, auth, persistence, or
+  workflow subsystem for this pass.
+
+## Non-Goals
+
+PUL-F028 does not implement a CLI UX, CI workflow, requirement status
+transition, GitHub automation, asset downloading, file existence
+probing, CDN health checks, image/audio decode checks, timeline beat
+existence linting, screenshot regression, scene rendering, presenter
+controls, auth, persistence, telemetry, or a new validation library.
+
+It should not change scene metadata, composition manifest shape,
+navigation URL grammar, workbench modes, timeline transport, audio
+service behavior, registry mutability, or lifecycle ordering.

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,15 +38,52 @@ import type { PrompterRenderer } from './runtime/prompter';
 import { createSceneRegistry } from './runtime/registry';
 import { type WorkbenchSceneCtx, createSceneLoader } from './runtime/scene-loader';
 import { createGsapCompositionTimeline, createTimelineEngine } from './runtime/timeline';
+import { assertNoValidationFindings, validateRuntime } from './runtime/validation';
 import { placeholderScene } from './scenes/placeholder';
 
 const stage = document.querySelector('#stage');
 stage?.setAttribute('data-pulsar', 'placeholder');
 
-const sceneRegistry = createSceneRegistry([placeholderScene]);
-const compositionRegistry = createCompositionRegistry([
-  { id: DEFAULT_COMPOSITION_ID, manifest: defaultComposition },
-]);
+// PUL-F028 / ADR-008 #7: structural validation pass BEFORE any
+// lifecycle effect. Runs over the same declarative inputs the
+// workbench is about to hand to `createSceneRegistry` and
+// `createCompositionRegistry`, surfacing every finding — missing
+// scenes in compositions, dangling assets, duplicate ids, undeclared
+// cleanup — in one aggregate. The workbench error sink picks up the
+// per-finding detail; the `data-pulsar-validation-failed` stage
+// attribute lets screenshot regression and agent-driven inspection
+// see at a glance that boot was aborted on structural grounds. The
+// throwing wrapper halts the workbench so navigation, the loader,
+// the preloader, and the resolver never touch a broken graph. Empty
+// findings array → boot proceeds untouched.
+//
+// `scenes` and `compositionEntries` are declared ONCE and passed to
+// both the validator and the registry constructors. Splitting them
+// into per-call literals would let a future scene get added to the
+// registry path without being added to validation, leaving the
+// PUL-F028 gate looking active while running unvalidated inputs
+// (codex review cycle 3).
+const scenes = [placeholderScene];
+const compositionEntries = [{ id: DEFAULT_COMPOSITION_ID, manifest: defaultComposition }];
+
+// Clear the failure marker before every boot. In a same-document
+// lifecycle (Vite HMR or repeated `import` evaluation) a previous
+// failed evaluation may have set the attribute; without an explicit
+// reset, the stage would stay marked as validation-failed even after
+// the author fixes the broken graph (codex review cycle 3).
+stage?.removeAttribute('data-pulsar-validation-failed');
+
+const validationFindings = validateRuntime({ scenes, compositions: compositionEntries });
+if (validationFindings.length > 0) {
+  stage?.setAttribute('data-pulsar-validation-failed', 'true');
+  for (const finding of validationFindings) {
+    console.error(`pulsar validation [${finding.code}]: ${finding.message}`);
+  }
+  assertNoValidationFindings(validationFindings);
+}
+
+const sceneRegistry = createSceneRegistry(scenes);
+const compositionRegistry = createCompositionRegistry(compositionEntries);
 
 // PUL-F022 / ADR-003: the GSAP timeline engine. Scenes receive it as
 // `ctx.gsap` and build their timeline with it; the runtime composes the

--- a/src/runtime/id-registry.ts
+++ b/src/runtime/id-registry.ts
@@ -56,12 +56,20 @@ export interface IdRegistry<T> {
  *  - `transform` — applied to each registered value before storage.
  *    Lets the composition registry deep-freeze its manifests without
  *    leaking that concern into the generic.
+ *  - `onDuplicate` — optional collector invoked instead of throwing
+ *    when an entry's id is already registered. Lets PUL-F028's
+ *    runtime validation pass aggregate every duplicate occurrence
+ *    rather than stopping at the first, while leaving the runtime
+ *    construction path (no callback supplied) fail-fast with the
+ *    `<label>: duplicate id "<id>"` envelope. The duplicating entry
+ *    is NOT registered; the first occurrence remains canonical.
  */
 export interface IdRegistryConfig<T> {
   readonly label: string;
   readonly subject?: string;
   readonly validateId: (id: string) => void;
   readonly transform?: (value: T) => T;
+  readonly onDuplicate?: (entry: IdRegistryEntry<T>) => void;
 }
 
 /**
@@ -89,6 +97,15 @@ export function createIdRegistry<T>(
   for (const entry of entries) {
     config.validateId(entry.id);
     if (byId.has(entry.id)) {
+      // `onDuplicate` lets the PUL-F028 validation pass aggregate every
+      // duplicate occurrence (registry stays the single source of truth
+      // for uniqueness + error grammar). Default path remains fail-fast:
+      // the runtime's boot construction never supplies the callback, so
+      // a duplicate at registry construction still throws.
+      if (config.onDuplicate !== undefined) {
+        config.onDuplicate(entry);
+        continue;
+      }
       throw new Error(`${config.label}: duplicate id "${entry.id}"`);
     }
     const stored = config.transform === undefined ? entry.value : config.transform(entry.value);

--- a/src/runtime/validation.ts
+++ b/src/runtime/validation.ts
@@ -169,152 +169,222 @@ export interface ValidationInput {
  * findings. Within each category, findings appear in iteration order
  * of the underlying input.
  */
+/**
+ * Per-record metadata extracted by phase 1 for phases 2 (duplicate-id)
+ * and 4 (asset). Fields are `null` when not locally valid; each
+ * downstream phase iterates the array and skips records that don't
+ * carry the field it needs.
+ */
+interface Inspected {
+  readonly id: string | null;
+  readonly assets: readonly string[] | null;
+}
+
 export function validateRuntime(input: ValidationInput): readonly Finding[] {
   const findings: Finding[] = [];
+  const inspected = runSceneShapePhase(input.scenes, findings);
+  const validIds = runDuplicateIdPhase(inspected, findings);
+  runCompositionPhase(input.compositions, validIds, findings);
+  runAssetPhase(inspected, input.assets, findings);
+  return Object.freeze(findings);
+}
 
-  // ── Phase 1: per-record inspection. ──────────────────────────────
-  //
-  // The four clauses of PUL-F028 are INDEPENDENT classes of breakage.
-  // A scene that fails the full PUL-F001 schema gate (e.g. missing
-  // `cleanup`) may still carry a locally-valid `id` or `assets` array
-  // — and a duplicate of that id, or a bad asset URL it declares, are
-  // their own findings the author needs to see. Gating phases 2–4 on
-  // the full schema check would suppress those independent findings
-  // (codex review cycle 2, class finding).
-  //
-  // So we walk every record once: run `assertSceneModule` to surface
-  // the schema finding when applicable, AND independently extract the
-  // minimal locally-valid fields needed by phases 2 / 4. The id check
-  // reuses `isKebabIdentifier` — the shared identifier rule the scene
-  // schema, registry, composition manifest, and URL parser already
-  // share. The assets check is the same `Array<string>` predicate
-  // `assertSceneModule` applies. No second schema, no parallel
-  // contract — just minimal field extraction next to the canonical
-  // gate.
-  interface Inspected {
-    readonly id: string | null;
-    readonly assets: readonly string[] | null;
-  }
+/**
+ * Phase 1 — per-record inspection (clause d falls out here).
+ *
+ * The four clauses of PUL-F028 are INDEPENDENT classes of breakage.
+ * A scene that fails the full PUL-F001 schema gate (e.g. missing
+ * `cleanup`) may still carry a locally-valid `id` or `assets` array
+ * — and a duplicate of that id, or a bad asset URL it declares, are
+ * their own findings the author needs to see. Gating phases 2–4 on
+ * the full schema check would suppress those independent findings
+ * (codex review cycle 2, class finding).
+ *
+ * So we walk every record once: run `assertSceneModule` to surface
+ * the schema finding when applicable, AND independently extract the
+ * minimal locally-valid fields needed by phases 2 / 4. The id check
+ * reuses `isKebabIdentifier` — the shared identifier rule the scene
+ * schema, registry, composition manifest, and URL parser already
+ * share. The assets check is the same `Array<string>` predicate
+ * `assertSceneModule` applies. No second schema, no parallel
+ * contract — just minimal field extraction next to the canonical
+ * gate.
+ */
+function runSceneShapePhase(scenes: Iterable<unknown>, findings: Finding[]): readonly Inspected[] {
   const inspected: Inspected[] = [];
-  for (const scene of input.scenes) {
+  for (const scene of scenes) {
     const shapeFinding = checkSceneShape(scene);
     if (shapeFinding !== null) findings.push(shapeFinding);
     inspected.push(inspectScene(scene));
   }
+  return inspected;
+}
 
-  // ── Phase 2: duplicate scene ids (clause c). ─────────────────────
-  //
-  // Reuses the same `createIdRegistry` path that builds the scene
-  // registry at runtime boot, with the new `onDuplicate` collector
-  // hook that accumulates rather than throws. Single source of truth
-  // for uniqueness semantics and the `<label>: duplicate id "<id>"`
-  // error grammar. First occurrence remains canonical (the registry
-  // does not register the duplicating entry — `ids()` mirrors what a
-  // boot-time registry would have held). Iterates over every record
-  // with a locally-valid id, regardless of full-schema status, so a
-  // duplicate id on a cleanup-less scene still surfaces.
-  const sceneIdRegistry = createIdRegistry<null>(
-    (function* idEntries() {
-      for (const item of inspected) {
-        if (item.id !== null) yield { id: item.id, value: null };
-      }
-    })(),
-    {
-      label: 'scene registry',
-      subject: 'scene',
-      // `isKebabIdentifier` already accepted the id during phase 1
-      // extraction; the id-registry's id-shape check would be
-      // redundant here. Matches `createSceneRegistry`'s wiring.
-      validateId: () => undefined,
-      onDuplicate: (entry) => {
-        findings.push({
-          code: 'duplicate-scene-id',
-          message: `scene registry: duplicate id "${entry.id}"`,
-          sceneId: entry.id,
-        });
-      },
+/**
+ * Phase 2 — duplicate scene ids (clause c).
+ *
+ * Reuses the same `createIdRegistry` path that builds the scene
+ * registry at runtime boot, with the `onDuplicate` collector hook
+ * that accumulates rather than throws. Single source of truth for
+ * uniqueness semantics and the `<label>: duplicate id "<id>"` error
+ * grammar. First occurrence remains canonical (the registry does not
+ * register the duplicating entry — `ids()` mirrors what a boot-time
+ * registry would have held). Iterates over every record with a
+ * locally-valid id, regardless of full-schema status, so a duplicate
+ * id on a cleanup-less scene still surfaces.
+ *
+ * Returns the set of unique scene ids the composition phase uses to
+ * resolve manifest references against.
+ */
+function runDuplicateIdPhase(
+  inspected: readonly Inspected[],
+  findings: Finding[],
+): ReadonlySet<string> {
+  const sceneIdRegistry = createIdRegistry<null>(idEntries(inspected), {
+    label: 'scene registry',
+    subject: 'scene',
+    // `isKebabIdentifier` already accepted the id during phase 1
+    // extraction; the id-registry's id-shape check would be
+    // redundant here. Matches `createSceneRegistry`'s wiring.
+    validateId: () => undefined,
+    onDuplicate: (entry) => {
+      findings.push({
+        code: 'duplicate-scene-id',
+        message: `scene registry: duplicate id "${entry.id}"`,
+        sceneId: entry.id,
+      });
     },
-  );
-  const validIds = new Set<string>(sceneIdRegistry.ids());
+  });
+  return new Set<string>(sceneIdRegistry.ids());
+}
 
-  // ── Phase 3: composition references (clause a + manifest shape). ─
-  //
-  // A composition with a malformed manifest emits one
-  // `composition-manifest-invalid` finding and is skipped for the
-  // reference check — walking a bad shape would produce misleading
-  // "missing scene" misses (preflight anti-pattern). `manifest` is
-  // typed `unknown` on the input; `checkCompositionShape` narrows
-  // through `assertCompositionManifest`.
-  if (input.compositions !== undefined) {
-    for (const composition of input.compositions) {
-      const manifestFinding = checkCompositionShape(composition);
-      if (manifestFinding !== null) {
-        findings.push(manifestFinding);
-        continue;
-      }
-      // After `assertCompositionManifest` has accepted the value,
-      // `findUnregisteredEntries` walks every entry through `entryId`
-      // and aggregates the misses in declaration order — the same
-      // helper the resolver uses for its preflight pass (single
-      // source of truth for the iteration shape).
-      const validManifest = composition.manifest as Parameters<typeof findUnregisteredEntries>[0];
-      const misses = findUnregisteredEntries(validManifest, (id) => validIds.has(id));
-      for (const miss of misses) {
-        findings.push({
-          code: 'unknown-scene-reference',
-          message: `composition "${composition.id}" entry [${miss.index}] references unknown scene id "${miss.id}"`,
-          compositionId: composition.id,
-          entryIndex: miss.index,
-          sceneId: miss.id,
-        });
-      }
-    }
+/** Yield `{id, value: null}` for every inspected record that has a kebab id. */
+function* idEntries(inspected: readonly Inspected[]): Iterable<{ id: string; value: null }> {
+  for (const item of inspected) {
+    if (item.id === null) continue;
+    yield { id: item.id, value: null };
   }
+}
 
-  // ── Phase 4: asset resolvability (clause b). ─────────────────────
-  //
-  // Iterates EVERY record with a locally-valid `assets` array,
-  // regardless of full-schema status. A scene missing `cleanup` may
-  // still declare an asset that fails resolution — reporting the
-  // schema fault and the asset fault are independent concerns. Also
-  // covers duplicate-id occurrences past the first: a duplicate
-  // scene's `.assets` may differ from the canonical one, and clause
-  // (b) covers "assets referenced in scene metadata".
-  //
-  // `resolveAssetUrl` is the canonical scheme + URL gate the preloader
-  // and audio service already share. We reuse it verbatim — there is
-  // ONE asset-policy rule for the runtime, parameterised by `baseUrl`
-  // and `allowedSchemes`, defaulting to `DEFAULT_ALLOWED_SCHEMES`. A
-  // future tightening of the preloader's allowlist flows here
-  // automatically.
-  const assetPolicy = input.assets;
-  const baseUrl = assetPolicy?.baseUrl;
-  const allowedSchemes = assetPolicy?.allowedSchemes ?? DEFAULT_ALLOWED_SCHEMES;
+/**
+ * Phase 3 — composition references (clause a + manifest shape).
+ *
+ * A composition with a malformed manifest emits one
+ * `composition-manifest-invalid` finding and is skipped for the
+ * reference check — walking a bad shape would produce misleading
+ * "missing scene" misses (preflight anti-pattern). After
+ * `assertCompositionManifest` has accepted the value,
+ * `findUnregisteredEntries` walks every entry through `entryId` and
+ * aggregates the misses in declaration order — the same helper the
+ * resolver uses for its preflight pass (single source of truth for
+ * the iteration shape).
+ */
+function runCompositionPhase(
+  compositions: Iterable<ValidationCompositionInput> | undefined,
+  validIds: ReadonlySet<string>,
+  findings: Finding[],
+): void {
+  if (compositions === undefined) return;
+  for (const composition of compositions) {
+    const manifestFinding = checkCompositionShape(composition);
+    if (manifestFinding !== null) {
+      findings.push(manifestFinding);
+      continue;
+    }
+    appendCompositionReferenceFindings(composition, validIds, findings);
+  }
+}
+
+/**
+ * After the composition's manifest has cleared shape validation, walk
+ * its entries through `findUnregisteredEntries` and emit one
+ * `unknown-scene-reference` finding per missing reference (clause a).
+ */
+function appendCompositionReferenceFindings(
+  composition: ValidationCompositionInput,
+  validIds: ReadonlySet<string>,
+  findings: Finding[],
+): void {
+  const validManifest = composition.manifest as Parameters<typeof findUnregisteredEntries>[0];
+  const misses = findUnregisteredEntries(validManifest, (id) => validIds.has(id));
+  for (const miss of misses) {
+    findings.push({
+      code: 'unknown-scene-reference',
+      message: `composition "${composition.id}" entry [${miss.index}] references unknown scene id "${miss.id}"`,
+      compositionId: composition.id,
+      entryIndex: miss.index,
+      sceneId: miss.id,
+    });
+  }
+}
+
+/**
+ * Phase 4 — asset resolvability (clause b).
+ *
+ * Iterates EVERY record with a locally-valid `assets` array,
+ * regardless of full-schema status. A scene missing `cleanup` may
+ * still declare an asset that fails resolution — reporting the
+ * schema fault and the asset fault are independent concerns. Also
+ * covers duplicate-id occurrences past the first: a duplicate
+ * scene's `.assets` may differ from the canonical one, and clause
+ * (b) covers "assets referenced in scene metadata".
+ *
+ * `resolveAssetUrl` is the canonical scheme + URL gate the preloader
+ * and audio service already share. We reuse it verbatim — there is
+ * ONE asset-policy rule for the runtime, parameterised by `baseUrl`
+ * and `allowedSchemes`, defaulting to `DEFAULT_ALLOWED_SCHEMES`. A
+ * future tightening of the preloader's allowlist flows here
+ * automatically.
+ */
+function runAssetPhase(
+  inspected: readonly Inspected[],
+  policy: ValidationInput['assets'],
+  findings: Finding[],
+): void {
+  const baseUrl = policy?.baseUrl;
+  const allowedSchemes = policy?.allowedSchemes ?? DEFAULT_ALLOWED_SCHEMES;
   for (const item of inspected) {
     if (item.assets === null) continue;
     for (const asset of item.assets) {
-      try {
-        resolveAssetUrl(asset, baseUrl, allowedSchemes);
-      } catch (cause) {
-        // Self-contained message: prepend the scene id when known so
-        // the AggregateError thrown by `assertNoValidationFindings` and
-        // the workbench's per-line `console.error` both identify which
-        // declaration to edit. Multiple scenes pointing at the same
-        // asset URL would otherwise produce indistinguishable lines
-        // (codex review cycle 3).
-        const detail = describeError(cause);
-        const message = item.id !== null ? `scene "${item.id}": ${detail}` : detail;
-        findings.push({
-          code: 'asset-unresolvable',
-          message,
-          ...(item.id !== null ? { sceneId: item.id } : {}),
-          asset,
-        });
-      }
+      const finding = checkAssetResolvable(item, asset, baseUrl, allowedSchemes);
+      if (finding !== null) findings.push(finding);
     }
   }
+}
 
-  return Object.freeze(findings);
+/**
+ * Resolve one asset URL and return either the `asset-unresolvable`
+ * finding for a rejection or `null` when the asset is well-formed.
+ *
+ * Self-contained message: prepends the scene id when known so the
+ * AggregateError thrown by `assertNoValidationFindings` and the
+ * workbench's per-line `console.error` both identify which
+ * declaration to edit. Multiple scenes pointing at the same asset URL
+ * would otherwise produce indistinguishable lines (codex review
+ * cycle 3).
+ */
+function checkAssetResolvable(
+  item: Inspected,
+  asset: string,
+  baseUrl: string | undefined,
+  allowedSchemes: readonly string[],
+): Finding | null {
+  try {
+    resolveAssetUrl(asset, baseUrl, allowedSchemes);
+    return null;
+  } catch (cause) {
+    const detail = describeError(cause);
+    const id = item.id;
+    if (id === null) {
+      return { code: 'asset-unresolvable', message: detail, asset };
+    }
+    return {
+      code: 'asset-unresolvable',
+      message: `scene "${id}": ${detail}`,
+      sceneId: id,
+      asset,
+    };
+  }
 }
 
 /**

--- a/src/runtime/validation.ts
+++ b/src/runtime/validation.ts
@@ -1,0 +1,421 @@
+// Runtime validation pass — PUL-F028.
+//
+// PUL-F028 mandates that the runtime SHALL provide a validation pass
+// that detects four classes of structural breakage:
+//
+//   (a) scene ids referenced in compositions but not present in the
+//       scene registry,
+//   (b) assets referenced in scene metadata but not resolvable,
+//   (c) duplicate scene ids,
+//   (d) scenes that do not export a `cleanup` function.
+//
+// ADR-008 #7 commits the runtime to a validation pass with this
+// exact scope. The pass is an inspection tool agents and authors run
+// over the same declarative inputs the runtime consumes at boot — raw
+// scene modules plus composition registrations. It collects every
+// finding rather than failing fast, so an author sees the whole
+// picture before reaching for the throwing registry / resolver / preloader
+// paths that already exist downstream.
+//
+// This module is a pure orchestrator over existing contracts. It does
+// not introduce a new scene schema, composition schema, registry, asset
+// inventory, URL parser, exception hierarchy, logging framework, or
+// config surface. The four clauses are answered by composing helpers
+// the runtime already owns — see the design preflight at
+// `docs/design/pul-f028-validation-preflight.md`.
+//
+// Boundary typing (codex review cycle 1, class finding):
+// public inputs are typed as `unknown` so callers can pass the
+// possibly-malformed data this API exists to inspect WITHOUT unsafe
+// casts. Internal narrowing happens through `assertSceneModule` and
+// `assertCompositionManifest` — the same gates the runtime uses at
+// boot — so there is one source of truth for "this is a valid scene
+// module / composition manifest".
+//
+// Helper reuse (codex review cycle 1, class finding):
+// duplicate scene-id detection reuses `createIdRegistry`'s
+// `onDuplicate` collector hook (same error grammar as the runtime
+// boot path); composition reference walking reuses
+// `findUnregisteredEntries` (same iteration order the resolver
+// uses). The validator is not allowed to maintain parallel
+// implementations of these behaviors.
+//
+// Side-effect ban (preflight):
+//  - never calls `scene.create`, `scene.timeline`, `scene.cleanup`;
+//  - never `fetch`es, stream-drains, or `import()`s anything;
+//  - does not touch the DOM, history, browser storage, cookies, the
+//    audio engine, the preloader, the timeline adapter, or the
+//    navigation dispatch;
+//  - does not read process argv or environment variables.
+//
+// Collection is separate from rendering: the pass returns a frozen
+// `readonly Finding[]`; callers format for the workbench error sink,
+// a CI summary, or a JSON report.
+
+import { DEFAULT_ALLOWED_SCHEMES, resolveAssetUrl } from './asset-preloader';
+import { assertCompositionManifest, findUnregisteredEntries } from './composition';
+import { describeError } from './error';
+import { createIdRegistry } from './id-registry';
+import { isKebabIdentifier } from './identifier';
+import { assertSceneModule } from './scene';
+
+/**
+ * One row of the validation pass output. Each finding maps to a single
+ * problem in the runtime inputs. `code` is a stable identifier so
+ * callers can branch on category; `message` mirrors the existing
+ * subsystem error grammar (`assertSceneModule`, `assertCompositionManifest`,
+ * id-registry duplicate-id, `resolveAssetUrl`) so an author who is
+ * already used to those messages does not learn a second envelope.
+ *
+ * Structured fields (`sceneId`, `compositionId`, `entryIndex`, `asset`)
+ * are populated where applicable so renderers can group and filter
+ * without parsing the message.
+ *
+ * Per the preflight error-envelope rule, findings carry only ids,
+ * indexes, asset strings, and bounded diagnostic text — never raw
+ * scene objects, full captions, request headers, cookies, or auth
+ * values.
+ */
+export interface Finding {
+  readonly code: FindingCode;
+  readonly message: string;
+  readonly sceneId?: string;
+  readonly compositionId?: string;
+  readonly entryIndex?: number;
+  readonly asset?: string;
+}
+
+/**
+ * Stable codes for the four clauses of PUL-F028 plus the manifest-
+ * shape pre-condition for clause (a). The names map 1:1 onto the
+ * requirement statement so traceability stays direct.
+ */
+export type FindingCode =
+  // Clause (d) — scenes that do not export a cleanup function. Also
+  // covers the rest of the PUL-F001 scene-schema envelope so the
+  // missing-cleanup case stays inside its existing grammar
+  // (`scene "<id>" is invalid: cleanup ...`) instead of growing a
+  // `CleanupError`.
+  | 'scene-schema-invalid'
+  // Clause (c) — duplicate scene ids. Mirrors the id-registry
+  // duplicate-id rule (`scene registry: duplicate id "<id>"`).
+  | 'duplicate-scene-id'
+  // Pre-condition for clause (a) — a malformed composition manifest
+  // cannot be walked for unknown references without producing
+  // misleading misses. Emitted once per composition; the reference
+  // check is skipped on that composition.
+  | 'composition-manifest-invalid'
+  // Clause (a) — scene ids referenced in compositions but not present
+  // in the registry. One finding per missing reference; the resolver's
+  // single-aggregate message stays untouched at the resolver boundary.
+  | 'unknown-scene-reference'
+  // Clause (b) — assets referenced in scene metadata but not
+  // resolvable. Resolvability uses the same `resolveAssetUrl` rule
+  // the preloader and audio service consume, so tightening the
+  // allowlist tightens validation automatically.
+  | 'asset-unresolvable';
+
+/**
+ * One composition registration as the validator sees it. Matches the
+ * `(id, manifest)` shape that `createCompositionRegistry` accepts;
+ * inputs may be sourced directly from the same module declarations
+ * the workbench bundles at boot.
+ *
+ * `manifest` is typed as `unknown` at the boundary so callers can
+ * hand the validator the same raw declarations the runtime gets at
+ * boot, before `assertCompositionManifest` has been run. The
+ * validator narrows internally — there is no caller-side cast on the
+ * unsafe path.
+ */
+export interface ValidationCompositionInput {
+  readonly id: string;
+  readonly manifest: unknown;
+}
+
+/**
+ * Input bundle for {@link validateRuntime}.
+ *
+ *  - `scenes` — every scene module the runtime intends to register.
+ *    Typed as `Iterable<unknown>` because the whole point of the pass
+ *    is to inspect possibly-malformed data; calling code should not
+ *    have to cast to `SceneModule` to feed a value the validator is
+ *    going to reject anyway.
+ *  - `compositions` — optional list of composition registrations. When
+ *    omitted, clauses (a) / manifest-shape are no-ops.
+ *  - `assets` — optional asset-policy block mirroring the preloader's
+ *    `baseUrl` / `allowedSchemes` options. Defaults match the
+ *    preloader: no `baseUrl`, {@link DEFAULT_ALLOWED_SCHEMES}.
+ */
+export interface ValidationInput {
+  readonly scenes: Iterable<unknown>;
+  readonly compositions?: Iterable<ValidationCompositionInput>;
+  readonly assets?: {
+    readonly baseUrl?: string;
+    readonly allowedSchemes?: readonly string[];
+  };
+}
+
+/**
+ * Run the structural validation pass over the supplied inputs.
+ *
+ * Returns a frozen array of findings — empty when the inputs satisfy
+ * every clause of PUL-F028. The pass is pure: it does not throw under
+ * any input shape, does not invoke scene lifecycle hooks, and does not
+ * touch the network, filesystem, DOM, history, audio engine, timeline
+ * adapter, or navigation dispatch.
+ *
+ * Order is deterministic: scene-schema findings precede duplicate-id
+ * findings, which precede composition findings, which precede asset
+ * findings. Within each category, findings appear in iteration order
+ * of the underlying input.
+ */
+export function validateRuntime(input: ValidationInput): readonly Finding[] {
+  const findings: Finding[] = [];
+
+  // ── Phase 1: per-record inspection. ──────────────────────────────
+  //
+  // The four clauses of PUL-F028 are INDEPENDENT classes of breakage.
+  // A scene that fails the full PUL-F001 schema gate (e.g. missing
+  // `cleanup`) may still carry a locally-valid `id` or `assets` array
+  // — and a duplicate of that id, or a bad asset URL it declares, are
+  // their own findings the author needs to see. Gating phases 2–4 on
+  // the full schema check would suppress those independent findings
+  // (codex review cycle 2, class finding).
+  //
+  // So we walk every record once: run `assertSceneModule` to surface
+  // the schema finding when applicable, AND independently extract the
+  // minimal locally-valid fields needed by phases 2 / 4. The id check
+  // reuses `isKebabIdentifier` — the shared identifier rule the scene
+  // schema, registry, composition manifest, and URL parser already
+  // share. The assets check is the same `Array<string>` predicate
+  // `assertSceneModule` applies. No second schema, no parallel
+  // contract — just minimal field extraction next to the canonical
+  // gate.
+  interface Inspected {
+    readonly id: string | null;
+    readonly assets: readonly string[] | null;
+  }
+  const inspected: Inspected[] = [];
+  for (const scene of input.scenes) {
+    const shapeFinding = checkSceneShape(scene);
+    if (shapeFinding !== null) findings.push(shapeFinding);
+    inspected.push(inspectScene(scene));
+  }
+
+  // ── Phase 2: duplicate scene ids (clause c). ─────────────────────
+  //
+  // Reuses the same `createIdRegistry` path that builds the scene
+  // registry at runtime boot, with the new `onDuplicate` collector
+  // hook that accumulates rather than throws. Single source of truth
+  // for uniqueness semantics and the `<label>: duplicate id "<id>"`
+  // error grammar. First occurrence remains canonical (the registry
+  // does not register the duplicating entry — `ids()` mirrors what a
+  // boot-time registry would have held). Iterates over every record
+  // with a locally-valid id, regardless of full-schema status, so a
+  // duplicate id on a cleanup-less scene still surfaces.
+  const sceneIdRegistry = createIdRegistry<null>(
+    (function* idEntries() {
+      for (const item of inspected) {
+        if (item.id !== null) yield { id: item.id, value: null };
+      }
+    })(),
+    {
+      label: 'scene registry',
+      subject: 'scene',
+      // `isKebabIdentifier` already accepted the id during phase 1
+      // extraction; the id-registry's id-shape check would be
+      // redundant here. Matches `createSceneRegistry`'s wiring.
+      validateId: () => undefined,
+      onDuplicate: (entry) => {
+        findings.push({
+          code: 'duplicate-scene-id',
+          message: `scene registry: duplicate id "${entry.id}"`,
+          sceneId: entry.id,
+        });
+      },
+    },
+  );
+  const validIds = new Set<string>(sceneIdRegistry.ids());
+
+  // ── Phase 3: composition references (clause a + manifest shape). ─
+  //
+  // A composition with a malformed manifest emits one
+  // `composition-manifest-invalid` finding and is skipped for the
+  // reference check — walking a bad shape would produce misleading
+  // "missing scene" misses (preflight anti-pattern). `manifest` is
+  // typed `unknown` on the input; `checkCompositionShape` narrows
+  // through `assertCompositionManifest`.
+  if (input.compositions !== undefined) {
+    for (const composition of input.compositions) {
+      const manifestFinding = checkCompositionShape(composition);
+      if (manifestFinding !== null) {
+        findings.push(manifestFinding);
+        continue;
+      }
+      // After `assertCompositionManifest` has accepted the value,
+      // `findUnregisteredEntries` walks every entry through `entryId`
+      // and aggregates the misses in declaration order — the same
+      // helper the resolver uses for its preflight pass (single
+      // source of truth for the iteration shape).
+      const validManifest = composition.manifest as Parameters<typeof findUnregisteredEntries>[0];
+      const misses = findUnregisteredEntries(validManifest, (id) => validIds.has(id));
+      for (const miss of misses) {
+        findings.push({
+          code: 'unknown-scene-reference',
+          message: `composition "${composition.id}" entry [${miss.index}] references unknown scene id "${miss.id}"`,
+          compositionId: composition.id,
+          entryIndex: miss.index,
+          sceneId: miss.id,
+        });
+      }
+    }
+  }
+
+  // ── Phase 4: asset resolvability (clause b). ─────────────────────
+  //
+  // Iterates EVERY record with a locally-valid `assets` array,
+  // regardless of full-schema status. A scene missing `cleanup` may
+  // still declare an asset that fails resolution — reporting the
+  // schema fault and the asset fault are independent concerns. Also
+  // covers duplicate-id occurrences past the first: a duplicate
+  // scene's `.assets` may differ from the canonical one, and clause
+  // (b) covers "assets referenced in scene metadata".
+  //
+  // `resolveAssetUrl` is the canonical scheme + URL gate the preloader
+  // and audio service already share. We reuse it verbatim — there is
+  // ONE asset-policy rule for the runtime, parameterised by `baseUrl`
+  // and `allowedSchemes`, defaulting to `DEFAULT_ALLOWED_SCHEMES`. A
+  // future tightening of the preloader's allowlist flows here
+  // automatically.
+  const assetPolicy = input.assets;
+  const baseUrl = assetPolicy?.baseUrl;
+  const allowedSchemes = assetPolicy?.allowedSchemes ?? DEFAULT_ALLOWED_SCHEMES;
+  for (const item of inspected) {
+    if (item.assets === null) continue;
+    for (const asset of item.assets) {
+      try {
+        resolveAssetUrl(asset, baseUrl, allowedSchemes);
+      } catch (cause) {
+        // Self-contained message: prepend the scene id when known so
+        // the AggregateError thrown by `assertNoValidationFindings` and
+        // the workbench's per-line `console.error` both identify which
+        // declaration to edit. Multiple scenes pointing at the same
+        // asset URL would otherwise produce indistinguishable lines
+        // (codex review cycle 3).
+        const detail = describeError(cause);
+        const message = item.id !== null ? `scene "${item.id}": ${detail}` : detail;
+        findings.push({
+          code: 'asset-unresolvable',
+          message,
+          ...(item.id !== null ? { sceneId: item.id } : {}),
+          asset,
+        });
+      }
+    }
+  }
+
+  return Object.freeze(findings);
+}
+
+/**
+ * Extract the minimum locally-valid fields phases 2 (duplicate-id)
+ * and 4 (asset) need from a candidate scene, INDEPENDENT of whether
+ * the full `assertSceneModule` gate passed for that record. Returns
+ * `null` for absent / not-locally-valid fields so the caller can
+ * still emit independent findings for each field that IS valid.
+ *
+ *  - `id` is populated only when `isKebabIdentifier` accepts the
+ *    record's `id` field — the same predicate the scene schema,
+ *    registry, composition manifest, and URL parser already share.
+ *  - `assets` is populated only when the record's `assets` field is
+ *    an array of strings — the same predicate `assertSceneModule`
+ *    applies internally.
+ *
+ * No second scene schema, no parallel contract: just the minimal
+ * field extraction the dependent phases need (codex review cycle 2).
+ */
+function inspectScene(scene: unknown): { id: string | null; assets: readonly string[] | null } {
+  if (scene === null || typeof scene !== 'object') return { id: null, assets: null };
+  const rec = scene as Record<string, unknown>;
+  const id = isKebabIdentifier(rec.id) ? rec.id : null;
+  const rawAssets = rec.assets;
+  const assets =
+    Array.isArray(rawAssets) && rawAssets.every((a) => typeof a === 'string')
+      ? (rawAssets as readonly string[])
+      : null;
+  return { id, assets };
+}
+
+/**
+ * Throw an {@link AggregateError} carrying one `Error` per finding
+ * (in order) when the list is non-empty. The wrapping message
+ * identifies the failure as a PUL-F028 validation failure so callers
+ * pattern-matching on origin can tell it apart from the
+ * composition-resolver's `composition resolution failed:` aggregate.
+ *
+ * Convenience for callers that want fail-loud semantics; the canonical
+ * collection API is {@link validateRuntime}.
+ */
+export function assertNoValidationFindings(findings: readonly Finding[]): void {
+  if (findings.length === 0) return;
+  throw new AggregateError(
+    findings.map((finding) => new Error(finding.message)),
+    `runtime validation failed: ${findings.length} finding(s)`,
+  );
+}
+
+/**
+ * Run {@link assertSceneModule} against `scene` and return either the
+ * finding for a shape failure or `null` when the scene is well-formed.
+ * The thrown message is preserved verbatim (PUL-F001 envelope —
+ * `scene "<id>" is invalid: <field> <condition>` or `scene ? is
+ * invalid: value must be a non-null object`).
+ *
+ * `sceneId` is attached to the finding only when the candidate
+ * carries a string `id` (regardless of whether the rest of the shape
+ * validated): a scene that is `null`, a primitive, or missing `id`
+ * does not surface a `sceneId`; the message still contains the
+ * validator's `?` placeholder so the renderer can find the offending
+ * position.
+ */
+function checkSceneShape(scene: unknown): Finding | null {
+  try {
+    assertSceneModule(scene);
+    return null;
+  } catch (cause) {
+    const finding: Finding = {
+      code: 'scene-schema-invalid',
+      message: describeError(cause),
+    };
+    if (scene !== null && typeof scene === 'object') {
+      const id = (scene as { id?: unknown }).id;
+      if (typeof id === 'string') return { ...finding, sceneId: id };
+    }
+    return finding;
+  }
+}
+
+/**
+ * Run {@link assertCompositionManifest} against the registration and
+ * return either the finding for a malformed manifest or `null` when
+ * the shape is well-formed.
+ *
+ * The composition id is prepended to the message so the
+ * AggregateError thrown by `assertNoValidationFindings` and the
+ * workbench's per-line `console.error` both identify the offending
+ * registration when multiple compositions are registered (codex
+ * review cycle 3). The structured `compositionId` field remains for
+ * callers that group / filter findings programmatically.
+ */
+function checkCompositionShape(composition: ValidationCompositionInput): Finding | null {
+  try {
+    assertCompositionManifest(composition.manifest);
+    return null;
+  } catch (cause) {
+    return {
+      code: 'composition-manifest-invalid',
+      message: `composition "${composition.id}": ${describeError(cause)}`,
+      compositionId: composition.id,
+    };
+  }
+}

--- a/tests/runtime/id-registry.test.ts
+++ b/tests/runtime/id-registry.test.ts
@@ -1,0 +1,117 @@
+// Focused tests for the id-registry's `onDuplicate` collector hook.
+//
+// Default behavior (no callback supplied) is already exercised at the
+// scene-registry and composition-registry level — those tests pin the
+// fail-fast `<label>: duplicate id "<id>"` throw. This file pins the
+// collector path PUL-F028's validation pass relies on: when
+// `onDuplicate` is set, the registry invokes the callback once per
+// duplicate occurrence (in iteration order) and skips it, leaving the
+// first occurrence canonical.
+
+import { describe, expect, it, vi } from 'vitest';
+import { type IdRegistryEntry, createIdRegistry } from '../../src/runtime/id-registry';
+
+describe('createIdRegistry — onDuplicate collector hook', () => {
+  it('invokes the callback (does not throw) when a duplicate id appears', () => {
+    const onDuplicate = vi.fn();
+    expect(() =>
+      createIdRegistry<number>(
+        [
+          { id: 'a', value: 1 },
+          { id: 'a', value: 2 },
+        ],
+        {
+          label: 'test',
+          subject: 'thing',
+          validateId: () => undefined,
+          onDuplicate,
+        },
+      ),
+    ).not.toThrow();
+    expect(onDuplicate).toHaveBeenCalledTimes(1);
+    const call = onDuplicate.mock.calls[0]?.[0] as IdRegistryEntry<number>;
+    expect(call).toEqual({ id: 'a', value: 2 });
+  });
+
+  it('keeps the first occurrence canonical and skips duplicates from registration', () => {
+    const onDuplicate = vi.fn();
+    const registry = createIdRegistry<number>(
+      [
+        { id: 'a', value: 1 },
+        { id: 'a', value: 2 },
+        { id: 'b', value: 3 },
+      ],
+      {
+        label: 'test',
+        subject: 'thing',
+        validateId: () => undefined,
+        onDuplicate,
+      },
+    );
+    expect(registry.size).toBe(2);
+    expect(registry.ids()).toEqual(['a', 'b']);
+    expect(registry.get('a')).toBe(1);
+    expect(registry.get('b')).toBe(3);
+  });
+
+  it('invokes the callback once per duplicate occurrence in iteration order', () => {
+    const seen: IdRegistryEntry<string>[] = [];
+    createIdRegistry<string>(
+      [
+        { id: 'a', value: 'first' },
+        { id: 'a', value: 'second' },
+        { id: 'a', value: 'third' },
+        { id: 'b', value: 'b1' },
+        { id: 'b', value: 'b2' },
+      ],
+      {
+        label: 'test',
+        subject: 'thing',
+        validateId: () => undefined,
+        onDuplicate: (entry) => seen.push(entry),
+      },
+    );
+    expect(seen).toEqual([
+      { id: 'a', value: 'second' },
+      { id: 'a', value: 'third' },
+      { id: 'b', value: 'b2' },
+    ]);
+  });
+
+  it('still throws on duplicate when no callback is supplied (default fail-fast)', () => {
+    expect(() =>
+      createIdRegistry<number>(
+        [
+          { id: 'a', value: 1 },
+          { id: 'a', value: 2 },
+        ],
+        {
+          label: 'scene registry',
+          subject: 'scene',
+          validateId: () => undefined,
+        },
+      ),
+    ).toThrow(/scene registry: duplicate id "a"/);
+  });
+
+  it('reports the duplicating value (not the canonical first occurrence)', () => {
+    // Confirms the registry hands the callback the entry that was
+    // about to register on top of an existing id — i.e., the source
+    // location an author needs to remove or rename to fix the dup.
+    const collected: IdRegistryEntry<{ marker: string }>[] = [];
+    createIdRegistry<{ marker: string }>(
+      [
+        { id: 'a', value: { marker: 'canonical' } },
+        { id: 'a', value: { marker: 'duplicate' } },
+      ],
+      {
+        label: 'test',
+        subject: 'thing',
+        validateId: () => undefined,
+        onDuplicate: (entry) => collected.push(entry),
+      },
+    );
+    expect(collected).toHaveLength(1);
+    expect(collected[0]?.value.marker).toBe('duplicate');
+  });
+});

--- a/tests/runtime/validation.test.ts
+++ b/tests/runtime/validation.test.ts
@@ -1,0 +1,524 @@
+// PUL-F028 — structural runtime validation pass.
+//
+// Each `describe` block corresponds to one clause of the requirement
+// statement; the structural / aggregate / `assertNoValidationFindings`
+// blocks at the end pin invariants that span the whole module.
+//
+// Tests use raw scene-module / composition fixtures so the validator is
+// exercised against the same declarative inputs the runtime consumes at
+// boot, NOT against an already-built registry. The pass is the agent /
+// author inspection tool that runs *before* the throwing registry path.
+
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_ALLOWED_SCHEMES } from '../../src/runtime/asset-preloader';
+import type { CompositionManifest } from '../../src/runtime/composition';
+import type { SceneModule } from '../../src/runtime/scene';
+import {
+  type Finding,
+  type ValidationInput,
+  assertNoValidationFindings,
+  validateRuntime,
+} from '../../src/runtime/validation';
+
+// The validator's public input is `Iterable<unknown>` so callers
+// hand it possibly-malformed data WITHOUT casts. Test fixtures
+// follow the same shape — well-formed scenes use `SceneModule`,
+// intentionally-broken scenes are plain records, both flow into
+// `validateRuntime` directly.
+
+// Shared scene fixture mirrors the other runtime test files
+// (asset-preloader.test.ts / registry.test.ts) so a future change to
+// the scene contract surfaces in one place.
+const buildScene = (overrides: Partial<SceneModule> = {}): SceneModule => ({
+  id: 'scene-a',
+  title: 'Scene A',
+  duration: 1000,
+  tags: [],
+  assets: [],
+  captions: [],
+  defaultNext: null,
+  standalone: false,
+  trailerSafe: false,
+  create: () => undefined,
+  timeline: () => undefined,
+  cleanup: () => undefined,
+  ...overrides,
+});
+
+const findingCodes = (findings: readonly Finding[]): readonly string[] =>
+  findings.map((f) => f.code);
+
+describe('validateRuntime (PUL-F028)', () => {
+  describe('clause d — scenes that do not export a cleanup function', () => {
+    it('reports scene-schema-invalid when cleanup is missing', () => {
+      const broken: Record<string, unknown> = { ...buildScene({ id: 'no-cleanup' }) };
+      // biome-ignore lint/performance/noDelete: structural delete used to mirror PUL-F001 test
+      delete broken.cleanup;
+      const findings = validateRuntime({
+        scenes: [broken],
+      });
+      expect(findings).toHaveLength(1);
+      expect(findings[0]?.code).toBe('scene-schema-invalid');
+      expect(findings[0]?.sceneId).toBe('no-cleanup');
+      expect(findings[0]?.message).toMatch(/cleanup/);
+    });
+
+    it('reports scene-schema-invalid when cleanup is not a function', () => {
+      const broken: Record<string, unknown> = { ...buildScene({ id: 'bad-cleanup' }) };
+      broken.cleanup = 'nope';
+      const findings = validateRuntime({
+        scenes: [broken],
+      });
+      expect(findings).toHaveLength(1);
+      expect(findings[0]?.code).toBe('scene-schema-invalid');
+      expect(findings[0]?.sceneId).toBe('bad-cleanup');
+      expect(findings[0]?.message).toMatch(/cleanup .*function/);
+    });
+
+    it('does not surface a scene-schema finding for a valid scene', () => {
+      const findings = validateRuntime({
+        scenes: [buildScene({ id: 'ok' })],
+      });
+      expect(findings).toEqual([]);
+    });
+  });
+
+  describe('clause c — duplicate scene ids', () => {
+    it('reports duplicate-scene-id for the second occurrence', () => {
+      const findings = validateRuntime({
+        scenes: [
+          buildScene({ id: 'shared' }),
+          buildScene({ id: 'shared', title: 'Different title' }),
+        ],
+      });
+      expect(findingCodes(findings)).toEqual(['duplicate-scene-id']);
+      expect(findings[0]?.sceneId).toBe('shared');
+      expect(findings[0]?.message).toMatch(/duplicate id "shared"/);
+    });
+
+    it('reports each duplicate occurrence past the first', () => {
+      const findings = validateRuntime({
+        scenes: [
+          buildScene({ id: 'shared' }),
+          buildScene({ id: 'shared' }),
+          buildScene({ id: 'shared' }),
+        ],
+      });
+      const dupes = findings.filter((f) => f.code === 'duplicate-scene-id');
+      expect(dupes).toHaveLength(2);
+      for (const finding of dupes) {
+        expect(finding.sceneId).toBe('shared');
+      }
+    });
+
+    it('treats the first occurrence as canonical (no self-duplicate)', () => {
+      const findings = validateRuntime({
+        scenes: [buildScene({ id: 'only-once' })],
+      });
+      expect(findings.some((f) => f.code === 'duplicate-scene-id')).toBe(false);
+    });
+
+    it('still reports duplicate-scene-id even when the duplicate scene is schema-invalid', () => {
+      // The four clauses are independent classes of breakage. A
+      // second occurrence with a valid `id` still counts as a
+      // duplicate even if its broader scene shape (e.g. missing
+      // `cleanup`) is invalid. Both findings surface so the author
+      // sees the full picture (codex review cycle 2).
+      const broken: Record<string, unknown> = { ...buildScene({ id: 'shared' }) };
+      broken.cleanup = undefined;
+      const findings = validateRuntime({
+        scenes: [buildScene({ id: 'shared' }), broken],
+      });
+      const codes = findingCodes(findings);
+      expect(codes).toContain('scene-schema-invalid');
+      expect(codes).toContain('duplicate-scene-id');
+    });
+
+    it('does not enter duplicate detection when the id itself is malformed', () => {
+      // Independent field validity: a scene record with `id: 42`
+      // fails BOTH `assertSceneModule` AND the `isKebabIdentifier`
+      // gate — there is no kebab id to count, so duplicate detection
+      // has no signal. Only the schema finding surfaces.
+      const broken: Record<string, unknown> = { ...buildScene({ id: 'real' }) };
+      broken.id = 42;
+      const findings = validateRuntime({
+        scenes: [buildScene({ id: 'real' }), broken],
+      });
+      const codes = findingCodes(findings);
+      expect(codes).toContain('scene-schema-invalid');
+      expect(codes).not.toContain('duplicate-scene-id');
+    });
+
+    it('still validates the assets of a duplicate-id second occurrence', () => {
+      // Reporting "this id is a duplicate" and "this asset is
+      // unresolvable" are independent concerns. A shape-valid
+      // duplicate's `.assets` array is still trustworthy metadata
+      // and clause (b) covers it; the second occurrence may declare
+      // a different (and broken) asset that the first does not.
+      const findings = validateRuntime({
+        scenes: [
+          buildScene({ id: 'dup', assets: [] }),
+          buildScene({ id: 'dup', assets: ['file:///etc/passwd'] }),
+        ],
+      });
+      const codes = findingCodes(findings);
+      expect(codes).toContain('duplicate-scene-id');
+      expect(codes).toContain('asset-unresolvable');
+      const assetFinding = findings.find((f) => f.code === 'asset-unresolvable');
+      expect(assetFinding?.sceneId).toBe('dup');
+      expect(assetFinding?.asset).toBe('file:///etc/passwd');
+    });
+  });
+
+  describe('clause a — scene ids referenced in compositions but not registered', () => {
+    it('reports unknown-scene-reference per missing entry', () => {
+      const manifest: CompositionManifest = ['ghost'];
+      const findings = validateRuntime({
+        scenes: [buildScene({ id: 'real' })],
+        compositions: [{ id: 'opener', manifest }],
+      });
+      expect(findings).toHaveLength(1);
+      expect(findings[0]).toMatchObject({
+        code: 'unknown-scene-reference',
+        compositionId: 'opener',
+        entryIndex: 0,
+        sceneId: 'ghost',
+      });
+      expect(findings[0]?.message).toMatch(/composition "opener".*entry \[0\].*"ghost"/);
+    });
+
+    it('reports every miss in declaration order — no fail-on-first', () => {
+      const manifest: CompositionManifest = ['real', 'ghost-a', 'real', 'ghost-b'];
+      const findings = validateRuntime({
+        scenes: [buildScene({ id: 'real' })],
+        compositions: [{ id: 'mixed', manifest }],
+      });
+      const misses = findings.filter((f) => f.code === 'unknown-scene-reference');
+      expect(misses).toHaveLength(2);
+      expect(misses[0]).toMatchObject({ entryIndex: 1, sceneId: 'ghost-a' });
+      expect(misses[1]).toMatchObject({ entryIndex: 3, sceneId: 'ghost-b' });
+    });
+
+    it('reads object-form entries through entryId (range/behavior not dropped)', () => {
+      // Object-form entries with `range` / `behavior` keys must still
+      // resolve their scene-id reference through `entryId`. This
+      // guards against re-flattening to bare strings (preflight anti-
+      // pattern).
+      const manifest: CompositionManifest = [{ id: 'ghost', range: ['intro', 'hook'] as const }];
+      const findings = validateRuntime({
+        scenes: [buildScene({ id: 'real' })],
+        compositions: [{ id: 'trailer', manifest }],
+      });
+      const misses = findings.filter((f) => f.code === 'unknown-scene-reference');
+      expect(misses).toHaveLength(1);
+      expect(misses[0]).toMatchObject({
+        entryIndex: 0,
+        sceneId: 'ghost',
+      });
+    });
+
+    it('reports composition-manifest-invalid for malformed manifest shape', () => {
+      const findings = validateRuntime({
+        scenes: [buildScene({ id: 'real' })],
+        compositions: [{ id: 'broken', manifest: 'not an array' }],
+      });
+      expect(findingCodes(findings)).toEqual(['composition-manifest-invalid']);
+      expect(findings[0]?.compositionId).toBe('broken');
+      expect(findings[0]?.message).toMatch(/composition manifest is invalid/);
+      // Self-contained location: composition id is prepended to the
+      // message so the AggregateError + console.error path identifies
+      // which registration to edit (codex review cycle 3).
+      expect(findings[0]?.message).toMatch(/^composition "broken":/);
+    });
+
+    it('reports composition-manifest-invalid for bad entry shape and skips reference check', () => {
+      const findings = validateRuntime({
+        scenes: [buildScene({ id: 'real' })],
+        compositions: [
+          {
+            id: 'broken',
+            manifest: [{ id: 'real', extraneous: 1 }],
+          },
+        ],
+      });
+      // Exactly one finding: the manifest-shape diagnostic. The
+      // validator does not pretend a malformed entry is a missing
+      // reference (preflight: "Do not silently accept malformed
+      // composition manifests and then report missing scenes from bad
+      // shapes.").
+      expect(findings).toHaveLength(1);
+      expect(findings[0]?.code).toBe('composition-manifest-invalid');
+      expect(findings[0]?.compositionId).toBe('broken');
+    });
+
+    it('produces no finding when every entry resolves', () => {
+      const findings = validateRuntime({
+        scenes: [buildScene({ id: 'a' }), buildScene({ id: 'b' })],
+        compositions: [{ id: 'opener', manifest: ['a', 'b', 'a'] }],
+      });
+      expect(findings).toEqual([]);
+    });
+  });
+
+  describe('clause b — assets referenced in scene metadata but not resolvable', () => {
+    it('accepts data: assets under the default scheme allowlist', () => {
+      const findings = validateRuntime({
+        scenes: [buildScene({ id: 'has-data', assets: ['data:text/plain,hi'] })],
+      });
+      expect(findings).toEqual([]);
+    });
+
+    it('rejects file: assets under the default scheme allowlist', () => {
+      const findings = validateRuntime({
+        scenes: [buildScene({ id: 'bad-scheme', assets: ['file:///etc/passwd'] })],
+      });
+      expect(findings).toHaveLength(1);
+      expect(findings[0]).toMatchObject({
+        code: 'asset-unresolvable',
+        sceneId: 'bad-scheme',
+        asset: 'file:///etc/passwd',
+      });
+      expect(findings[0]?.message).toMatch(/scheme "file:" not in allowed list/);
+      // Self-contained location: scene id is prepended so the
+      // AggregateError + console.error path identifies which scene
+      // owns the bad asset when multiple scenes share asset URLs
+      // (codex review cycle 3).
+      expect(findings[0]?.message).toMatch(/^scene "bad-scheme":/);
+    });
+
+    it('rejects protocol-relative asset without baseUrl', () => {
+      const findings = validateRuntime({
+        scenes: [buildScene({ id: 'proto-rel', assets: ['//cdn.example.com/asset.png'] })],
+      });
+      expect(findings).toHaveLength(1);
+      expect(findings[0]).toMatchObject({
+        code: 'asset-unresolvable',
+        sceneId: 'proto-rel',
+        asset: '//cdn.example.com/asset.png',
+      });
+      expect(findings[0]?.message).toMatch(/protocol-relative URL requires/);
+    });
+
+    it('passes relative path through unchanged when no baseUrl is supplied', () => {
+      // resolveAssetUrl returns the asset string verbatim and does not
+      // scheme-check it (the browser resolves against document.baseURI
+      // at fetch time). PUL-F028 mirrors that exactly — no stricter
+      // sub-rule for static validation.
+      const findings = validateRuntime({
+        scenes: [buildScene({ id: 'rel', assets: ['./img.png', 'images/x.svg'] })],
+      });
+      expect(findings).toEqual([]);
+    });
+
+    it('resolves relative paths against baseUrl', () => {
+      // No `allowedSchemes` override — the resolver normalizes
+      // `./img.png` against `http://example.com/`, the resolved scheme
+      // is `http:`, and the default allowlist accepts it.
+      const findings = validateRuntime({
+        scenes: [buildScene({ id: 'rel-base', assets: ['./img.png'] })],
+        assets: { baseUrl: 'http://example.com/' },
+      });
+      expect(findings).toEqual([]);
+    });
+
+    it('rejects http: when allowedSchemes is restricted to https:', () => {
+      const findings = validateRuntime({
+        scenes: [buildScene({ id: 'http-only', assets: ['http://example.com/x.png'] })],
+        assets: { allowedSchemes: ['https:'] },
+      });
+      expect(findings).toHaveLength(1);
+      expect(findings[0]).toMatchObject({
+        code: 'asset-unresolvable',
+        sceneId: 'http-only',
+        asset: 'http://example.com/x.png',
+      });
+      expect(findings[0]?.message).toMatch(/not in allowed list/);
+    });
+
+    it('rejects a URL that cannot be parsed against the baseUrl', () => {
+      // The URL constructor accepts most strings as path components, so
+      // we force a real parse failure by passing a non-string-ish
+      // baseUrl that the URL constructor will reject. Use a known
+      // bad pair: an empty asset against an unparseable baseUrl.
+      const findings = validateRuntime({
+        scenes: [buildScene({ id: 'bad-url', assets: ['http://[bad'] })],
+        assets: { baseUrl: 'http://example.com/' },
+      });
+      expect(findings).toHaveLength(1);
+      expect(findings[0]).toMatchObject({
+        code: 'asset-unresolvable',
+        sceneId: 'bad-url',
+        asset: 'http://[bad',
+      });
+      expect(findings[0]?.message).toMatch(/invalid URL relative to baseUrl/);
+    });
+
+    it('uses DEFAULT_ALLOWED_SCHEMES when no allowedSchemes override is given', () => {
+      // Sanity check: the canonical default actually accepts http/https.
+      // Pinning this stops a drift in DEFAULT_ALLOWED_SCHEMES from
+      // turning validation into a silent net-new rejection.
+      expect(DEFAULT_ALLOWED_SCHEMES).toContain('http:');
+      expect(DEFAULT_ALLOWED_SCHEMES).toContain('https:');
+      const findings = validateRuntime({
+        scenes: [buildScene({ id: 'http-default', assets: ['http://example.com/a.png'] })],
+      });
+      expect(findings).toEqual([]);
+    });
+
+    it('still runs asset checks against a schema-invalid scene when assets is a valid array', () => {
+      // Schema-failure and asset-failure are independent findings.
+      // A scene missing `cleanup` but carrying a valid string-array
+      // `assets` field still has its assets checked — the author
+      // needs to see BOTH findings to fix both classes of breakage
+      // (codex review cycle 2).
+      const broken: Record<string, unknown> = {
+        ...buildScene({ id: 'bad-shape', assets: ['file:///etc/passwd'] }),
+      };
+      broken.cleanup = undefined;
+      const findings = validateRuntime({ scenes: [broken] });
+      const codes = findingCodes(findings);
+      expect(codes).toContain('scene-schema-invalid');
+      expect(codes).toContain('asset-unresolvable');
+      const assetFinding = findings.find((f) => f.code === 'asset-unresolvable');
+      expect(assetFinding?.sceneId).toBe('bad-shape');
+      expect(assetFinding?.asset).toBe('file:///etc/passwd');
+    });
+
+    it('does not run asset checks when the assets field itself is not a string array', () => {
+      // Independent field validity: if `assets` is not `string[]`,
+      // there is nothing to validate at the asset boundary. Only
+      // the schema finding surfaces (the schema gate catches the
+      // bad shape).
+      const broken: Record<string, unknown> = { ...buildScene({ id: 'no-array' }) };
+      broken.assets = 'not an array';
+      const findings = validateRuntime({ scenes: [broken] });
+      const codes = findingCodes(findings);
+      expect(codes).toEqual(['scene-schema-invalid']);
+    });
+  });
+
+  describe('composite + structural invariants', () => {
+    it('returns an empty (frozen) array for empty input', () => {
+      const findings = validateRuntime({ scenes: [] });
+      expect(findings).toEqual([]);
+      expect(Object.isFrozen(findings)).toBe(true);
+    });
+
+    it('returns an empty (frozen) array for a valid graph', () => {
+      const scenes: SceneModule[] = [
+        buildScene({ id: 'a', assets: ['data:text/plain,hi'] }),
+        buildScene({ id: 'b' }),
+      ];
+      const findings = validateRuntime({
+        scenes,
+        compositions: [{ id: 'full', manifest: ['a', 'b'] }],
+      });
+      expect(findings).toEqual([]);
+      expect(Object.isFrozen(findings)).toBe(true);
+    });
+
+    it('aggregates findings across all four clauses in one pass', () => {
+      const broken: Record<string, unknown> = { ...buildScene({ id: 'no-cleanup' }) };
+      // biome-ignore lint/performance/noDelete: structural delete
+      delete broken.cleanup;
+      const scenes: unknown[] = [
+        buildScene({ id: 'dup' }),
+        buildScene({ id: 'dup' }),
+        buildScene({ id: 'bad-asset', assets: ['file:///x'] }),
+        broken,
+      ];
+      const findings = validateRuntime({
+        scenes,
+        compositions: [{ id: 'cmp', manifest: ['dup', 'ghost'] }],
+      });
+      const codes = findingCodes(findings);
+      expect(codes).toContain('scene-schema-invalid');
+      expect(codes).toContain('duplicate-scene-id');
+      expect(codes).toContain('unknown-scene-reference');
+      expect(codes).toContain('asset-unresolvable');
+      // One scene-schema (no-cleanup), one duplicate (second `dup`),
+      // one asset (bad-asset), one unknown-scene-reference (`ghost`).
+      expect(findings).toHaveLength(4);
+    });
+
+    it('never throws on otherwise pathological input', () => {
+      // Several malformed scenes, malformed manifest, and an unknown
+      // composition entry. The validator must collect, not throw.
+      const inputs: ValidationInput = {
+        scenes: [null, undefined, 'not a scene'],
+        compositions: [{ id: 'broken-manifest', manifest: 5 }],
+      };
+      expect(() => validateRuntime(inputs)).not.toThrow();
+      const findings = validateRuntime(inputs);
+      // 3 schema findings + 1 manifest finding = 4
+      expect(findings).toHaveLength(4);
+    });
+
+    it('does not invoke scene lifecycle hooks during validation', () => {
+      // Pure-static guarantee — the four clauses are answerable from
+      // metadata alone. Wiring asserts the validator never calls
+      // create / timeline / cleanup (the lifecycle ban from the
+      // preflight).
+      let called = 0;
+      const spy: SceneModule = buildScene({
+        id: 'no-side-effects',
+        create: () => {
+          called += 1;
+          return undefined;
+        },
+        timeline: () => {
+          called += 1;
+          return undefined;
+        },
+        cleanup: () => {
+          called += 1;
+          return undefined;
+        },
+      });
+      validateRuntime({ scenes: [spy] });
+      expect(called).toBe(0);
+    });
+  });
+
+  describe('compositions input is optional', () => {
+    it('runs without a compositions block', () => {
+      const findings = validateRuntime({
+        scenes: [buildScene({ id: 'a' })],
+      });
+      expect(findings).toEqual([]);
+    });
+  });
+});
+
+describe('assertNoValidationFindings (PUL-F028)', () => {
+  it('does not throw when findings is empty', () => {
+    expect(() => assertNoValidationFindings([])).not.toThrow();
+  });
+
+  it('throws an AggregateError carrying every finding message', () => {
+    const findings = validateRuntime({
+      scenes: [
+        buildScene({ id: 'dup' }),
+        buildScene({ id: 'dup' }),
+        buildScene({ id: 'bad-asset', assets: ['file:///x'] }),
+      ],
+    });
+    let thrown: unknown = null;
+    try {
+      assertNoValidationFindings(findings);
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(AggregateError);
+    const agg = thrown as AggregateError;
+    expect(agg.errors).toHaveLength(findings.length);
+    for (let i = 0; i < findings.length; i++) {
+      expect(agg.errors[i]).toBeInstanceOf(Error);
+      expect((agg.errors[i] as Error).message).toBe(findings[i]?.message);
+    }
+    // The wrapping message identifies this as a validation failure so
+    // a caller pattern-matching on origin can tell it apart from a
+    // composition-resolution AggregateError.
+    expect(agg.message).toMatch(/runtime validation failed/i);
+  });
+});


### PR DESCRIPTION
Implements PUL-F028 — a structural runtime validation pass that detects:

- scene ids referenced in compositions but not present in the registry,
- assets referenced in scene metadata but not resolvable,
- duplicate scene ids,
- scenes that do not export a \`cleanup\` function.

ADR-008 #7 commits the runtime to this pass; this PR ships it.

## What ships

- **`src/runtime/validation.ts`** — `validateRuntime(input)` returns a frozen
  `readonly Finding[]` over the four clauses, plus
  `composition-manifest-invalid` as a pre-condition for clause (a). Public
  inputs are typed `Iterable<unknown>` / `unknown` so callers hand the
  validator raw declarations directly; internal narrowing uses the canonical
  `assertSceneModule` / `assertCompositionManifest` gates. Pure: never calls
  scene lifecycle hooks, never fetches, never imports, never touches the DOM /
  history / storage / audio / preloader / timeline / navigation. Findings carry
  ids, indexes, asset strings, and bounded diagnostic text — never raw scene
  objects, full captions, or auth values. Self-contained messages: composition
  and asset findings prepend their structured location so the
  `AggregateError` + workbench `console.error` path identify which declaration
  to edit. \`assertNoValidationFindings(findings)\` is the thin throwing wrapper.

- **`src/runtime/id-registry.ts`** — Adds an optional \`onDuplicate\` collector
  hook to \`IdRegistryConfig\`. Lets validation aggregate every duplicate
  occurrence while the runtime boot path stays fail-fast (no callback → throw
  with the existing \`<label>: duplicate id \"<id>\"\` grammar). One source of
  truth for duplicate-id semantics.

- **`src/main.ts`** — Wires the pass at boot. \`scenes\` and
  \`compositionEntries\` are declared once and shared between
  \`validateRuntime\`, \`createSceneRegistry\`, and
  \`createCompositionRegistry\` so the gate cannot drift from the registry
  path. Non-empty findings log through \`console.error\`, set a
  \`data-pulsar-validation-failed\` stage attribute (cleared on each boot for
  Vite HMR / re-evaluation), and halt the workbench before navigation, loader,
  preloader, or resolver run.

- **`tests/runtime/validation.test.ts`** — 33 tests covering each clause,
  malformed inputs, self-contained message prefixes, structural invariants
  (frozen output, no throws, no lifecycle side effects), and
  \`assertNoValidationFindings\`.

- **`tests/runtime/id-registry.test.ts`** — 5 tests locking the \`onDuplicate\`
  contract (default fail-fast preserved when callback omitted).

- **`docs/design/pul-f028-validation-preflight.md`** — guardrails from the
  codex architecture preflight; \`docs/design/README.md\` index updated.

- **`CHANGELOG.md`** — \`[Unreleased] / Added\` entry.

## Architecture

Reuses every canonical helper:
| Clause | Helper |
|--------|--------|
| (d) missing cleanup | \`assertSceneModule\` (PUL-F001 envelope) |
| (c) duplicate scene id | \`createIdRegistry\` with \`onDuplicate\` |
| (a) unknown scene reference | \`findUnregisteredEntries\` |
| (a) malformed manifest | \`assertCompositionManifest\` |
| (b) unresolvable asset | \`resolveAssetUrl\` + \`DEFAULT_ALLOWED_SCHEMES\` |

No new scene/composition schema, registry, asset inventory, URL parser,
exception hierarchy, logging framework, or config surface. No new URL
parameter, workbench mode, presenter command, env var, or auth gate.

The four clauses are INDEPENDENT classes of breakage — a scene missing
\`cleanup\` but with a valid \`id\` and \`assets\` array still produces the
duplicate-id and asset-unresolvable findings the author needs to see.

## Review history

Three pre-push codex review cycles ran with all findings addressed (8 total —
6 class, 2 one-off); see [the issue thread](https://github.com/KeplerOps/pulsar/issues/37)
for the per-cycle fix summaries. Per ADR-029 the 3-cycle cap was reached and
the user authorized push-as-is rather than running cycle 4 to re-verify.

## Verification

- \`pnpm lint && pnpm typecheck && pnpm test\` green (964 tests).
- \`pre-commit run --all-files\` green.

Closes #37