### PR TITLE
Implement PUL-F030 present-mode audio unlock interaction (ADR-029)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Present-mode audio unlock interaction — PUL-F030 / ADR-029 — in
+  `src/runtime/scene.ts`, `src/runtime/audio.ts`, `src/runtime/scene-loader.ts`,
+  and `src/main.ts`: a static `scene.audio: readonly string[]` field on
+  `SceneModule` (subset of `scene.assets`) and a matching
+  `sceneDeclaresAudio(scene)` predicate become the one source of truth
+  for "this scene declares audio." The audio engine gains an
+  `unlock(): Promise<void>` operation — Howler-backed in production
+  (`Howler.ctx?.resume()`), no-op for the silent fallback engine — that
+  the loader's new `AudioUnlockAdapter` seam invokes via the
+  composition-context-bound `gate.unlock()` callback. The scene loader
+  awaits the workbench-supplied adapter BEFORE preload, `create(ctx)`,
+  `timeline(ctx)`, and master playback whenever
+  `effectiveMode(target) === 'present'` AND the resolved target carries
+  a composition slice AND at least one scene in that slice declares
+  audio; non-present modes, single-scene present-mode loads, and
+  audio-less compositions bypass the gate. The gate's signal is the
+  navigation signal — supersession / dispose / popstate aborts the
+  adapter; an adapter rejection surfaces through the existing
+  `onError` + `data-pulsar-navigation-error` channel without starting
+  lifecycle work; a present-mode-audio composition with no adapter
+  wired fails loud through the same channel (the gate IS the
+  structural defense — an inert seam would silently violate the
+  requirement). The workbench bootstrap (`src/main.ts`) wires a real
+  adapter that mounts one `data-pulsar-audio-unlock="gesture"` button
+  on the stage, awaits the click, calls `gate.unlock()`, and removes
+  itself; the adapter receives only the bounded semantic context
+  ADR-029 records (`compositionId`, `sceneIds`, `signal`, `unlock`) —
+  never raw scene objects, source URLs, headers, cookies, or Howler
+  handles. The placeholder scene declares `audio: []`. The
+  `scene-loader-audio` test suite gains the PUL-F030 gate section
+  pinning the trigger predicate, bypass cases, supersession behavior,
+  adapter-rejection error envelope, the fail-loud unwired-adapter
+  path, and the engine-bound `unlock` callback round-trip. ADR-029
+  supersedes ADR-004's passive-Howler-`autoUnlock`-only clause for
+  present-mode audio-declaring compositions.
+
 ### Changed
 
 - Scene-level error isolation — PUL-F029 / ADR-028 — in

--- a/changelog.d/39.added.md
+++ b/changelog.d/39.added.md
@@ -1,0 +1,30 @@
+Present-mode audio unlock interaction — PUL-F030 / ADR-029. New static
+`scene.audio: readonly string[]` field on `SceneModule` (subset of
+`scene.assets`) and a matching `sceneDeclaresAudio(scene)` predicate
+become the one source of truth for "this scene declares audio." The
+audio engine gains an `unlock(): Promise<void>` operation — Howler-
+backed in production (triggers Howler's own `_setup()` via a
+throwaway Howl, or unlocks HTML5 audio via a silent `<audio>` element
+when `usingWebAudio === false`; fails closed when neither route can
+satisfy autoplay policy), no-op for the silent fallback engine. The
+scene loader awaits a workbench-supplied `AudioUnlockAdapter` BEFORE
+preload, `create(ctx)`, `timeline(ctx)`, and master playback whenever
+`effectiveMode(target) === 'present'` AND the resolved target carries
+a composition slice AND at least one scene in that slice declares
+audio; non-present modes, single-scene present-mode loads, and
+audio-less compositions bypass the gate. The gate's signal is the
+navigation signal — supersession / dispose / popstate aborts the
+adapter; an adapter rejection surfaces through the existing
+`onError` + `data-pulsar-navigation-error` channel without starting
+lifecycle work; a present-mode-audio composition with no adapter
+wired fails loud through the same channel. The workbench bootstrap
+(`src/main.ts`) wires the production adapter via the new
+`createDomAudioUnlockAdapter` factory in
+`src/runtime/audio-unlock-dom.ts`, which mounts a single
+`data-pulsar-audio-unlock="gesture"` button on the stage, awaits the
+click, calls `gate.unlock()`, and removes itself. `scene.audio` is
+also authoritative for the audio-service source allowlist
+(`ctx.audio.load()` rejects any URL not in `scene.audio`), so the
+gate predicate and runtime allowlist agree on one source of truth.
+ADR-029 supersedes ADR-004's passive-Howler-`autoUnlock`-only clause
+for present-mode audio-declaring compositions.

--- a/docs/adrs/029-present-mode-audio-unlock-gate.md
+++ b/docs/adrs/029-present-mode-audio-unlock-gate.md
@@ -1,0 +1,104 @@
+# ADR-029: Present-Mode Audio Unlock Gate Before Composition Start
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-12
+
+## Context
+
+PUL-F030 requires:
+
+> On loading `mode=present` for a composition that declares audio, the
+> runtime SHALL provide a single explicit user-gesture interaction that
+> satisfies browser autoplay policy before the composition begins.
+
+ADR-004 already centralizes audio behind the runtime-owned Howler
+adapter and forbids scene-local unlock code. Its implementation note
+relied on Howler's passive `autoUnlock`: a scene may call `play()`
+before the browser audio context is resumed, then Howler resumes after
+the first user gesture.
+
+That is not enough for PUL-F030. PUL-F030 requires an explicit
+presenter interaction before the composition lifecycle begins, not a
+deferred first cue after scenes have mounted.
+
+## Decision
+
+Supersede ADR-004's passive-autounlock clause for present-mode
+composition loads that declare audio.
+
+The runtime SHALL gate `mode=present` composition playback behind one
+workbench-owned explicit user gesture when the resolved composition
+slice declares audio. The gate runs before the resolver lifecycle:
+before asset preload, scene `create(ctx)`, scene `timeline(ctx)`, and
+master timeline playback.
+
+The gate belongs at the loader/workbench boundary because that layer
+has all required facts:
+
+- the effective workbench mode from `effectiveMode()`,
+- the resolved composition slice from `resolveSceneNavigation()`,
+- the per-navigation `AbortSignal`,
+- the runtime audio engine boundary from ADR-004,
+- the visible workbench DOM surface that can collect a user gesture.
+
+Scenes do not own autoplay policy. They still use `ctx.audio` only.
+The composition resolver remains mode-opaque and must not prompt,
+inspect DOM, import Howler, or learn audio-unlock semantics.
+
+The unlock operation itself remains behind the runtime audio boundary.
+The workbench or loader must not import Howler directly. A no-audio
+engine resolves the same unlock contract without visible policy work.
+
+## Consequences
+
+### Positive
+
+- Browser autoplay policy is satisfied before the first scene starts,
+  so a present-mode composition cannot begin with a suspended first
+  cue.
+- The gesture is centralized once per navigation, not copied into
+  scenes or repeated per scene.
+- The resolver and timeline contracts stay unchanged.
+- Future status UI can observe the same loader/workbench gate instead
+  of reading Howler globals or scene state.
+
+### Negative
+
+- The runtime needs a static way to know that a composition slice
+  declares audio before lifecycle execution. Imperative
+  `ctx.audio.load()` calls inside `create(ctx)` are too late for this
+  requirement.
+- A present-mode navigation with audio can now wait for presenter
+  interaction before any preload or scene mount work begins.
+- Test harnesses need a deterministic unlock adapter so runtime tests
+  do not depend on browser audio APIs.
+
+### Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Audio declaration drifts into a second schema | If a declaration field is needed, add it to the existing `SceneModule` / `assertSceneModule()` contract and require its sources to reference `scene.assets`. Do not add a composition-level audio manifest or separate audio DTO. |
+| Unlock UI leaks into scenes | Keep gesture collection in the workbench surface and unlock execution behind the runtime audio boundary. Scenes continue to receive only `ctx.audio`. |
+| A stale unlock click starts a superseded navigation | The gate must be tied to the same per-navigation `AbortSignal` the loader already uses for preload, timeline, presenter cleanup, and audio disposal. |
+| Non-present modes inherit present-mode prompting | Gate only for effective `present` composition navigations that declare audio. Screenshot, paused, rehearsal, prompter, scrub, loop, and standalone keep their existing contracts. |
+| The implementation keeps relying on Howler `autoUnlock` alone | Treat Howler auto-unlock as a fallback inside the engine, not as satisfaction of PUL-F030's explicit pre-composition interaction. |
+
+## Related ADRs
+
+- [ADR-004](004-howler-audio-engine.md) - Howler remains the audio
+  engine and `ctx.audio` remains the scene-facing API.
+- [ADR-007](007-browser-workbench.md) - mode selection is URL-owned.
+- [ADR-013](013-url-navigation-grammar-boundary.md) - URL parsing
+  preserves absent `mode`; the loader derives effective `present`.
+- [ADR-014](014-url-scene-target-selection.md) - composition targets
+  are resolved before lifecycle execution.
+- [ADR-016](016-workbench-mode-present.md) - `mode=present` is the
+  baseline mode that renders audio.
+- [ADR-025](025-timeline-adapter-boundary.md) - the resolver lifecycle
+  remains preload, create, timeline, cleanup; unlock happens before
+  that lifecycle starts.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -54,3 +54,4 @@ Each ADR includes:
 | [026](026-named-timeline-beats.md) | Named Timeline Beats — Scene-Local Kebab Labels, Validated at Compose Time, Referenced Through the Master | Accepted |
 | [027](027-caption-timestamp-grammar.md) | Caption Timestamp Grammar — `at` Accepts a Millisecond Offset or a Beat Label, Validated at the Scene Schema Boundary | Accepted |
 | [028](028-scene-level-error-isolation.md) | Scene-Level Error Isolation | Accepted |
+| [029](029-present-mode-audio-unlock-gate.md) | Present-Mode Audio Unlock Gate Before Composition Start | Accepted |

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -22,6 +22,7 @@ Design context for Pulsar. Source material for the ADRs in `../adrs/`.
 | [pul-f026-rehearsal-mode-preflight.md](pul-f026-rehearsal-mode-preflight.md) | Guardrails for implementing rehearsal audio suppression or cue logging without timeline-state changes. |
 | [pul-f027-caption-metadata-prompter-preflight.md](pul-f027-caption-metadata-prompter-preflight.md) | Guardrails for widening caption metadata timing and keeping prompter content single-sourced. |
 | [pul-f028-validation-preflight.md](pul-f028-validation-preflight.md) | Guardrails for implementing structural runtime validation without duplicating schemas, registries, asset policy, or lifecycle logic. |
+| [pul-f030-audio-unlock-interaction-preflight.md](pul-f030-audio-unlock-interaction-preflight.md) | Guardrails for implementing present-mode audio unlock before an audio-declaring composition begins. |
 
 Design docs are mutable. Decisions are captured as ADRs (immutable once
 accepted).

--- a/docs/design/pul-f030-audio-unlock-interaction-preflight.md
+++ b/docs/design/pul-f030-audio-unlock-interaction-preflight.md
@@ -1,0 +1,141 @@
+# PUL-F030 Audio Unlock Interaction Preflight
+
+PUL-F030 refines ADR-004 for live presentation: when an effective
+`mode=present` navigation resolves to a composition slice that declares
+audio, the runtime must present one explicit user-gesture interaction
+and satisfy browser autoplay policy before the composition begins.
+
+ADR-029 is the binding decision. This note names the repo-wide
+contracts the implementation must reuse.
+
+## Boundary
+
+- `src/runtime/navigation.ts` remains the URL grammar owner. Do not add
+  `unlock=`, `audio=`, `autoplay=`, a new mode, or a second mode enum.
+  Use `effectiveMode()` so omitted `mode` and explicit `mode=present`
+  follow the same present-mode path.
+- `src/runtime/scene-navigation.ts` remains the composition-slice
+  resolver. The unlock decision uses the resolved composition slice.
+  Do not re-resolve manifests, bypass registries, or flatten object-form
+  entries.
+- `src/runtime/scene-loader.ts` is the runtime coordination point. It
+  sees mode, composition context, the navigation `AbortSignal`, the
+  audio engine, and the workbench adapters. The unlock gate belongs
+  before `loadSceneNavigationTarget()` starts resolver lifecycle work.
+- `src/runtime/audio.ts` remains the only Howler boundary. Any
+  browser-audio-context resume/unlock call must be hidden behind the
+  existing audio engine/service contract. The workbench and loader must
+  not import Howler.
+- The workbench bootstrap (`src/main.ts`) owns visible DOM gesture
+  collection or supplies an injected adapter for it. Scenes never add
+  unlock buttons, hidden `<audio>` elements, global key listeners, or
+  raw Web Audio unlock code.
+- `src/runtime/composition-resolver.ts` stays mode-opaque. Unlock is
+  not a lifecycle phase, timeline hint, scene failure, cleanup hook, or
+  resolver option.
+
+## Required Reuse
+
+- Mode and URL validation: `parseNavigationSearch()`,
+  `NAVIGATION_MODES`, `effectiveMode()`, and loader-side
+  `validateModeGrammar()`.
+- Scene and composition contracts: `SceneModule`,
+  `assertSceneModule()`, `createSceneRegistry()`,
+  `assertCompositionManifest()`, `createCompositionRegistry()`, and the
+  frozen `SceneNavigationCompositionContext` slice.
+- Audio boundary: `AudioEngine`, `createHowlerAudioEngine()`,
+  `noopAudioEngine`, `AudioService`, `createAudioService()`, and the
+  existing audio error classes.
+- Audio declaration/source policy: `scene.assets`,
+  `collectAudioSources()`, `resolveAssetUrl()`,
+  `DEFAULT_ALLOWED_SCHEMES`, `isKebabIdentifier()`, and
+  `KEBAB_IDENTIFIER_FORM`. If a static audio declaration is added, add
+  it to the existing scene schema once and require every source to
+  reference `scene.assets`.
+- Lifecycle and cleanup: one per-navigation `AbortController.signal`,
+  `loadSceneNavigationTarget()`, `resolveComposition()`, resolver-owned
+  cleanup, and audio `stopAll()` / `stopGroup(sceneId)` cleanup.
+- Errors and observability: `describeError()`, loader `onError`,
+  `data-pulsar-navigation-error`, and existing scene-failure
+  diagnostics. Do not add an unlock exception hierarchy or logging
+  framework.
+- Tests: existing Vitest suites under `tests/runtime/*`, especially
+  scene-loader mode tests, audio tests, navigation tests, and
+  validation tests.
+
+## Cross-Cutting Layers
+
+| Layer | Guardrail |
+|-------|-----------|
+| URL grammar / mode gate | The gate applies only when `effectiveMode(target) === 'present'` and the resolved target carries a composition slice that declares audio. Unknown modes still fail through `validateModeGrammar()`. |
+| Programmatic navigation | Hand-built `NavigationTarget`s pass the same loader mode validation before unlock decisions. Do not trust caller-side TypeScript casts. |
+| Scene schema | `ctx.audio.load()` inside `create(ctx)` is too late to decide whether to prompt. The declaration predicate must be static and canonical. If current metadata is insufficient, extend `SceneModule` / `assertSceneModule()` once; do not sniff file extensions or inspect scene code. |
+| Composition schema | Do not add audio flags to composition manifests. Composition audio presence is derived from the resolved scene slice so existing composition slicing, `range`, and `behavior` semantics remain intact. |
+| Asset security | Audio sources remain declared assets. They must pass the same `scene.assets` membership and `resolveAssetUrl()` scheme policy as the audio service and preloader. No `ctx.audio.play(url)` or unlock-time URL fetch path. |
+| Workbench gesture surface | The visible prompt is a workbench concern. It should receive bounded semantic context only, such as composition id, scene ids/count, and `AbortSignal`; not raw scene objects, source URLs, headers, cookies, or Howler handles. |
+| Audio engine boundary | Unlock/resume browser audio through `src/runtime/audio.ts`. `noopAudioEngine` must satisfy the same contract deterministically. Master mute and output policy are separate state and must not be reset by unlock. |
+| Lifecycle / cancellation | Waiting for a gesture must block preload/create/timeline for that navigation and must be abort-aware. A stale gesture after supersession or dispose must not start the old composition or write stale diagnostics. |
+| Error envelope | A failed unlock is a navigation-level failure surfaced through loader `onError` and `data-pulsar-navigation-error` using `describeError()`. Do not serialize raw DOM events, audio sources, scene objects, stacks, headers, cookies, or auth values. |
+| Config / env / OS exposure | No env vars, process argv tokens, CLI flags, config files, cookies, localStorage, sessionStorage, history state, or persisted "unlocked" state are needed. Do not put composition/audio state or secrets in command-line arguments or URLs. |
+| Auth / remote input | No remote-auth surface exists. A future remote presenter source must authenticate before emitting into an existing workbench/presenter source; PUL-F030 should not add HTTP, WebSocket, or token handling. |
+| Observability | Reuse existing stage diagnostics and `onError`. Do not add analytics, per-pointer logs, or stage attributes for unlock state until a concrete UI/status requirement needs them. |
+
+## Extensibility
+
+The required extension point is a loader/workbench unlock adapter plus
+an audio-boundary unlock operation. Keep it parameterized by:
+
+- the per-navigation `AbortSignal`,
+- semantic composition context,
+- the current audio engine's unlock capability.
+
+That shape allows later variations such as branded prompt copy,
+keyboard vs pointer activation, already-unlocked short-circuiting,
+status UI, or remote presenter initiation without changing scene
+lifecycle, URL grammar, composition manifests, or `ctx.audio`.
+
+If a static audio declaration is introduced, keep the predicate reusable
+as a small scene-schema helper so validation, loader gating, and future
+authoring checks agree on "declares audio." Do not make the workbench
+parse audio definitions independently.
+
+## Gotchas And Anti-Patterns
+
+- Do not rely on Howler `autoUnlock` alone. It can remain an engine
+  fallback, but it does not satisfy the explicit pre-composition
+  interaction.
+- Do not prompt per scene, per cue, or per `ctx.audio.play()`.
+- Do not gate non-present modes. Rehearsal logs/suppresses audio,
+  screenshot and paused are silent, prompter bypasses lifecycle, and
+  standalone/loop/scrub have their own mode contracts.
+- Do not broaden PUL-F030 to direct `scene=` targets unless a separate
+  requirement says so. This requirement names present-mode composition
+  loads.
+- Do not use file extension, MIME guesses, asset URL substrings, or
+  runtime observation of `ctx.audio.load()` as the declaration test.
+- Do not mutate composition manifests to mark audio. Derive from scene
+  metadata in the resolved slice.
+- Do not let the unlock prompt start lifecycle work after the
+  navigation was aborted.
+- Do not reset master mute, output policy, presenter state, timeline
+  state, or URL state as part of unlock.
+- Do not add scene-local unlock UI, hidden media elements, Howler
+  imports outside `audio.ts`, or raw Web Audio calls in ordinary scenes.
+- Do not create a new exception hierarchy, config surface, persistence
+  key, auth surface, telemetry stream, or workflow controller.
+
+## Non-Goals
+
+PUL-F030 should not implement audio orchestration, cue scheduling,
+master mute, rehearsal cue logging, scrub cue gating, presenter
+transport controls, chrome/status UI beyond the required gesture,
+remote presenter protocols, auth, telemetry, persistence, export
+audio, decode-complete preloading, requirement status transition, or
+GitHub/Ground Control workflow automation.
+
+It should not change URL grammar, workbench mode names, composition
+manifest semantics, resolver lifecycle ordering, timeline transport,
+scene cleanup policy, asset scheme policy, or the scene-facing
+`ctx.audio` playback API except for the minimum static audio
+declaration needed to know whether a present composition requires
+unlock.

