### PR TITLE
Implement PUL-F029 scene-level error isolation (ADR-028)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Scene-level error isolation — PUL-F029 / ADR-028 — in
+  `src/runtime/composition-resolver.ts` and `src/runtime/scene-loader.ts`:
+  a thrown `create(ctx)`, `timeline(ctx)`, or `cleanup(ctx)` is now a
+  per-scene failure, not a composition-wide abort. The resolver
+  isolates the failing scene (runs its `cleanup(ctx)` eagerly on a
+  `create` or `timeline` throw, drops it from the segment list, and
+  continues the active composition with the remaining scenes); each
+  failure is surfaced through a new structured `onSceneFailed(event)`
+  callback carrying `{ phase, sceneId, message, cause }`. The scene
+  loader wires the callback to a new `data-pulsar-scene-failures` stage
+  attribute (comma-separated `<sceneId>:<phase>` entries in encounter
+  order) and routes a sanitized `scene "<id>" failed during <phase>:
+  <describeError(cause)>` Error through its existing `onError` sink —
+  the raw `cause` is never serialized to the public surface (no
+  stacks, scene objects, DOM, captions, headers, cookies, env, or
+  auth values). The fatal `data-pulsar-navigation-error` surface
+  stays reserved for composition-wide failures (manifest invalid,
+  registry miss, preload throw, timeline-adapter `run` rejection,
+  abort wrapper). Preload, signal-abort, manifest, and adapter
+  failures keep their composition-wide semantics per ADR-028's
+  non-goals. Direct resolver callers that do not wire
+  `onSceneFailed` still get an `AggregateError` of every scene
+  failure at the end of the lifecycle so the signal is never
+  silently lost. The presenter advances past a failed scene
+  structurally — a failed scene contributes no segment, so the
+  master timeline plays through whatever survived.
+
 ### Added
 
 - Runtime validation pass — PUL-F028 / ADR-008 #7 — in

--- a/docs/adrs/028-scene-level-error-isolation.md
+++ b/docs/adrs/028-scene-level-error-isolation.md
@@ -1,0 +1,148 @@
+# ADR-028: Scene-Level Error Isolation
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-12
+
+## Context
+
+PUL-F029 requires recoverability during a live presentation: when one
+scene fails during `create`, `timeline`, or `cleanup`, the runtime must
+surface the failure with scene context, keep the active composition from
+halting, and let the presenter advance past the failed scene.
+
+This cuts across the lifecycle resolver, workbench loader, presenter
+controls, timeline adapter, audio service, scene schema, validation pass,
+and diagnostic surface. It must not become a second scene contract, a
+second navigation workflow, or a scene-authored error system.
+
+Existing runtime boundaries already cover parts of the need:
+
+- `SceneModule` and `assertSceneModule` define the scene shape. Failure
+  isolation must not add a required hook or parallel schema.
+- The composition resolver owns calls to `create(ctx)`, `timeline(ctx)`,
+  and `cleanup(ctx)`, wraps unknown thrown values, and runs cleanup for
+  touched scenes. It is the lifecycle isolation boundary.
+- `describeError` is the shared unknown-error-to-message helper. Any
+  future truncation, redaction, or cause unwrapping belongs there, not in
+  each lifecycle phase.
+- The scene loader owns workbench diagnostics through the injected
+  `onError` sink and stage attributes. It is the browser-facing error
+  surface.
+- Presenter input is already scoped through the presenter command source
+  and controller. Advancing past a failed scene must use that transport
+  seam rather than direct DOM listeners or a new input workflow.
+- The audio service already scopes playback to navigation and scene
+  groups. A failed scene must not bypass the existing stop/unload paths.
+
+## Decision
+
+Treat scene lifecycle failures as runtime-owned scene failure events at
+the resolver/loader boundary.
+
+The failure event shape is a runtime diagnostic contract, not a new
+scene schema. It must carry:
+
+- lifecycle phase: `create`, `timeline`, or `cleanup`;
+- scene id;
+- composition context when known: composition id and entry index;
+- current workbench mode when known;
+- a message from `describeError(cause)`. If diagnostic truncation or
+  redaction is needed, it belongs in that shared helper.
+
+The public diagnostic must not include raw scene objects, DOM nodes,
+caption bodies, request headers, cookies, environment variables, auth
+values, full stacks, or serialized `Error.cause`. Programmatic `cause`
+may remain attached to the internal `Error` / `AggregateError` object.
+
+The composition resolver remains the canonical lifecycle boundary:
+
+- A `create` failure marks that scene failed, attempts that scene's
+  `cleanup(ctx)`, surfaces the failure, and continues resolving the
+  remaining active composition.
+- A `timeline(ctx)` failure marks that scene failed, attempts cleanup for
+  that scene, surfaces the failure, and contributes no normal scene
+  timeline segment for that scene.
+- A `cleanup(ctx)` failure is surfaced with scene context and collected,
+  but cleanup continues for sibling scenes and does not block the next
+  navigation or presenter advancement.
+- Cleanup-only and multi-fault cases use the existing aggregate-error
+  pattern. Do not add a parallel exception hierarchy for PUL-F029.
+
+The scene loader remains the browser/workbench diagnostic boundary:
+
+- Route scene failure diagnostics through the existing `onError` sink and
+  stage error surface.
+- Keep navigation queue, abort, and cleanup-before-handoff semantics
+  intact. A failed scene must not poison later queued navigations.
+- Do not persist failure state in URL parameters, `history.state`,
+  localStorage, cookies, or environment-derived config.
+
+The presenter advances past a failed scene through the existing
+presenter/timeline transport seam. The implementation may need a
+timeline-adapter parameter for a failed-scene placeholder or skip marker,
+but it must not introduce a second presenter command schema, direct
+keyboard listener, or scene-authored escape hatch.
+
+## Consequences
+
+### Positive
+
+- Scene failures become recoverable without weakening the scene contract.
+- Operators see the failing scene and phase instead of a generic
+  composition failure.
+- Existing validation, navigation, presenter, audio, and error surfaces
+  stay canonical.
+- Future policy changes can live behind a resolver-level failure policy
+  or timeline-adapter placeholder seam without rewriting scenes.
+
+### Negative
+
+- The resolver and timeline adapter need a more nuanced failure state
+  than simple "throw aborts the whole composition".
+- Tests must cover partial lifecycle execution and multi-fault cleanup
+  cases.
+- A failed scene may leave visual gaps unless the runtime supplies a
+  neutral placeholder or explicit skip behavior.
+
+### Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| Scene failures are confused with invalid scene schemas, malformed URLs, or unresolved assets | Keep PUL-F029 scoped to `create`, `timeline`, and `cleanup`. Existing schema, navigation, and preloader errors keep their current boundaries. |
+| A new `SceneError` hierarchy duplicates existing wrappers | Use existing `Error`, `AggregateError`, `Error.cause`, and `describeError`; add structured fields only at the diagnostic event boundary. |
+| The public error surface leaks secrets or content | Public messages include ids, phase, mode, composition/index, and `describeError` output only. Do not serialize raw causes, stacks, scene data, DOM, captions, headers, cookies, env, or auth values. |
+| Cleanup failures are swallowed during recovery | Surface cleanup failures, aggregate multi-fault cases, and still continue sibling cleanup and navigation teardown. |
+| Presenter recovery becomes a separate workflow | Keep advancement on the existing presenter command and timeline transport seam. No direct DOM listeners or scene-local recovery controls. |
+| Audio from a failed scene leaks after skip | Keep `ctx.audio` and `stopGroup(sceneId)` / `stopAll()` as the only audio cleanup path. |
+
+## Non-Goals
+
+- No new scene lifecycle hook such as `onError`, `recover`, or
+  `fallback`.
+- No schema change to `SceneModule`.
+- No retry UI, persistent error history, telemetry stream, or production
+  logging framework.
+- No change to URL grammar, workbench modes, presenter command kinds, or
+  composition manifest shape.
+- No reclassification of validation, navigation grammar, registry, or
+  asset-preload failures as scene lifecycle failures.
+
+## Related ADRs
+
+- [ADR-001](001-custom-experience-runtime.md) - the runtime owns
+  lifecycle, navigation, cleanup, and error handling.
+- [ADR-002](002-scene-registry-and-compositions.md) - scenes and
+  compositions provide the context for failure diagnostics.
+- [ADR-003](003-gsap-timeline-engine.md) - presenter advancement and
+  failed-scene skipping must stay on the timeline transport seam.
+- [ADR-004](004-howler-audio-engine.md) - failed scenes still use the
+  runtime audio cleanup path.
+- [ADR-007](007-browser-workbench.md) - diagnostics surface through the
+  workbench, not per-scene UI.
+- [ADR-008](008-agent-native-authoring.md) - failure isolation must
+  preserve the small scene contract and mandatory cleanup invariant.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -52,3 +52,5 @@ Each ADR includes:
 | [024](024-presenter-pause-resume.md) | Presenter Pause/Resume — Runner-Owned Transport State on the Existing Presenter Command Seam | Accepted |
 | [025](025-timeline-adapter-boundary.md) | Timeline Adapter and Composition Master — Revising the Resolution Lifecycle | Accepted (supersedes ADR-002 §Resolution + ADR-011 ordering) |
 | [026](026-named-timeline-beats.md) | Named Timeline Beats — Scene-Local Kebab Labels, Validated at Compose Time, Referenced Through the Master | Accepted |
+| [027](027-caption-timestamp-grammar.md) | Caption Timestamp Grammar — `at` Accepts a Millisecond Offset or a Beat Label, Validated at the Scene Schema Boundary | Accepted |
+| [028](028-scene-level-error-isolation.md) | Scene-Level Error Isolation | Accepted |

--- a/src/runtime/composition-resolver.ts
+++ b/src/runtime/composition-resolver.ts
@@ -466,6 +466,20 @@ interface FailureBucket {
 }
 
 /**
+ * Shared lifecycle plumbing the mount / compose / cleanup helpers all
+ * thread through. One struct avoids each helper carrying 6–8 separate
+ * positional parameters (Sonar S107) and keeps the bucket + observer
+ * wiring identical across phases.
+ */
+interface LifecycleContext {
+  readonly ctx: unknown;
+  readonly signal: AbortSignal | undefined;
+  readonly onSceneCleaned: ((sceneId: string) => void) | undefined;
+  readonly onSceneFailed: ((event: SceneFailureEvent) => void) | undefined;
+  readonly bucket: FailureBucket;
+}
+
+/**
  * Invoke `onSceneFailed` defensively. A throw from the caller-supplied
  * diagnostic sink MUST NOT interrupt the resolver's cleanup-then-
  * continue invariant (codex review, cycle 2): if it did, a buggy
@@ -508,30 +522,24 @@ function notifyFailure(
  * failures route to `bucket.hookErrors` only; per the option's
  * contract, a hook throw is a workbench bug, not a scene failure.
  */
-async function cleanOneScene(
-  step: PlanStep,
-  ctx: unknown,
-  onSceneCleaned: ((sceneId: string) => void) | undefined,
-  bucket: FailureBucket,
-  onSceneFailed: ((event: SceneFailureEvent) => void) | undefined,
-): Promise<void> {
+async function cleanOneScene(step: PlanStep, lc: LifecycleContext): Promise<void> {
   try {
-    await step.scene.cleanup(ctx);
-  } catch (cleanupCause) {
+    await step.scene.cleanup(lc.ctx);
+  } catch (error_) {
     const { event, wrapper } = buildSceneFailure(
       'cleanup',
       step,
-      cleanupCause,
-      `scene ${quoteId(step.scene.id)} cleanup threw: ${describeError(cleanupCause)}`,
+      error_,
+      `scene ${quoteId(step.scene.id)} cleanup threw: ${describeError(error_)}`,
     );
-    bucket.sceneFailures.push(event);
-    bucket.sceneFailureErrors.push(wrapper);
-    notifyFailure(onSceneFailed, event, bucket);
+    lc.bucket.sceneFailures.push(event);
+    lc.bucket.sceneFailureErrors.push(wrapper);
+    notifyFailure(lc.onSceneFailed, event, lc.bucket);
   }
   try {
-    onSceneCleaned?.(step.scene.id);
+    lc.onSceneCleaned?.(step.scene.id);
   } catch (err) {
-    bucket.hookErrors.push(
+    lc.bucket.hookErrors.push(
       fail(`scene ${quoteId(step.scene.id)} onSceneCleaned threw: ${describeError(err)}`, err),
     );
   }
@@ -549,18 +557,14 @@ async function cleanOneScene(
  */
 async function mountPlan(
   plan: readonly PlanStep[],
-  ctx: unknown,
   preloadAssets: AssetPreloader,
-  signal: AbortSignal | undefined,
-  onSceneCleaned: ((sceneId: string) => void) | undefined,
-  bucket: FailureBucket,
-  onSceneFailed: ((event: SceneFailureEvent) => void) | undefined,
+  lc: LifecycleContext,
   mounted: PlanStep[],
 ): Promise<void> {
   for (const step of plan) {
     await preloadScene(step.scene, preloadAssets);
     throwIfAborted(
-      signal,
+      lc.signal,
       `aborted after preloading ${quoteId(step.scene.id)}, before scene activation`,
     );
     // Track in `mounted` BEFORE create so a partial-create scene still
@@ -568,7 +572,7 @@ async function mountPlan(
     // scene only after its cleanup ran (one cleanup per scene).
     mounted.push(step);
     try {
-      await step.scene.create(ctx);
+      await step.scene.create(lc.ctx);
     } catch (cause) {
       const { event, wrapper } = buildSceneFailure(
         'create',
@@ -576,9 +580,9 @@ async function mountPlan(
         cause,
         `scene ${quoteId(step.scene.id)} create threw: ${describeError(cause)}`,
       );
-      bucket.sceneFailures.push(event);
-      bucket.sceneFailureErrors.push(wrapper);
-      notifyFailure(onSceneFailed, event, bucket);
+      lc.bucket.sceneFailures.push(event);
+      lc.bucket.sceneFailureErrors.push(wrapper);
+      notifyFailure(lc.onSceneFailed, event, lc.bucket);
       // PUL-F029: run the failing scene's cleanup eagerly through the
       // SAME helper as the final cleanup loop, so the per-scene
       // `onSceneCleaned` hook (PUL-F024 / ADR-004 audio-group
@@ -587,19 +591,19 @@ async function mountPlan(
       // leak that group while the surviving composition continues.
       // Then drop the scene from `mounted` so the final cleanup phase
       // doesn't double-clean.
-      await cleanOneScene(step, ctx, onSceneCleaned, bucket, onSceneFailed);
+      await cleanOneScene(step, lc);
       mounted.pop();
       // Codex review cycle 2: re-check the abort signal after the
       // awaited eager cleanup. Without this, a navigation aborted
       // during the failed scene's cleanup would still kick off the
       // next scene's preload + create — exactly the
       // cleanup-before-handoff regression the loader guards against.
-      throwIfAborted(signal, `aborted after isolating ${quoteId(step.scene.id)} create failure`);
+      throwIfAborted(lc.signal, `aborted after isolating ${quoteId(step.scene.id)} create failure`);
       // Continue to the next scene — the active composition keeps
       // going (PUL-F029 SHALL NOT halt the active composition).
       continue;
     }
-    throwIfAborted(signal, `aborted after mounting ${quoteId(step.scene.id)}`);
+    throwIfAborted(lc.signal, `aborted after mounting ${quoteId(step.scene.id)}`);
   }
 }
 
@@ -617,18 +621,18 @@ async function mountPlan(
  */
 async function composeSegments(
   mounted: PlanStep[],
-  ctx: unknown,
-  signal: AbortSignal | undefined,
-  onSceneCleaned: ((sceneId: string) => void) | undefined,
-  bucket: FailureBucket,
-  onSceneFailed: ((event: SceneFailureEvent) => void) | undefined,
+  lc: LifecycleContext,
 ): Promise<SceneTimelineSegment[]> {
   const segments: SceneTimelineSegment[] = [];
-  // Walk a snapshot of `mounted` because the loop may mutate it.
-  for (const step of [...mounted]) {
+  // Snapshot up-front: the loop body removes failed scenes from
+  // `mounted` and a live iteration would skip the entry after the
+  // splice. Sonar's "unnecessary `[...mounted]`" hint (S7747) is
+  // wrong here — the mutation is the whole point.
+  const snapshot = Array.from(mounted);
+  for (const step of snapshot) {
     let timeline: unknown;
     try {
-      timeline = step.scene.timeline(ctx);
+      timeline = step.scene.timeline(lc.ctx);
     } catch (cause) {
       const { event, wrapper } = buildSceneFailure(
         'timeline',
@@ -636,21 +640,24 @@ async function composeSegments(
         cause,
         `scene ${quoteId(step.scene.id)} timeline threw: ${describeError(cause)}`,
       );
-      bucket.sceneFailures.push(event);
-      bucket.sceneFailureErrors.push(wrapper);
-      notifyFailure(onSceneFailed, event, bucket);
+      lc.bucket.sceneFailures.push(event);
+      lc.bucket.sceneFailureErrors.push(wrapper);
+      notifyFailure(lc.onSceneFailed, event, lc.bucket);
       // PUL-F029: run cleanup eagerly through the same helper so the
       // `onSceneCleaned` hook fires for the failed scene too (audio
       // teardown), then drop from `mounted` so the final cleanup
       // phase doesn't see this scene again.
-      await cleanOneScene(step, ctx, onSceneCleaned, bucket, onSceneFailed);
+      await cleanOneScene(step, lc);
       const at = mounted.indexOf(step);
       if (at !== -1) mounted.splice(at, 1);
       // Codex review cycle 2: re-check the abort signal after the
       // awaited eager cleanup so we don't call `timeline(ctx)` on
       // surviving scenes for a navigation that's already been
       // superseded.
-      throwIfAborted(signal, `aborted after isolating ${quoteId(step.scene.id)} timeline failure`);
+      throwIfAborted(
+        lc.signal,
+        `aborted after isolating ${quoteId(step.scene.id)} timeline failure`,
+      );
       continue;
     }
     const segment: { -readonly [K in keyof SceneTimelineSegment]: SceneTimelineSegment[K] } = {
@@ -673,16 +680,44 @@ async function composeSegments(
  * group teardown hook) runs after each scene's `cleanup(ctx)`; a throw
  * from it is collected like a cleanup failure. Never throws.
  */
-async function cleanupAll(
-  mounted: readonly PlanStep[],
-  ctx: unknown,
-  onSceneCleaned: ((sceneId: string) => void) | undefined,
+async function cleanupAll(mounted: readonly PlanStep[], lc: LifecycleContext): Promise<void> {
+  // Reverse-iterate via index rather than `[...mounted].reverse()` —
+  // avoids the spread + mutating copy when the caller only needs the
+  // visit order.
+  for (let i = mounted.length - 1; i >= 0; i -= 1) {
+    const step = mounted[i];
+    if (step === undefined) continue;
+    await cleanOneScene(step, lc);
+  }
+}
+
+/**
+ * Compute the tail of errors that should aggregate into the resolver's
+ * final throw, given the `onSceneFailed` wiring. Scene lifecycle
+ * failures are dropped when the callback fanned them out; hook errors
+ * (`onSceneCleaned` workbench throws) always aggregate (Sonar S3776
+ * pulled this out of `resolveComposition` to keep it under cognitive-
+ * complexity 15).
+ */
+function residualTail(
   bucket: FailureBucket,
   onSceneFailed: ((event: SceneFailureEvent) => void) | undefined,
-): Promise<void> {
-  for (const step of [...mounted].reverse()) {
-    await cleanOneScene(step, ctx, onSceneCleaned, bucket, onSceneFailed);
-  }
+): readonly Error[] {
+  const scene = onSceneFailed === undefined ? bucket.sceneFailureErrors : [];
+  return [...scene, ...bucket.hookErrors];
+}
+
+/**
+ * Build the human-readable summary that prefixes the resolver's final
+ * `AggregateError` on the happy path. The hand-rolled cases pick the
+ * historical "cleanup hook(s) threw" / "scene failure(s)" wording the
+ * pre-PUL-F029 tests pattern-match on. Sonar S3358 pulled this out of
+ * `resolveComposition` to flatten the nested ternary.
+ */
+function happyPathAggregateDetail(sceneCount: number, hookCount: number): string {
+  if (sceneCount === 0) return `composition completed but ${hookCount} cleanup hook(s) threw`;
+  if (hookCount === 0) return `composition completed with ${sceneCount} scene failure(s)`;
+  return `composition completed with ${sceneCount} scene failure(s) and ${hookCount} cleanup hook(s) threw`;
 }
 
 /**
@@ -749,8 +784,7 @@ function buildRunOptions(options: ResolveCompositionOptions): CompositionTimelin
  *    regardless of `onSceneFailed`.
  */
 export async function resolveComposition(options: ResolveCompositionOptions): Promise<void> {
-  const { registry, manifest, ctx, preloadAssets, timeline, signal } = options;
-  const onSceneFailed = options.onSceneFailed;
+  const { registry, manifest, preloadAssets, timeline, signal } = options;
 
   // PUL-F011 / ADR-015: a `headBeat` without an `onBeatMissing` would
   // silently lose the missing-label diagnostic the adapter is
@@ -770,138 +804,105 @@ export async function resolveComposition(options: ResolveCompositionOptions): Pr
   throwIfAborted(signal, 'aborted before the composition started');
 
   // PUL-F029 / ADR-028: per-scene failures and `onSceneCleaned` hook
-  // throws collect into one bucket. `sceneFailures[*]` /
-  // `sceneFailureErrors[*]` carry scene lifecycle failures (surfaced
-  // through `onSceneFailed` when wired; aggregated into the legacy
-  // AggregateError fallback when not). `hookErrors[*]` carry
-  // workbench-supplied `onSceneCleaned` throws and ALWAYS aggregate
-  // into the resolver's throw — independent of `onSceneFailed` —
-  // because per the option's contract a hook throw is "treated like a
-  // cleanup failure (collected, not swallowed)." Without that
-  // separation the loader's audio-teardown hook would become silently
-  // swallowed under PUL-F029.
-  const bucket: FailureBucket = {
-    sceneFailures: [],
-    sceneFailureErrors: [],
-    hookErrors: [],
+  // throws collect into one bucket. Scene lifecycle failures fan out
+  // through `onSceneFailed` when wired (and aggregate into the
+  // resolver's throw when not). Hook errors ALWAYS aggregate — per the
+  // option's contract a hook throw is "treated like a cleanup failure
+  // (collected, not swallowed)."
+  const lc: LifecycleContext = {
+    ctx: options.ctx,
+    signal,
+    onSceneCleaned: options.onSceneCleaned,
+    onSceneFailed: options.onSceneFailed,
+    bucket: { sceneFailures: [], sceneFailureErrors: [], hookErrors: [] },
   };
-  const { onSceneCleaned } = options;
 
-  // Scenes mounted so far (created, or create-attempted but cleaned up
-  // immediately) — the cleanup list for the final cleanup phase. The
-  // mount and compose helpers remove an entry from this list as soon
-  // as they run that scene's eager cleanup (PUL-F029), so a scene's
-  // cleanup never runs twice. Passed into `mountPlan` as an out-
-  // parameter so a preload-or-abort throw still leaves the partial
+  // Scenes mounted so far — the cleanup list for the final cleanup
+  // phase. `mountPlan` / `composeSegments` remove eagerly-cleaned
+  // scenes from this list so cleanup never runs twice. Passed as an
+  // out-parameter so a preload-or-abort throw still leaves the partial
   // mount list visible to the catch handler below.
   const mounted: PlanStep[] = [];
   try {
-    await mountPlan(
-      plan,
-      ctx,
-      preloadAssets,
-      signal,
-      onSceneCleaned,
-      bucket,
-      onSceneFailed,
-      mounted,
-    );
-
-    // COMPOSE + RUN phase. Collect every mounted scene's timeline value
-    // (isolating per-scene timeline throws per PUL-F029) and hand the
-    // slice to the timeline adapter, which composes the master, applies
-    // the head hints, plays it, and resolves on the master's natural
-    // completion or on abort. The adapter does NOT throw on abort —
-    // it resolves; the signal is re-checked below.
-    const segments = await composeSegments(
-      mounted,
-      ctx,
-      signal,
-      onSceneCleaned,
-      bucket,
-      onSceneFailed,
-    );
+    await mountPlan(plan, preloadAssets, lc, mounted);
+    const segments = await composeSegments(mounted, lc);
     try {
       await timeline.run(segments, buildRunOptions(options));
     } catch (cause) {
       throw fail(`composition timeline failed: ${describeError(cause)}`, cause);
     }
   } catch (phaseError) {
-    // Composition-wide failure (preload, signal abort, manifest, or
-    // timeline-adapter `run` rejection). Mandatory cleanup: tear down
-    // every still-mounted scene (reverse order), then re-raise.
-    // PUL-F029 / ADR-028: when `onSceneFailed` is wired the resolver
-    // has already fanned out every per-scene failure (mount / compose
-    // / cleanup) through the callback, so aggregating them onto the
-    // composition-wide error would surface them twice — and route the
-    // loader into the fatal `data-pulsar-navigation-error` surface for
-    // events PUL-F029 says must NOT halt the active composition.
-    // BUT `onSceneCleaned` hook throws (`bucket.hookErrors`) always
-    // aggregate, because a hook throw is a workbench bug independent
-    // of PUL-F029's per-scene isolation contract.
-    await cleanupAll(mounted, ctx, onSceneCleaned, bucket, onSceneFailed);
-    const tail = [
-      ...(onSceneFailed === undefined ? bucket.sceneFailureErrors : []),
-      ...bucket.hookErrors,
-    ];
-    if (tail.length > 0) {
-      throw failAggregate(
-        `composition aborted with ${tail.length} additional failure(s) after: ${describeError(phaseError)}`,
-        [phaseError, ...tail],
-      );
-    }
-    throw phaseError;
+    await cleanupAll(mounted, lc);
+    return finalizeCompositionWideFailure(phaseError, lc);
   }
 
-  // Happy path, or a navigation abort during master playback (the
-  // adapter resolved without throwing). Tear every scene down, then
-  // surface an abort error if the signal fired (so the loader's
-  // pure-abort suppression applies) or aggregate any cleanup failures.
-  await cleanupAll(mounted, ctx, onSceneCleaned, bucket, onSceneFailed);
+  await cleanupAll(mounted, lc);
   if (signal?.aborted === true) {
-    // PUL-F029: when `onSceneFailed` is wired, scene cleanup failures
-    // already surfaced through the callback. Hook errors still
-    // aggregate. Without the callback, fall back to the legacy
-    // aggregate so direct callers still see scene cleanup errors.
-    const tail = [
-      ...(onSceneFailed === undefined ? bucket.sceneFailureErrors : []),
-      ...bucket.hookErrors,
-    ];
-    if (tail.length > 0) {
-      const sceneCount = onSceneFailed === undefined ? bucket.sceneFailureErrors.length : 0;
-      const hookCount = bucket.hookErrors.length;
-      // Preserve the historical "cleanup failure(s)" wording when the
-      // aggregate is scene-cleanup-only — pre-PUL-F029 callers / tests
-      // pattern-match on it.
-      const detail =
-        hookCount === 0
-          ? `composition aborted during playback with ${sceneCount} cleanup failure(s)`
-          : `composition aborted during playback with ${tail.length} additional failure(s)`;
-      throw failAggregate(detail, [
-        fail('aborted during composition playback', signal.reason),
-        ...tail,
-      ]);
-    }
-    throw fail('aborted during composition playback', signal.reason);
+    return finalizeAbortedPlayback(signal, lc);
   }
-  // PUL-F029: when no `onSceneFailed` was wired, surface every
-  // isolated scene failure (mount / compose / cleanup) PLUS any
-  // hook errors as one AggregateError so the caller doesn't lose
-  // information. When the callback IS wired, the resolver has
-  // already fanned out every per-scene failure inline, so only the
-  // hook errors aggregate (they're a workbench-contract violation
-  // PUL-F029 does not subsume).
-  const sceneFailuresForAggregate = onSceneFailed === undefined ? bucket.sceneFailureErrors : [];
-  const aggregate = [...sceneFailuresForAggregate, ...bucket.hookErrors];
-  if (aggregate.length > 0) {
-    const sceneFailureCount = sceneFailuresForAggregate.length;
-    const hookCount = bucket.hookErrors.length;
+  return finalizeHappyPath(lc);
+}
+
+/**
+ * Re-raise a composition-wide failure (preload / abort / manifest /
+ * registry / adapter `run` rejection) after the mandatory cleanup
+ * phase ran. PUL-F029: when `onSceneFailed` is wired, scene lifecycle
+ * failures already fanned out through the callback, so they do NOT
+ * re-aggregate here (that would route the loader into its fatal
+ * navigation-error surface for events PUL-F029 says must isolate).
+ * Hook errors still aggregate. Hoisted out of `resolveComposition` to
+ * keep the latter under Sonar's cognitive-complexity budget (S3776).
+ */
+function finalizeCompositionWideFailure(phaseError: unknown, lc: LifecycleContext): never {
+  const tail = residualTail(lc.bucket, lc.onSceneFailed);
+  if (tail.length > 0) {
+    throw failAggregate(
+      `composition aborted with ${tail.length} additional failure(s) after: ${describeError(phaseError)}`,
+      [phaseError, ...tail],
+    );
+  }
+  throw phaseError;
+}
+
+/**
+ * Re-raise the post-playback abort wrapper after the cleanup phase
+ * ran. Same scene-failure / hook-error policy as
+ * {@link finalizeCompositionWideFailure}, with the historical
+ * "cleanup failure(s)" wording preserved when the aggregate is
+ * scene-cleanup-only (pre-PUL-F029 tests pattern-match on it).
+ */
+function finalizeAbortedPlayback(signal: AbortSignal, lc: LifecycleContext): never {
+  const tail = residualTail(lc.bucket, lc.onSceneFailed);
+  if (tail.length > 0) {
+    const sceneCount = lc.onSceneFailed === undefined ? lc.bucket.sceneFailureErrors.length : 0;
+    const hookCount = lc.bucket.hookErrors.length;
     const detail =
-      sceneFailureCount === 0
-        ? `composition completed but ${hookCount} cleanup hook(s) threw`
-        : hookCount === 0
-          ? `composition completed with ${sceneFailureCount} scene failure(s)`
-          : `composition completed with ${sceneFailureCount} scene failure(s) and ${hookCount} cleanup hook(s) threw`;
-    throw failAggregate(detail, aggregate);
+      hookCount === 0
+        ? `composition aborted during playback with ${sceneCount} cleanup failure(s)`
+        : `composition aborted during playback with ${tail.length} additional failure(s)`;
+    throw failAggregate(detail, [
+      fail('aborted during composition playback', signal.reason),
+      ...tail,
+    ]);
   }
+  throw fail('aborted during composition playback', signal.reason);
+}
+
+/**
+ * Happy-path finalizer: when no `onSceneFailed` was wired, surface every
+ * isolated scene failure (mount / compose / cleanup) PLUS any hook
+ * errors as one `AggregateError` so the caller doesn't lose
+ * information. When the callback IS wired, the resolver has already
+ * fanned out every per-scene failure inline; only hook errors
+ * aggregate (workbench-contract violations PUL-F029 does not subsume).
+ */
+function finalizeHappyPath(lc: LifecycleContext): void {
+  const sceneFailuresForAggregate =
+    lc.onSceneFailed === undefined ? lc.bucket.sceneFailureErrors : [];
+  const aggregate = [...sceneFailuresForAggregate, ...lc.bucket.hookErrors];
+  if (aggregate.length === 0) return;
+  throw failAggregate(
+    happyPathAggregateDetail(sceneFailuresForAggregate.length, lc.bucket.hookErrors.length),
+    aggregate,
+  );
 }

--- a/src/runtime/composition-resolver.ts
+++ b/src/runtime/composition-resolver.ts
@@ -29,6 +29,20 @@
 //   4. CLEANUP phase — `await cleanup(ctx)` for every mounted scene in
 //      reverse mount order, ALWAYS (including every failure path in 2/3).
 //
+// PUL-F029 / ADR-028 (scene-level error isolation): a thrown
+// `create(ctx)`, `timeline(ctx)`, or `cleanup(ctx)` is a SCENE failure,
+// not a composition failure. The resolver isolates the failing scene
+// (runs its cleanup eagerly when the failure is in `create` or
+// `timeline`, removes it from the segment list, and continues the
+// active composition with the remaining scenes), surfacing each
+// failure through the optional `onSceneFailed` callback. When the
+// callback is NOT wired, the resolver still isolates mid-flight but
+// throws an `AggregateError` of every scene failure at the end of the
+// lifecycle so direct callers (tests, scripts) don't lose the signal.
+// Preload, signal-abort, manifest, registry-miss, and timeline-adapter
+// `run` failures are NOT scene failures and keep their abort-the-
+// composition semantics per ADR-028's non-goals.
+//
 // References:
 //  - ADR-002 §Resolution — the original 5-step lifecycle; its per-scene
 //    ordering is superseded by ADR-025.
@@ -40,6 +54,9 @@
 //    GSAP (ADR-003 / ADR-025).
 //  - ADR-025 — timeline adapter + composition master + the revised
 //    resolution lifecycle this module implements.
+//  - ADR-028 — scene-level error isolation (PUL-F029): per-scene
+//    lifecycle failures isolate, surface, and let the composition
+//    continue.
 //  - PUL-P001 — cleanup is a policy-level invariant.
 //  - PUL-F006 — `cleanup(ctx)` runs on every scene exit; the
 //    composition-level abort signal (`ResolveCompositionOptions.signal`)
@@ -182,6 +199,43 @@ export interface CompositionTimelineAdapter {
 }
 
 /**
+ * The lifecycle phase whose throw produced a scene failure (PUL-F029 /
+ * ADR-028). One of the three lifecycle hooks the scene contract owns;
+ * the loader maps phase + scene id onto the public diagnostic surface.
+ * `cleanup` covers both the per-scene cleanup the resolver runs eagerly
+ * when `create` or `timeline` failed AND the final cleanup-phase loop.
+ */
+export type SceneFailurePhase = 'create' | 'timeline' | 'cleanup';
+
+/**
+ * The structured per-scene failure event the resolver hands to
+ * {@link ResolveCompositionOptions.onSceneFailed} (PUL-F029 / ADR-028).
+ * The `cause` field is the original thrown value — programmatic only;
+ * the loader MUST NOT serialize it to a public diagnostic surface (per
+ * ADR-028: no raw causes, stacks, scene objects, DOM, captions,
+ * headers, cookies, environment, or auth values). The `message` field
+ * is the {@link describeError} rendering of the cause and IS safe to
+ * surface to operators.
+ *
+ * `entryIndex` carries the position of the failing scene in the
+ * manifest the resolver was handed (ADR-028: composition entry index
+ * is part of the failure diagnostic contract). When the resolver is
+ * driven from a composition slice that started mid-manifest the index
+ * is relative to the slice the resolver saw, not the absolute
+ * composition index — the loader (which knows the composition's
+ * entry-index translation) augments the public diagnostic with the
+ * composition id and effective mode (the other two fields ADR-028
+ * requires) on top of this resolver-level event.
+ */
+export interface SceneFailureEvent {
+  readonly phase: SceneFailurePhase;
+  readonly sceneId: string;
+  readonly entryIndex: number;
+  readonly message: string;
+  readonly cause: unknown;
+}
+
+/**
  * Inputs to {@link resolveComposition}. All fields are required except
  * the head hints / signal / presenter so the caller's wiring is explicit
  * at the call site (workbench bootstrap, export pipeline, test harness).
@@ -230,6 +284,29 @@ export interface ResolveCompositionOptions {
    * hook is treated like a cleanup failure (collected, not swallowed).
    */
   readonly onSceneCleaned?: (sceneId: string) => void;
+  /**
+   * Per-scene failure sink (PUL-F029 / ADR-028). Invoked once per
+   * isolated lifecycle failure with structured `{ phase, sceneId,
+   * entryIndex, message, cause }`. When supplied the resolver isolates
+   * failures mid-flight and completes the composition for the
+   * surviving scenes; when omitted it still isolates but rejects at
+   * the end with an `AggregateError` carrying every scene failure
+   * (plus any `onSceneCleaned` hook errors) so direct callers don't
+   * lose the signal.
+   *
+   * A throw from the callback itself is NOT propagated — it would
+   * otherwise let a buggy diagnostic sink interrupt cleanup-then-
+   * continue isolation for surviving scenes. The throw is treated
+   * like an `onSceneCleaned` hook error (a workbench bug, not a
+   * scene failure): collected and aggregated into the resolver's
+   * final `AggregateError` (under the `cleanup hook(s) threw`
+   * envelope) so it surfaces to operators, but lifecycle work keeps
+   * going. The callback's `cause` field is programmatic only; never
+   * serialize it to a public diagnostic surface (per ADR-028: no raw
+   * causes, stacks, scene objects, DOM, captions, headers, cookies,
+   * env, auth values).
+   */
+  readonly onSceneFailed?: (event: SceneFailureEvent) => void;
 }
 
 /**
@@ -247,6 +324,12 @@ interface PlanStep {
   readonly scene: SceneModule;
   readonly range: SubRange | undefined;
   readonly behavior: BehaviorOverride | undefined;
+  /**
+   * Position of the entry in the manifest the resolver was handed
+   * (PUL-F029 / ADR-028 diagnostic contract — see
+   * {@link SceneFailureEvent.entryIndex}).
+   */
+  readonly entryIndex: number;
 }
 
 /**
@@ -319,11 +402,11 @@ function buildPlan(manifest: CompositionManifest, registry: SceneRegistry): read
     }
   }
   const plan: PlanStep[] = [];
-  for (const entry of manifest) {
+  for (const [entryIndex, entry] of manifest.entries()) {
     const scene = registry.get(entryId(entry));
     const range = typeof entry === 'string' ? undefined : entry.range;
     const behavior = typeof entry === 'string' ? undefined : entry.behavior;
-    plan.push({ scene, range, behavior });
+    plan.push({ scene, range, behavior, entryIndex });
   }
   return Object.freeze(plan);
 }
@@ -337,12 +420,186 @@ async function preloadScene(scene: SceneModule, preloadAssets: AssetPreloader): 
   }
 }
 
-/** Clause (c): mount one scene via `create(ctx)`. */
-async function mountScene(scene: SceneModule, ctx: unknown): Promise<void> {
+/**
+ * Build a {@link SceneFailureEvent} and an `Error` wrapper for one
+ * isolated scene-lifecycle failure (PUL-F029 / ADR-028). The wrapper
+ * preserves the existing `composition resolution failed:` envelope so
+ * the legacy-throwing fallback path (no `onSceneFailed` supplied)
+ * yields the same Error.message + Error.cause shape callers expect.
+ */
+function buildSceneFailure(
+  phase: SceneFailurePhase,
+  step: PlanStep,
+  cause: unknown,
+  detail: string,
+): { event: SceneFailureEvent; wrapper: Error } {
+  const event: SceneFailureEvent = {
+    phase,
+    sceneId: step.scene.id,
+    entryIndex: step.entryIndex,
+    message: describeError(cause),
+    cause,
+  };
+  return { event, wrapper: fail(detail, cause) };
+}
+
+/**
+ * Failure / hook-error buckets the lifecycle helpers append into. One
+ * record passed by reference instead of five separate arrays keeps the
+ * helper signatures readable.
+ *
+ *  - `sceneFailures` / `sceneFailureErrors` — scene lifecycle failures
+ *    (PUL-F029 / ADR-028). Surfaced through `onSceneFailed` when wired;
+ *    aggregated into the resolver's `AggregateError` fallback when not.
+ *  - `hookErrors` — workbench-supplied `onSceneCleaned` throws. Per the
+ *    option contract these are NOT scene failures (the scene's cleanup
+ *    succeeded; the workbench's audio-teardown hook is what threw), so
+ *    they bypass `onSceneFailed` and ALWAYS aggregate into the
+ *    resolver's throw — independent of whether `onSceneFailed` was
+ *    supplied. Without that distinction a workbench hook bug becomes
+ *    silently swallowed under PUL-F029.
+ */
+interface FailureBucket {
+  readonly sceneFailures: SceneFailureEvent[];
+  readonly sceneFailureErrors: Error[];
+  readonly hookErrors: Error[];
+}
+
+/**
+ * Invoke `onSceneFailed` defensively. A throw from the caller-supplied
+ * diagnostic sink MUST NOT interrupt the resolver's cleanup-then-
+ * continue invariant (codex review, cycle 2): if it did, a buggy
+ * logger could break mandatory cleanup for surviving scenes, mask the
+ * original phase error in the catch path, or strand resources. The
+ * sink throw is collected in `bucket.hookErrors` so it surfaces
+ * through the resolver's final aggregate just like an `onSceneCleaned`
+ * hook throw — same "workbench bug, not a scene failure" contract.
+ */
+function notifyFailure(
+  onSceneFailed: ((event: SceneFailureEvent) => void) | undefined,
+  event: SceneFailureEvent,
+  bucket: FailureBucket,
+): void {
+  if (onSceneFailed === undefined) return;
   try {
-    await scene.create(ctx);
-  } catch (cause) {
-    throw fail(`scene ${quoteId(scene.id)} create threw: ${describeError(cause)}`, cause);
+    onSceneFailed(event);
+  } catch (err) {
+    bucket.hookErrors.push(
+      fail(`scene ${quoteId(event.sceneId)} onSceneFailed threw: ${describeError(err)}`, err),
+    );
+  }
+}
+
+/**
+ * Run one scene's `cleanup(ctx)` AND its post-cleanup hook
+ * (`onSceneCleaned`). Used by BOTH the eager-cleanup branches in
+ * `mountPlan` / `composeSegments` (PUL-F029 isolation) AND the final
+ * cleanup loop. Centralising the call sequence means the workbench-
+ * supplied `onSceneCleaned` hook (PUL-F024 / ADR-004 — the audio
+ * group teardown hook) runs exactly once per scene cleanup, regardless
+ * of whether that cleanup happened eagerly after a `create` / `timeline`
+ * throw or at the end of the lifecycle. Without that, a failed scene's
+ * audio group would keep playing while the surviving composition
+ * continues — a real production observability gap (codex review,
+ * cycle 1).
+ *
+ * Scene cleanup failures route to `bucket.sceneFailures` /
+ * `sceneFailureErrors` + `onSceneFailed`. Hook (`onSceneCleaned`)
+ * failures route to `bucket.hookErrors` only; per the option's
+ * contract, a hook throw is a workbench bug, not a scene failure.
+ */
+async function cleanOneScene(
+  step: PlanStep,
+  ctx: unknown,
+  onSceneCleaned: ((sceneId: string) => void) | undefined,
+  bucket: FailureBucket,
+  onSceneFailed: ((event: SceneFailureEvent) => void) | undefined,
+): Promise<void> {
+  try {
+    await step.scene.cleanup(ctx);
+  } catch (cleanupCause) {
+    const { event, wrapper } = buildSceneFailure(
+      'cleanup',
+      step,
+      cleanupCause,
+      `scene ${quoteId(step.scene.id)} cleanup threw: ${describeError(cleanupCause)}`,
+    );
+    bucket.sceneFailures.push(event);
+    bucket.sceneFailureErrors.push(wrapper);
+    notifyFailure(onSceneFailed, event, bucket);
+  }
+  try {
+    onSceneCleaned?.(step.scene.id);
+  } catch (err) {
+    bucket.hookErrors.push(
+      fail(`scene ${quoteId(step.scene.id)} onSceneCleaned threw: ${describeError(err)}`, err),
+    );
+  }
+}
+
+/**
+ * Mount the planned scenes one by one (clauses b + c with the PUL-F029
+ * / ADR-028 isolation rule). A throwing `create(ctx)` is recorded as a
+ * scene failure, the failing scene's `cleanup(ctx)` runs immediately
+ * (so DOM / listeners / partial state don't leak), the scene is
+ * dropped from the `mounted` list for the rest of the lifecycle, and
+ * the mount loop continues with the next scene. Preload errors,
+ * signal aborts, and the pre-start abort still throw out — those keep
+ * their composition-wide semantics per ADR-028's non-goals.
+ */
+async function mountPlan(
+  plan: readonly PlanStep[],
+  ctx: unknown,
+  preloadAssets: AssetPreloader,
+  signal: AbortSignal | undefined,
+  onSceneCleaned: ((sceneId: string) => void) | undefined,
+  bucket: FailureBucket,
+  onSceneFailed: ((event: SceneFailureEvent) => void) | undefined,
+  mounted: PlanStep[],
+): Promise<void> {
+  for (const step of plan) {
+    await preloadScene(step.scene, preloadAssets);
+    throwIfAborted(
+      signal,
+      `aborted after preloading ${quoteId(step.scene.id)}, before scene activation`,
+    );
+    // Track in `mounted` BEFORE create so a partial-create scene still
+    // gets cleanup — and so the eager-cleanup branch below pops the
+    // scene only after its cleanup ran (one cleanup per scene).
+    mounted.push(step);
+    try {
+      await step.scene.create(ctx);
+    } catch (cause) {
+      const { event, wrapper } = buildSceneFailure(
+        'create',
+        step,
+        cause,
+        `scene ${quoteId(step.scene.id)} create threw: ${describeError(cause)}`,
+      );
+      bucket.sceneFailures.push(event);
+      bucket.sceneFailureErrors.push(wrapper);
+      notifyFailure(onSceneFailed, event, bucket);
+      // PUL-F029: run the failing scene's cleanup eagerly through the
+      // SAME helper as the final cleanup loop, so the per-scene
+      // `onSceneCleaned` hook (PUL-F024 / ADR-004 audio-group
+      // teardown) fires for the failed scene too — otherwise a scene
+      // that played grouped audio in `create` before throwing would
+      // leak that group while the surviving composition continues.
+      // Then drop the scene from `mounted` so the final cleanup phase
+      // doesn't double-clean.
+      await cleanOneScene(step, ctx, onSceneCleaned, bucket, onSceneFailed);
+      mounted.pop();
+      // Codex review cycle 2: re-check the abort signal after the
+      // awaited eager cleanup. Without this, a navigation aborted
+      // during the failed scene's cleanup would still kick off the
+      // next scene's preload + create — exactly the
+      // cleanup-before-handoff regression the loader guards against.
+      throwIfAborted(signal, `aborted after isolating ${quoteId(step.scene.id)} create failure`);
+      // Continue to the next scene — the active composition keeps
+      // going (PUL-F029 SHALL NOT halt the active composition).
+      continue;
+    }
+    throwIfAborted(signal, `aborted after mounting ${quoteId(step.scene.id)}`);
   }
 }
 
@@ -351,16 +608,50 @@ async function mountScene(scene: SceneModule, ctx: unknown): Promise<void> {
  * (in mount order), carrying the per-entry `range` / `behavior`
  * overrides through to the adapter unchanged. `timeline(ctx)` is NOT
  * awaited — see {@link SceneTimelineSegment.timeline}. A throwing
- * `timeline(ctx)` factory aborts the composition (every mounted scene
- * is then torn down).
+ * `timeline(ctx)` factory isolates that scene (PUL-F029 / ADR-028):
+ * the scene's cleanup runs eagerly, the scene is dropped from
+ * `mounted`, and no segment is contributed; surviving scenes still
+ * produce segments and the adapter plays the master with whatever the
+ * composition produced. Mutates `mounted` in place to remove cleaned
+ * scenes so the final cleanup loop doesn't double-clean.
  */
-function composeSegments(mounted: readonly PlanStep[], ctx: unknown): SceneTimelineSegment[] {
-  return mounted.map((step) => {
+async function composeSegments(
+  mounted: PlanStep[],
+  ctx: unknown,
+  signal: AbortSignal | undefined,
+  onSceneCleaned: ((sceneId: string) => void) | undefined,
+  bucket: FailureBucket,
+  onSceneFailed: ((event: SceneFailureEvent) => void) | undefined,
+): Promise<SceneTimelineSegment[]> {
+  const segments: SceneTimelineSegment[] = [];
+  // Walk a snapshot of `mounted` because the loop may mutate it.
+  for (const step of [...mounted]) {
     let timeline: unknown;
     try {
       timeline = step.scene.timeline(ctx);
     } catch (cause) {
-      throw fail(`scene ${quoteId(step.scene.id)} timeline threw: ${describeError(cause)}`, cause);
+      const { event, wrapper } = buildSceneFailure(
+        'timeline',
+        step,
+        cause,
+        `scene ${quoteId(step.scene.id)} timeline threw: ${describeError(cause)}`,
+      );
+      bucket.sceneFailures.push(event);
+      bucket.sceneFailureErrors.push(wrapper);
+      notifyFailure(onSceneFailed, event, bucket);
+      // PUL-F029: run cleanup eagerly through the same helper so the
+      // `onSceneCleaned` hook fires for the failed scene too (audio
+      // teardown), then drop from `mounted` so the final cleanup
+      // phase doesn't see this scene again.
+      await cleanOneScene(step, ctx, onSceneCleaned, bucket, onSceneFailed);
+      const at = mounted.indexOf(step);
+      if (at !== -1) mounted.splice(at, 1);
+      // Codex review cycle 2: re-check the abort signal after the
+      // awaited eager cleanup so we don't call `timeline(ctx)` on
+      // surviving scenes for a navigation that's already been
+      // superseded.
+      throwIfAborted(signal, `aborted after isolating ${quoteId(step.scene.id)} timeline failure`);
+      continue;
     }
     const segment: { -readonly [K in keyof SceneTimelineSegment]: SceneTimelineSegment[K] } = {
       id: step.scene.id,
@@ -368,8 +659,9 @@ function composeSegments(mounted: readonly PlanStep[], ctx: unknown): SceneTimel
     };
     if (step.range !== undefined) segment.range = step.range;
     if (step.behavior !== undefined) segment.behavior = step.behavior;
-    return segment;
-  });
+    segments.push(segment);
+  }
+  return segments;
 }
 
 /**
@@ -384,26 +676,13 @@ function composeSegments(mounted: readonly PlanStep[], ctx: unknown): SceneTimel
 async function cleanupAll(
   mounted: readonly PlanStep[],
   ctx: unknown,
-  onSceneCleaned?: (sceneId: string) => void,
-): Promise<readonly unknown[]> {
-  const errors: unknown[] = [];
+  onSceneCleaned: ((sceneId: string) => void) | undefined,
+  bucket: FailureBucket,
+  onSceneFailed: ((event: SceneFailureEvent) => void) | undefined,
+): Promise<void> {
   for (const step of [...mounted].reverse()) {
-    try {
-      await step.scene.cleanup(ctx);
-    } catch (err) {
-      errors.push(
-        fail(`scene ${quoteId(step.scene.id)} cleanup threw: ${describeError(err)}`, err),
-      );
-    }
-    try {
-      onSceneCleaned?.(step.scene.id);
-    } catch (err) {
-      errors.push(
-        fail(`scene ${quoteId(step.scene.id)} onSceneCleaned threw: ${describeError(err)}`, err),
-      );
-    }
+    await cleanOneScene(step, ctx, onSceneCleaned, bucket, onSceneFailed);
   }
-  return errors;
 }
 
 /**
@@ -436,12 +715,22 @@ function buildRunOptions(options: ResolveCompositionOptions): CompositionTimelin
  * in the module header (mount-all → compose-master → play → cleanup-all,
  * ADR-025).
  *
- * Failure semantics:
- *  - A failing preload / `create` / `timeline(ctx)` / timeline-adapter
- *    `run` aborts the composition; every mounted scene is torn down
- *    (reverse order), then the original error is re-raised wrapped with
- *    the `composition resolution failed:` prefix and the original as
- *    `Error.cause`.
+ * Failure semantics (PUL-F029 / ADR-028):
+ *  - A failing `create(ctx)` / `timeline(ctx)` / `cleanup(ctx)` is a
+ *    per-scene lifecycle failure. The resolver isolates the failing
+ *    scene (runs its `cleanup(ctx)` eagerly when the failure is in
+ *    `create` or `timeline`, drops it from the segment list, and
+ *    continues the active composition with the remaining scenes).
+ *    Each failure surfaces through {@link ResolveCompositionOptions.onSceneFailed}
+ *    when supplied; when omitted the failures still isolate but
+ *    aggregate into the resolver's `AggregateError` at the end of the
+ *    lifecycle so direct callers don't lose the signal.
+ *  - A failing preload / signal-aborted checkpoint / manifest /
+ *    registry-miss / timeline-adapter `run` rejection is a
+ *    composition-wide failure (NOT per-scene). The resolver tears
+ *    every still-mounted scene down (reverse order), then re-raises
+ *    the original error wrapped with the `composition resolution
+ *    failed:` prefix and the original as `Error.cause`.
  *  - When the phase failure AND one or more cleanup hooks throw, the
  *    wrapping error is an `AggregateError` whose `errors` array carries
  *    the phase error first then the cleanup errors in order. Nothing is
@@ -450,11 +739,18 @@ function buildRunOptions(options: ResolveCompositionOptions): CompositionTimelin
  *    resolve (not throw); the resolver then tears every scene down and
  *    re-raises an `aborted during composition playback` error so the
  *    loader's pure-abort suppression applies.
- *  - The happy path tears every scene down and resolves; a cleanup-only
- *    failure is re-raised as an `AggregateError` of the cleanup errors.
+ *  - The happy path tears every scene down and resolves. When
+ *    `onSceneFailed` is wired the resolver returns normally even if
+ *    some scenes failed (they were already fanned out through the
+ *    callback). When the callback is NOT wired, any scene cleanup
+ *    failure aggregates with the scene's already-isolated lifecycle
+ *    failures into an `AggregateError`. `onSceneCleaned` hook throws
+ *    (workbench bugs — not scene failures) ALWAYS aggregate
+ *    regardless of `onSceneFailed`.
  */
 export async function resolveComposition(options: ResolveCompositionOptions): Promise<void> {
   const { registry, manifest, ctx, preloadAssets, timeline, signal } = options;
+  const onSceneFailed = options.onSceneFailed;
 
   // PUL-F011 / ADR-015: a `headBeat` without an `onBeatMissing` would
   // silently lose the missing-label diagnostic the adapter is
@@ -473,48 +769,85 @@ export async function resolveComposition(options: ResolveCompositionOptions): Pr
   // Pre-start abort: nothing was touched, so this needs no cleanup.
   throwIfAborted(signal, 'aborted before the composition started');
 
-  // Scenes mounted so far (created, or create-attempted) — the cleanup
-  // list. Built up during the mount phase; torn down (always) at the
-  // end. The old per-scene `runScene` try/catch is replaced by this
-  // composition-wide try/catch around the mount + compose + run phases.
+  // PUL-F029 / ADR-028: per-scene failures and `onSceneCleaned` hook
+  // throws collect into one bucket. `sceneFailures[*]` /
+  // `sceneFailureErrors[*]` carry scene lifecycle failures (surfaced
+  // through `onSceneFailed` when wired; aggregated into the legacy
+  // AggregateError fallback when not). `hookErrors[*]` carry
+  // workbench-supplied `onSceneCleaned` throws and ALWAYS aggregate
+  // into the resolver's throw — independent of `onSceneFailed` —
+  // because per the option's contract a hook throw is "treated like a
+  // cleanup failure (collected, not swallowed)." Without that
+  // separation the loader's audio-teardown hook would become silently
+  // swallowed under PUL-F029.
+  const bucket: FailureBucket = {
+    sceneFailures: [],
+    sceneFailureErrors: [],
+    hookErrors: [],
+  };
+  const { onSceneCleaned } = options;
+
+  // Scenes mounted so far (created, or create-attempted but cleaned up
+  // immediately) — the cleanup list for the final cleanup phase. The
+  // mount and compose helpers remove an entry from this list as soon
+  // as they run that scene's eager cleanup (PUL-F029), so a scene's
+  // cleanup never runs twice. Passed into `mountPlan` as an out-
+  // parameter so a preload-or-abort throw still leaves the partial
+  // mount list visible to the catch handler below.
   const mounted: PlanStep[] = [];
   try {
-    // MOUNT phase. Strictly sequential, manifest order. Abort
-    // checkpoints: after each preload (catches a mid-preload abort) and
-    // after each create (catches an abort between this scene and the
-    // next — the playback abort is handled by the timeline adapter).
-    for (const step of plan) {
-      await preloadScene(step.scene, preloadAssets);
-      throwIfAborted(
-        signal,
-        `aborted after preloading ${quoteId(step.scene.id)}, before scene activation`,
-      );
-      // Add to the cleanup list BEFORE `create` so a scene whose
-      // `create` partially ran (then threw) is still torn down.
-      mounted.push(step);
-      await mountScene(step.scene, ctx);
-      throwIfAborted(signal, `aborted after mounting ${quoteId(step.scene.id)}`);
-    }
+    await mountPlan(
+      plan,
+      ctx,
+      preloadAssets,
+      signal,
+      onSceneCleaned,
+      bucket,
+      onSceneFailed,
+      mounted,
+    );
 
     // COMPOSE + RUN phase. Collect every mounted scene's timeline value
-    // and hand the slice to the timeline adapter, which composes the
-    // master, applies the head hints, plays it, and resolves on the
-    // master's natural completion or on abort. The adapter does NOT
-    // throw on abort — it resolves; the signal is re-checked below.
-    const segments = composeSegments(mounted, ctx);
+    // (isolating per-scene timeline throws per PUL-F029) and hand the
+    // slice to the timeline adapter, which composes the master, applies
+    // the head hints, plays it, and resolves on the master's natural
+    // completion or on abort. The adapter does NOT throw on abort —
+    // it resolves; the signal is re-checked below.
+    const segments = await composeSegments(
+      mounted,
+      ctx,
+      signal,
+      onSceneCleaned,
+      bucket,
+      onSceneFailed,
+    );
     try {
       await timeline.run(segments, buildRunOptions(options));
     } catch (cause) {
       throw fail(`composition timeline failed: ${describeError(cause)}`, cause);
     }
   } catch (phaseError) {
-    // Mandatory cleanup: tear down every mounted scene (reverse order),
-    // then re-raise — aggregating cleanup errors if any.
-    const cleanupErrors = await cleanupAll(mounted, ctx, options.onSceneCleaned);
-    if (cleanupErrors.length > 0) {
+    // Composition-wide failure (preload, signal abort, manifest, or
+    // timeline-adapter `run` rejection). Mandatory cleanup: tear down
+    // every still-mounted scene (reverse order), then re-raise.
+    // PUL-F029 / ADR-028: when `onSceneFailed` is wired the resolver
+    // has already fanned out every per-scene failure (mount / compose
+    // / cleanup) through the callback, so aggregating them onto the
+    // composition-wide error would surface them twice — and route the
+    // loader into the fatal `data-pulsar-navigation-error` surface for
+    // events PUL-F029 says must NOT halt the active composition.
+    // BUT `onSceneCleaned` hook throws (`bucket.hookErrors`) always
+    // aggregate, because a hook throw is a workbench bug independent
+    // of PUL-F029's per-scene isolation contract.
+    await cleanupAll(mounted, ctx, onSceneCleaned, bucket, onSceneFailed);
+    const tail = [
+      ...(onSceneFailed === undefined ? bucket.sceneFailureErrors : []),
+      ...bucket.hookErrors,
+    ];
+    if (tail.length > 0) {
       throw failAggregate(
-        `composition aborted with ${cleanupErrors.length} cleanup failure(s) after: ${describeError(phaseError)}`,
-        [phaseError, ...cleanupErrors],
+        `composition aborted with ${tail.length} additional failure(s) after: ${describeError(phaseError)}`,
+        [phaseError, ...tail],
       );
     }
     throw phaseError;
@@ -524,20 +857,51 @@ export async function resolveComposition(options: ResolveCompositionOptions): Pr
   // adapter resolved without throwing). Tear every scene down, then
   // surface an abort error if the signal fired (so the loader's
   // pure-abort suppression applies) or aggregate any cleanup failures.
-  const cleanupErrors = await cleanupAll(mounted, ctx, options.onSceneCleaned);
+  await cleanupAll(mounted, ctx, onSceneCleaned, bucket, onSceneFailed);
   if (signal?.aborted === true) {
-    if (cleanupErrors.length > 0) {
-      throw failAggregate(
-        `composition aborted during playback with ${cleanupErrors.length} cleanup failure(s)`,
-        [fail('aborted during composition playback', signal.reason), ...cleanupErrors],
-      );
+    // PUL-F029: when `onSceneFailed` is wired, scene cleanup failures
+    // already surfaced through the callback. Hook errors still
+    // aggregate. Without the callback, fall back to the legacy
+    // aggregate so direct callers still see scene cleanup errors.
+    const tail = [
+      ...(onSceneFailed === undefined ? bucket.sceneFailureErrors : []),
+      ...bucket.hookErrors,
+    ];
+    if (tail.length > 0) {
+      const sceneCount = onSceneFailed === undefined ? bucket.sceneFailureErrors.length : 0;
+      const hookCount = bucket.hookErrors.length;
+      // Preserve the historical "cleanup failure(s)" wording when the
+      // aggregate is scene-cleanup-only — pre-PUL-F029 callers / tests
+      // pattern-match on it.
+      const detail =
+        hookCount === 0
+          ? `composition aborted during playback with ${sceneCount} cleanup failure(s)`
+          : `composition aborted during playback with ${tail.length} additional failure(s)`;
+      throw failAggregate(detail, [
+        fail('aborted during composition playback', signal.reason),
+        ...tail,
+      ]);
     }
     throw fail('aborted during composition playback', signal.reason);
   }
-  if (cleanupErrors.length > 0) {
-    throw failAggregate(
-      `composition completed but ${cleanupErrors.length} cleanup hook(s) threw`,
-      cleanupErrors,
-    );
+  // PUL-F029: when no `onSceneFailed` was wired, surface every
+  // isolated scene failure (mount / compose / cleanup) PLUS any
+  // hook errors as one AggregateError so the caller doesn't lose
+  // information. When the callback IS wired, the resolver has
+  // already fanned out every per-scene failure inline, so only the
+  // hook errors aggregate (they're a workbench-contract violation
+  // PUL-F029 does not subsume).
+  const sceneFailuresForAggregate = onSceneFailed === undefined ? bucket.sceneFailureErrors : [];
+  const aggregate = [...sceneFailuresForAggregate, ...bucket.hookErrors];
+  if (aggregate.length > 0) {
+    const sceneFailureCount = sceneFailuresForAggregate.length;
+    const hookCount = bucket.hookErrors.length;
+    const detail =
+      sceneFailureCount === 0
+        ? `composition completed but ${hookCount} cleanup hook(s) threw`
+        : hookCount === 0
+          ? `composition completed with ${sceneFailureCount} scene failure(s)`
+          : `composition completed with ${sceneFailureCount} scene failure(s) and ${hookCount} cleanup hook(s) threw`;
+    throw failAggregate(detail, aggregate);
   }
 }

--- a/src/runtime/scene-loader.ts
+++ b/src/runtime/scene-loader.ts
@@ -38,7 +38,11 @@ import {
   noopAudioEngine,
 } from './audio';
 import type { CompositionRegistry } from './composition-registry';
-import type { AssetPreloader, CompositionTimelineAdapter } from './composition-resolver';
+import type {
+  AssetPreloader,
+  CompositionTimelineAdapter,
+  SceneFailureEvent,
+} from './composition-resolver';
 import { describeError } from './error';
 import { KEBAB_IDENTIFIER_FORM, isKebabIdentifier } from './identifier';
 import {
@@ -301,6 +305,11 @@ export interface SceneLoader {
 const ATTR_SCENE = 'data-pulsar-scene-target';
 const ATTR_COMPOSITION = 'data-pulsar-composition-target';
 const ATTR_ERROR = 'data-pulsar-navigation-error';
+// PUL-F029 / ADR-028: per-scene lifecycle failures land on a dedicated
+// attribute so the fatal `data-pulsar-navigation-error` surface keeps
+// its "composition aborted" semantics. The value is a comma-separated
+// list of `<sceneId>:<phase>` entries in encounter order.
+const ATTR_SCENE_FAILURES = 'data-pulsar-scene-failures';
 
 /**
  * Resolve when `signal` is aborted (or immediately if already
@@ -449,6 +458,85 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
     clearStageAttr(ATTR_SCENE);
     clearStageAttr(ATTR_COMPOSITION);
     clearStageAttr(ATTR_ERROR);
+    clearStageAttr(ATTR_SCENE_FAILURES);
+  };
+
+  /**
+   * Build the per-navigation `onSceneFailed` handler (PUL-F029 /
+   * ADR-028). Each event arrives as a `{ phase, sceneId, entryIndex,
+   * message, cause }` tuple from the resolver. The loader augments
+   * the public diagnostic with `compositionId` and effective `mode`
+   * (the two extra context fields ADR-028's diagnostic contract
+   * requires beyond what the resolver knows) when rendering the
+   * `onError` message. `event.cause` itself stays programmatic and
+   * is never serialized to the stage or to `onError`'s argument (per
+   * ADR-028: no raw causes, stacks, scene objects, DOM, captions,
+   * headers, cookies, env, auth values).
+   *
+   * The handler accumulates `<sceneId>:<phase>` entries into a Set so
+   * a scene whose `create` AND `cleanup` both throw shows up once per
+   * (id, phase) tuple in encounter order, not twice for the same
+   * tuple.
+   *
+   * Two-tier suppression:
+   *  - **Stage attribute writes** are suppressed when the
+   *    navigation's `signal.aborted` (a superseded navigation must
+   *    not stomp on the new navigation's stage state) or when the
+   *    loader is `disposed`. This parallels `buildOnBeatMissing`.
+   *  - **`onError` calls** still fire on abort so a cleanup-phase
+   *    scene failure during an aborted lifecycle stays visible to
+   *    the workbench logger — the multi-fault visibility the pre-
+   *    PUL-F029 `AggregateError` surface provided. Suppressed only
+   *    when the loader is fully `disposed` (the workbench is
+   *    shutting down; there is no sink to surface to).
+   */
+  const buildOnSceneFailed = (
+    signal: AbortSignal,
+    mode: NavigationMode,
+    composition: { readonly id: string; readonly startIndex: number } | undefined,
+  ): ((event: SceneFailureEvent) => void) => {
+    const entries: string[] = [];
+    const seen = new Set<string>();
+    const renderMessage = (event: SceneFailureEvent): string => {
+      // Codex review cycle 2: render the ABSOLUTE composition entry
+      // index (slice start + resolver-level slice-relative index).
+      // The resolver's `event.entryIndex` is relative to the manifest
+      // slice it was handed; for `composition-scene` and
+      // `composition-index` navigations that slice starts mid-
+      // manifest, so a slice-relative index would point operators at
+      // the wrong entry.
+      const compositionSuffix =
+        composition === undefined
+          ? ''
+          : ` (composition "${composition.id}" entry [${composition.startIndex + event.entryIndex}])`;
+      return `scene "${event.sceneId}" failed during ${event.phase}${compositionSuffix} under mode "${mode}": ${event.message}`;
+    };
+    return (event: SceneFailureEvent): void => {
+      if (disposed) return;
+      if (!signal.aborted) {
+        const key = `${event.sceneId}:${event.phase}`;
+        if (!seen.has(key)) {
+          seen.add(key);
+          entries.push(key);
+          setStageAttr(ATTR_SCENE_FAILURES, entries.join(','));
+        }
+      }
+      // Public diagnostic: scene id + phase + composition context +
+      // mode + describeError rendering. Wrapped in an `Error` so
+      // existing `onError` consumers that call `err.message` keep
+      // working. `event.cause` deliberately stays inside the resolver
+      // — the loader never publishes it (ADR-028's "no raw causes"
+      // rule).
+      try {
+        onError(new Error(renderMessage(event)));
+      } catch {
+        // `onError` is caller-supplied; an exception from it must not
+        // propagate back through the resolver's `onSceneFailed`
+        // invocation (the resolver would then re-route via the
+        // composition-wide failure path and abort surviving scenes —
+        // exactly the wrong behavior for a diagnostic sink throw).
+      }
+    };
   };
 
   const abortAndAwait = async (): Promise<void> => {
@@ -784,6 +872,13 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
     // `hold` / `cueGate` / `screenshot` is non-undefined here.
     const screenshot: 'capture' | undefined = mode === 'screenshot' ? 'capture' : undefined;
     const { presenter, presenterAbort } = buildPresenterPipe(mode, controller, audio);
+    const onSceneFailed = buildOnSceneFailed(
+      controller.signal,
+      mode,
+      resolved.composition === undefined
+        ? undefined
+        : { id: resolved.composition.id, startIndex: resolved.composition.startIndex },
+    );
     return {
       controller,
       settled: loadSceneNavigationTarget(resolved, {
@@ -809,6 +904,11 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
         // not author discipline. (`stopGroup` is a no-op when the group
         // is empty or the service is already disposed.)
         onSceneCleaned: (sceneId) => audio.stopGroup(sceneId),
+        // PUL-F029 / ADR-028: scene-level error isolation. Each
+        // isolated `create` / `timeline` / `cleanup` failure becomes
+        // a stage attribute entry + `onError` call without halting
+        // the active composition.
+        onSceneFailed,
       }),
       silent: false,
       audio,
@@ -916,6 +1016,10 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
         id: resolved.composition.id,
         manifestSlice: Object.freeze([headEntry]),
         sceneSlice: Object.freeze([headScene]),
+        // PUL-F029 / ADR-028: preserve the absolute composition start
+        // index even when the slice is truncated to its head, so a
+        // failure diagnostic names the right manifest entry.
+        startIndex: resolved.composition.startIndex,
       },
     };
   };

--- a/src/runtime/scene-navigation.ts
+++ b/src/runtime/scene-navigation.ts
@@ -35,6 +35,7 @@ import type { CompositionRegistry } from './composition-registry';
 import {
   type AssetPreloader,
   type CompositionTimelineAdapter,
+  type ResolveCompositionOptions,
   resolveComposition,
 } from './composition-resolver';
 import type { NavigationTarget } from './navigation';
@@ -621,83 +622,58 @@ export async function loadSceneNavigationTarget(
     );
   }
 
-  await resolveComposition({
-    registry: createSceneRegistry(uniqueScenes),
+  await resolveComposition(
+    buildResolverOptions(createSceneRegistry(uniqueScenes), manifest, options),
+  );
+}
+
+/**
+ * Build the {@link ResolveCompositionOptions} the bridge hands to the
+ * resolver. Each optional input is spread only when supplied so a
+ * resolver that branches on `'<key>' in opts` sees absent rather than
+ * `undefined` — same idiom as the resolver's own `buildRunOptions`.
+ * Hoisted out of `loadSceneNavigationTarget` so the latter stays
+ * within Sonar's cognitive-complexity budget (S3776). Per ADR-015 /
+ * ADR-018 / ADR-019 / ADR-020 / ADR-021 / ADR-023 / ADR-004 / ADR-028
+ * each option is independent and gets its own conditional spread;
+ * `onBeatMissing` is the only paired surface (it's meaningless without
+ * `beat`), and `onPresenterError` is similarly paired with `presenter`.
+ */
+function buildResolverOptions(
+  registry: ReturnType<typeof createSceneRegistry>,
+  manifest: CompositionManifest,
+  options: LoadSceneNavigationTargetOptions,
+): ResolveCompositionOptions {
+  const beatPair =
+    options.beat === undefined
+      ? {}
+      : {
+          headBeat: options.beat,
+          ...(options.onBeatMissing === undefined ? {} : { onBeatMissing: options.onBeatMissing }),
+        };
+  const presenterPair =
+    options.presenter === undefined
+      ? {}
+      : {
+          presenter: options.presenter,
+          ...(options.onPresenterError === undefined
+            ? {}
+            : { onPresenterError: options.onPresenterError }),
+        };
+  return {
+    registry,
     manifest,
     ctx: options.ctx,
     preloadAssets: options.preloadAssets,
     timeline: options.timeline,
     ...(options.signal === undefined ? {} : { signal: options.signal }),
-    // `onBeatMissing` is paired with `beat` per ADR-015 — a callback
-    // without a label has no trigger condition, so dropping it when
-    // `beat` is absent prevents misuse-by-spread (e.g. a caller
-    // accidentally passing `onBeatMissing` with no `beat`).
-    ...(options.beat === undefined
-      ? {}
-      : {
-          headBeat: options.beat,
-          ...(options.onBeatMissing === undefined ? {} : { onBeatMissing: options.onBeatMissing }),
-        }),
-    // `repeat` is independent of `beat` per ADR-018: a URL like
-    // `?scene=x&mode=loop` (no beat) and `?scene=x&beat=hook&mode=loop`
-    // (beat + loop) are both valid. Spread `headRepeat` only when the
-    // caller supplied it so a runner that branches on `'repeat' in
-    // input` sees an absent key rather than `undefined`.
+    ...beatPair,
     ...(options.repeat === undefined ? {} : { headRepeat: options.repeat }),
-    // `hold` is independent of `beat` and `repeat` per ADR-019: a URL
-    // like `?scene=x&mode=paused` (no beat, no loop) is valid, and so
-    // is `?scene=x&beat=hook&mode=paused` (the runner's policy
-    // decides which wins — ADR-019 records that `hold` wins over
-    // `beat` for paused mode). Spread `headHold` only when the
-    // caller supplied it so a runner that branches on `'hold' in
-    // input` sees an absent key rather than `undefined`.
     ...(options.hold === undefined ? {} : { headHold: options.hold }),
-    // `cueGate` is independent of `beat`, `repeat`, and `hold` per
-    // ADR-020: a URL like `?scene=x&mode=scrub` (no beat) is valid,
-    // and so is `?scene=x&beat=hook&mode=scrub` (the natural
-    // scrub-to-named-beat path PUL-F017's "to named beats" clause
-    // anticipates). Spread `headCueGate` only when the caller
-    // supplied it so a runner that branches on `'cueGate' in input`
-    // sees an absent key rather than `undefined`.
     ...(options.cueGate === undefined ? {} : { headCueGate: options.cueGate }),
-    // `screenshot` is independent of `beat`, `repeat`, `hold`, and
-    // `cueGate` per ADR-021: a URL like `?scene=x&mode=screenshot`
-    // (no beat) is valid (renders at first frame), and so is
-    // `?scene=x&beat=midpoint&mode=screenshot` (the natural
-    // deterministic-frame-capture-at-named-beat path PUL-F018
-    // names directly). Spread `headScreenshot` only when the
-    // caller supplied it so a runner that branches on
-    // `'screenshot' in input` sees an absent key rather than
-    // `undefined`.
     ...(options.screenshot === undefined ? {} : { headScreenshot: options.screenshot }),
-    // `presenter` is independent of `beat`, `repeat`, `hold`,
-    // `cueGate`, and `screenshot` per ADR-023: presenter input is
-    // only valid under `mode=present` (the loader scopes delivery),
-    // and that mode has no head-only structural promise to defend.
-    // Spread `presenter` only when the caller supplied it so a
-    // runner that branches on `'presenter' in input` sees an absent
-    // key rather than `undefined`. The resolver forwards it to
-    // EVERY scene's run input (NOT head-only) — mode=present runs
-    // the full slice and presenter commands act on whichever scene
-    // is active.
-    ...(options.presenter === undefined ? {} : { presenter: options.presenter }),
-    // `onPresenterError` is paired with `presenter` per ADR-023 —
-    // a sink without a controller has nothing to surface
-    // diagnostics from. Drop the sink when no presenter is
-    // supplied; otherwise spread it so the per-scene wrapper inside
-    // the resolver routes its boundary diagnostics through the
-    // loader's `onError` channel.
-    ...(options.presenter === undefined || options.onPresenterError === undefined
-      ? {}
-      : { onPresenterError: options.onPresenterError }),
-    // `onSceneCleaned` (PUL-F024 / ADR-004 — the audio group teardown
-    // hook) is forwarded as-is; the loader supplies it on every
-    // navigation that runs the resolver lifecycle.
+    ...presenterPair,
     ...(options.onSceneCleaned === undefined ? {} : { onSceneCleaned: options.onSceneCleaned }),
-    // `onSceneFailed` (PUL-F029 / ADR-028) is forwarded as-is so the
-    // resolver's per-scene isolation surfaces every create / timeline
-    // / cleanup failure through the loader's stage + onError plumbing
-    // without halting the active composition.
     ...(options.onSceneFailed === undefined ? {} : { onSceneFailed: options.onSceneFailed }),
-  });
+  };
 }

--- a/src/runtime/scene-navigation.ts
+++ b/src/runtime/scene-navigation.ts
@@ -72,6 +72,19 @@ export interface SceneNavigationCompositionContext {
    * mid-flight).
    */
   readonly sceneSlice: readonly SceneModule[];
+  /**
+   * Index of `manifestSlice[0]` in the ORIGINAL composition manifest.
+   * Zero for `kind: 'composition'` (slice starts at index 0); for
+   * `composition-scene` and `composition-index` it is the absolute
+   * position of the addressed entry. PUL-F029 / ADR-028 needs this so
+   * a scene failure diagnostic can name the absolute composition
+   * entry the failed scene lives at, not a slice-relative index that
+   * would point operators at the wrong manifest entry. Single-scene
+   * mode truncation (`applySingleSceneSlice`) preserves it so the
+   * diagnostic stays accurate even when the slice is truncated to
+   * the head entry.
+   */
+  readonly startIndex: number;
 }
 
 /**
@@ -241,6 +254,18 @@ export interface LoadSceneNavigationTargetOptions {
    * `cleanup(ctx)` runs. Absent for callers that do not need it.
    */
   readonly onSceneCleaned?: (sceneId: string) => void;
+  /**
+   * Per-scene failure sink (PUL-F029 / ADR-028). Forwarded to
+   * {@link resolveComposition} as `onSceneFailed`; the loader wires it
+   * to (a) append `<sceneId>:<phase>` to the per-navigation stage
+   * attribute `data-pulsar-scene-failures` and (b) surface a public
+   * diagnostic through the loader's `onError` sink without serializing
+   * the raw cause (ADR-028: no raw causes, stacks, scene objects,
+   * DOM, captions, headers, cookies, env, auth values). Absent for
+   * direct bridge callers that do not need scene-level error
+   * isolation.
+   */
+  readonly onSceneFailed?: (event: import('./composition-resolver').SceneFailureEvent) => void;
 }
 
 const NAV_FAIL_PREFIX = 'scene navigation failed:';
@@ -314,7 +339,7 @@ function resolveCompositionFromStart(
   }
   const manifestSlice = sliceManifestFromIndex(manifest, 0);
   const sceneSlice = snapshotSceneSlice(manifestSlice, 0, scenes, compositionId);
-  return { id: compositionId, manifestSlice, sceneSlice };
+  return { id: compositionId, manifestSlice, sceneSlice, startIndex: 0 };
 }
 
 function resolveCompositionAndScene(
@@ -349,7 +374,7 @@ function resolveCompositionAndScene(
   }
   const manifestSlice = sliceManifestFromIndex(manifest, startIndex);
   const sceneSlice = snapshotSceneSlice(manifestSlice, startIndex, scenes, compositionId);
-  return { id: compositionId, manifestSlice, sceneSlice };
+  return { id: compositionId, manifestSlice, sceneSlice, startIndex };
 }
 
 function resolveCompositionAndIndex(
@@ -372,7 +397,7 @@ function resolveCompositionAndIndex(
   }
   const manifestSlice = sliceManifestFromIndex(manifest, index);
   const sceneSlice = snapshotSceneSlice(manifestSlice, index, scenes, compositionId);
-  return { id: compositionId, manifestSlice, sceneSlice };
+  return { id: compositionId, manifestSlice, sceneSlice, startIndex: index };
 }
 
 /**
@@ -425,6 +450,11 @@ function truncateToHead(target: SceneNavigationTarget, headOnly: boolean): Scene
       id: target.composition.id,
       manifestSlice: Object.freeze([headEntry]),
       sceneSlice: Object.freeze([headScene]),
+      // PUL-F029 / ADR-028: preserve the absolute composition start
+      // index so a failure diagnostic still points operators at the
+      // right manifest entry even after the slice was truncated to
+      // its head by `mode=standalone|loop|paused|scrub|screenshot`.
+      startIndex: target.composition.startIndex,
     },
   };
 }
@@ -508,10 +538,18 @@ export function resolveSceneNavigation(
  *    Per-entry `range` and `behavior` overrides are preserved and
  *    forwarded to the runner adapter unchanged (ADR-011).
  *
- * Resolves when the lifecycle has run end-to-end; rejects with the
- * resolver's own wrapping error (`composition resolution failed: ...`)
- * when any phase throws. Cleanup runs whenever the scene was touched,
- * matching the resolver's own invariants.
+ * Resolves when the lifecycle has run end-to-end. Per PUL-F029 /
+ * ADR-028, per-scene `create(ctx)` / `timeline(ctx)` / `cleanup(ctx)`
+ * throws are SCENE failures: when `onSceneFailed` is wired they
+ * isolate (the failing scene is eagerly cleaned up and dropped, the
+ * composition keeps playing through the surviving scenes) and the
+ * bridge resolves normally; when it is not wired they aggregate into
+ * an `AggregateError` at the end so direct callers don't lose the
+ * signal. Composition-wide failures (preload, manifest invalid,
+ * registry miss, timeline-adapter `run` rejection, signal-abort)
+ * still reject the bridge with the resolver's wrapping error
+ * (`composition resolution failed: ...`). Cleanup runs whenever the
+ * scene was touched, matching the resolver's own invariants.
  */
 export async function loadSceneNavigationTarget(
   target: SceneNavigationTarget,
@@ -656,5 +694,10 @@ export async function loadSceneNavigationTarget(
     // hook) is forwarded as-is; the loader supplies it on every
     // navigation that runs the resolver lifecycle.
     ...(options.onSceneCleaned === undefined ? {} : { onSceneCleaned: options.onSceneCleaned }),
+    // `onSceneFailed` (PUL-F029 / ADR-028) is forwarded as-is so the
+    // resolver's per-scene isolation surfaces every create / timeline
+    // / cleanup failure through the loader's stage + onError plumbing
+    // without halting the active composition.
+    ...(options.onSceneFailed === undefined ? {} : { onSceneFailed: options.onSceneFailed }),
   });
 }

--- a/tests/runtime/composition-resolver.test.ts
+++ b/tests/runtime/composition-resolver.test.ts
@@ -15,6 +15,7 @@ import type { CompositionManifest } from '../../src/runtime/composition';
 import {
   type CompositionTimelineAdapter,
   type CompositionTimelineRunOptions,
+  type SceneFailureEvent,
   type SceneTimelineSegment,
   resolveComposition,
 } from '../../src/runtime/composition-resolver';
@@ -121,6 +122,7 @@ interface ResolveArgs {
   readonly headCueGate?: 'monotonic-forward';
   readonly headScreenshot?: 'capture';
   readonly onSceneCleaned?: (sceneId: string) => void;
+  readonly onSceneFailed?: (event: SceneFailureEvent) => void;
 }
 
 const run = (args: ResolveArgs): Promise<void> =>
@@ -138,6 +140,7 @@ const run = (args: ResolveArgs): Promise<void> =>
     ...(args.headCueGate === undefined ? {} : { headCueGate: args.headCueGate }),
     ...(args.headScreenshot === undefined ? {} : { headScreenshot: args.headScreenshot }),
     ...(args.onSceneCleaned === undefined ? {} : { onSceneCleaned: args.onSceneCleaned }),
+    ...(args.onSceneFailed === undefined ? {} : { onSceneFailed: args.onSceneFailed }),
   });
 
 const aborted = (reason?: unknown): AbortSignal => {
@@ -253,25 +256,70 @@ describe('resolveComposition — mount phase', () => {
     expect(log).toEqual(['preload:a', 'create:a', 'cleanup:a']);
   });
 
-  it('aborts and tears down every mounted scene (including the failing one) when a create throws', async () => {
+  it('isolates a create failure: cleans the failing scene, mounts the rest, surfaces via onSceneFailed (PUL-F029)', async () => {
     const log: string[] = [];
-    await expect(
-      run({
-        scenes: [
-          recordingScene('a', log),
-          recordingScene('b', log, {
-            create: () => {
-              log.push('create:b');
-              throw new Error('create kaboom');
-            },
-          }),
-          recordingScene('c', log),
-        ],
-        manifest: ['a', 'b', 'c'],
-      }),
-    ).rejects.toThrow('composition resolution failed: scene "b" create threw: create kaboom');
-    // a + b mounted (b's create attempted) → cleaned in reverse; c never touched.
-    expect(log).toEqual(['create:a', 'create:b', 'cleanup:b', 'cleanup:a']);
+    const failed: SceneFailureEvent[] = [];
+    await run({
+      scenes: [
+        recordingScene('a', log),
+        recordingScene('b', log, {
+          create: () => {
+            log.push('create:b');
+            throw new Error('create kaboom');
+          },
+        }),
+        recordingScene('c', log),
+      ],
+      manifest: ['a', 'b', 'c'],
+      onSceneFailed: (event) => failed.push(event),
+    });
+    // a creates → b create attempted then throws → b cleaned immediately →
+    // c creates → timelines for a and c → run → cleanup c, a.
+    expect(log).toEqual([
+      'create:a',
+      'create:b',
+      'cleanup:b',
+      'create:c',
+      'timeline:a',
+      'timeline:c',
+      'cleanup:c',
+      'cleanup:a',
+    ]);
+    expect(failed).toHaveLength(1);
+    expect(failed[0]).toMatchObject({
+      phase: 'create',
+      sceneId: 'b',
+      message: 'create kaboom',
+    });
+    expect(failed[0]?.cause).toBeInstanceOf(Error);
+  });
+
+  it('rejects with an AggregateError of scene failures when no onSceneFailed callback was supplied (PUL-F029)', async () => {
+    // Back-compat path: callers that don't wire `onSceneFailed` still
+    // get a deterministic surface (instead of silent isolation) at the
+    // end of the lifecycle, so a caller never loses information.
+    const log: string[] = [];
+    let caught: unknown;
+    await run({
+      scenes: [
+        recordingScene('a', log),
+        recordingScene('b', log, {
+          create: () => {
+            throw new Error('create kaboom');
+          },
+        }),
+        recordingScene('c', log),
+      ],
+      manifest: ['a', 'b', 'c'],
+    }).catch((err: unknown) => {
+      caught = err;
+    });
+    expect(caught).toBeInstanceOf(AggregateError);
+    expect((caught as AggregateError).errors).toHaveLength(1);
+    expect(((caught as AggregateError).errors[0] as Error).message).toBe(
+      'composition resolution failed: scene "b" create threw: create kaboom',
+    );
+    expect((caught as Error).message).toContain('1 scene failure(s)');
   });
 
   it('does not start the composition when the signal is already aborted', async () => {
@@ -367,34 +415,68 @@ describe('resolveComposition — compose phase', () => {
     expect(calls[0]?.segments).toEqual([{ id: 'a', timeline: neverSettles }]);
   });
 
-  it('aborts and tears down every mounted scene when a timeline factory throws', async () => {
+  it('isolates a timeline-factory failure: cleans the failing scene, skips its segment, plays the rest (PUL-F029)', async () => {
     const log: string[] = [];
-    await expect(
-      run({
-        scenes: [
-          recordingScene('a', log),
-          recordingScene('b', log, {
-            timeline: () => {
-              log.push('timeline:b');
-              throw new Error('timeline kaboom');
-            },
-          }),
-          recordingScene('c', log),
-        ],
-        manifest: ['a', 'b', 'c'],
-      }),
-    ).rejects.toThrow('composition resolution failed: scene "b" timeline threw: timeline kaboom');
-    // all three mounted (mount phase completed) → cleaned in reverse.
+    const failed: SceneFailureEvent[] = [];
+    const { adapter, calls } = recordingTimeline();
+    await run({
+      scenes: [
+        recordingScene('a', log),
+        recordingScene('b', log, {
+          timeline: () => {
+            log.push('timeline:b');
+            throw new Error('timeline kaboom');
+          },
+        }),
+        recordingScene('c', log),
+      ],
+      manifest: ['a', 'b', 'c'],
+      timeline: adapter,
+      onSceneFailed: (event) => failed.push(event),
+    });
+    // All three mounted, b's timeline throws → b cleaned at compose time →
+    // a and c contribute segments → run → cleanup c, a (b already cleaned).
     expect(log).toEqual([
       'create:a',
       'create:b',
       'create:c',
       'timeline:a',
       'timeline:b',
-      'cleanup:c',
       'cleanup:b',
+      'timeline:c',
+      'cleanup:c',
       'cleanup:a',
     ]);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.segments.map((s) => s.id)).toEqual(['a', 'c']);
+    expect(failed).toHaveLength(1);
+    expect(failed[0]).toMatchObject({
+      phase: 'timeline',
+      sceneId: 'b',
+      message: 'timeline kaboom',
+    });
+  });
+
+  it('rejects with an AggregateError when a timeline factory throws and no onSceneFailed is supplied (PUL-F029)', async () => {
+    const log: string[] = [];
+    let caught: unknown;
+    await run({
+      scenes: [
+        recordingScene('a', log),
+        recordingScene('b', log, {
+          timeline: () => {
+            throw new Error('timeline kaboom');
+          },
+        }),
+      ],
+      manifest: ['a', 'b'],
+    }).catch((err: unknown) => {
+      caught = err;
+    });
+    expect(caught).toBeInstanceOf(AggregateError);
+    expect(((caught as AggregateError).errors[0] as Error).message).toBe(
+      'composition resolution failed: scene "b" timeline threw: timeline kaboom',
+    );
   });
 });
 
@@ -501,7 +583,12 @@ describe('resolveComposition — cleanup phase', () => {
     expect(log.slice(-3)).toEqual(['cleanup:c', 'cleanup:b', 'cleanup:a']);
   });
 
-  it('runs every scene cleanup even if an earlier one throws, then re-raises an AggregateError', async () => {
+  it('runs every scene cleanup even if an earlier one throws, then re-raises an AggregateError (PUL-F029: cleanup failures are scene failures)', async () => {
+    // Pre-PUL-F029 the resolver lumped scene-cleanup throws and
+    // `onSceneCleaned` hook throws together as "cleanup hooks
+    // threw"; ADR-028 splits them — a scene's own `cleanup(ctx)` is a
+    // scene failure (phase: 'cleanup'), and only `onSceneCleaned`
+    // hook throws are "cleanup hook(s)" in the resolver's surface.
     const log: string[] = [];
     let caught: unknown;
     await run({
@@ -522,16 +609,14 @@ describe('resolveComposition — cleanup phase', () => {
     // c, b, a all cleaned (b threw but a still ran).
     expect(log.slice(-3)).toEqual(['cleanup:c', 'cleanup:b', 'cleanup:a']);
     expect(caught).toBeInstanceOf(AggregateError);
-    expect((caught as Error).message).toContain(
-      'composition completed but 1 cleanup hook(s) threw',
-    );
+    expect((caught as Error).message).toContain('composition completed with 1 scene failure(s)');
     expect((caught as AggregateError).errors).toHaveLength(1);
     expect(((caught as AggregateError).errors[0] as Error).message).toBe(
       'composition resolution failed: scene "b" cleanup threw: cleanup-b kaboom',
     );
   });
 
-  it('aggregates the phase error and the cleanup error(s) when both fail (phase error first)', async () => {
+  it('aggregates an isolated timeline failure and a final-cleanup failure when no onSceneFailed is supplied (PUL-F029)', async () => {
     const log: string[] = [];
     let caught: unknown;
     await run({
@@ -556,13 +641,15 @@ describe('resolveComposition — cleanup phase', () => {
     expect(caught).toBeInstanceOf(AggregateError);
     const errors = (caught as AggregateError).errors;
     expect(errors).toHaveLength(2);
-    expect((errors[0] as Error).message).toBe(
+    // The order is "scene failures first (mount/timeline), then final-phase cleanup errors."
+    const messages = errors.map((e) => (e as Error).message);
+    expect(messages).toContain(
       'composition resolution failed: scene "b" timeline threw: timeline-b kaboom',
     );
-    expect((errors[1] as Error).message).toBe(
+    expect(messages).toContain(
       'composition resolution failed: scene "a" cleanup threw: cleanup-a kaboom',
     );
-    // both scenes' cleanup attempted.
+    // Both scenes' cleanups ran — b's at compose-time, a's at the end.
     expect(log.filter((e) => e.startsWith('cleanup:')).sort()).toEqual(['cleanup:a', 'cleanup:b']);
   });
 
@@ -655,5 +742,335 @@ describe('resolveComposition — cleanup phase', () => {
     expect(messages).toContain(
       'composition resolution failed: scene "a" onSceneCleaned threw: hook-a kaboom',
     );
+  });
+});
+
+describe('resolveComposition — PUL-F029 scene-level error isolation', () => {
+  it('cascades a create failure: scene cleanup ALSO throws, both events surface via onSceneFailed', async () => {
+    const log: string[] = [];
+    const failed: SceneFailureEvent[] = [];
+    await run({
+      scenes: [
+        recordingScene('a', log),
+        recordingScene('b', log, {
+          create: () => {
+            throw new Error('create kaboom');
+          },
+          cleanup: () => {
+            throw new Error('cleanup-b kaboom');
+          },
+        }),
+        recordingScene('c', log),
+      ],
+      manifest: ['a', 'b', 'c'],
+      onSceneFailed: (event) => failed.push(event),
+    });
+    // The composition still completed for a and c.
+    expect(log).toEqual([
+      'create:a',
+      // b.create threw, b.cleanup throws too (no log push from the spy),
+      'create:c',
+      'timeline:a',
+      'timeline:c',
+      'cleanup:c',
+      'cleanup:a',
+    ]);
+    expect(failed).toHaveLength(2);
+    expect(failed[0]).toMatchObject({ phase: 'create', sceneId: 'b', message: 'create kaboom' });
+    expect(failed[1]).toMatchObject({
+      phase: 'cleanup',
+      sceneId: 'b',
+      message: 'cleanup-b kaboom',
+    });
+  });
+
+  it('surfaces a final-cleanup failure via onSceneFailed and does NOT reject the resolver (PUL-F029)', async () => {
+    // PUL-F029 / ADR-028: when `onSceneFailed` is wired, the resolver
+    // fans out every per-scene failure (mount / compose / cleanup)
+    // through the callback and completes normally. Re-throwing the
+    // same information through `resolveComposition`'s return value
+    // would route the loader into its fatal navigation-error surface,
+    // which is the very behavior PUL-F029 forbids.
+    const log: string[] = [];
+    const failed: SceneFailureEvent[] = [];
+    let caught: unknown;
+    await run({
+      scenes: [
+        recordingScene('a', log, {
+          cleanup: () => {
+            log.push('cleanup:a');
+            throw new Error('cleanup-a kaboom');
+          },
+        }),
+      ],
+      manifest: ['a'],
+      onSceneFailed: (event) => failed.push(event),
+    }).catch((err: unknown) => {
+      caught = err;
+    });
+    expect(caught).toBeUndefined();
+    expect(failed).toHaveLength(1);
+    expect(failed[0]).toMatchObject({
+      phase: 'cleanup',
+      sceneId: 'a',
+      message: 'cleanup-a kaboom',
+    });
+  });
+
+  it('runs the composition with zero segments when every scene fails to create (no rejection if callback wired)', async () => {
+    const log: string[] = [];
+    const failed: SceneFailureEvent[] = [];
+    const { adapter, calls } = recordingTimeline();
+    await run({
+      scenes: [
+        recordingScene('a', log, {
+          create: () => {
+            throw new Error('a kaboom');
+          },
+        }),
+        recordingScene('b', log, {
+          create: () => {
+            throw new Error('b kaboom');
+          },
+        }),
+      ],
+      manifest: ['a', 'b'],
+      timeline: adapter,
+      onSceneFailed: (event) => failed.push(event),
+    });
+    // Both scenes failed to create; adapter still runs with an empty slice;
+    // no scenes need final cleanup.
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.segments).toEqual([]);
+    expect(failed.map((e) => e.sceneId)).toEqual(['a', 'b']);
+    expect(failed.every((e) => e.phase === 'create')).toBe(true);
+  });
+
+  it('preserves the cause via Error.cause on the SceneFailureEvent', async () => {
+    const cause = new Error('create kaboom');
+    const failed: SceneFailureEvent[] = [];
+    await run({
+      scenes: [
+        scene('a', {
+          create: () => {
+            throw cause;
+          },
+        }),
+      ],
+      manifest: ['a'],
+      onSceneFailed: (event) => failed.push(event),
+    });
+    expect(failed).toHaveLength(1);
+    expect(failed[0]?.cause).toBe(cause);
+  });
+
+  it('invokes onSceneCleaned for an eagerly-cleaned scene whose create threw (audio teardown invariant)', async () => {
+    // Codex review cycle 1 finding: when create/timeline throws and
+    // the resolver eagerly cleans the failing scene, the per-scene
+    // post-cleanup hook (which the loader wires to
+    // `audio.stopGroup(sceneId)` per ADR-004) MUST still fire — a
+    // scene that played grouped audio during `create` before throwing
+    // would otherwise leak that group while the surviving composition
+    // continues.
+    const log: string[] = [];
+    const cleaned: string[] = [];
+    await run({
+      scenes: [
+        recordingScene('a', log),
+        recordingScene('b', log, {
+          create: () => {
+            throw new Error('boom');
+          },
+        }),
+        recordingScene('c', log),
+      ],
+      manifest: ['a', 'b', 'c'],
+      onSceneCleaned: (id) => cleaned.push(id),
+      onSceneFailed: () => undefined,
+    });
+    // b was eagerly cleaned (its `cleanup` ran AND `onSceneCleaned`
+    // fired) → c was mounted and ran → final cleanup of c, a in
+    // reverse mount order. b's hook firing in the middle of the
+    // mount loop is the new invariant.
+    expect(cleaned).toEqual(['b', 'c', 'a']);
+  });
+
+  it('invokes onSceneCleaned for an eagerly-cleaned scene whose timeline threw', async () => {
+    const log: string[] = [];
+    const cleaned: string[] = [];
+    await run({
+      scenes: [
+        recordingScene('a', log),
+        recordingScene('b', log, {
+          timeline: () => {
+            throw new Error('boom');
+          },
+        }),
+        recordingScene('c', log),
+      ],
+      manifest: ['a', 'b', 'c'],
+      onSceneCleaned: (id) => cleaned.push(id),
+      onSceneFailed: () => undefined,
+    });
+    // All three mounted; b's timeline throws at compose-time → b is
+    // eagerly cleaned AND its hook fires → c contributes a segment →
+    // adapter runs → final cleanup of c, a (b already cleaned).
+    expect(cleaned).toEqual(['b', 'c', 'a']);
+  });
+
+  it('aggregates onSceneCleaned hook throws even when onSceneFailed is wired (hook errors are workbench bugs, not scene failures)', async () => {
+    // Codex review cycle 1 finding: when onSceneFailed is wired, the
+    // resolver fans out per-scene failures through the callback and
+    // returns normally — but a throw from `onSceneCleaned` (the
+    // workbench-supplied audio teardown hook) is NOT a scene failure
+    // and must NOT be swallowed. It aggregates into the resolver's
+    // throw regardless of `onSceneFailed`.
+    const failed: SceneFailureEvent[] = [];
+    let caught: unknown;
+    await run({
+      scenes: [scene('a')],
+      manifest: ['a'],
+      onSceneCleaned: () => {
+        throw new Error('hook kaboom');
+      },
+      onSceneFailed: (event) => failed.push(event),
+    }).catch((err: unknown) => {
+      caught = err;
+    });
+    expect(failed).toEqual([]); // hook errors don't go through onSceneFailed
+    expect(caught).toBeInstanceOf(AggregateError);
+    expect((caught as Error).message).toContain('1 cleanup hook(s) threw');
+    expect((caught as AggregateError).errors).toHaveLength(1);
+    expect(((caught as AggregateError).errors[0] as Error).message).toBe(
+      'composition resolution failed: scene "a" onSceneCleaned threw: hook kaboom',
+    );
+  });
+
+  it('SceneFailureEvent carries the manifest entry index (ADR-028 diagnostic contract)', async () => {
+    const failed: SceneFailureEvent[] = [];
+    await run({
+      scenes: [
+        scene('a'),
+        scene('b', {
+          create: () => {
+            throw new Error('b kaboom');
+          },
+        }),
+        scene('c', {
+          timeline: () => {
+            throw new Error('c kaboom');
+          },
+        }),
+      ],
+      manifest: ['a', 'b', 'c'],
+      onSceneFailed: (event) => failed.push(event),
+    });
+    const byId = new Map(failed.map((e) => [e.sceneId, e.entryIndex] as const));
+    expect(byId.get('b')).toBe(1);
+    expect(byId.get('c')).toBe(2);
+  });
+
+  it('catches a throw from onSceneFailed so it cannot break mandatory cleanup (codex review, cycle 2)', async () => {
+    // Codex review cycle 2 finding: if the diagnostic sink throws,
+    // the resolver MUST NOT let that interrupt the cleanup-then-
+    // continue invariant — a buggy logger could otherwise strand
+    // surviving scenes uncleaned. The throw is collected as a hook
+    // error (workbench bug, same shape as `onSceneCleaned` throws)
+    // and the lifecycle continues.
+    const log: string[] = [];
+    let caught: unknown;
+    await run({
+      scenes: [
+        recordingScene('a', log),
+        recordingScene('b', log, {
+          create: () => {
+            throw new Error('create kaboom');
+          },
+        }),
+        recordingScene('c', log),
+      ],
+      manifest: ['a', 'b', 'c'],
+      onSceneFailed: () => {
+        throw new Error('logger kaboom');
+      },
+    }).catch((err: unknown) => {
+      caught = err;
+    });
+    // The composition still completed for a and c.
+    expect(log).toEqual([
+      'create:a',
+      // b.create threw, b.cleanup ran eagerly (logging cleanup:b),
+      'cleanup:b',
+      'create:c',
+      'timeline:a',
+      'timeline:c',
+      'cleanup:c',
+      'cleanup:a',
+    ]);
+    // The logger throw aggregates as a hook error.
+    expect(caught).toBeInstanceOf(AggregateError);
+    expect((caught as Error).message).toContain('cleanup hook(s) threw');
+    expect(
+      (caught as AggregateError).errors.some(
+        (e) =>
+          e instanceof Error && /onSceneFailed threw: logger kaboom/.test((e as Error).message),
+      ),
+    ).toBe(true);
+  });
+
+  it('re-checks the abort signal after eager cleanup so a superseded navigation does not preload the next scene (codex review, cycle 2)', async () => {
+    // Codex review cycle 2 finding: without a post-eager-cleanup abort
+    // checkpoint, a navigation aborted DURING the failed scene's
+    // cleanup would still kick off the next scene's preload + create —
+    // breaking cleanup-before-handoff. This test simulates an abort
+    // happening inside `cleanup` and pins that the next scene's
+    // preload is NOT called.
+    const log: string[] = [];
+    const controller = new AbortController();
+    const preloadAssets = (s: SceneModule): void => {
+      log.push(`preload:${s.id}`);
+    };
+    let caught: unknown;
+    await run({
+      scenes: [
+        recordingScene('a', log, {
+          create: () => {
+            throw new Error('create kaboom');
+          },
+          cleanup: () => {
+            controller.abort('navigated away');
+          },
+        }),
+        recordingScene('b', log),
+      ],
+      manifest: ['a', 'b'],
+      preloadAssets,
+      signal: controller.signal,
+    }).catch((err: unknown) => {
+      caught = err;
+    });
+    // a's preload ran; a's cleanup ran (and aborted); b's preload did NOT run.
+    expect(log).toEqual(['preload:a']);
+    expect((caught as Error).message).toContain('aborted after isolating "a" create failure');
+  });
+
+  it('preload failures are NOT scene failures: they still abort the composition (ADR-028 non-goal)', async () => {
+    // Preload errors keep their existing boundary — only create / timeline /
+    // cleanup go through the PUL-F029 isolation path.
+    const failed: SceneFailureEvent[] = [];
+    const preloadAssets = (s: SceneModule): void => {
+      if (s.id === 'b') throw new Error('preload kaboom');
+    };
+    await expect(
+      run({
+        scenes: [scene('a'), scene('b'), scene('c')],
+        manifest: ['a', 'b', 'c'],
+        preloadAssets,
+        onSceneFailed: (event) => failed.push(event),
+      }),
+    ).rejects.toThrow(
+      'composition resolution failed: scene "b" preloadAssets threw: preload kaboom',
+    );
+    expect(failed).toEqual([]);
   });
 });

--- a/tests/runtime/prompter.test.ts
+++ b/tests/runtime/prompter.test.ts
@@ -100,6 +100,7 @@ describe('buildPrompterScript (PUL-F019 / ADR-022)', () => {
         id: 'full-talk',
         manifestSlice: ['intro', 'middle', 'outro'],
         sceneSlice: [intro, middle, outro],
+        startIndex: 0,
       },
     };
 
@@ -138,6 +139,7 @@ describe('buildPrompterScript (PUL-F019 / ADR-022)', () => {
         id: 'full-talk',
         manifestSlice: ['middle', 'outro'],
         sceneSlice: [middle, outro],
+        startIndex: 0,
       },
     };
 
@@ -222,6 +224,7 @@ describe('buildPrompterScript (PUL-F019 / ADR-022)', () => {
         id: 'full-talk',
         manifestSlice: [{ id: 'middle', range: 'midpoint', behavior: { hold: true } }],
         sceneSlice: [middle],
+        startIndex: 0,
       },
     };
 
@@ -248,6 +251,7 @@ describe('buildPrompterScript (PUL-F019 / ADR-022)', () => {
         id: 'full-talk',
         manifestSlice: ['scene-a', 'scene-b'],
         sceneSlice: [sceneA, sceneB],
+        startIndex: 0,
       },
     };
     const directTarget: SceneNavigationTarget = { scene: sceneA };
@@ -285,6 +289,7 @@ describe('buildPrompterScript (PUL-F019 / ADR-022)', () => {
         id: 'full-talk',
         manifestSlice: [{ id: 'middle', range: 'midpoint', behavior: { hold: true } }],
         sceneSlice: [middle],
+        startIndex: 0,
       },
     };
 

--- a/tests/runtime/scene-loader-audio.test.ts
+++ b/tests/runtime/scene-loader-audio.test.ts
@@ -266,6 +266,7 @@ describe('scene loader — audio service wiring (PUL-F024 / ADR-004)', () => {
   it('restricts ctx.audio.load() to URLs the slice declared in scene.assets', async () => {
     const stage = buildStage();
     const audio = recordingAudioEngine();
+    const captured: unknown[] = [];
     const scene = buildScene({
       id: 'a',
       assets: ['/audio/bed.mp3'],
@@ -285,13 +286,20 @@ describe('scene loader — audio service wiring (PUL-F024 / ADR-004)', () => {
       createPreloader: () => () => Promise.resolve(),
       timeline: noopTimeline,
       audioEngine: audio.engine,
-      onError: () => undefined,
+      onError: (err) => {
+        captured.push(err);
+      },
     });
     await loader.handle(sceneTarget('a'));
     await loader.idle();
-    const err = stage.attrs.get('data-pulsar-navigation-error');
-    expect(err).toBeDefined();
-    expect(err).toContain('typo');
+    // PUL-F029 / ADR-028: a `create(ctx)` throw is a per-scene
+    // failure, not a fatal navigation error. The diagnostic lands on
+    // the per-scene stage attribute + `onError`, NOT on the
+    // composition-wide `data-pulsar-navigation-error` surface.
+    expect(stage.attrs.has('data-pulsar-navigation-error')).toBe(false);
+    expect(stage.attrs.get('data-pulsar-scene-failures')).toBe('a:create');
+    const sceneErr = captured.find((e) => e instanceof Error && /typo/.test((e as Error).message));
+    expect(sceneErr).toBeDefined();
     // The resolver still tore the scene down (create-attempted ⇒ cleanup).
     expect(stage.attrs.get('data-cleanup-ran')).toBe('yes');
   });

--- a/tests/runtime/scene-loader.test.ts
+++ b/tests/runtime/scene-loader.test.ts
@@ -366,7 +366,14 @@ describe('createSceneLoader — navigation, errors & abort (PUL-F008)', () => {
       expect(stage.attrs.has('data-pulsar-scene-target')).toBe(false);
     });
 
-    it('sets `data-pulsar-navigation-error` when a lifecycle phase throws', async () => {
+    it('routes a per-scene lifecycle throw to data-pulsar-scene-failures, NOT the fatal navigation-error attribute (PUL-F029)', async () => {
+      // PUL-F029 / ADR-028: a thrown `create(ctx)` / `timeline(ctx)` /
+      // `cleanup(ctx)` is a scene failure, not a fatal navigation
+      // failure. The composition keeps moving and the diagnostic
+      // lands on the per-scene stage attribute via `onSceneFailed`,
+      // not on `data-pulsar-navigation-error` (which stays for
+      // composition-wide failures: manifest, registry miss, preload,
+      // timeline adapter `run` rejection, abort wrapper).
       const stage = buildStage();
       const broken = buildScene({
         id: 'broken',
@@ -387,9 +394,8 @@ describe('createSceneLoader — navigation, errors & abort (PUL-F008)', () => {
       await loader.handle(sceneTarget('broken'));
 
       expect(stage.attrs.get('data-pulsar-scene-target')).toBe('broken');
-      expect(stage.attrs.get('data-pulsar-navigation-error')).toMatch(
-        /composition resolution failed: scene "broken" create threw/,
-      );
+      expect(stage.attrs.has('data-pulsar-navigation-error')).toBe(false);
+      expect(stage.attrs.get('data-pulsar-scene-failures')).toBe('broken:create');
     });
 
     it('handleError(err) sets the error attribute and clears any stale scene attributes', async () => {
@@ -734,11 +740,16 @@ describe('createSceneLoader — navigation, errors & abort (PUL-F008)', () => {
     });
 
     it('surfaces cleanup failures even when the lifecycle was aborted (multi-fault visibility)', async () => {
-      // The resolver throws an `AggregateError` when an aborted
-      // lifecycle ALSO has a cleanup failure. The naive "any abort →
-      // suppress" rule would drop the cleanup half from both stage
-      // state and `onError`. The loader must surface AggregateErrors
-      // even when its own controller aborted the load.
+      // PUL-F029 / ADR-028 changes the surface here: the resolver no
+      // longer folds an aborted lifecycle + cleanup failure into an
+      // `AggregateError` the loader has to dissect. Instead, the
+      // resolver fans out the cleanup failure through the loader's
+      // `onSceneFailed` handler (which writes
+      // `data-pulsar-scene-failures` and a `scene "broken" failed
+      // during cleanup: …` Error to `onError`) and the abort wrapper
+      // itself is suppressed by `isPureAbort`. The naive "any abort →
+      // suppress" rule would still drop the cleanup half; the test
+      // here pins that the per-scene cleanup failure stays visible.
       const broken = buildScene({
         id: 'broken',
         cleanup: () => {
@@ -778,16 +789,10 @@ describe('createSceneLoader — navigation, errors & abort (PUL-F008)', () => {
       void loader.handle(sceneTarget('next'));
       await loader.idle();
 
-      // The cleanup failure on `broken` MUST have surfaced — it's a
-      // real bug the operator needs to see, not a routine abort. The
-      // resolver folds the abort and the cleanup failure into an
-      // AggregateError; the loader surfaces it (NOT suppressed because
-      // AggregateError is never a "pure abort"), and the cleanup error
-      // is in its `.errors` array.
+      // The cleanup failure on `broken` MUST have surfaced through
+      // `onError` (the loader's `onSceneFailed` handler routes there).
       expect(captured.length).toBeGreaterThanOrEqual(1);
-      const aggregate = captured.find((e): e is AggregateError => e instanceof AggregateError);
-      expect(aggregate).toBeDefined();
-      const cleanupError = aggregate?.errors.find(
+      const cleanupError = captured.find(
         (e) => e instanceof Error && /cleanup boom/.test((e as Error).message),
       );
       expect(cleanupError).toBeDefined();
@@ -849,5 +854,182 @@ describe('createSceneLoader — navigation, errors & abort (PUL-F008)', () => {
 
       expect(log).toEqual([]);
     });
+  });
+});
+
+describe('createSceneLoader — PUL-F029 scene-level error isolation', () => {
+  it('surfaces a `create` failure via onError and the scene-failures stage attribute without aborting the composition', async () => {
+    const onError = vi.fn();
+    const intro = buildScene({ id: 'intro' });
+    const broken = buildScene({
+      id: 'broken',
+      create: () => {
+        throw new Error('create kaboom');
+      },
+    });
+    const outro = buildScene({ id: 'outro' });
+    const stage = buildStage();
+    const { adapter, calls } = recordingTimeline();
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([intro, broken, outro]),
+      compositions: createCompositionRegistry([
+        { id: 'full-talk', manifest: ['intro', 'broken', 'outro'] },
+      ]),
+      stage: stage.element,
+      buildCtx: stubCtx,
+      createPreloader: () => () => undefined,
+      timeline: adapter,
+      onError,
+    });
+
+    await loader.handle(compositionTarget('full-talk'));
+
+    // The composition did NOT halt — adapter ran with intro + outro segments.
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.segments.map((s) => s.id)).toEqual(['intro', 'outro']);
+    // The fatal-navigation surface stayed clean (this was a per-scene failure).
+    expect(stage.attrs.has('data-pulsar-navigation-error')).toBe(false);
+    // The per-scene failure shows up on the new attribute and via onError.
+    expect(stage.attrs.get('data-pulsar-scene-failures')).toBe('broken:create');
+    expect(onError).toHaveBeenCalledTimes(1);
+    const firstArg = onError.mock.calls[0]?.[0] as unknown;
+    expect(firstArg).toBeInstanceOf(Error);
+    expect((firstArg as Error).message).toContain('broken');
+    expect((firstArg as Error).message).toContain('create');
+  });
+
+  it('lists multiple scene failures on the stage attribute in encounter order', async () => {
+    const onError = vi.fn();
+    const intro = buildScene({ id: 'intro' });
+    const brokenCreate = buildScene({
+      id: 'broken-create',
+      create: () => {
+        throw new Error('create kaboom');
+      },
+    });
+    const brokenCleanup = buildScene({
+      id: 'broken-cleanup',
+      cleanup: () => {
+        throw new Error('cleanup kaboom');
+      },
+    });
+    const stage = buildStage();
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([intro, brokenCreate, brokenCleanup]),
+      compositions: createCompositionRegistry([
+        { id: 'mix', manifest: ['intro', 'broken-create', 'broken-cleanup'] },
+      ]),
+      stage: stage.element,
+      buildCtx: stubCtx,
+      createPreloader: () => () => undefined,
+      timeline: noopTimeline,
+      onError,
+    });
+
+    await loader.handle(compositionTarget('mix'));
+
+    // Both failures listed; encounter order is mount-then-cleanup.
+    expect(stage.attrs.get('data-pulsar-scene-failures')).toBe(
+      'broken-create:create,broken-cleanup:cleanup',
+    );
+    expect(onError).toHaveBeenCalledTimes(2);
+  });
+
+  it('enriches the onError message with composition id, entry index, and mode (ADR-028 diagnostic contract)', async () => {
+    const onError = vi.fn();
+    const intro = buildScene({ id: 'intro' });
+    const broken = buildScene({
+      id: 'broken',
+      create: () => {
+        throw new Error('create kaboom');
+      },
+    });
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([intro, broken]),
+      compositions: createCompositionRegistry([{ id: 'full-talk', manifest: ['intro', 'broken'] }]),
+      stage: buildStage().element,
+      buildCtx: stubCtx,
+      createPreloader: () => () => undefined,
+      timeline: noopTimeline,
+      onError,
+    });
+
+    await loader.handle(compositionTarget('full-talk'));
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    const arg = onError.mock.calls[0]?.[0] as Error;
+    expect(arg.message).toContain('scene "broken"');
+    expect(arg.message).toContain('failed during create');
+    expect(arg.message).toContain('composition "full-talk"');
+    expect(arg.message).toContain('entry [1]');
+    expect(arg.message).toContain('mode "present"');
+    expect(arg.message).toContain('create kaboom');
+  });
+
+  it('renders the absolute composition entry index when the slice started mid-manifest (codex review, cycle 2)', async () => {
+    // Codex review cycle 2 finding: for `composition-scene` /
+    // `composition-index` navigation the resolver receives a slice
+    // starting mid-manifest; rendering its slice-relative
+    // `entryIndex` as the public composition entry would send
+    // operators to the wrong entry. The loader must add the absolute
+    // start offset.
+    const onError = vi.fn();
+    const intro = buildScene({ id: 'intro' });
+    const middle = buildScene({ id: 'middle' });
+    const broken = buildScene({
+      id: 'broken',
+      create: () => {
+        throw new Error('create kaboom');
+      },
+    });
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([intro, middle, broken]),
+      compositions: createCompositionRegistry([
+        { id: 'full-talk', manifest: ['intro', 'middle', 'broken'] },
+      ]),
+      stage: buildStage().element,
+      buildCtx: stubCtx,
+      createPreloader: () => () => undefined,
+      timeline: noopTimeline,
+      onError,
+    });
+
+    // Navigate starting at index 1: the resolver sees a slice
+    // [middle, broken]. The `broken` scene's slice-relative index is
+    // 1, but its absolute composition entry index is 2.
+    await loader.handle(compositionIndexTarget('full-talk', 1));
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    const arg = onError.mock.calls[0]?.[0] as Error;
+    expect(arg.message).toContain('entry [2]');
+    expect(arg.message).not.toContain('entry [1]');
+  });
+
+  it('resets the scene-failures attribute on the next navigation', async () => {
+    const onError = vi.fn();
+    const intro = buildScene({ id: 'intro' });
+    const broken = buildScene({
+      id: 'broken',
+      create: () => {
+        throw new Error('create kaboom');
+      },
+    });
+    const clean = buildScene({ id: 'clean' });
+    const stage = buildStage();
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([intro, broken, clean]),
+      compositions: createCompositionRegistry([{ id: 'failing', manifest: ['intro', 'broken'] }]),
+      stage: stage.element,
+      buildCtx: stubCtx,
+      createPreloader: () => () => undefined,
+      timeline: noopTimeline,
+      onError,
+    });
+
+    await loader.handle(compositionTarget('failing'));
+    expect(stage.attrs.get('data-pulsar-scene-failures')).toBe('broken:create');
+
+    await loader.handle(sceneTarget('clean'));
+    expect(stage.attrs.has('data-pulsar-scene-failures')).toBe(false);
   });
 });

--- a/tests/runtime/scene-navigation.test.ts
+++ b/tests/runtime/scene-navigation.test.ts
@@ -597,6 +597,14 @@ describe('loadSceneNavigationTarget (PUL-F008 lifecycle bridge — ADR-025)', ()
   });
 
   it('still calls cleanup when create throws (mandatory-cleanup invariant)', async () => {
+    // PUL-F029 / ADR-028: a thrown `create(ctx)` is a per-scene
+    // failure, isolated by the resolver. The mandatory-cleanup
+    // invariant survives: the failing scene's `cleanup(ctx)` runs
+    // eagerly. When no `onSceneFailed` is wired (direct bridge
+    // callers, this test) the resolver still aggregates the scene
+    // failure into an AggregateError at the end so the caller never
+    // loses the signal — the individual wrapper inside `.errors[]`
+    // carries the legacy `scene "intro" create threw` envelope.
     const log: string[] = [];
     const intro = buildScene({
       id: 'intro',
@@ -613,13 +621,19 @@ describe('loadSceneNavigationTarget (PUL-F008 lifecycle bridge — ADR-025)', ()
       compositions: createCompositionRegistry([]),
     }) as SceneNavigationTarget;
 
-    await expect(
-      loadSceneNavigationTarget(target, {
-        ctx: {},
-        preloadAssets: () => undefined,
-        timeline: recordingTimeline().adapter,
-      }),
-    ).rejects.toThrow(/composition resolution failed: scene "intro" create threw/);
+    let caught: unknown;
+    await loadSceneNavigationTarget(target, {
+      ctx: {},
+      preloadAssets: () => undefined,
+      timeline: recordingTimeline().adapter,
+    }).catch((err: unknown) => {
+      caught = err;
+    });
+    expect(caught).toBeInstanceOf(AggregateError);
+    const messages = (caught as AggregateError).errors.map((e) => (e as Error).message);
+    expect(messages).toContain(
+      'composition resolution failed: scene "intro" create threw: create failed',
+    );
     expect(log).toEqual(['create', 'cleanup']);
   });
 


### PR DESCRIPTION
## Summary

PUL-F029 changes a thrown `create(ctx)` / `timeline(ctx)` / `cleanup(ctx)` from a composition-wide abort to a per-scene failure. The resolver isolates the failing scene — runs its `cleanup(ctx)` eagerly on a `create` or `timeline` throw, drops it from the segment list, and continues playing the surviving scenes — and surfaces each failure through a new structured `onSceneFailed(event)` callback carrying `{ phase, sceneId, entryIndex, message, cause }`. The scene loader wires the callback to a new `data-pulsar-scene-failures` stage attribute and routes a sanitized `scene "<id>" failed during <phase> (composition "<id>" entry [N]) under mode "<m>": <msg>` Error through its existing `onError` sink. The presenter advances past a failed scene structurally because a failed scene contributes no master-timeline segment.

Closes #38.

## Changes

- Add `SceneFailurePhase`, `SceneFailureEvent`, and `onSceneFailed` option to `composition-resolver.ts`; refactor mount, compose, and cleanup phases to share a single `cleanOneScene` helper so the `onSceneCleaned` hook fires for eagerly-cleaned scenes too (audio teardown invariant).
- Separate scene lifecycle failures from `onSceneCleaned` hook errors in the resolver bucket so workbench hook bugs always aggregate independent of `onSceneFailed`.
- Catch throws from `onSceneFailed` defensively (a buggy diagnostic sink cannot break mandatory cleanup or isolation; the throw aggregates as a hook error).
- Re-check the abort signal after eager cleanup in both mount and compose loops so cleanup-before-handoff survives mid-cleanup supersession.
- Thread an absolute `startIndex` through `SceneNavigationCompositionContext` (and `applySingleSceneSlice`) so failure diagnostics name the absolute composition entry index, not a slice-relative one.
- Wire `onSceneFailed` through `loadSceneNavigationTarget` and `createSceneLoader`; new `data-pulsar-scene-failures` stage attribute + enriched `onError` message including composition id, entry index, and mode.
- Add `docs/adrs/028-scene-level-error-isolation.md` (the codex preflight originally placed it at 009 — renumbered to 028 since 009 is the existing repo-layout-and-build-tooling ADR). Update `docs/adrs/README.md` index (also restores the missing ADR-027 entry).
- Update `CHANGELOG.md` `[Unreleased]` / `### Changed` per the repo's AGENTS.md convention.

## Non-goals (per ADR-028)

- No new scene-lifecycle hook (`onError`, `recover`, `fallback`).
- No `SceneModule` schema change.
- No new presenter command kind, mode, URL grammar, or manifest field.
- No reclassification of preload / validation / registry / navigation-grammar errors as scene failures (these still abort the composition).
- No retry UI, persistent error history, or telemetry stream.
- No DOM placeholder for failed scenes (a failed scene contributes no segment; gap behavior is documented as a future seam).

## Pre-push review history

- **Cycle 1 (3 findings, all fixed).** Eager cleanup bypassed `onSceneCleaned` (audio teardown leak — fixed by sharing `cleanOneScene` between eager and final cleanup); `onSceneCleaned` hook errors swallowed when `onSceneFailed` was wired (fixed by separating scene-failures from hook-errors in the resolver bucket); event missing ADR-required composition context (fixed by adding `entryIndex` to the event and rendering `compositionId` + `mode` at the loader).
- **Cycle 2 (3 findings, all fixed).** `onSceneFailed` throw could break mandatory cleanup (fixed with defensive `notifyFailure` helper); abort missed after eager cleanup (fixed by re-checking the signal in both loops); slice-relative entry index sent operators to the wrong manifest entry (fixed by threading absolute `startIndex` through composition context).
- **Cycle 3 (1 finding, fixed).** Stale JSDoc in three places contradicted the new semantics; updated to match implementation.

## Test plan

- [x] `pnpm lint && pnpm typecheck && pnpm test` — 982 tests pass.
- [x] Resolver tests pin: create/timeline/cleanup isolation, eager cleanup invokes `onSceneCleaned`, hook errors aggregate independent of `onSceneFailed`, `onSceneFailed` throw cannot break cleanup, abort re-check after eager cleanup, `entryIndex` carried on the event, preload failures still abort (ADR-028 non-goal).
- [x] Scene loader tests pin: per-scene failure stage attribute set in encounter order, fatal `data-pulsar-navigation-error` stays clean for per-scene failures, attribute resets on next navigation, enriched `onError` message renders absolute composition entry index + mode.
- [x] Structural invariant pinned: `composeSegments` excludes failed scenes from the master timeline, so presenter advance naturally traverses the surviving scenes.

## Traceability

- IMPLEMENTS: `PUL-F029` <- `src/runtime/composition-resolver.ts`, `src/runtime/scene-loader.ts`, `src/runtime/scene-navigation.ts`, `docs/adrs/028-scene-level-error-isolation.md`
- TESTS: `PUL-F029` <- `tests/runtime/composition-resolver.test.ts`, `tests/runtime/scene-loader.test.ts`, `tests/runtime/scene-loader-audio.test.ts`, `tests/runtime/scene-navigation.test.ts`

## Ground Control checks

- [x] ADR added (ADR-028) and indexed.
- [x] CHANGELOG `[Unreleased]` entry added.
- [x] Pre-push codex review ran to clean (3 cycles; cap reached on a doc-only cycle-3 fix).