--- a/src/main.ts
+++ b/src/main.ts
@@ -201,7 +201,7 @@ const audioUnlockAdapter = createDomAudioUnlockAdapter({
   createButton: () => {
     const button = document.createElement('button');
     button.type = 'button';
-    button.setAttribute('data-pulsar-audio-unlock', 'gesture');
+    button.dataset.pulsarAudioUnlock = 'gesture';
     button.textContent = 'Start presentation';
     return button;
   },

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,6 +26,7 @@
 import { DEFAULT_COMPOSITION_ID, defaultComposition } from './compositions/default';
 import { createAssetPreloader } from './runtime/asset-preloader';
 import { type AudioService, createHowlerAudioEngine } from './runtime/audio';
+import { createDomAudioUnlockAdapter } from './runtime/audio-unlock-dom';
 import { createCompositionRegistry } from './runtime/composition-registry';
 import {
   type NavigationMode,
@@ -186,6 +187,26 @@ const renderPrompter: PrompterRenderer = () => undefined;
 // record the DRAFT → ACTIVE bar (presenter UI module + GSAP runner
 // that translates commands to transport calls — including playhead-
 // preserving pause/resume — + end-to-end tests).
+// PUL-F030 / ADR-029: present-mode audio unlock adapter. The loader
+// invokes this BEFORE preload + scene `create(ctx)` + scene
+// `timeline(ctx)` + master timeline playback when a present-mode
+// composition declares audio (any scene's `scene.audio` non-empty).
+// The factory in `./runtime/audio-unlock-dom` owns the click / abort /
+// cleanup contract; this wiring just supplies the stage and the
+// concrete `<button>` element. Tests cover the factory directly so a
+// regression in click handling, abort race, or cleanup surfaces in
+// `tests/runtime/audio-unlock-dom.test.ts` (codex review cycle 3).
+const audioUnlockAdapter = createDomAudioUnlockAdapter({
+  mount: stage === null ? null : (button) => stage.appendChild(button as unknown as Node),
+  createButton: () => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.setAttribute('data-pulsar-audio-unlock', 'gesture');
+    button.textContent = 'Start presentation';
+    return button;
+  },
+});
+
 const loader = createSceneLoader({
   scenes: sceneRegistry,
   compositions: compositionRegistry,
@@ -195,6 +216,7 @@ const loader = createSceneLoader({
   timeline,
   audioEngine,
   renderPrompter,
+  audioUnlockAdapter,
 });
 
 const onNavigate = (event: Event): void => {

--- a/src/runtime/audio-unlock-dom.ts
+++ b/src/runtime/audio-unlock-dom.ts
@@ -1,0 +1,147 @@
+// DOM-backed workbench audio-unlock adapter — PUL-F030 / ADR-029.
+//
+// `src/main.ts` (the production browser bootstrap) wires the
+// `AudioUnlockAdapter` the loader invokes BEFORE preload + scene
+// `create(ctx)` + scene `timeline(ctx)` + master timeline playback
+// for present-mode compositions that declare audio. The adapter mounts
+// a single button on the workbench stage, awaits the user's click,
+// calls `gate.unlock()` to satisfy the browser autoplay policy through
+// the audio engine, removes the button, and resolves the promise. On
+// navigation supersession / dispose / popstate, the gate's signal
+// aborts: the adapter rejects, removes the button, and the loader's
+// existing catch-and-surface path runs.
+//
+// The factory shape (rather than an inline function in `main.ts`) is
+// what makes the workbench DOM behaviors actually testable — the
+// `cycle-3 codex review` flagged that the inline adapter in
+// `src/main.ts` was not covered by the gate test suite. Injecting
+// `mount` (the stage) and `createButton` (the gesture surface) keeps
+// the adapter logic — click wiring, abort race, button removal,
+// failure-path cleanup — testable against fakes while production
+// `main.ts` supplies real `document.createElement` and the `#stage`
+// element.
+
+import type { AudioUnlockAdapter, AudioUnlockContext } from './scene-loader';
+
+/**
+ * Minimal `HTMLElement`-like surface the adapter writes to. Production
+ * `main.ts` passes a real `HTMLElement`; tests pass a fake. Click
+ * dispatch / removal happens through these methods.
+ */
+export interface UnlockButtonElement {
+  addEventListener(event: 'click', listener: () => void, options?: { once?: boolean }): void;
+  removeEventListener(event: 'click', listener: () => void): void;
+  /**
+   * Remove this element from its parent. Production: `Element.remove()`.
+   * Tests: a no-op or a flag setter to verify cleanup.
+   */
+  remove(): void;
+}
+
+/**
+ * Mount callback the adapter invokes to attach the gesture surface to
+ * the workbench. Decoupling the mount from a specific `Element` /
+ * `appendChild` shape lets the production wiring stay compatible with
+ * the real DOM (`(b) => stage.appendChild(b as unknown as Node)`) while
+ * tests pass a fake that records the appended button — without forcing
+ * the factory to know about `Node` or jsdom.
+ */
+export type UnlockMount = (button: UnlockButtonElement) => void;
+
+/**
+ * Inputs to {@link createDomAudioUnlockAdapter}.
+ *
+ *  - `mount` is the callback that attaches the gesture surface to the
+ *    workbench. When `null`, the adapter rejects with a clear
+ *    navigation-level error (the gate IS the structural defense for
+ *    PUL-F030; an inert seam would silently violate the requirement).
+ *  - `createButton` builds the gesture surface. The adapter wires
+ *    one click listener and one signal-abort listener; the factory
+ *    is responsible for any pre-wiring (label, attributes, type).
+ *    Production `main.ts` builds a `<button data-pulsar-audio-
+ *    unlock="gesture">Start presentation</button>`; tests build a
+ *    minimal fake with an `addEventListener` / `remove` shape.
+ */
+export interface DomAudioUnlockHost {
+  readonly mount: UnlockMount | null;
+  readonly createButton: () => UnlockButtonElement;
+}
+
+/**
+ * Build a {@link AudioUnlockAdapter} that collects an explicit user
+ * click through the workbench DOM, satisfies the autoplay policy via
+ * `gate.unlock()`, and resolves so the present-mode composition can
+ * proceed.
+ *
+ * Contract (verified by `tests/runtime/audio-unlock-dom.test.ts`):
+ *
+ *  - `mount === null` → reject immediately with a clear error.
+ *  - Signal already aborted on entry → reject immediately, no button
+ *    mounted.
+ *  - Otherwise → mount the button, install one click listener
+ *    (`{ once: true }`) and one signal-abort listener. On click,
+ *    call `gate.unlock()`; on the unlock's resolve, remove the
+ *    button and resolve the adapter; on the unlock's reject or on
+ *    a signal-abort, remove the button and reject the adapter.
+ *  - The `settled` flag is set only AFTER `gate.unlock()` settles,
+ *    so a supersession during `AudioContext.resume()` propagates
+ *    promptly (cycle-1 review fix). The unlock then-callback bails
+ *    on `settled` if abort ran first.
+ *  - The adapter never receives raw scene objects, source URLs, or
+ *    Howler handles — only the bounded {@link AudioUnlockContext}.
+ */
+export function createDomAudioUnlockAdapter(host: DomAudioUnlockHost): AudioUnlockAdapter {
+  return (gate: AudioUnlockContext) =>
+    new Promise<void>((resolve, reject) => {
+      if (host.mount === null) {
+        reject(
+          new Error('audio unlock gate: workbench has no mount element for the gesture surface'),
+        );
+        return;
+      }
+      if (gate.signal.aborted) {
+        reject(new Error('audio unlock gate: navigation aborted before user gesture'));
+        return;
+      }
+      const button = host.createButton();
+      let settled = false;
+      const cleanup = (): void => {
+        button.removeEventListener('click', onClick);
+        gate.signal.removeEventListener('abort', onAbort);
+        button.remove();
+      };
+      // Codex review cycle 1 (one-off "abort after the click no longer
+      // cancels the unlock adapter"): do NOT set `settled = true`
+      // inside `onClick` — keep the abort race active across the
+      // `gate.unlock()` await so a supersession during
+      // `AudioContext.resume()` rejects promptly. The unlock
+      // resolution then-callback bails on `settled` and never resolves
+      // the navigation that has already been superseded.
+      function onClick(): void {
+        if (settled) return;
+        gate.unlock().then(
+          () => {
+            if (settled) return;
+            settled = true;
+            cleanup();
+            resolve();
+          },
+          (err: unknown) => {
+            if (settled) return;
+            settled = true;
+            cleanup();
+            reject(err instanceof Error ? err : new Error(String(err)));
+          },
+        );
+      }
+      function onAbort(): void {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        reject(new Error('audio unlock gate: navigation aborted before unlock completed'));
+      }
+      button.addEventListener('click', onClick, { once: true });
+      gate.signal.addEventListener('abort', onAbort, { once: true });
+      host.mount(button);
+    });
+}

--- a/src/runtime/audio-unlock-dom.ts
+++ b/src/runtime/audio-unlock-dom.ts
@@ -90,6 +90,63 @@ export interface DomAudioUnlockHost {
  *  - The adapter never receives raw scene objects, source URLs, or
  *    Howler handles — only the bounded {@link AudioUnlockContext}.
  */
+/**
+ * Per-invocation state the gate keeps so the click/abort race stays
+ * coherent across the async `gate.unlock()` await. Hoisted to module
+ * scope so the gate adapter's nested-function depth stays under
+ * Sonar's S2004 4-level limit.
+ */
+interface GateState {
+  readonly button: UnlockButtonElement;
+  readonly gate: AudioUnlockContext;
+  readonly resolve: () => void;
+  readonly reject: (err: Error) => void;
+  readonly onClick: () => void;
+  readonly onAbort: () => void;
+  settled: boolean;
+}
+
+function cleanup(state: GateState): void {
+  state.button.removeEventListener('click', state.onClick);
+  state.gate.signal.removeEventListener('abort', state.onAbort);
+  state.button.remove();
+}
+
+function onUnlockResolved(state: GateState): void {
+  if (state.settled) return;
+  state.settled = true;
+  cleanup(state);
+  state.resolve();
+}
+
+function onUnlockRejected(state: GateState, err: unknown): void {
+  if (state.settled) return;
+  state.settled = true;
+  cleanup(state);
+  state.reject(err instanceof Error ? err : new Error(String(err)));
+}
+
+function onAbortFired(state: GateState): void {
+  if (state.settled) return;
+  state.settled = true;
+  cleanup(state);
+  state.reject(new Error('audio unlock gate: navigation aborted before unlock completed'));
+}
+
+// Codex review cycle 1 (one-off "abort after the click no longer
+// cancels the unlock adapter"): do NOT set `settled = true` inside
+// `onClick` — keep the abort race active across the `gate.unlock()`
+// await so a supersession during `AudioContext.resume()` rejects
+// promptly. The unlock resolution callback bails on `settled` and
+// never resolves the navigation that has already been superseded.
+function onClickFired(state: GateState): void {
+  if (state.settled) return;
+  state.gate.unlock().then(
+    () => onUnlockResolved(state),
+    (err: unknown) => onUnlockRejected(state, err),
+  );
+}
+
 export function createDomAudioUnlockAdapter(host: DomAudioUnlockHost): AudioUnlockAdapter {
   return (gate: AudioUnlockContext) =>
     new Promise<void>((resolve, reject) => {
@@ -104,44 +161,17 @@ export function createDomAudioUnlockAdapter(host: DomAudioUnlockHost): AudioUnlo
         return;
       }
       const button = host.createButton();
-      let settled = false;
-      const cleanup = (): void => {
-        button.removeEventListener('click', onClick);
-        gate.signal.removeEventListener('abort', onAbort);
-        button.remove();
+      const state: GateState = {
+        button,
+        gate,
+        resolve,
+        reject,
+        settled: false,
+        onClick: () => onClickFired(state),
+        onAbort: () => onAbortFired(state),
       };
-      // Codex review cycle 1 (one-off "abort after the click no longer
-      // cancels the unlock adapter"): do NOT set `settled = true`
-      // inside `onClick` — keep the abort race active across the
-      // `gate.unlock()` await so a supersession during
-      // `AudioContext.resume()` rejects promptly. The unlock
-      // resolution then-callback bails on `settled` and never resolves
-      // the navigation that has already been superseded.
-      function onClick(): void {
-        if (settled) return;
-        gate.unlock().then(
-          () => {
-            if (settled) return;
-            settled = true;
-            cleanup();
-            resolve();
-          },
-          (err: unknown) => {
-            if (settled) return;
-            settled = true;
-            cleanup();
-            reject(err instanceof Error ? err : new Error(String(err)));
-          },
-        );
-      }
-      function onAbort(): void {
-        if (settled) return;
-        settled = true;
-        cleanup();
-        reject(new Error('audio unlock gate: navigation aborted before unlock completed'));
-      }
-      button.addEventListener('click', onClick, { once: true });
-      gate.signal.addEventListener('abort', onAbort, { once: true });
+      button.addEventListener('click', state.onClick, { once: true });
+      gate.signal.addEventListener('abort', state.onAbort, { once: true });
       host.mount(button);
     });
 }

--- a/src/runtime/audio.ts
+++ b/src/runtime/audio.ts
@@ -285,9 +285,8 @@ export function createHowlerAudioEngine(): AudioEngine {
       // Branch 2: HTML5 audio fallback. Howler will play sounds via
       // `<audio>` elements, which are subject to autoplay policy too.
       if (howlerHandle.usingWebAudio === false) {
-        const AudioCtor = (
-          globalThis as unknown as { Audio?: { new (src?: string): HTMLAudioElement } }
-        ).Audio;
+        type AudioCtor = new (src?: string) => HTMLAudioElement;
+        const AudioCtor = (globalThis as unknown as { Audio?: AudioCtor }).Audio;
         if (AudioCtor === undefined) {
           throw new Error(
             'audio unlock: Howler is in HTML5 mode but globalThis.Audio is unavailable — cannot satisfy autoplay policy',
@@ -318,7 +317,7 @@ export function createHowlerAudioEngine(): AudioEngine {
         );
       }
       if (typeof ctx.resume !== 'function') {
-        throw new Error('audio unlock: Howler.ctx.resume is not a function');
+        throw new TypeError('audio unlock: Howler.ctx.resume is not a function');
       }
       await ctx.resume();
     },

--- a/src/runtime/audio.ts
+++ b/src/runtime/audio.ts
@@ -37,19 +37,22 @@
 //
 // Source URLs reuse PUL-F005's `resolveAssetUrl` scheme resolver — no
 // copied scheme rules — and every registered source must be in the
-// active composition slice's declared `scene.assets` (ADR-008 #5: the
-// only audio inventory is `scene.assets`; there is no `audio:` field on
-// `SceneModule`). The preloader (PUL-F005) warms those URLs before
-// `create(ctx)` runs. Sound ids and group names obey the kebab-case
-// rule every other Pulsar identifier obeys (ADR-008 #1).
+// active composition slice's declared `scene.audio` (PUL-F030 / ADR-029
+// — `scene.audio` is the audio-source allowlist; every entry must also
+// be a member of `scene.assets` so the preloader (PUL-F005) warmed it).
+// Sound ids and group names obey the kebab-case rule every other Pulsar
+// identifier obeys (ADR-008 #1).
 //
 // References:
 //  - ADR-004 — Howler as the audio engine, exposed through `ctx.audio`;
 //    runtime-guaranteed per-scene cleanup; master mute.
 //  - ADR-003 — timeline callbacks are how most audio cues fire (scenes
 //    hang `ctx.audio.play(...)` off their `ctx.gsap` timeline).
-//  - ADR-008 — agent-native authoring; #1 kebab ids, #5 the only asset
-//    inventory is `scene.assets`.
+//  - ADR-008 — agent-native authoring; #1 kebab ids, #5 `scene.assets`
+//    is the canonical asset inventory; PUL-F030 / ADR-029 narrows audio
+//    to a `scene.audio` subset of `scene.assets`.
+//  - ADR-029 / PUL-F030 — `scene.audio` is the audio-source allowlist
+//    AND the predicate the present-mode unlock gate consults.
 //  - PUL-F005 / ADR-012 — the asset preloader whose URL resolver this
 //    module reuses; declared audio sources are warmed before mount.
 
@@ -77,7 +80,9 @@ export class AudioGroupError extends AudioError {}
 
 /**
  * A sound source URL has a disallowed scheme, is malformed, or was not
- * declared in `scene.assets` (so the preloader never warmed it).
+ * declared in `scene.audio` (PUL-F030 / ADR-029 — the audio-source
+ * allowlist; every entry must also be in `scene.assets` so the
+ * preloader warms it).
  */
 export class AudioSourceError extends AudioError {}
 
@@ -143,6 +148,17 @@ export interface AudioEngine {
   setMasterMute(muted: boolean): void;
   /** Whether the engine is currently master-muted. */
   isMasterMuted(): boolean;
+  /**
+   * Resume the underlying audio context so subsequent playback satisfies
+   * browser autoplay policy (PUL-F030 / ADR-029). The loader/workbench
+   * unlock adapter calls this AFTER collecting an explicit user gesture
+   * and BEFORE present-mode composition lifecycle work begins. The
+   * Howler-backed engine forwards to `Howler.ctx.resume()` (a no-op when
+   * Howler runs in its no-audio fallback, e.g. Node tests). The no-op
+   * engine resolves immediately. Idempotent — successive calls after the
+   * context is running resolve without side effects.
+   */
+  unlock(): Promise<void>;
 }
 
 /* ------------------------------------------------------------------ *
@@ -222,6 +238,90 @@ export function createHowlerAudioEngine(): AudioEngine {
     isMasterMuted() {
       return masterMuted;
     },
+    // PUL-F030 / ADR-029: satisfy browser autoplay policy so the
+    // present-mode composition can play audio. The function MUST
+    // either actually unlock playback (resume Web Audio context OR
+    // exercise HTML5 audio under the active user gesture) OR REJECT,
+    // so the gate fails closed instead of "click resolved but the
+    // first cue is still suspended." The codex cycle-3 review named
+    // four success-without-unlock failure modes the previous code
+    // hit (`usingWebAudio === false` silently returning, seed-Howl
+    // setup throwing under a try/catch that resolved, ctx still
+    // missing after setup, ctx without a `resume()`). This rewrite
+    // closes each of them.
+    //
+    // The three success branches:
+    //
+    //  1. `noAudio === true` — Howler has no audio backend at all
+    //     (Node tests, browser with audio disabled). No autoplay
+    //     policy to satisfy; resolve. The composition's `ctx.audio`
+    //     calls are already no-ops in this engine.
+    //  2. `usingWebAudio === false` — Howler falls back to HTML5
+    //     audio. The HTML5 autoplay-policy unlock pattern is to
+    //     `play()` a silent `<audio>` during the user gesture, which
+    //     marks the document's HTML5 audio as user-activated.
+    //     Requires `globalThis.Audio`; if absent, reject.
+    //  3. Web Audio path — construct/resume an `AudioContext`. The
+    //     ctx must be created INSIDE the user-activation tick so the
+    //     browser marks it `running` not `suspended`; we trigger
+    //     Howler's own `_setup()` via a throwaway `new Howl()` so
+    //     `Howler.ctx` AND `Howler.masterGain` are created
+    //     consistently (cycle-2 review fix). If Howler's setup
+    //     throws, or the ctx remains null, or the ctx has no
+    //     `resume()`, REJECT. Idempotent: a second unlock with a
+    //     running ctx just calls `resume()` again (no-op when
+    //     already running).
+    async unlock() {
+      const howlerHandle = Howler as unknown as {
+        ctx: AudioContext | null | undefined;
+        noAudio: boolean | undefined;
+        usingWebAudio: boolean | undefined;
+      };
+      // Branch 1: explicit no-audio fallback.
+      if (howlerHandle.noAudio === true) return;
+      // 44-byte silent WAV used by both unlock branches.
+      const SILENT_WAV =
+        'data:audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAAABAAEARKwAAIhYAQACABAAZGF0YQAAAAA=';
+      // Branch 2: HTML5 audio fallback. Howler will play sounds via
+      // `<audio>` elements, which are subject to autoplay policy too.
+      if (howlerHandle.usingWebAudio === false) {
+        const AudioCtor = (
+          globalThis as unknown as { Audio?: { new (src?: string): HTMLAudioElement } }
+        ).Audio;
+        if (AudioCtor === undefined) {
+          throw new Error(
+            'audio unlock: Howler is in HTML5 mode but globalThis.Audio is unavailable — cannot satisfy autoplay policy',
+          );
+        }
+        const probe = new AudioCtor(SILENT_WAV);
+        probe.muted = true;
+        await probe.play();
+        probe.pause();
+        return;
+      }
+      // Branch 3: Web Audio path. Trigger Howler's setup if needed.
+      if (howlerHandle.ctx === null || howlerHandle.ctx === undefined) {
+        try {
+          const seed = new Howl({ src: [SILENT_WAV] });
+          seed.unload();
+        } catch (cause) {
+          throw new Error(
+            `audio unlock: Howler setup failed: ${cause instanceof Error ? cause.message : String(cause)}`,
+            { cause },
+          );
+        }
+      }
+      const ctx = howlerHandle.ctx;
+      if (ctx === null || ctx === undefined) {
+        throw new Error(
+          'audio unlock: Howler setup completed but Howler.ctx is still null — cannot resume audio',
+        );
+      }
+      if (typeof ctx.resume !== 'function') {
+        throw new Error('audio unlock: Howler.ctx.resume is not a function');
+      }
+      await ctx.resume();
+    },
   };
 }
 
@@ -249,6 +349,9 @@ export const noopAudioEngine: AudioEngine = (() => {
       masterMuted = muted;
     },
     isMasterMuted: () => masterMuted,
+    // PUL-F030 / ADR-029: a no-audio engine has no browser context to
+    // resume, so unlock is a deterministic resolved promise.
+    unlock: () => Promise.resolve(),
   };
 })();
 
@@ -260,9 +363,11 @@ export const noopAudioEngine: AudioEngine = (() => {
 export interface SoundDefinition {
   /**
    * Source URL, or URLs in codec-preference order. Every URL must be
-   * declared in the active composition slice's `scene.assets` so the
-   * preloader warms it (ADR-008 #5) and must pass the asset scheme
-   * allowlist ({@link import('./asset-preloader').DEFAULT_ALLOWED_SCHEMES}).
+   * declared in the active composition slice's `scene.audio` (PUL-F030
+   * / ADR-029 — the audio-source allowlist; every `scene.audio` entry
+   * is also a member of `scene.assets` so the preloader warms it,
+   * ADR-008 #5) and must pass the asset scheme allowlist
+   * ({@link import('./asset-preloader').DEFAULT_ALLOWED_SCHEMES}).
    * Re-registering an id with the same definition (same `src` list,
    * same `sprite` map) is idempotent — e.g. a shared transition SFX two
    * scenes both `load`; re-registering it with a different definition
@@ -434,10 +539,12 @@ export interface AudioServiceOptions {
   readonly onCue?: (entry: AudioCueLogEntry) => void;
   /**
    * The source URLs scenes may register. Every {@link SoundDefinition.src}
-   * URL must be in this set (ADR-008 #5 — audio is declared in
-   * `scene.assets`, which the preloader warms). Omit to skip the
-   * membership check (non-composition / test callers); scheme
-   * validation still applies.
+   * URL must be in this set (PUL-F030 / ADR-029 — `scene.audio` is the
+   * authoritative audio-source allowlist; the loader passes the union
+   * of every scene's `scene.audio` in the active slice. Every entry is
+   * also a member of `scene.assets`, which the preloader warms,
+   * ADR-008 #5). Omit to skip the membership check (non-composition /
+   * test callers); scheme validation still applies.
    */
   readonly allowedSources?: Iterable<string>;
   /** Sink for non-fatal async audio errors (load / play failure). Defaults to a no-op. */
@@ -830,15 +937,15 @@ export function createAudioService(
           `audio sound "${soundId}" source must be a non-empty URL string`,
         );
       }
-      // Defense-in-depth (codex review, cycle 3): even when
-      // `allowedSources` is provided (the slice's declared
-      // `scene.assets`, which the preloader warmed), the audio service
-      // also runs the same default scheme allowlist the preloader uses
-      // by default — so a no-op or weak preloader cannot let `file:` /
-      // `//host` URLs through. Threading the preloader's exact
-      // `baseUrl` / `allowedSchemes` policy into the audio service is a
-      // documented follow-up; for now the service is at least as
-      // restrictive as `DEFAULT_ALLOWED_SCHEMES`.
+      // Defense-in-depth: even when `allowedSources` is provided (the
+      // slice's declared `scene.audio`, every entry of which is also
+      // in `scene.assets` so the preloader warmed it), the audio
+      // service also runs the same default scheme allowlist the
+      // preloader uses by default — so a no-op or weak preloader
+      // cannot let `file:` / `//host` URLs through. Threading the
+      // preloader's exact `baseUrl` / `allowedSchemes` policy into
+      // the audio service is a documented follow-up; for now the
+      // service is at least as restrictive as `DEFAULT_ALLOWED_SCHEMES`.
       try {
         resolveAssetUrl(url, undefined, DEFAULT_ALLOWED_SCHEMES);
       } catch (cause) {
@@ -848,11 +955,14 @@ export function createAudioService(
         );
       }
       if (allowed !== null && !allowed.has(url)) {
-        // ADR-008 #5: the only audio inventory is `scene.assets`. A URL
-        // outside the slice's declared assets is not preloader-warmed
-        // and is rejected here regardless of scheme.
+        // PUL-F030 / ADR-029: `scene.audio` is the audio-source
+        // allowlist. A URL outside the slice's declared `scene.audio`
+        // is rejected — even if it happens to be in `scene.assets`.
+        // This is what makes the present-mode unlock gate predicate
+        // and the runtime audio-source allowlist agree: a scene
+        // cannot quietly register audio it did not also declare.
         throw new AudioSourceError(
-          `audio sound "${soundId}" source "${url}" is not a declared asset — list it in scene.assets so the preloader warms it (ADR-008 #5)`,
+          `audio sound "${soundId}" source "${url}" is not a declared audio source — list it in scene.audio (and ensure it is also in scene.assets so the preloader warms it) per PUL-F030 / ADR-029`,
         );
       }
     }

--- a/src/runtime/scene-loader.ts
+++ b/src/runtime/scene-loader.ts
@@ -59,6 +59,7 @@ import {
   buildPrompterScript,
 } from './prompter';
 import type { SceneRegistry } from './registry';
+import { sceneDeclaresAudio } from './scene';
 import {
   type SceneNavigationTarget,
   loadSceneNavigationTarget,
@@ -281,7 +282,84 @@ export interface SceneLoaderOptions {
    * via `data-pulsar-navigation-error` regardless of this hook.
    */
   readonly onError?: (err: unknown) => void;
+  /**
+   * PUL-F030 / ADR-029: workbench-supplied unlock adapter that collects
+   * one explicit user gesture and resolves once browser autoplay policy
+   * is satisfied for a present-mode composition that declares audio.
+   * The loader invokes the adapter BEFORE asset preload, scene
+   * `create(ctx)`, scene `timeline(ctx)`, and master timeline playback
+   * — so a present-mode composition cannot begin with a suspended
+   * `AudioContext` mid-cue. Gate semantics:
+   *
+   *  - Triggered when `effectiveMode(target) === 'present'` AND the
+   *    resolved target carries a composition slice (composition
+   *    navigation, not a direct `?scene=...&mode=present`) AND at
+   *    least one scene in `sceneSlice` declares audio statically via
+   *    {@link import('./scene').sceneDeclaresAudio} (`scene.audio`
+   *    list non-empty).
+   *  - Bypassed for every non-`present` mode (rehearsal / screenshot /
+   *    paused / scrub / loop / standalone / prompter) and for present-
+   *    mode loads that don't carry audio.
+   *  - Bound to the navigation's `AbortSignal`: supersession /
+   *    `dispose()` / popstate aborts the gate, the adapter observes
+   *    `signal.aborted`, and the lifecycle never starts.
+   *  - Adapter receives bounded semantic context only (composition id,
+   *    scene ids, signal) plus a one-shot `unlock()` callback bound to
+   *    the audio engine — never raw scene objects, source URLs,
+   *    headers, cookies, or Howler handles.
+   *  - An adapter rejection is surfaced through the existing
+   *    `onError` + `data-pulsar-navigation-error` channel without
+   *    starting lifecycle work.
+   *  - When the gate triggers but no adapter is supplied, the loader
+   *    fails loud through the same diagnostic channel — the gate IS
+   *    the structural defense PUL-F030 records, so an unwired gate is
+   *    a workbench-bootstrap defect, not an inert seam.
+   */
+  readonly audioUnlockAdapter?: AudioUnlockAdapter;
 }
+
+/**
+ * PUL-F030 / ADR-029: semantic context handed to the workbench-supplied
+ * unlock adapter. The adapter MUST NOT receive raw scene objects, source
+ * URLs, scheme parsers, Howler handles, request headers, cookies, or
+ * any payload outside this shape — the gate is the structural defense,
+ * and the workbench gesture surface only needs bounded identifiers and
+ * a callback into the audio boundary.
+ */
+export interface AudioUnlockContext {
+  /** Composition id (from the resolved navigation target). */
+  readonly compositionId: string;
+  /**
+   * Scene ids in the resolved composition slice, in playback order.
+   * Lets the workbench prompt copy (when it lands) reflect what is
+   * about to play without exposing scene objects or URLs.
+   */
+  readonly sceneIds: readonly string[];
+  /**
+   * Navigation `AbortSignal`. Adapters that show a gesture surface
+   * MUST listen for abort and reject (or resolve cleanly without
+   * starting playback) so a superseded navigation does not start the
+   * old composition after the user finally clicks.
+   */
+  readonly signal: AbortSignal;
+  /**
+   * Audio-boundary unlock callback bound to the runtime audio engine.
+   * The adapter calls this AFTER collecting the user gesture; the
+   * engine resumes its `AudioContext` so subsequent playback satisfies
+   * browser autoplay policy. Idempotent.
+   */
+  readonly unlock: () => Promise<void>;
+}
+
+/**
+ * PUL-F030 / ADR-029: signature of the workbench-supplied unlock
+ * adapter. Resolves when the gate is satisfied (engine unlocked, the
+ * navigation may proceed); rejects when the user dismissed the gesture
+ * or another error prevents unlock. The loader awaits the returned
+ * promise BEFORE running asset preload / scene lifecycle for the
+ * present-mode composition.
+ */
+export type AudioUnlockAdapter = (gate: AudioUnlockContext) => Promise<void>;
 
 /**
  * Returned by {@link createSceneLoader}. Each call to `handle(target)`
@@ -348,18 +426,27 @@ function isPureAbort(err: unknown, signal: AbortSignal): boolean {
 
 /**
  * The audio source URLs the resolved (possibly head-truncated) slice
- * declared — every scene's `assets` in the slice (just the head scene's
- * for a bare `kind: 'scene'` target, the full composition slice's for
- * `mode=present`). The per-navigation audio service uses this so
- * `ctx.audio.load()` can only register a URL the preloader (PUL-F005)
- * already warmed — ADR-008 #5: the only audio inventory is
- * `scene.assets`. Pure function (no closure captures), hoisted to
- * module scope so the loader factory does not recreate it per instance.
+ * declared as audio — every scene's static {@link import('./scene').SceneModule.audio}
+ * list in the slice (just the head scene's for a bare `kind: 'scene'`
+ * target, the full composition slice's for composition targets). The
+ * per-navigation audio service uses this so `ctx.audio.load()` can
+ * only register URLs the scene EXPLICITLY declared as audio — not any
+ * URL that happens to be in `scene.assets`. This makes the PUL-F030 /
+ * ADR-029 unlock-gate predicate ({@link import('./scene').sceneDeclaresAudio})
+ * AND the audio-service allowlist consistent: a scene that registers
+ * audio MUST declare it in `scene.audio`, so the present-mode unlock
+ * gate cannot be bypassed by a scene that hides its audio in `assets`
+ * (codex review, cycle 1 — class finding "audio gate can be bypassed
+ * by undeclared ctx.audio loads"). `scene.audio` is validated at the
+ * schema boundary to be a subset of `scene.assets`, so the preloader
+ * still warms every declared audio URL. Pure function (no closure
+ * captures), hoisted to module scope so the loader factory does not
+ * recreate it per instance.
  */
 function collectAudioSources(target: SceneNavigationTarget): readonly string[] {
   return target.composition === undefined
-    ? target.scene.assets
-    : target.composition.sceneSlice.flatMap((scene) => scene.assets);
+    ? target.scene.audio
+    : target.composition.sceneSlice.flatMap((scene) => scene.audio);
 }
 
 /**
@@ -427,6 +514,21 @@ interface InFlightLoad {
 type NavigationEvent =
   | { readonly kind: 'target'; readonly target: NavigationTarget }
   | { readonly kind: 'error'; readonly err: unknown };
+
+/**
+ * PUL-F030 / ADR-029: the internal gate-prelude callback `buildLoad`
+ * invokes BEFORE the resolver lifecycle. Distinct from the public
+ * {@link AudioUnlockAdapter}: the public adapter receives a semantic
+ * composition context (composition id, scene ids, signal, unlock);
+ * this internal helper is what `buildLoad` actually awaits, with the
+ * composition context already partially-applied by `buildUnlockGate`.
+ * The adapter is workbench-supplied; the helper is the loader's
+ * internal closure over it.
+ */
+type UnlockGate = (env: {
+  readonly signal: AbortSignal;
+  readonly unlock: () => Promise<void>;
+}) => Promise<void>;
 
 export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
   const { stage } = options;
@@ -741,9 +843,41 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
    * should bail. Hoisted out of `runTarget` so the latter stays
    * within Sonar's cognitive-complexity budget.
    */
+  /**
+   * PUL-F030 / ADR-029: build the per-navigation closure that calls
+   * the workbench-supplied unlock adapter with the composition context
+   * captured here and the navigation-bound signal + engine-bound
+   * unlock callback supplied at gate-invocation time by `buildLoad`.
+   * Partial application keeps the composition context out of the
+   * `buildLoad` body so the latter stays within Sonar's cognitive-
+   * complexity budget.
+   *
+   * Pure factory — captures only `adapter` and `composition`. The
+   * adapter receives bounded semantic context: composition id, scene
+   * ids in playback order, the navigation `AbortSignal`, and the
+   * engine-bound `unlock()` callback. It does NOT receive scene
+   * objects, source URLs, asset payloads, or Howler handles (per
+   * ADR-029's "workbench gesture surface" guardrail).
+   */
+  const buildUnlockGate = (
+    adapter: AudioUnlockAdapter,
+    composition: SceneNavigationTarget['composition'] & object,
+  ): UnlockGate => {
+    const compositionId = composition.id;
+    const sceneIds = Object.freeze(composition.sceneSlice.map((scene) => scene.id));
+    return ({ signal, unlock }) =>
+      adapter({
+        compositionId,
+        sceneIds,
+        signal,
+        unlock,
+      });
+  };
+
   const buildLoad = (
     resolved: SceneNavigationTarget,
     target: NavigationTarget,
+    unlockGate: UnlockGate | null,
   ): InFlightLoad | null => {
     const controller = new AbortController();
     // PUL-F012 / ADR-007: mode dispatch lives at the runtime-core seam.
@@ -771,8 +905,9 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
     // PUL-F024 / PUL-F026 / ADR-004: the per-navigation audio service.
     // Built over `audioEngine`, scoped to `controller.signal` (abort ⇒
     // every sound stopped + unloaded), restricted to the URLs the slice
-    // declared in `scene.assets` (ADR-008 #5 — the preloader warmed
-    // them), and with a per-mode `AudioOutputPolicy`:
+    // declared in `scene.audio` (PUL-F030 / ADR-029 — every audio entry
+    // must also be in `scene.assets` so the preloader warmed it), and
+    // with a per-mode `AudioOutputPolicy`:
     //  - `'silent'`   under `mode=screenshot` / `mode=paused` (audible
     //                 playback suppressed — ADR-019 / ADR-021).
     //  - `'log-cues'` under `mode=rehearsal` (audible playback
@@ -879,9 +1014,8 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
         ? undefined
         : { id: resolved.composition.id, startIndex: resolved.composition.startIndex },
     );
-    return {
-      controller,
-      settled: loadSceneNavigationTarget(resolved, {
+    const runLifecycle = (): Promise<void> =>
+      loadSceneNavigationTarget(resolved, {
         ctx,
         preloadAssets,
         timeline: options.timeline,
@@ -909,7 +1043,32 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
         // a stage attribute entry + `onError` call without halting
         // the active composition.
         onSceneFailed,
-      }),
+      });
+    // PUL-F030 / ADR-029: when the gate applies, the settled promise
+    // begins with the adapter await — the lifecycle runs only after
+    // unlock succeeds AND the navigation has not been aborted. The
+    // gate's signal IS the navigation signal, so supersession /
+    // dispose / popstate aborts the gate; adapters that respect the
+    // signal can reject deterministically. The audio service / ctx /
+    // preloader are constructed BEFORE the gate (above), but none of
+    // them touches the network or DOM until `loadSceneNavigationTarget`
+    // calls `preloadAssets(scene)` and `create(ctx)` — so the gate
+    // running first preserves the structural invariant "no lifecycle
+    // work before unlock."
+    const settled =
+      unlockGate === null
+        ? runLifecycle()
+        : (async (): Promise<void> => {
+            await unlockGate({
+              signal: controller.signal,
+              unlock: () => audioEngine.unlock(),
+            });
+            if (controller.signal.aborted) return;
+            return runLifecycle();
+          })();
+    return {
+      controller,
+      settled,
       silent: false,
       audio,
       presenterAbort,
@@ -1140,7 +1299,34 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
       load = buildPrompterLoad(resolved);
     } else {
       const runnable = applySingleSceneSlice(resolved, target);
-      load = buildLoad(runnable, target);
+      // PUL-F030 / ADR-029: decide whether the present-mode audio
+      // unlock gate applies to this navigation and resolve the adapter
+      // up front. The gate triggers only when (a) the effective mode
+      // is 'present', (b) the resolved target carries a composition
+      // slice, and (c) at least one scene in that slice declares
+      // audio. When the gate applies but no adapter is supplied, the
+      // loader fails loud — the gate IS the structural defense for
+      // PUL-F030, so an unwired gate is a workbench-bootstrap defect.
+      const gateApplies =
+        effectiveMode(target) === 'present' &&
+        resolved.composition !== undefined &&
+        resolved.composition.sceneSlice.some(sceneDeclaresAudio);
+      if (gateApplies && options.audioUnlockAdapter === undefined) {
+        resetStageAttrs();
+        surfaceError(
+          new Error(
+            'audio unlock gate: present-mode composition declares audio but no audioUnlockAdapter was supplied — workbench bootstrap must wire one to satisfy PUL-F030 / ADR-029',
+          ),
+        );
+        return;
+      }
+      const unlockGate: UnlockGate | null =
+        gateApplies &&
+        options.audioUnlockAdapter !== undefined &&
+        resolved.composition !== undefined
+          ? buildUnlockGate(options.audioUnlockAdapter, resolved.composition)
+          : null;
+      load = buildLoad(runnable, target, unlockGate);
     }
     if (load === null) return;
     inFlight = load;

--- a/src/runtime/scene-loader.ts
+++ b/src/runtime/scene-loader.ts
@@ -874,6 +874,36 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
       });
   };
 
+  /**
+   * PUL-F030 / ADR-029: decide whether the present-mode audio unlock
+   * gate applies to this navigation, and if so build the gate. Returns
+   * one of:
+   *
+   *  - `null` — the gate does not apply (mode is not present, no
+   *    composition slice, or no scene in the slice declares audio).
+   *    The lifecycle runs without a prelude.
+   *  - `'fail-loud'` — the gate applies but no `audioUnlockAdapter`
+   *    is supplied. The caller surfaces a navigation-level error and
+   *    skips the lifecycle.
+   *  - `UnlockGate` — a closure that invokes the workbench adapter
+   *    with the composition context. The lifecycle awaits it before
+   *    preload / `create(ctx)` / `timeline(ctx)` / master playback.
+   *
+   * Hoisted out of `runTarget` so the latter stays within Sonar's
+   * cognitive-complexity budget (S3776).
+   */
+  const resolveUnlockGate = (
+    target: NavigationTarget,
+    resolved: SceneNavigationTarget,
+  ): UnlockGate | 'fail-loud' | null => {
+    if (effectiveMode(target) !== 'present') return null;
+    const composition = resolved.composition;
+    if (composition === undefined) return null;
+    if (!composition.sceneSlice.some(sceneDeclaresAudio)) return null;
+    if (options.audioUnlockAdapter === undefined) return 'fail-loud';
+    return buildUnlockGate(options.audioUnlockAdapter, composition);
+  };
+
   const buildLoad = (
     resolved: SceneNavigationTarget,
     target: NavigationTarget,
@@ -1299,19 +1329,14 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
       load = buildPrompterLoad(resolved);
     } else {
       const runnable = applySingleSceneSlice(resolved, target);
-      // PUL-F030 / ADR-029: decide whether the present-mode audio
-      // unlock gate applies to this navigation and resolve the adapter
-      // up front. The gate triggers only when (a) the effective mode
-      // is 'present', (b) the resolved target carries a composition
-      // slice, and (c) at least one scene in that slice declares
-      // audio. When the gate applies but no adapter is supplied, the
-      // loader fails loud — the gate IS the structural defense for
-      // PUL-F030, so an unwired gate is a workbench-bootstrap defect.
-      const gateApplies =
-        effectiveMode(target) === 'present' &&
-        resolved.composition !== undefined &&
-        resolved.composition.sceneSlice.some(sceneDeclaresAudio);
-      if (gateApplies && options.audioUnlockAdapter === undefined) {
+      // PUL-F030 / ADR-029: resolve the present-mode audio unlock
+      // gate up front. The helper returns `'fail-loud'` when the gate
+      // applies but no adapter is supplied (workbench-bootstrap
+      // defect — the gate IS the structural defense), `null` when
+      // the gate does not apply or there is no composition, and a
+      // built unlock gate otherwise.
+      const gateOrFailure = resolveUnlockGate(target, resolved);
+      if (gateOrFailure === 'fail-loud') {
         resetStageAttrs();
         surfaceError(
           new Error(
@@ -1320,13 +1345,7 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
         );
         return;
       }
-      const unlockGate: UnlockGate | null =
-        gateApplies &&
-        options.audioUnlockAdapter !== undefined &&
-        resolved.composition !== undefined
-          ? buildUnlockGate(options.audioUnlockAdapter, resolved.composition)
-          : null;
-      load = buildLoad(runnable, target, unlockGate);
+      load = buildLoad(runnable, target, gateOrFailure);
     }
     if (load === null) return;
     inFlight = load;

--- a/src/runtime/scene.ts
+++ b/src/runtime/scene.ts
@@ -75,6 +75,26 @@ export interface SceneModule {
   tags: readonly string[];
   assets: readonly string[];
   captions: readonly Caption[];
+  /**
+   * Static audio-declaration list (PUL-F030 / ADR-029). Names the
+   * subset of `assets` that are audio sources. An empty array means
+   * "this scene declares no audio" — the loader/workbench unlock
+   * gate, the validation pass (PUL-F028), and future authoring lints
+   * all consult the same {@link sceneDeclaresAudio} predicate built
+   * over this field, so "declares audio" never depends on file
+   * extension sniffing, MIME guesses, asset URL substrings, or
+   * runtime observation of `ctx.audio.load()`.
+   *
+   * Every entry MUST be a member of `assets` so the preloader
+   * (PUL-F005) warms it. `scene.audio` itself IS the runtime
+   * audio-source allowlist for `ctx.audio.load()` — a scene cannot
+   * register audio it did not declare here. ADR-008 #5 keeps
+   * `scene.assets` as the canonical asset inventory; PUL-F030 /
+   * ADR-029 narrows audio to this `scene.audio` subset so the
+   * present-mode unlock-gate predicate and the runtime allowlist
+   * agree on one source of truth.
+   */
+  audio: readonly string[];
   defaultNext: string | null;
   standalone: boolean;
   trailerSafe: boolean;
@@ -90,6 +110,7 @@ const REQUIRED_FIELDS = [
   'tags',
   'assets',
   'captions',
+  'audio',
   'defaultNext',
   'standalone',
   'trailerSafe',
@@ -192,6 +213,11 @@ const FIELD_GUARDS: readonly FieldGuard[] = [
     condition: 'must be an array',
   },
   {
+    field: 'audio',
+    check: (v) => isStringArray(v.audio),
+    condition: 'must be an array of strings',
+  },
+  {
     field: 'defaultNext',
     check: (v) => isSceneIdOrNull(v.defaultNext),
     condition: `must be a kebab-case scene id (${KEBAB_IDENTIFIER_FORM}) or null`,
@@ -270,6 +296,39 @@ export function assertSceneModule(value: unknown): asserts value is SceneModule 
       throw new Error(`scene ${idLabel} is invalid: ${fault}`);
     }
   }
+
+  // PUL-F030 / ADR-029 cross-field invariant: every `audio` entry must
+  // be a member of `assets`. The shape guard above accepts an
+  // arbitrary string array; this loop enforces the "audio sources
+  // reference scene.assets" rule the preflight names, so the
+  // preloader (PUL-F005) warms every declared audio URL and the audio
+  // service's allowlist accepts it (ADR-008 #5). Reported by index so
+  // a multi-entry scene's bad declaration is locatable, mirroring the
+  // caption validator's `captions[N]` envelope.
+  const assetsSet = new Set(value.assets as readonly string[]);
+  const audioList = value.audio as readonly string[];
+  for (let i = 0; i < audioList.length; i++) {
+    const entry = audioList[i] as string;
+    if (!assetsSet.has(entry)) {
+      throw new Error(
+        `scene ${idLabel} is invalid: audio[${i}] "${entry}" must be a member of scene.assets (PUL-F030 / ADR-029)`,
+      );
+    }
+  }
+}
+
+/**
+ * PUL-F030 / ADR-029: predicate the loader/workbench unlock gate, the
+ * validation pass, and future authoring lints all consult so "this
+ * scene declares audio" has one source of truth. True when the
+ * scene's static {@link SceneModule.audio} list has at least one
+ * entry. The shape and membership invariants of `audio` are
+ * established by {@link assertSceneModule} — this predicate only
+ * reads the field length, so it is safe to call on any
+ * already-validated scene module.
+ */
+export function sceneDeclaresAudio(scene: SceneModule): boolean {
+  return scene.audio.length > 0;
 }
 
 /**

--- a/src/scenes/placeholder.ts
+++ b/src/scenes/placeholder.ts
@@ -79,6 +79,7 @@ export const placeholderScene: SceneModule = {
   tags: ['placeholder'],
   assets: [],
   captions: [],
+  audio: [],
   defaultNext: null,
   standalone: true,
   trailerSafe: false,

--- a/tests/runtime/asset-preloader.test.ts
+++ b/tests/runtime/asset-preloader.test.ts
@@ -14,6 +14,7 @@ const buildScene = (id: string, assets: readonly string[] = []): SceneModule => 
   tags: [],
   assets,
   captions: [],
+  audio: [],
   defaultNext: null,
   standalone: false,
   trailerSafe: false,

--- a/tests/runtime/audio-engine.test.ts
+++ b/tests/runtime/audio-engine.test.ts
@@ -14,6 +14,7 @@ import {
   type AudioSoundConfig,
   createAudioService,
   createHowlerAudioEngine,
+  noopAudioEngine,
 } from '../../src/runtime/audio';
 
 // A tiny silent WAV — valid bytes so Howler does not choke on the URL
@@ -78,5 +79,244 @@ describe('createHowlerAudioEngine (Howler boundary)', () => {
       service.stopAll();
     }).not.toThrow();
     expect(service.isDisposed()).toBe(true);
+  });
+
+  // PUL-F030 / ADR-029: the engine's unlock operation is the
+  // audio-boundary capability the loader/workbench unlock adapter
+  // calls AFTER collecting a user gesture. The Howler-backed engine
+  // resumes its AudioContext; the no-op engine resolves immediately.
+  // Both branches must surface a Promise so the adapter can `await`
+  // unlock before allowing lifecycle work to proceed.
+  describe('unlock (PUL-F030 / ADR-029)', () => {
+    it('resolves on the Howler-backed engine even when the context is unavailable (Node no-audio path)', async () => {
+      const engine = createHowlerAudioEngine();
+      await expect(engine.unlock()).resolves.toBeUndefined();
+    });
+
+    it('is idempotent across multiple invocations on the Howler engine', async () => {
+      const engine = createHowlerAudioEngine();
+      await expect(engine.unlock()).resolves.toBeUndefined();
+      await expect(engine.unlock()).resolves.toBeUndefined();
+      await expect(engine.unlock()).resolves.toBeUndefined();
+    });
+
+    // Codex review cycle 2 (one-off "Direct Howler.ctx assignment
+    // bypasses Howler setup"): the cycle-1 fix pre-set `Howler.ctx`
+    // directly and skipped Howler's `_setup()`, which left
+    // `Howler.masterGain` null and broke the next `new Howl()`. The
+    // cycle-2 fix instead triggers Howler's OWN setup path by
+    // constructing a throwaway Howl with a silent data URL during the
+    // unlock call. The post-unlock contract is: `engine.createSound()`
+    // works — Howler's global state is self-consistent — and `unlock()`
+    // does not throw. Verified end-to-end against the real Howler
+    // library (Node uses Howler's `noAudio` fallback, but the same
+    // public surface is exercised end-to-end so a future regression
+    // that re-introduces direct-ctx-assignment surfaces here too).
+    it('triggers Howler setup so subsequent createSound() works end-to-end after unlock()', async () => {
+      const engine = createHowlerAudioEngine();
+      // unlock() must not throw even when Howler is in noAudio
+      // fallback. The seed-Howl construction is guarded with try/catch
+      // so a setup failure under restrictive environments still
+      // resolves the gate cleanly.
+      await expect(engine.unlock()).resolves.toBeUndefined();
+      // The first-audio path the gate is meant to protect: build a
+      // sound and forward methods. Must not throw — Howler's global
+      // state remains self-consistent through the unlock call.
+      const handle = engine.createSound({
+        src: [SILENT_WAV],
+        muted: false,
+        onError: () => undefined,
+      });
+      expect(() => {
+        const playId = handle.play();
+        handle.stop(playId);
+        handle.unload();
+      }).not.toThrow();
+    });
+
+    // Cycle-3 review (class finding "Howler unlock resolves even
+    // when no audio backend was unlocked") closes the fail-open
+    // branches the cycle-2 fix still left behind. Under simulated
+    // "Web Audio path, no ctx, Howler setup fails" the unlock now
+    // REJECTS — not silently resolves — so the workbench gate
+    // surfaces a navigation error and the lifecycle never starts.
+    it('rejects when the Web Audio path cannot produce a usable AudioContext', async () => {
+      const { Howler } = await import('howler');
+      const howlerHandle = Howler as unknown as {
+        ctx: AudioContext | null | undefined;
+        usingWebAudio: boolean | undefined;
+        noAudio: boolean | undefined;
+      };
+      const originalCtx = howlerHandle.ctx;
+      const originalUsing = howlerHandle.usingWebAudio;
+      const originalNo = howlerHandle.noAudio;
+      // Simulate "browser-like: Web Audio claimed, no ctx yet".
+      // Under Node, the seed-Howl construction throws (no `Audio` /
+      // `AudioContext`) — the new code surfaces that as a rejection.
+      howlerHandle.ctx = null;
+      howlerHandle.noAudio = false;
+      howlerHandle.usingWebAudio = true;
+      try {
+        const engine = createHowlerAudioEngine();
+        await expect(engine.unlock()).rejects.toThrow(/audio unlock:/);
+      } finally {
+        howlerHandle.ctx = originalCtx;
+        howlerHandle.usingWebAudio = originalUsing;
+        howlerHandle.noAudio = originalNo;
+      }
+    });
+
+    // HTML5 audio fallback path: Howler falls back to `<audio>`
+    // elements when Web Audio is unavailable. HTML5 is also subject
+    // to browser autoplay policy, so the gate must perform an HTML5-
+    // compatible unlock. When `globalThis.Audio` exists, `unlock()`
+    // plays a silent muted Audio element to satisfy the policy; when
+    // it does NOT, `unlock()` rejects so the gate fails closed.
+    it('exercises the HTML5 unlock path when usingWebAudio is false and globalThis.Audio is available', async () => {
+      const { Howler } = await import('howler');
+      const howlerHandle = Howler as unknown as {
+        usingWebAudio: boolean | undefined;
+        noAudio: boolean | undefined;
+      };
+      const globalHandle = globalThis as unknown as {
+        Audio: { new (src?: string): HTMLAudioElement } | undefined;
+      };
+      const originalUsing = howlerHandle.usingWebAudio;
+      const originalNo = howlerHandle.noAudio;
+      const originalAudio = globalHandle.Audio;
+      let constructedSrc: string | undefined;
+      let playCalled = 0;
+      let pauseCalled = 0;
+      let muted = false;
+      const FakeAudio: { new (src?: string): HTMLAudioElement } = new Proxy(
+        class {} as unknown as { new (): HTMLAudioElement },
+        {
+          construct(_target, args) {
+            constructedSrc = args[0] as string | undefined;
+            return {
+              play: () => {
+                playCalled += 1;
+                return Promise.resolve();
+              },
+              pause: () => {
+                pauseCalled += 1;
+              },
+              get muted() {
+                return muted;
+              },
+              set muted(value: boolean) {
+                muted = value;
+              },
+            } as unknown as HTMLAudioElement;
+          },
+        },
+      );
+      howlerHandle.usingWebAudio = false;
+      howlerHandle.noAudio = false;
+      globalHandle.Audio = FakeAudio;
+      try {
+        const engine = createHowlerAudioEngine();
+        await expect(engine.unlock()).resolves.toBeUndefined();
+        expect(constructedSrc).toMatch(/^data:audio\/wav;base64,/);
+        expect(playCalled).toBe(1);
+        expect(pauseCalled).toBe(1);
+        expect(muted).toBe(true);
+      } finally {
+        howlerHandle.usingWebAudio = originalUsing;
+        howlerHandle.noAudio = originalNo;
+        globalHandle.Audio = originalAudio;
+      }
+    });
+
+    it('rejects when usingWebAudio is false and globalThis.Audio is missing', async () => {
+      const { Howler } = await import('howler');
+      const howlerHandle = Howler as unknown as {
+        usingWebAudio: boolean | undefined;
+        noAudio: boolean | undefined;
+      };
+      const globalHandle = globalThis as unknown as {
+        Audio: { new (src?: string): HTMLAudioElement } | undefined;
+      };
+      const originalUsing = howlerHandle.usingWebAudio;
+      const originalNo = howlerHandle.noAudio;
+      const originalAudio = globalHandle.Audio;
+      howlerHandle.usingWebAudio = false;
+      howlerHandle.noAudio = false;
+      globalHandle.Audio = undefined;
+      try {
+        const engine = createHowlerAudioEngine();
+        await expect(engine.unlock()).rejects.toThrow(/audio unlock:.*HTML5/);
+      } finally {
+        howlerHandle.usingWebAudio = originalUsing;
+        howlerHandle.noAudio = originalNo;
+        globalHandle.Audio = originalAudio;
+      }
+    });
+
+    it('resumes an already-constructed Howler AudioContext when one exists', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { Howler } = await import('howler');
+      const howlerHandle = Howler as unknown as {
+        ctx: AudioContext | null | undefined;
+        usingWebAudio: boolean | undefined;
+        noAudio: boolean | undefined;
+      };
+      const originalCtx = howlerHandle.ctx;
+      const originalUsing = howlerHandle.usingWebAudio;
+      const originalNo = howlerHandle.noAudio;
+      let resumeCalled = 0;
+      const fakeCtx: AudioContext = {
+        resume: () => {
+          resumeCalled += 1;
+          return Promise.resolve();
+        },
+      } as unknown as AudioContext;
+      howlerHandle.ctx = fakeCtx;
+      howlerHandle.usingWebAudio = true;
+      howlerHandle.noAudio = false;
+      try {
+        const engine = createHowlerAudioEngine();
+        await engine.unlock();
+        expect(resumeCalled).toBe(1);
+      } finally {
+        howlerHandle.ctx = originalCtx;
+        howlerHandle.usingWebAudio = originalUsing;
+        howlerHandle.noAudio = originalNo;
+      }
+    });
+
+    it('is a no-op when noAudio is true (Howler running with audio disabled)', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { Howler } = await import('howler');
+      const howlerHandle = Howler as unknown as {
+        ctx: AudioContext | null | undefined;
+        noAudio: boolean | undefined;
+      };
+      const originalCtx = howlerHandle.ctx;
+      const originalNo = howlerHandle.noAudio;
+      let resumeCalled = 0;
+      const fakeCtx: AudioContext = {
+        resume: () => {
+          resumeCalled += 1;
+          return Promise.resolve();
+        },
+      } as unknown as AudioContext;
+      howlerHandle.ctx = fakeCtx;
+      howlerHandle.noAudio = true;
+      try {
+        const engine = createHowlerAudioEngine();
+        await engine.unlock();
+        expect(resumeCalled).toBe(0);
+      } finally {
+        howlerHandle.ctx = originalCtx;
+        howlerHandle.noAudio = originalNo;
+      }
+    });
+  });
+});
+
+describe('noopAudioEngine.unlock (PUL-F030 / ADR-029)', () => {
+  it('resolves immediately', async () => {
+    await expect(noopAudioEngine.unlock()).resolves.toBeUndefined();
   });
 });

--- a/tests/runtime/audio-engine.test.ts
+++ b/tests/runtime/audio-engine.test.ts
@@ -100,6 +100,43 @@ describe('createHowlerAudioEngine (Howler boundary)', () => {
       await expect(engine.unlock()).resolves.toBeUndefined();
     });
 
+    // Idempotency on the Web Audio branch: a real-context fake records
+    // every `resume()` call. The Node `noAudio` early-return wouldn't
+    // catch a regression that breaks the Web Audio path on the second
+    // invocation, so we exercise the branch directly here.
+    it('calls AudioContext.resume() on every invocation when a Web Audio context exists', async () => {
+      const { Howler } = await import('howler');
+      const howlerHandle = Howler as unknown as {
+        ctx: AudioContext | null | undefined;
+        usingWebAudio: boolean | undefined;
+        noAudio: boolean | undefined;
+      };
+      const originalCtx = howlerHandle.ctx;
+      const originalUsing = howlerHandle.usingWebAudio;
+      const originalNo = howlerHandle.noAudio;
+      let resumeCalled = 0;
+      const fakeCtx: AudioContext = {
+        resume: () => {
+          resumeCalled += 1;
+          return Promise.resolve();
+        },
+      } as unknown as AudioContext;
+      howlerHandle.ctx = fakeCtx;
+      howlerHandle.usingWebAudio = true;
+      howlerHandle.noAudio = false;
+      try {
+        const engine = createHowlerAudioEngine();
+        await engine.unlock();
+        await engine.unlock();
+        await engine.unlock();
+        expect(resumeCalled).toBe(3);
+      } finally {
+        howlerHandle.ctx = originalCtx;
+        howlerHandle.usingWebAudio = originalUsing;
+        howlerHandle.noAudio = originalNo;
+      }
+    });
+
     // Codex review cycle 2 (one-off "Direct Howler.ctx assignment
     // bypasses Howler setup"): the cycle-1 fix pre-set `Howler.ctx`
     // directly and skipped Howler's `_setup()`, which left

--- a/tests/runtime/audio-unlock-dom.test.ts
+++ b/tests/runtime/audio-unlock-dom.test.ts
@@ -1,0 +1,197 @@
+// Tests for the workbench DOM-backed audio-unlock adapter — PUL-F030
+// / ADR-029. The codex cycle-3 review flagged that the inline adapter
+// in `src/main.ts` was not covered by the gate test suite; this file
+// pins the click/abort/cleanup contract against the factory shape
+// (`src/runtime/audio-unlock-dom.ts`) so `main.ts`'s thin wiring stays
+// the only untestable surface (it just supplies `document.createElement`
+// and `document.querySelector('#stage')`).
+
+import { describe, expect, it } from 'vitest';
+import {
+  type DomAudioUnlockHost,
+  type UnlockButtonElement,
+  type UnlockMount,
+  createDomAudioUnlockAdapter,
+} from '../../src/runtime/audio-unlock-dom';
+import type { AudioUnlockContext } from '../../src/runtime/scene-loader';
+
+interface FakeButton extends UnlockButtonElement {
+  click(): void;
+  readonly removeCount: () => number;
+}
+
+const buildFakeButton = (): FakeButton => {
+  let clickHandler: (() => void) | null = null;
+  let removeCount = 0;
+  return {
+    addEventListener(_event: 'click', handler: () => void): void {
+      clickHandler = handler;
+    },
+    removeEventListener(): void {
+      clickHandler = null;
+    },
+    remove(): void {
+      removeCount += 1;
+    },
+    click(): void {
+      clickHandler?.();
+    },
+    removeCount: () => removeCount,
+  };
+};
+
+interface FakeMount {
+  readonly mount: UnlockMount;
+  readonly appended: readonly UnlockButtonElement[];
+}
+
+const buildFakeMount = (): FakeMount => {
+  const appended: UnlockButtonElement[] = [];
+  return {
+    mount: (node) => {
+      appended.push(node);
+    },
+    get appended(): readonly UnlockButtonElement[] {
+      return appended;
+    },
+  };
+};
+
+const buildGate = (
+  unlockBehavior: 'resolve' | 'reject' | 'park' = 'resolve',
+): {
+  readonly gate: AudioUnlockContext;
+  readonly controller: AbortController;
+  readonly unlockCalls: () => number;
+  readonly resolveUnlock: () => void;
+  readonly rejectUnlock: (err: Error) => void;
+} => {
+  let unlockCalls = 0;
+  const controller = new AbortController();
+  let resolveUnlock: () => void = () => undefined;
+  let rejectUnlock: (err: Error) => void = () => undefined;
+  return {
+    controller,
+    unlockCalls: () => unlockCalls,
+    resolveUnlock: () => resolveUnlock(),
+    rejectUnlock: (err) => rejectUnlock(err),
+    gate: {
+      compositionId: 'show',
+      sceneIds: Object.freeze(['scene-a']),
+      signal: controller.signal,
+      unlock: () => {
+        unlockCalls += 1;
+        if (unlockBehavior === 'resolve') return Promise.resolve();
+        if (unlockBehavior === 'reject') return Promise.reject(new Error('unlock failed'));
+        return new Promise<void>((res, rej) => {
+          resolveUnlock = res;
+          rejectUnlock = rej;
+        });
+      },
+    },
+  };
+};
+
+const buildHost = (
+  mount: UnlockMount | null,
+  button: FakeButton,
+): DomAudioUnlockHost & { readonly button: FakeButton } => ({
+  mount,
+  createButton: () => button,
+  button,
+});
+
+const hostFromFake = (
+  fake: FakeMount,
+  button: FakeButton,
+): DomAudioUnlockHost & { readonly button: FakeButton } => buildHost(fake.mount, button);
+
+describe('createDomAudioUnlockAdapter (PUL-F030 / ADR-029)', () => {
+  it('rejects immediately when mount is null (no gesture surface available)', async () => {
+    const adapter = createDomAudioUnlockAdapter({
+      mount: null,
+      createButton: () => buildFakeButton(),
+    });
+    const { gate } = buildGate('resolve');
+    await expect(adapter(gate)).rejects.toThrow(/no mount element/);
+  });
+
+  it('rejects immediately when the navigation signal is already aborted', async () => {
+    const button = buildFakeButton();
+    const mount = buildFakeMount();
+    const adapter = createDomAudioUnlockAdapter(hostFromFake(mount, button));
+    const { gate, controller } = buildGate('resolve');
+    controller.abort();
+    await expect(adapter(gate)).rejects.toThrow(/aborted/);
+    expect(mount.appended).toHaveLength(0);
+  });
+
+  it('mounts the button, awaits the click, calls gate.unlock(), removes the button, and resolves', async () => {
+    const button = buildFakeButton();
+    const mount = buildFakeMount();
+    const adapter = createDomAudioUnlockAdapter(hostFromFake(mount, button));
+    const { gate, unlockCalls } = buildGate('resolve');
+    const promise = adapter(gate);
+    expect(mount.appended).toEqual([button]);
+    expect(unlockCalls()).toBe(0);
+    button.click();
+    await expect(promise).resolves.toBeUndefined();
+    expect(unlockCalls()).toBe(1);
+    expect(button.removeCount()).toBe(1);
+  });
+
+  it('rejects with the gate.unlock() error when the engine unlock rejects, and removes the button', async () => {
+    const button = buildFakeButton();
+    const mount = buildFakeMount();
+    const adapter = createDomAudioUnlockAdapter(hostFromFake(mount, button));
+    const { gate } = buildGate('reject');
+    const promise = adapter(gate);
+    button.click();
+    await expect(promise).rejects.toThrow(/unlock failed/);
+    expect(button.removeCount()).toBe(1);
+  });
+
+  it('rejects when the signal aborts while waiting for the user gesture, and removes the button', async () => {
+    const button = buildFakeButton();
+    const mount = buildFakeMount();
+    const adapter = createDomAudioUnlockAdapter(hostFromFake(mount, button));
+    const { gate, controller } = buildGate('park');
+    const promise = adapter(gate);
+    controller.abort();
+    await expect(promise).rejects.toThrow(/aborted/);
+    expect(button.removeCount()).toBe(1);
+  });
+
+  it('rejects when the signal aborts while gate.unlock() is pending (abort wins the race)', async () => {
+    const button = buildFakeButton();
+    const mount = buildFakeMount();
+    const adapter = createDomAudioUnlockAdapter(hostFromFake(mount, button));
+    const { gate, controller, unlockCalls, resolveUnlock } = buildGate('park');
+    const promise = adapter(gate);
+    button.click();
+    expect(unlockCalls()).toBe(1);
+    // gate.unlock() is parked; now abort the navigation.
+    controller.abort();
+    // The unlock then-callback should bail on `settled` when it later
+    // resolves; verify the adapter rejects via the abort path.
+    await expect(promise).rejects.toThrow(/aborted/);
+    // Even if we now resolve the pending unlock, the adapter has
+    // already settled — no double-resolve, no further side effect.
+    resolveUnlock();
+    expect(button.removeCount()).toBe(1);
+  });
+
+  it('ignores the unlock resolution when the adapter already settled via abort', async () => {
+    const button = buildFakeButton();
+    const mount = buildFakeMount();
+    const adapter = createDomAudioUnlockAdapter(hostFromFake(mount, button));
+    const { gate, controller, resolveUnlock } = buildGate('park');
+    const promise = adapter(gate);
+    button.click();
+    controller.abort();
+    // Now resolve the engine-bound unlock AFTER abort — the adapter
+    // should remain rejected with the abort error.
+    resolveUnlock();
+    await expect(promise).rejects.toThrow(/aborted/);
+  });
+});

--- a/tests/runtime/audio.test.ts
+++ b/tests/runtime/audio.test.ts
@@ -94,6 +94,7 @@ const fakeEngine = (): FakeEngine => {
         masterMuted = muted;
       },
       isMasterMuted: () => masterMuted,
+      unlock: () => Promise.resolve(),
     },
   };
 };
@@ -244,7 +245,7 @@ describe('createAudioService — load (C2 register a sound)', () => {
     expect(() => service.load('d', { src: 'data:audio/wav;base64,AAAA' })).not.toThrow();
   });
 
-  describe('allowedSources — ADR-008 #5 (audio is declared in scene.assets)', () => {
+  describe('allowedSources — PUL-F030 / ADR-029 (audio is declared in scene.audio)', () => {
     it('rejects a source not in allowedSources', () => {
       const { service } = buildService({ allowedSources: ['/audio/bed.mp3'] });
       expect(() => service.load('bed', { src: '/audio/bed.mp3' })).not.toThrow();
@@ -260,7 +261,7 @@ describe('createAudioService — load (C2 register a sound)', () => {
 
     it('still applies the default scheme allowlist even when in allowedSources (defense-in-depth)', () => {
       // A weak / no-op preloader could declare a non-default-scheme URL
-      // in `scene.assets`; audio refuses it regardless because the
+      // in `scene.audio`; audio refuses it regardless because the
       // audio service runs its own scheme check on top of membership.
       const { service } = buildService({ allowedSources: ['file:///etc/passwd.mp3'] });
       expect(() => service.load('x', { src: 'file:///etc/passwd.mp3' })).toThrow(AudioSourceError);

--- a/tests/runtime/composition-resolver.test.ts
+++ b/tests/runtime/composition-resolver.test.ts
@@ -34,6 +34,7 @@ const scene = (id: string, hooks: HookOverrides = {}): SceneModule => ({
   tags: [],
   assets: [],
   captions: [],
+  audio: [],
   defaultNext: null,
   standalone: true,
   trailerSafe: false,

--- a/tests/runtime/prompter.test.ts
+++ b/tests/runtime/prompter.test.ts
@@ -25,6 +25,7 @@ const buildScene = (opts: BuildSceneOpts): SceneModule => ({
   tags: [],
   assets: [],
   captions: opts.captions ?? [],
+  audio: [],
   defaultNext: null,
   standalone: true,
   trailerSafe: false,

--- a/tests/runtime/registry.test.ts
+++ b/tests/runtime/registry.test.ts
@@ -10,6 +10,7 @@ const buildScene = (overrides: Partial<SceneModule> = {}): SceneModule => ({
   tags: [],
   assets: [],
   captions: [],
+  audio: [],
   defaultNext: null,
   standalone: true,
   trailerSafe: false,

--- a/tests/runtime/scene-loader-audio.test.ts
+++ b/tests/runtime/scene-loader-audio.test.ts
@@ -796,6 +796,11 @@ const presentCompositionTarget = (composition: string): NavigationTarget => ({
   mode: 'present',
 });
 
+const presentCompositionSceneTarget = (composition: string, scene: string): NavigationTarget => ({
+  locator: { kind: 'composition-scene', composition, scene },
+  mode: 'present',
+});
+
 describe('scene loader — PUL-F030 audio unlock gate (ADR-029)', () => {
   describe('gate triggers', () => {
     it('awaits the unlock adapter BEFORE preload/create/timeline run, then runs lifecycle in order once the gate resolves', async () => {
@@ -1116,7 +1121,33 @@ describe('scene loader — PUL-F030 audio unlock gate (ADR-029)', () => {
       await loader.idle();
       expect(calls).toHaveLength(1);
     });
+
+    // Pin every present-mode composition-navigation shape: bare
+    // `?composition=...&mode=present`, `?composition=...&scene=...&mode=present`
+    // (id-locator), and `?composition=...&index=...&mode=present`
+    // (positional). All three should trigger the gate when the
+    // resolved slice declares audio.
+    it.each<['composition' | 'composition-scene' | 'composition-index', NavigationTarget]>([
+      ['composition', presentCompositionTarget('show')],
+      ['composition-scene', presentCompositionSceneTarget('show', 'a')],
+      ['composition-index', presentTarget('show', 0)],
+    ])('invokes the adapter for present-mode locator kind=%s', async (_kind, target) => {
+      const audio = recordingAudioEngine();
+      const a = audioScene('a');
+      const { adapter, calls } = buildRecordingUnlockAdapter('resolve');
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([a]),
+        compositions: createCompositionRegistry([{ id: 'show', manifest: ['a'] }]),
+        stage: null,
+        buildCtx: stubCtx,
+        createPreloader: () => () => Promise.resolve(),
+        timeline: noopTimeline,
+        audioEngine: audio.engine,
+        audioUnlockAdapter: adapter,
+      });
+      await loader.handle(target);
+      await loader.idle();
+      expect(calls).toHaveLength(1);
+    });
   });
 });
-// Reference presentTarget so it's exercised by composition-index path tests if added later.
-void presentTarget;

--- a/tests/runtime/scene-loader-audio.test.ts
+++ b/tests/runtime/scene-loader-audio.test.ts
@@ -87,6 +87,7 @@ const recordingAudioEngine = (): RecordingEngine => {
         masterMuted = muted;
       },
       isMasterMuted: () => masterMuted,
+      unlock: () => Promise.resolve(),
     },
   };
 };
@@ -105,6 +106,7 @@ describe('scene loader — audio service wiring (PUL-F024 / ADR-004)', () => {
     const scene = buildScene({
       id: 'a',
       assets: ['/audio/bed.mp3'],
+      audio: ['/audio/bed.mp3'],
       create: (ctx) => {
         const a = (ctx as { audio?: AudioService }).audio;
         seen.push({ phase: 'create', audio: a });
@@ -151,6 +153,7 @@ describe('scene loader — audio service wiring (PUL-F024 / ADR-004)', () => {
     const long = buildScene({
       id: 'long',
       assets: ['/audio/bed.mp3'],
+      audio: ['/audio/bed.mp3'],
       create: (ctx) => {
         captured = (ctx as { audio: AudioService }).audio;
         captured.load('bed', { src: '/audio/bed.mp3' });
@@ -217,6 +220,7 @@ describe('scene loader — audio service wiring (PUL-F024 / ADR-004)', () => {
       const scene = buildScene({
         id: 'a',
         assets: ['/audio/bed.mp3'],
+        audio: ['/audio/bed.mp3'],
         create: (ctx) => {
           (ctx as { audio: AudioService }).audio.load('bed', { src: '/audio/bed.mp3' });
         },
@@ -245,6 +249,7 @@ describe('scene loader — audio service wiring (PUL-F024 / ADR-004)', () => {
     const scene = buildScene({
       id: 'a',
       assets: ['/audio/bed.mp3'],
+      audio: ['/audio/bed.mp3'],
       create: (ctx) => {
         (ctx as { audio: AudioService }).audio.load('bed', { src: '/audio/bed.mp3' });
       },
@@ -263,15 +268,18 @@ describe('scene loader — audio service wiring (PUL-F024 / ADR-004)', () => {
     expect(audio.created[0]?.muted).toBe(false);
   });
 
-  it('restricts ctx.audio.load() to URLs the slice declared in scene.assets', async () => {
+  it('restricts ctx.audio.load() to URLs the slice declared in scene.audio (PUL-F030 makes the audio list authoritative)', async () => {
     const stage = buildStage();
     const audio = recordingAudioEngine();
     const captured: unknown[] = [];
     const scene = buildScene({
       id: 'a',
       assets: ['/audio/bed.mp3'],
+      audio: ['/audio/bed.mp3'],
       create: (ctx) => {
-        // Not in scene.assets — the per-navigation service rejects it.
+        // Not in scene.audio — the per-navigation service rejects it.
+        // (PUL-F030 / ADR-029: scene.audio is the audio-source allowlist
+        // so the unlock gate cannot be bypassed by undeclared loads.)
         (ctx as { audio: AudioService }).audio.load('typo', { src: '/audio/typo.mp3' });
       },
       cleanup: () => {
@@ -304,11 +312,13 @@ describe('scene loader — audio service wiring (PUL-F024 / ADR-004)', () => {
     expect(stage.attrs.get('data-cleanup-ran')).toBe('yes');
   });
 
-  it('exposes every declared composition-slice asset to ctx.audio under mode=present', async () => {
+  it('exposes every declared composition-slice audio source to ctx.audio under mode=present', async () => {
     const audio = recordingAudioEngine();
+    const { adapter } = buildRecordingUnlockAdapter('resolve');
     const a = buildScene({
       id: 'scene-a',
       assets: ['/audio/a.mp3'],
+      audio: ['/audio/a.mp3'],
       create: (ctx) => {
         (ctx as { audio: AudioService }).audio.load('a-bed', { src: '/audio/a.mp3' });
       },
@@ -316,9 +326,11 @@ describe('scene loader — audio service wiring (PUL-F024 / ADR-004)', () => {
     const b = buildScene({
       id: 'scene-b',
       assets: ['/audio/b.mp3'],
+      audio: ['/audio/b.mp3'],
       create: (ctx) => {
         // `scene-b` may register `scene-a`'s declared URL too — the
-        // slice's declared assets are the union (preloader warmed all).
+        // slice's declared audio sources are the union of every scene's
+        // `audio` list (PUL-F030 makes the audio list authoritative).
         (ctx as { audio: AudioService }).audio.load('a-from-b', { src: '/audio/a.mp3' });
         (ctx as { audio: AudioService }).audio.load('b-bed', { src: '/audio/b.mp3' });
       },
@@ -331,6 +343,7 @@ describe('scene loader — audio service wiring (PUL-F024 / ADR-004)', () => {
       createPreloader: () => () => Promise.resolve(),
       timeline: noopTimeline,
       audioEngine: audio.engine,
+      audioUnlockAdapter: adapter,
     });
     await loader.handle(compositionTarget('pair'));
     await loader.idle();
@@ -370,6 +383,7 @@ describe('scene loader — audio service wiring (PUL-F024 / ADR-004)', () => {
     const scene = buildScene({
       id: 'a',
       assets: ['/audio/bed.mp3'],
+      audio: ['/audio/bed.mp3'],
       create: (ctx) => {
         (ctx as { audio: AudioService }).audio.load('bed', { src: '/audio/bed.mp3' });
         (ctx as { audio: AudioService }).audio.play('bed');
@@ -397,6 +411,7 @@ describe('scene loader — audio service wiring (PUL-F024 / ADR-004)', () => {
     const scene = buildScene({
       id: 'a',
       assets: ['/audio/bed.mp3'],
+      audio: ['/audio/bed.mp3'],
       create: (ctx) => {
         captured = (ctx as { audio: AudioService }).audio;
         // The no-op engine still backs a working service.
@@ -450,6 +465,7 @@ describe('scene loader — mode=rehearsal (PUL-F026 / ADR-004)', () => {
     const scene = buildScene({
       id: 'a',
       assets: ['/audio/bed.mp3'],
+      audio: ['/audio/bed.mp3'],
       create: (ctx) => {
         (ctx as { audio: AudioService }).audio.load('bed', { src: '/audio/bed.mp3' });
       },
@@ -481,6 +497,7 @@ describe('scene loader — mode=rehearsal (PUL-F026 / ADR-004)', () => {
     const scene = buildScene({
       id: 'a',
       assets: ['/audio/bed.mp3'],
+      audio: ['/audio/bed.mp3'],
       create: (ctx) => {
         const x = (ctx as { audio: AudioService }).audio;
         x.load('bed', { src: '/audio/bed.mp3' });
@@ -636,14 +653,15 @@ describe('scene loader — mode=rehearsal (PUL-F026 / ADR-004)', () => {
     expect(seen.some((s) => s.id === 'scene-b')).toBe(true);
   });
 
-  it('exposes every declared composition-slice asset to ctx.audio under mode=rehearsal', async () => {
+  it('exposes every declared composition-slice audio source to ctx.audio under mode=rehearsal', async () => {
     // Rehearsal preserves the full slice, so the audio service's
-    // allowedSources is the union of every scene's `scene.assets` —
+    // allowedSources is the union of every scene's `scene.audio` —
     // same invariant as `mode=present`. A scene further down the slice
     // can register a sibling scene's declared URL.
     const a = buildScene({
       id: 'scene-a',
       assets: ['/audio/a.mp3'],
+      audio: ['/audio/a.mp3'],
       create: (ctx) => {
         (ctx as { audio: AudioService }).audio.load('a-bed', { src: '/audio/a.mp3' });
       },
@@ -651,6 +669,7 @@ describe('scene loader — mode=rehearsal (PUL-F026 / ADR-004)', () => {
     const b = buildScene({
       id: 'scene-b',
       assets: ['/audio/b.mp3'],
+      audio: ['/audio/b.mp3'],
       create: (ctx) => {
         (ctx as { audio: AudioService }).audio.load('a-from-b', { src: '/audio/a.mp3' });
         (ctx as { audio: AudioService }).audio.load('b-bed', { src: '/audio/b.mp3' });
@@ -697,3 +716,407 @@ describe('scene loader — mode=rehearsal (PUL-F026 / ADR-004)', () => {
 });
 
 type WorkbenchSceneCtxLike = { readonly mode?: string };
+
+/* ===================================================================== *
+ *  PUL-F030 / ADR-029 — Present-mode audio unlock gate.
+ *
+ *  Gate triggers when:
+ *    - `effectiveMode(target) === 'present'` (URL absent mode collapses
+ *      to 'present', mirroring ADR-007); AND
+ *    - the resolved target carries a composition slice (composition
+ *      navigation, not a direct `?scene=...&mode=present`); AND
+ *    - at least one scene in `sceneSlice` declares audio via the
+ *      static `scene.audio` field (PUL-F030 declaration predicate).
+ *
+ *  When the gate triggers AND an `audioUnlockAdapter` is supplied,
+ *  the loader awaits the adapter — passing semantic composition
+ *  context, the navigation `AbortSignal`, and an engine-bound
+ *  `unlock()` callback — BEFORE any lifecycle work begins.
+ *
+ *  When the gate triggers AND no adapter is supplied, the loader
+ *  surfaces a navigation error and skips the lifecycle (no
+ *  inert-seam degradation here — the gate IS the structural
+ *  defense PUL-F030 records).
+ * ===================================================================== */
+
+interface GateCall {
+  readonly compositionId: string;
+  readonly sceneIds: readonly string[];
+  readonly signal: AbortSignal;
+  readonly unlock: () => Promise<void>;
+}
+
+const buildRecordingUnlockAdapter = (
+  behavior: 'resolve' | 'reject' | 'park' = 'resolve',
+  err: Error | null = null,
+): {
+  readonly adapter: import('../../src/runtime/scene-loader').AudioUnlockAdapter;
+  readonly calls: GateCall[];
+  readonly releaseGate: () => void;
+} => {
+  const calls: GateCall[] = [];
+  let release: () => void = () => undefined;
+  return {
+    calls,
+    releaseGate: () => release(),
+    adapter: (gate) => {
+      calls.push(gate);
+      if (behavior === 'resolve') return Promise.resolve();
+      if (behavior === 'reject') {
+        return Promise.reject(err ?? new Error('unlock adapter rejected'));
+      }
+      return new Promise<void>((resolve, reject) => {
+        release = () => resolve();
+        if (gate.signal.aborted) reject(new Error('aborted before gate released'));
+        else
+          gate.signal.addEventListener(
+            'abort',
+            () => reject(new Error('aborted before gate released')),
+            { once: true },
+          );
+      });
+    },
+  };
+};
+
+const audioScene = (id: string): import('../../src/runtime/scene').SceneModule =>
+  buildScene({
+    id,
+    assets: [`/audio/${id}.mp3`],
+    audio: [`/audio/${id}.mp3`],
+  });
+
+const presentTarget = (composition: string, index = 0): NavigationTarget => ({
+  locator: { kind: 'composition-index', composition, index },
+  mode: 'present',
+});
+
+const presentCompositionTarget = (composition: string): NavigationTarget => ({
+  locator: { kind: 'composition', composition },
+  mode: 'present',
+});
+
+describe('scene loader — PUL-F030 audio unlock gate (ADR-029)', () => {
+  describe('gate triggers', () => {
+    it('awaits the unlock adapter BEFORE preload/create/timeline run, then runs lifecycle in order once the gate resolves', async () => {
+      // Codex review cycle 1 (one-off "gate ordering test never
+      // releases or awaits the parked gate"): both halves of the
+      // ordering contract must be verified — (a) lifecycle has NOT
+      // started while the gate is parked, AND (b) lifecycle DOES
+      // start, in the canonical preload/create/timeline/cleanup
+      // order, after the gate resolves. A test that asserts only
+      // (a) would still pass if a regression made the loader
+      // permanently stop after unlock; releasing the gate and
+      // awaiting the navigation exercises both halves.
+      const order: string[] = [];
+      const audio = recordingAudioEngine();
+      const scene = audioScene('intro');
+      const { adapter, calls, releaseGate } = buildRecordingUnlockAdapter('park');
+      const sceneWithHooks: import('../../src/runtime/scene').SceneModule = {
+        ...scene,
+        create: () => {
+          order.push('create');
+        },
+        timeline: () => {
+          order.push('timeline');
+          return null;
+        },
+        cleanup: () => {
+          order.push('cleanup');
+        },
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneWithHooks]),
+        compositions: createCompositionRegistry([{ id: 'show', manifest: ['intro'] }]),
+        stage: null,
+        buildCtx: stubCtx,
+        createPreloader: () => (): Promise<void> => {
+          order.push('preload');
+          return Promise.resolve();
+        },
+        timeline: noopTimeline,
+        audioEngine: audio.engine,
+        audioUnlockAdapter: adapter,
+      });
+      const pending = loader.handle(presentCompositionTarget('show'));
+      // Yield the microtask so the gate adapter has been invoked.
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(calls).toHaveLength(1);
+      // Gate parked — no lifecycle phase has run yet.
+      expect(order).toEqual([]);
+      // Release the gate; the lifecycle now proceeds.
+      releaseGate();
+      await pending;
+      await loader.idle();
+      // Lifecycle ran AFTER the gate, in the canonical order.
+      expect(order).toEqual(['preload', 'create', 'timeline', 'cleanup']);
+    });
+
+    it('passes semantic composition context and a one-shot unlock callback to the adapter', async () => {
+      const audio = recordingAudioEngine();
+      const a = audioScene('a');
+      const b = buildScene({ id: 'b' }); // declares no audio
+      const c = audioScene('c');
+      const { adapter, calls } = buildRecordingUnlockAdapter('resolve');
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([a, b, c]),
+        compositions: createCompositionRegistry([{ id: 'show', manifest: ['a', 'b', 'c'] }]),
+        stage: null,
+        buildCtx: stubCtx,
+        createPreloader: () => () => Promise.resolve(),
+        timeline: noopTimeline,
+        audioEngine: audio.engine,
+        audioUnlockAdapter: adapter,
+      });
+      await loader.handle(presentCompositionTarget('show'));
+      await loader.idle();
+      expect(calls).toHaveLength(1);
+      const gate = calls[0];
+      if (gate === undefined) throw new Error('gate not called');
+      expect(gate.compositionId).toBe('show');
+      expect(gate.sceneIds).toEqual(['a', 'b', 'c']);
+      // The signal exists and is NOT aborted (lifecycle completed).
+      expect(typeof gate.signal.aborted).toBe('boolean');
+      // Adapter received an `unlock` callback that, when called,
+      // forwards to engine.unlock() — but we don't call it here in
+      // the success path; that's covered by the "adapter calls
+      // engine.unlock" test below.
+      expect(typeof gate.unlock).toBe('function');
+    });
+
+    it("forwards the adapter's unlock() to engine.unlock() exactly when called", async () => {
+      const audio = recordingAudioEngine();
+      let unlockInvocations = 0;
+      const customEngine: typeof audio.engine = {
+        ...audio.engine,
+        unlock: () => {
+          unlockInvocations += 1;
+          return Promise.resolve();
+        },
+      };
+      let captured: GateCall | undefined;
+      const adapter: import('../../src/runtime/scene-loader').AudioUnlockAdapter = async (gate) => {
+        captured = gate;
+        await gate.unlock();
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([audioScene('a')]),
+        compositions: createCompositionRegistry([{ id: 'show', manifest: ['a'] }]),
+        stage: null,
+        buildCtx: stubCtx,
+        createPreloader: () => () => Promise.resolve(),
+        timeline: noopTimeline,
+        audioEngine: customEngine,
+        audioUnlockAdapter: adapter,
+      });
+      await loader.handle(presentCompositionTarget('show'));
+      await loader.idle();
+      expect(captured).toBeDefined();
+      expect(unlockInvocations).toBe(1);
+    });
+
+    it('surfaces an adapter rejection through onError and data-pulsar-navigation-error, skipping lifecycle', async () => {
+      const audio = recordingAudioEngine();
+      const stage = buildStage();
+      const errors: unknown[] = [];
+      let createCalled = false;
+      const scene: import('../../src/runtime/scene').SceneModule = {
+        ...audioScene('a'),
+        create: () => {
+          createCalled = true;
+        },
+      };
+      const { adapter } = buildRecordingUnlockAdapter(
+        'reject',
+        new Error('user dismissed gesture'),
+      );
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([scene]),
+        compositions: createCompositionRegistry([{ id: 'show', manifest: ['a'] }]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => Promise.resolve(),
+        timeline: noopTimeline,
+        audioEngine: audio.engine,
+        audioUnlockAdapter: adapter,
+        onError: (e) => {
+          errors.push(e);
+        },
+      });
+      await loader.handle(presentCompositionTarget('show'));
+      await loader.idle();
+      expect(createCalled).toBe(false);
+      expect(errors).toHaveLength(1);
+      expect((errors[0] as Error).message).toMatch(/user dismissed gesture/);
+      expect(stage.attrs.get('data-pulsar-navigation-error')).toMatch(/user dismissed gesture/);
+    });
+
+    it('fails loud when the gate applies but no audioUnlockAdapter is supplied', async () => {
+      const audio = recordingAudioEngine();
+      const stage = buildStage();
+      const errors: unknown[] = [];
+      let createCalled = false;
+      const scene: import('../../src/runtime/scene').SceneModule = {
+        ...audioScene('a'),
+        create: () => {
+          createCalled = true;
+        },
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([scene]),
+        compositions: createCompositionRegistry([{ id: 'show', manifest: ['a'] }]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => Promise.resolve(),
+        timeline: noopTimeline,
+        audioEngine: audio.engine,
+        // audioUnlockAdapter intentionally omitted
+        onError: (e) => {
+          errors.push(e);
+        },
+      });
+      await loader.handle(presentCompositionTarget('show'));
+      await loader.idle();
+      expect(createCalled).toBe(false);
+      expect(errors.length).toBeGreaterThan(0);
+      expect((errors[0] as Error).message).toMatch(/audio unlock/i);
+      expect(stage.attrs.get('data-pulsar-navigation-error')).toMatch(/audio unlock/i);
+    });
+
+    it('aborts the adapter on supersession (signal fires; lifecycle never starts)', async () => {
+      const audio = recordingAudioEngine();
+      const a = audioScene('a');
+      const b = buildScene({ id: 'b' });
+      let createA = false;
+      const aWithHook: import('../../src/runtime/scene').SceneModule = {
+        ...a,
+        create: () => {
+          createA = true;
+        },
+      };
+      const { adapter, calls } = buildRecordingUnlockAdapter('park');
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([aWithHook, b]),
+        compositions: createCompositionRegistry([{ id: 'show', manifest: ['a'] }]),
+        stage: null,
+        buildCtx: stubCtx,
+        createPreloader: () => () => Promise.resolve(),
+        timeline: noopTimeline,
+        audioEngine: audio.engine,
+        audioUnlockAdapter: adapter,
+      });
+      const firstNav = loader.handle(presentCompositionTarget('show'));
+      // Let the gate be invoked.
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(calls).toHaveLength(1);
+      const gate = calls[0];
+      if (gate === undefined) throw new Error('gate not called');
+      expect(gate.signal.aborted).toBe(false);
+      // Supersede with a no-gate navigation.
+      await loader.handle(sceneTarget('b'));
+      await firstNav.catch(() => undefined);
+      await loader.idle();
+      expect(gate.signal.aborted).toBe(true);
+      expect(createA).toBe(false);
+    });
+  });
+
+  describe('gate bypass cases', () => {
+    it('does not invoke the adapter for a present-mode single-scene target (no composition)', async () => {
+      const audio = recordingAudioEngine();
+      const scene = audioScene('a');
+      const { adapter, calls } = buildRecordingUnlockAdapter('resolve');
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([scene]),
+        compositions: createCompositionRegistry([]),
+        stage: null,
+        buildCtx: stubCtx,
+        createPreloader: () => () => Promise.resolve(),
+        timeline: noopTimeline,
+        audioEngine: audio.engine,
+        audioUnlockAdapter: adapter,
+      });
+      // `?scene=a&mode=present` — present mode but NOT a composition load.
+      await loader.handle({ locator: { kind: 'scene', scene: 'a' }, mode: 'present' });
+      await loader.idle();
+      expect(calls).toHaveLength(0);
+    });
+
+    it('does not invoke the adapter when no scene in the composition slice declares audio', async () => {
+      const audio = recordingAudioEngine();
+      const a = buildScene({ id: 'a' }); // no audio
+      const b = buildScene({ id: 'b' }); // no audio
+      const { adapter, calls } = buildRecordingUnlockAdapter('resolve');
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([a, b]),
+        compositions: createCompositionRegistry([{ id: 'show', manifest: ['a', 'b'] }]),
+        stage: null,
+        buildCtx: stubCtx,
+        createPreloader: () => () => Promise.resolve(),
+        timeline: noopTimeline,
+        audioEngine: audio.engine,
+        audioUnlockAdapter: adapter,
+      });
+      await loader.handle(presentCompositionTarget('show'));
+      await loader.idle();
+      expect(calls).toHaveLength(0);
+    });
+
+    it.each<['rehearsal' | 'screenshot' | 'paused' | 'scrub' | 'loop' | 'standalone' | 'prompter']>(
+      [
+        ['rehearsal'],
+        ['screenshot'],
+        ['paused'],
+        ['scrub'],
+        ['loop'],
+        ['standalone'],
+        ['prompter'],
+      ],
+    )('does not invoke the adapter under mode=%s', async (mode) => {
+      const audio = recordingAudioEngine();
+      const scene = audioScene('a');
+      const { adapter, calls } = buildRecordingUnlockAdapter('resolve');
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([scene]),
+        compositions: createCompositionRegistry([{ id: 'show', manifest: ['a'] }]),
+        stage: null,
+        buildCtx: stubCtx,
+        createPreloader: () => () => Promise.resolve(),
+        timeline: noopTimeline,
+        audioEngine: audio.engine,
+        audioUnlockAdapter: adapter,
+      });
+      const target: NavigationTarget = {
+        locator: { kind: 'composition-index', composition: 'show', index: 0 },
+        mode,
+      };
+      await loader.handle(target);
+      await loader.idle();
+      expect(calls).toHaveLength(0);
+    });
+
+    it('invokes the adapter for an absent-mode composition load (effective mode collapses to present)', async () => {
+      const audio = recordingAudioEngine();
+      const scene = audioScene('a');
+      const { adapter, calls } = buildRecordingUnlockAdapter('resolve');
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([scene]),
+        compositions: createCompositionRegistry([{ id: 'show', manifest: ['a'] }]),
+        stage: null,
+        buildCtx: stubCtx,
+        createPreloader: () => () => Promise.resolve(),
+        timeline: noopTimeline,
+        audioEngine: audio.engine,
+        audioUnlockAdapter: adapter,
+      });
+      // No `mode=` in the target → effectiveMode collapses to 'present'.
+      await loader.handle({ locator: { kind: 'composition', composition: 'show' } });
+      await loader.idle();
+      expect(calls).toHaveLength(1);
+    });
+  });
+});
+// Reference presentTarget so it's exercised by composition-index path tests if added later.
+void presentTarget;

--- a/tests/runtime/scene-loader-present.test.ts
+++ b/tests/runtime/scene-loader-present.test.ts
@@ -1021,6 +1021,7 @@ describe('createSceneLoader — present-mode & presenter seams (PUL-F008)', () =
           muted = m;
         },
         isMasterMuted: () => muted,
+        unlock: () => Promise.resolve(),
       };
     };
 

--- a/tests/runtime/scene-loader.helpers.ts
+++ b/tests/runtime/scene-loader.helpers.ts
@@ -80,6 +80,7 @@ export interface BuildSceneOpts {
   readonly title?: string;
   readonly assets?: readonly string[];
   readonly captions?: readonly Caption[];
+  readonly audio?: readonly string[];
   readonly create?: SceneModule['create'];
   readonly timeline?: SceneModule['timeline'];
   readonly cleanup?: SceneModule['cleanup'];
@@ -92,6 +93,7 @@ export const buildScene = (opts: BuildSceneOpts): SceneModule => ({
   tags: [],
   assets: opts.assets ?? [],
   captions: opts.captions ?? [],
+  audio: opts.audio ?? [],
   defaultNext: null,
   standalone: true,
   trailerSafe: false,

--- a/tests/runtime/scene-navigation.test.ts
+++ b/tests/runtime/scene-navigation.test.ts
@@ -44,6 +44,7 @@ const buildScene = (opts: BuildSceneOpts = {}): SceneModule => ({
   tags: [],
   assets: opts.assets ?? [],
   captions: [],
+  audio: [],
   defaultNext: null,
   standalone: true,
   trailerSafe: false,

--- a/tests/runtime/scene.test.ts
+++ b/tests/runtime/scene.test.ts
@@ -4,6 +4,7 @@ import {
   type SceneModule,
   assertSceneModule,
   isSceneModule,
+  sceneDeclaresAudio,
 } from '../../src/runtime/scene';
 
 const validScene = (): SceneModule => ({
@@ -13,6 +14,7 @@ const validScene = (): SceneModule => ({
   tags: ['act-i'],
   assets: [],
   captions: [],
+  audio: [],
   defaultNext: null,
   standalone: true,
   trailerSafe: false,
@@ -28,6 +30,7 @@ const REQUIRED_FIELDS = [
   'tags',
   'assets',
   'captions',
+  'audio',
   'defaultNext',
   'standalone',
   'trailerSafe',
@@ -374,6 +377,7 @@ describe('SceneModule contract (PUL-F001)', () => {
           { at: 0, text: 'Opening hook.' },
           { at: 4000, text: 'First payoff.' },
         ],
+        audio: ['assets/audio/stinger.mp3'],
         defaultNext: 'scene-a',
         standalone: true,
         trailerSafe: true,
@@ -382,6 +386,87 @@ describe('SceneModule contract (PUL-F001)', () => {
         cleanup: () => undefined,
       };
       expect(() => assertSceneModule(scene)).not.toThrow();
+    });
+  });
+
+  // PUL-F030 / ADR-029: a static audio-declaration field on the scene
+  // schema. The loader/workbench unlock gate, the validation pass
+  // (PUL-F028), and future authoring lints all read this one
+  // predicate, so "this scene declares audio" never depends on file
+  // extension sniffing, MIME guesses, or runtime observation of
+  // `ctx.audio.load()`. Per the preflight, every entry must be in
+  // `scene.assets` so the preloader (PUL-F005) warms it and the audio
+  // service's allowlist accepts it (ADR-008 #5 — `scene.assets` is
+  // the only asset inventory).
+  describe('audio field (PUL-F030 / ADR-029)', () => {
+    it('accepts an empty audio array (scene declares no audio)', () => {
+      expect(() => assertSceneModule(withField('audio', []))).not.toThrow();
+    });
+
+    it('accepts audio entries that are members of scene.assets', () => {
+      const scene = {
+        ...validScene(),
+        assets: ['assets/audio/stinger.mp3', 'assets/img/title.png'],
+        audio: ['assets/audio/stinger.mp3'],
+      };
+      expect(() => assertSceneModule(scene)).not.toThrow();
+    });
+
+    it('rejects a non-array audio field', () => {
+      expect(() => assertSceneModule(withField('audio', 'assets/audio/stinger.mp3'))).toThrow(
+        /audio/,
+      );
+    });
+
+    it('rejects non-string elements in audio', () => {
+      expect(() => assertSceneModule(withField('audio', [42]))).toThrow(/audio/);
+    });
+
+    it('rejects an audio entry that is not in scene.assets', () => {
+      const scene = {
+        ...validScene(),
+        assets: ['assets/audio/stinger.mp3'],
+        audio: ['assets/audio/bed.mp3'],
+      };
+      expect(() => assertSceneModule(scene)).toThrow(/audio/);
+      expect(() => assertSceneModule(scene)).toThrow(/scene\.assets/);
+    });
+
+    it('reports the offending audio entry by index', () => {
+      const scene = {
+        ...validScene(),
+        assets: ['assets/audio/stinger.mp3'],
+        audio: ['assets/audio/stinger.mp3', 'assets/audio/missing.mp3'],
+      };
+      expect(() => assertSceneModule(scene)).toThrow(/audio\[1\]/);
+    });
+
+    it('requires audio to be present', () => {
+      expect(() => assertSceneModule(omitField('audio'))).toThrow(/\baudio\b/);
+    });
+  });
+
+  describe('sceneDeclaresAudio predicate (PUL-F030 / ADR-029)', () => {
+    it('returns false when audio is empty', () => {
+      expect(sceneDeclaresAudio({ ...validScene(), audio: [] })).toBe(false);
+    });
+
+    it('returns true when audio has one entry', () => {
+      const scene: SceneModule = {
+        ...validScene(),
+        assets: ['assets/audio/stinger.mp3'],
+        audio: ['assets/audio/stinger.mp3'],
+      };
+      expect(sceneDeclaresAudio(scene)).toBe(true);
+    });
+
+    it('returns true when audio has multiple entries', () => {
+      const scene: SceneModule = {
+        ...validScene(),
+        assets: ['assets/audio/stinger.mp3', 'assets/audio/bed.mp3'],
+        audio: ['assets/audio/stinger.mp3', 'assets/audio/bed.mp3'],
+      };
+      expect(sceneDeclaresAudio(scene)).toBe(true);
     });
   });
 

--- a/tests/runtime/timeline.test.ts
+++ b/tests/runtime/timeline.test.ts
@@ -73,6 +73,7 @@ const stubScene = (
   tags: [],
   assets: [],
   captions: [],
+  audio: [],
   defaultNext: null,
   standalone: true,
   trailerSafe: false,

--- a/tests/runtime/validation.test.ts
+++ b/tests/runtime/validation.test.ts
@@ -36,6 +36,7 @@ const buildScene = (overrides: Partial<SceneModule> = {}): SceneModule => ({
   tags: [],
   assets: [],
   captions: [],
+  audio: [],
   defaultNext: null,
   standalone: false,
   trailerSafe: false,


### PR DESCRIPTION
## Summary

Implements PUL-F030 — present-mode audio unlock interaction (ADR-029). The runtime SHALL provide a single explicit user-gesture interaction that satisfies browser autoplay policy before a present-mode composition that declares audio begins. Adds a static `scene.audio` field to SceneModule as the single source of truth for audio declarations (also serving as the runtime audio-source allowlist for `ctx.audio.load()`), an `unlock()` method on the audio engine that resumes Howler's AudioContext via the engine's own setup path (HTML5 fallback supported), and an `audioUnlockAdapter` seam on the scene loader that the workbench wires to mount a gesture surface and call the engine unlock before any lifecycle work begins. Supersession aborts the gate; missing adapter fails loud through the existing navigation-error channel.

## Requirement UIDs

- `PUL-F030`

## Related Issues

Closes #39

## ADR Impact

- ADR-029
- ADR-004 (amended)

## Changes

- Add `audio: readonly string[]` to `SceneModule` (PUL-F030 declaration field; subset of `scene.assets`) with a schema-level cross-field membership check and a `sceneDeclaresAudio` predicate.
- Add `unlock(): Promise<void>` to `AudioEngine`. Howler-backed engine triggers Howler's own `_setup` via a throwaway Howl (avoids leaving `Howler.masterGain` null), or unlocks HTML5 audio via a silent `<audio>` element when `usingWebAudio === false`. Fails closed if neither route is usable.
- Add `audioUnlockAdapter` / `AudioUnlockAdapter` / `AudioUnlockContext` to `SceneLoaderOptions`. Gate triggers when `effectiveMode === 'present'` AND a composition slice is resolved AND at least one scene in the slice declares audio. Adapter awaits BEFORE preload / `create(ctx)` / `timeline(ctx)` / master playback. Bound to navigation `AbortSignal`; missing adapter fails loud through `data-pulsar-navigation-error`.
- Make `scene.audio` authoritative for the audio-service source allowlist: `collectAudioSources` now returns `scene.audio` not `scene.assets`, so the unlock-gate predicate and the runtime allowlist agree on one source of truth.
- Extract the workbench DOM gesture surface to `src/runtime/audio-unlock-dom.ts` (`createDomAudioUnlockAdapter` factory) for testability. Production `src/main.ts` wires `document.createElement` and the `#stage` element.
- Add `audio: []` to the placeholder scene and to every existing test fixture that constructs full `SceneModule` shapes.

## Test Plan

- [x] Unit tests pass (`pnpm test`)
- [x] Lint + typecheck pass (`pnpm lint && pnpm typecheck`)
- [x] No coverage regression

- 1025 vitest tests pass (was 996; +29 new tests for PUL-F030 schema, engine unlock, loader gate, and DOM adapter factory).
- `pnpm lint && pnpm typecheck && pnpm test` green.
- Three pre-push codex review cycles completed (4 / 2 / 3 findings, all fixed); cycle-3 fixes were committed without a verification pass per the hard-cap-3 policy and user authorization.

## Traceability

- IMPLEMENTS: PUL-F030 ← src/runtime/scene.ts (audio field + sceneDeclaresAudio), PUL-F030 ← src/runtime/audio.ts (AudioEngine.unlock), PUL-F030 ← src/runtime/scene-loader.ts (audioUnlockAdapter gate), PUL-F030 ← src/runtime/audio-unlock-dom.ts (workbench DOM adapter), PUL-F030 ← src/main.ts (production wiring), PUL-F030 ← docs/adrs/029-present-mode-audio-unlock-gate.md
- TESTS: PUL-F030 ← tests/runtime/scene.test.ts (audio field + predicate), PUL-F030 ← tests/runtime/audio-engine.test.ts (unlock branches: Web Audio, HTML5, fail-close), PUL-F030 ← tests/runtime/scene-loader-audio.test.ts (gate trigger + bypass + supersession + fail-loud), PUL-F030 ← tests/runtime/audio-unlock-dom.test.ts (workbench adapter contract)

## Checklist

- [x] Changelog fragment added at `changelog.d/39.added.md`
- [x] ADRs updated (`docs/adrs/029-present-mode-audio-unlock-gate.md` added; ADR-004 amended in prose)
- [x] Code follows project coding standards