### PR TITLE
Document PUL-Q001 screenshot determinism contract (ADR-007)

### DIFF
--- a/.gc/plan-rules.md
+++ b/.gc/plan-rules.md
@@ -2,7 +2,33 @@
 
 Mandatory constraints the `/implement` skill applies during plan phase.
 
-This file is intentionally empty for the moment. Plan rules will be
-added as the runtime gains concrete subsystems with cross-cutting
-invariants (e.g. scene registration, asset preloading, audio cleanup,
-URL navigation contracts).
+## Screenshot determinism
+
+For `PUL-Q001`, implementation must reuse the canonical runtime
+surfaces from ADR-007:
+
+- Parse and validate `mode=screenshot` through the workbench URL
+  grammar. Do not let scenes parse query strings or define local mode
+  flags.
+- Resolve scenes, compositions, beats, assets, captions, and cleanup
+  through the ADR-002 contracts. Do not add a parallel screenshot
+  manifest or scene schema.
+- Freeze timeline state through the ADR-003 GSAP runtime integration.
+  Do not use wall-clock animation, CSS animation time, timers, or
+  `requestAnimationFrame` time to determine the captured frame.
+- Silence audio through the ADR-004 audio service. Do not add raw
+  screenshot-only `<audio>` handling in scenes.
+- Gate capture readiness on declared asset and font loading. Do not
+  accept remote mutable assets, undeclared fonts, or network-order races
+  as deterministic.
+- Keep entropy runtime-mediated. Screenshot output must not depend on
+  `Date`, `Math.random`, `crypto.getRandomValues`, `performance.now`,
+  local/session storage, cookies, environment variables, or process
+  arguments.
+- Route invalid URL, target, asset, and readiness failures through the
+  existing navigation/error surface. Error envelopes must not echo
+  secrets, credentials, cookies, headers, raw environment values, or raw
+  scene payloads.
+
+Future screenshot variants belong in validated screenshot options beside
+the workbench URL grammar, not in scene-local flags or duplicate schemas.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Screenshot determinism contract — PUL-Q001 / ADR-007 — in
+  `docs/adrs/007-browser-workbench.md`, `.gc/plan-rules.md`, and
+  `tests/runtime/screenshot-determinism-source.test.ts`: ADR-007 gains
+  a `### Screenshot determinism contract` section recording the
+  runtime-level byte-identical-rendering rule for `mode=screenshot`
+  (URL-parsing and mode validation stay in the workbench/runtime
+  layer, scenes do not parse query strings or invent screenshot-mode
+  flags, scene/composition/beat/asset/cleanup contracts come from
+  ADR-002, timeline state runs through ADR-003's GSAP integration
+  with screenshot freezing at the addressed frame, audio stays silent
+  through ADR-004's service, assets and fonts must be declared and
+  loaded before the capture-ready signal, and entropy sources —
+  `Date`, `Math.random`, `crypto.getRandomValues`, `performance.now`,
+  `requestAnimationFrame` time, storage, cookies, environment
+  variables, process arguments — are runtime-mediated or forbidden);
+  `.gc/plan-rules.md` adopts the same constraints as mandatory plan
+  rules; and a new structural-gate vitest suite (TypeScript-AST-based)
+  walks every `.ts` file under `src/` and fails when any of the
+  forbidden primitives are introduced without an inline
+  `// PUL-Q001-allow: <reason>` exemption (with a non-empty rationale)
+  on the same line. Detection is semantic and root-anchored, not
+  regex-over-text: destructuring (`const { random } = Math; …`),
+  bracket access (`Date['now']()`), global wrappers
+  (`globalThis.Math.random`, `window.localStorage`, `self.setTimeout`),
+  file-local aliases (`const m = Math; m.random()`, `const Clock =
+  Date; new Clock()`), TS wrappers (`(Math).random()`,
+  `(Date as DateCtor).now()`, `performance!.now()`), optional
+  chaining, and object-shorthand reads are caught the same way as
+  the direct spelling. Ordinary data graphs whose property chain
+  ends in a forbidden name but whose root is not an ambient global
+  (e.g., `snapshot.history.state`) do not produce false positives.
+  The scanner uses TS's tokenizer so a marker hidden inside a
+  string literal does not bypass the scan.
+  PUL-Q001
+  stays DRAFT — ADR-003's GSAP master timeline (`src/runtime/
+  timeline.ts` seeks-and-pauses under `opts.headScreenshot ===
+  'capture'`) and ADR-004's audio service (`src/runtime/scene-
+  loader.ts` builds the audio service silent under `mode=screenshot`
+  via `audioOutputPolicyFor`) have already landed, so the remaining
+  gap is the scene-side deterministic-randomness convention (a seed
+  surface on `ctx` consumed via the existing `ctx.mode ===
+  'screenshot'` seam) plus an end-to-end byte-identical-capture test
+  against rendered output. The same gap ADR-021 records as
+  condition 3 of PUL-F018's DRAFT → ACTIVE.
+
 - Present-mode audio unlock interaction — PUL-F030 / ADR-029 — in
   `src/runtime/scene.ts`, `src/runtime/audio.ts`, `src/runtime/scene-loader.ts`,
   and `src/main.ts`: a static `scene.audio: readonly string[]` field on

--- a/changelog.d/40.added.md
+++ b/changelog.d/40.added.md
@@ -1,0 +1,53 @@
+Screenshot determinism contract — PUL-Q001 / ADR-007. ADR-007 gains a
+`### Screenshot determinism contract` section that records the runtime-
+level byte-identical-rendering rule for `mode=screenshot`: URL parsing
+and mode validation stay in the runtime/workbench layer, scenes must
+not parse query strings or invent screenshot-mode flags, scene
+identity / composition entries / beats / assets / captions / cleanup
+keep using the ADR-002 contracts, timeline state runs through the
+ADR-003 GSAP integration with screenshot freezing at the addressed
+frame, audio stays silent through the ADR-004 service, assets
+(including fonts) must be declared and loaded before the capture-
+ready signal, and entropy sources (`Date`, `Math.random`,
+`crypto.getRandomValues`, `performance.now`, `requestAnimationFrame`
+time, storage state, cookies, environment variables, process
+arguments) are runtime-mediated or forbidden. `.gc/plan-rules.md`
+gains the same constraints as mandatory plan rules so future
+`/implement` runs see the determinism guardrails next to the planning
+agent. `tests/runtime/screenshot-determinism-source.test.ts` is a new
+structural gate that walks every `.ts` file under `src/` via the
+TypeScript compiler API and fails when any of the forbidden
+primitives (`Math.random`, `Date.now`, `new Date()` no-arg, bare
+`Date()` function-call form, `performance.now`,
+`crypto.getRandomValues`, `requestAnimationFrame`, `Element.animate`,
+`setTimeout`, `setInterval`, `localStorage`, `sessionStorage`,
+`document.cookie`, `history.state`, `process.env`, `process.argv`,
+`import.meta.env`) are introduced without an inline
+`// PUL-Q001-allow: <reason>` exemption (with a non-empty rationale)
+on the same line. Detection is semantic, not regex-over-text:
+destructuring (`const { random } = Math; random();`), bracket
+access (`Date['now']()`), global wrappers (`globalThis.Math.random`,
+`window.localStorage`, `self.setTimeout`), file-local aliases
+(`const m = Math; m.random()`, `const Clock = Date; new Clock()`),
+TypeScript wrappers (`(Math).random()`, `(Date as DateCtor).now()`,
+`performance!.now()`, `(Math satisfies object).random()`), optional
+chaining (`el?.animate(...)`, `el?.['animate'](...)`), and object
+shorthand reads (`return { localStorage }`) are caught the same way
+as the direct spelling. Path matching is root-anchored — only
+accesses rooted at an ambient global (directly or through an alias
+of one) are flagged, so ordinary data graphs like
+`snapshot.history.state` do not produce false positives. The scanner
+uses TS's tokenizer to collect comment ranges so a marker hidden
+inside a string literal does not bypass the scan; type-position
+references (e.g., an interface property named `setTimeout`) are
+ignored because they do not execute at runtime. PUL-Q001 stays
+DRAFT: ADR-003's GSAP master timeline (`src/runtime/timeline.ts`
+seeks-and-pauses under `opts.headScreenshot === 'capture'`) and
+ADR-004's audio service (`src/runtime/scene-loader.ts` builds the
+audio service silent under `mode=screenshot` via
+`audioOutputPolicyFor`) have already landed; the remaining gap is the
+scene-side deterministic-randomness convention (a seed surface on
+`ctx` consumed via the existing `ctx.mode === 'screenshot'` seam) plus
+an end-to-end byte-identical-capture test against rendered output —
+the same gap ADR-021 records as condition 3 of PUL-F018's
+DRAFT → ACTIVE.

--- a/docs/adrs/007-browser-workbench.md
+++ b/docs/adrs/007-browser-workbench.md
@@ -84,6 +84,47 @@ The runtime supports the following modes:
 Modes are explicit, addressable, and orthogonal to navigation: any
 scene + beat target works in any mode that makes sense for that target.
 
+### Screenshot determinism contract
+
+`mode=screenshot` is a runtime-level capture contract. For a fixed code
+revision and normalized workbench URL, reloads on the same browser engine
+and platform must produce byte-identical rendered output.
+
+The runtime owns that guarantee:
+
+- URL parsing, target resolution, mode validation, and error surfacing
+  stay in the workbench/runtime layer. Scenes must not parse query
+  strings or invent screenshot-mode flags.
+- Scene identity, composition entries, beats, assets, captions, and
+  cleanup keep using the scene/composition contracts from
+  [ADR-002](002-scene-registry-and-compositions.md).
+- Timeline state is driven through the runtime's GSAP integration from
+  [ADR-003](003-gsap-timeline-engine.md). Screenshot mode freezes at the
+  addressed frame; it does not wait for wall-clock animation.
+- Audio is silent through the runtime audio service from
+  [ADR-004](004-howler-audio-engine.md). Scenes do not special-case raw
+  `<audio>` playback for screenshots.
+- Assets, including fonts, must be declared and loaded through the
+  runtime preflight before the capture-ready signal. Remote mutable
+  assets, cache-race-dependent ordering, and undeclared font loading are
+  not compatible with byte-identical output.
+- Entropy sources are runtime-mediated. Scene code must not read
+  `Date`, `Math.random`, `crypto.getRandomValues`, `performance.now`,
+  `requestAnimationFrame` time, storage state, cookies, environment
+  variables, or process arguments to influence screenshot output.
+- Any deterministic seed is derived only from the normalized target and
+  explicit screenshot options. It is not stored in local storage,
+  cookies, or ambient process state.
+- Runtime diagnostics use the existing navigation/error surface. Error
+  messages must identify invalid public inputs without echoing secrets,
+  environment values, cookies, headers, full URLs containing credentials,
+  or raw scene payloads.
+
+If screenshot variants are needed later (viewport profile, density,
+theme, locale, capture frame), add them as validated screenshot options
+beside the existing workbench URL grammar. Do not add per-scene capture
+switches or a second screenshot schema.
+
 ### Agent contract
 
 Coding agents can rely on the URL grammar and modes as a stable

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
     "@types/howler": "^2.2.12",
+    "@types/node": "^22.18.0",
     "@vitest/coverage-v8": "^3.0.0",
     "typescript": "^5.7.2",
     "vite": "^6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,18 +21,21 @@ importers:
       '@types/howler':
         specifier: ^2.2.12
         version: 2.2.12
+      '@types/node':
+        specifier: ^22.18.0
+        version: 22.19.19
       '@vitest/coverage-v8':
         specifier: ^3.0.0
-        version: 3.2.4(vitest@3.2.4)
+        version: 3.2.4(vitest@3.2.4(@types/node@22.19.19))
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
       vite:
         specifier: ^6.0.0
-        version: 6.4.2
+        version: 6.4.2(@types/node@22.19.19)
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4
+        version: 3.2.4(@types/node@22.19.19)
 
 packages:
 
@@ -432,6 +435,9 @@ packages:
   '@types/howler@2.2.12':
     resolution: {integrity: sha512-hy769UICzOSdK0Kn1FBk4gN+lswcj1EKRkmiDtMkUGvFfYJzgaDXmVXkSShS2m89ERAatGIPnTUlp2HhfkVo5g==}
 
+  '@types/node@22.19.19':
+    resolution: {integrity: sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==}
+
   '@vitest/coverage-v8@3.2.4':
     resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
     peerDependencies:
@@ -789,6 +795,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -1129,7 +1138,11 @@ snapshots:
 
   '@types/howler@2.2.12': {}
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4)':
+  '@types/node@22.19.19':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@22.19.19))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -1144,7 +1157,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.4
+      vitest: 3.2.4(@types/node@22.19.19)
     transitivePeerDependencies:
       - supports-color
 
@@ -1156,13 +1169,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@6.4.2)':
+  '@vitest/mocker@3.2.4(vite@6.4.2(@types/node@22.19.19))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.2
+      vite: 6.4.2(@types/node@22.19.19)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -1512,13 +1525,15 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  vite-node@3.2.4:
+  undici-types@6.21.0: {}
+
+  vite-node@3.2.4(@types/node@22.19.19):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.4.2
+      vite: 6.4.2(@types/node@22.19.19)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -1533,7 +1548,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.4.2:
+  vite@6.4.2(@types/node@22.19.19):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
@@ -1542,13 +1557,14 @@ snapshots:
       rollup: 4.60.2
       tinyglobby: 0.2.16
     optionalDependencies:
+      '@types/node': 22.19.19
       fsevents: 2.3.3
 
-  vitest@3.2.4:
+  vitest@3.2.4(@types/node@22.19.19):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.4.2)
+      '@vitest/mocker': 3.2.4(vite@6.4.2(@types/node@22.19.19))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -1566,9 +1582,11 @@ snapshots:
       tinyglobby: 0.2.16
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.4.2
-      vite-node: 3.2.4
+      vite: 6.4.2(@types/node@22.19.19)
+      vite-node: 3.2.4(@types/node@22.19.19)
       why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.19
     transitivePeerDependencies:
       - jiti
       - less

--- a/tests/runtime/screenshot-determinism-source.test.ts
+++ b/tests/runtime/screenshot-determinism-source.test.ts
@@ -1,0 +1,998 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import * as ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+// PUL-Q001 — screenshot determinism source scan.
+//
+// PUL-Q001's clause: "For a given code revision and a given workbench
+// URL with `mode=screenshot`, the rendered output SHALL be byte-
+// identical across reloads on the same browser engine and platform."
+//
+// Byte-identical output requires the runtime/scene/composition source
+// to be free of wall-clock and ambient-state primitives that would
+// inject entropy into the captured frame. ADR-007's screenshot
+// determinism contract and `.gc/plan-rules.md`'s screenshot-determinism
+// rule both forbid these primitives in scene and runtime code; this
+// test makes the rule structurally enforceable so a regression cannot
+// silently land.
+//
+// Scope: all `.ts` files under `src/`. Generated artifacts
+// (`coverage/`, `dist/`), declared configs (`vite.config.ts`,
+// `vitest.config.ts`), and tests are out of scope — tests legitimately
+// use `Date.now()` for synthetic timestamps, and configs do not
+// influence captured rendering.
+//
+// Detection: the scanner uses the TypeScript compiler API to walk the
+// AST. Each forbidden surface is matched as a semantic access path
+// — root-anchored on either the ambient global identifier itself
+// (`Math`, `Date`, `performance`, `crypto`, `document`, `history`,
+// `process`) or a recognised global wrapper (`globalThis`, `window`,
+// `self`, `global`). Suffix-only matching (e.g., flagging
+// `snapshot.history.state` because it ends in `[history, state]`)
+// would produce false positives on ordinary data graphs; the
+// scanner therefore requires the root of every flagged access to
+// resolve to a known ambient global, directly or through a file-
+// local alias.
+//
+// Equivalent spellings covered:
+//   - direct property access (`Math.random`)
+//   - element access with string-literal / template-literal subscript
+//     (`Date['now']`, `Date[\`now\`]`)
+//   - global-wrapper access (`globalThis.Math.random`,
+//     `window.localStorage`, `self.setTimeout`)
+//   - file-local aliasing (`const m = Math; m.random()`,
+//     `const D = Date; new D()`)
+//   - destructuring (`const { random } = Math; random();`)
+//   - parenthesized / `as` / non-null / `satisfies` / type-assertion
+//     wrappers (`(Math).random()`, `(Date as unknown as DateCtor).now()`,
+//     `performance!.now()`)
+//   - optional chaining (`el?.animate(...)`, `el?.['animate'](...)`)
+//   - object-shorthand property reads (`return { localStorage }`)
+//
+// Exemption: a line carrying a real `// PUL-Q001-allow: <reason>`
+// line comment (with at least one non-whitespace character after the
+// colon) is intentionally excluded from the scan. The exemption is
+// line-scoped to keep approval narrow and visible in code review.
+// Exempted lines are determined by tokenizing the source through TS's
+// scanner so a marker hidden inside a string literal is NOT honored.
+
+interface SourceFinding {
+  readonly file: string;
+  readonly line: number;
+  readonly text: string;
+  readonly label: string;
+}
+
+// --- Forbidden semantic surfaces ---
+
+// Ambient-global roots that carry nondeterministic data. A property
+// or element access against any of these roots — directly, through a
+// recognised global wrapper, or through a file-local alias — is a
+// determinism hazard for the specific properties listed below.
+const FORBIDDEN_ROOT_PROPERTIES: readonly {
+  readonly root: string;
+  readonly prop: string;
+  readonly label: string;
+}[] = [
+  { root: 'Math', prop: 'random', label: 'Math.random' },
+  { root: 'Date', prop: 'now', label: 'Date.now' },
+  { root: 'performance', prop: 'now', label: 'performance.now' },
+  { root: 'crypto', prop: 'getRandomValues', label: 'crypto.getRandomValues' },
+  { root: 'document', prop: 'cookie', label: 'document.cookie' },
+  { root: 'history', prop: 'state', label: 'history.state' },
+  { root: 'process', prop: 'env', label: 'process.env' },
+  { root: 'process', prop: 'argv', label: 'process.argv' },
+];
+
+// Set of all ambient roots referenced by the table above. A bare
+// identifier read of one of these names that isn't followed by an
+// allowed deterministic member is still suspect, but the scan flags
+// access to the listed properties only; `Math` by itself is not a
+// hazard (e.g., `Math.floor` is deterministic).
+const FORBIDDEN_ROOTS = new Set(FORBIDDEN_ROOT_PROPERTIES.map((e) => e.root));
+
+// Ambient globals that can carry the forbidden roots as their own
+// properties (`globalThis.Math`, `window.crypto`, `self.localStorage`,
+// `global.setTimeout`). The scan allows one of these as the outer
+// segment when matching an access path.
+const GLOBAL_ROOTS = new Set(['globalThis', 'window', 'self', 'global']);
+
+// Direct identifier references that are forbidden as value reads.
+// Each entry is also matched as `<GLOBAL_ROOT>.<name>` so
+// `globalThis.localStorage`, `window.setTimeout`, etc. are caught.
+const FORBIDDEN_GLOBAL_IDENTIFIERS: readonly { readonly name: string; readonly label: string }[] = [
+  { name: 'localStorage', label: 'localStorage' },
+  { name: 'sessionStorage', label: 'sessionStorage' },
+  { name: 'requestAnimationFrame', label: 'requestAnimationFrame' },
+  { name: 'setTimeout', label: 'setTimeout' },
+  { name: 'setInterval', label: 'setInterval' },
+];
+const FORBIDDEN_GLOBAL_IDENTIFIER_NAMES = new Set(FORBIDDEN_GLOBAL_IDENTIFIERS.map((e) => e.name));
+const FORBIDDEN_GLOBAL_IDENTIFIER_LABEL_BY_NAME = new Map(
+  FORBIDDEN_GLOBAL_IDENTIFIERS.map((e) => [e.name, e.label]),
+);
+
+// Property-access leaf names whose semantic is animation orchestration
+// against wall-clock time. `Element.prototype.animate(…)` introduces a
+// CSS Web Animations API timeline; the captured frame would depend on
+// when the capture fires relative to the animation start time. The
+// scan flags ANY READ of the leaf name (property access, element
+// access with a string-literal subscript, optional chaining) — not
+// only immediate dot-calls — so `const animate = el.animate` and
+// `el?.['animate'](...)` are caught alongside `el.animate(...)`.
+const FORBIDDEN_LEAF_NAMES: readonly { readonly name: string; readonly label: string }[] = [
+  { name: 'animate', label: 'Element.animate' },
+];
+const FORBIDDEN_LEAF_LABEL_BY_NAME = new Map(FORBIDDEN_LEAF_NAMES.map((e) => [e.name, e.label]));
+
+const EXEMPT_REGEX = /PUL-Q001-allow:\s*\S/;
+
+// --- Expression unwrapping ---
+
+// Strip ordinary TypeScript wrappers that do not change the runtime
+// value: parentheses, `as` assertions, `<T>x` legacy type assertions,
+// non-null assertions (`x!`), and `satisfies`. These show up in
+// normal refactors and must not let a forbidden access slip past
+// the gate.
+function unwrap(node: ts.Expression): ts.Expression {
+  let current: ts.Expression = node;
+  while (true) {
+    if (
+      ts.isParenthesizedExpression(current) ||
+      ts.isAsExpression(current) ||
+      ts.isTypeAssertionExpression(current) ||
+      ts.isNonNullExpression(current) ||
+      ts.isSatisfiesExpression(current)
+    ) {
+      current = current.expression;
+      continue;
+    }
+    return current;
+  }
+}
+
+// --- Access-path resolution ---
+
+interface AccessPath {
+  readonly path: readonly string[]; // resolved segment names (post-alias)
+  readonly originalRoot: string; // root identifier as written
+}
+
+function getAccessPath(
+  node: ts.PropertyAccessExpression | ts.ElementAccessExpression,
+  aliases: ReadonlyMap<string, string>,
+): AccessPath | null {
+  const parts: string[] = [];
+  let current: ts.Expression = node;
+  while (true) {
+    current = unwrap(current);
+    if (ts.isPropertyAccessExpression(current)) {
+      parts.unshift(current.name.text);
+      current = current.expression;
+    } else if (ts.isElementAccessExpression(current)) {
+      const arg = unwrap(current.argumentExpression);
+      if (ts.isStringLiteralLike(arg)) {
+        parts.unshift(arg.text);
+        current = current.expression;
+      } else {
+        // Computed access (`obj[expr]` with non-literal `expr`) is
+        // too dynamic to track semantically; bail out.
+        return null;
+      }
+    } else if (ts.isIdentifier(current)) {
+      const originalRoot = current.text;
+      const resolvedRoot = aliases.get(originalRoot) ?? originalRoot;
+      parts.unshift(resolvedRoot);
+      return { path: parts, originalRoot };
+    } else if (ts.isMetaProperty(current)) {
+      // `import.meta` — synthesize a single root token. Not aliasable.
+      parts.unshift('import.meta');
+      return { path: parts, originalRoot: 'import.meta' };
+    } else {
+      return null;
+    }
+  }
+}
+
+// `path` matches the surface when, after stripping any leading
+// recognised global-wrapper segments, the remaining segments equal
+// `[root, prop]`. Returns the label of the matched surface or null.
+function matchRootPropertySurface(path: readonly string[]): string | null {
+  let start = 0;
+  while (start < path.length && GLOBAL_ROOTS.has(path[start] ?? '')) {
+    start += 1;
+  }
+  const tail = path.slice(start);
+  if (tail.length !== 2) return null;
+  const [root, prop] = tail;
+  for (const surface of FORBIDDEN_ROOT_PROPERTIES) {
+    if (surface.root === root && surface.prop === prop) {
+      return surface.label;
+    }
+  }
+  return null;
+}
+
+// Match `[..global-roots.., <forbidden-identifier-name>]` — e.g.,
+// `window.localStorage`, `globalThis.setTimeout`.
+function matchWrappedGlobalIdentifier(path: readonly string[]): string | null {
+  let start = 0;
+  while (start < path.length && GLOBAL_ROOTS.has(path[start] ?? '')) {
+    start += 1;
+  }
+  const tail = path.slice(start);
+  if (tail.length !== 1) return null;
+  const name = tail[0] ?? '';
+  return FORBIDDEN_GLOBAL_IDENTIFIER_LABEL_BY_NAME.get(name) ?? null;
+}
+
+// Match `[import.meta, env]`.
+function matchImportMetaEnv(path: readonly string[]): string | null {
+  if (path.length === 2 && path[0] === 'import.meta' && path[1] === 'env') {
+    return 'import.meta.env';
+  }
+  return null;
+}
+
+// --- Alias collection ---
+
+// File-local aliases of ambient global roots / globals. `const m =
+// Math; m.random()` resolves to `Math.random`. Shadowing isn't
+// universally handled (a `const Math = somethingElse` would still
+// be matched by the suffix table because root resolution is
+// alias-by-name, not symbol-by-identity), but the practical
+// failure mode is rare and is bounded by `FORBIDDEN_ROOTS` /
+// `GLOBAL_ROOTS` membership: we only record aliases whose
+// initializer is one of the known global roots, and a redeclared
+// `Math` (etc.) without a forbidden-root initializer is treated
+// as a regular variable that, if it appears as the root of an
+// access path, will not resolve via the alias map.
+function collectAliases(sourceFile: ts.SourceFile): Map<string, string> {
+  const aliases = new Map<string, string>();
+  const visit = (node: ts.Node): void => {
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
+      const init = unwrap(node.initializer);
+      if (ts.isIdentifier(init)) {
+        const targetName = init.text;
+        if (FORBIDDEN_ROOTS.has(targetName) || GLOBAL_ROOTS.has(targetName)) {
+          aliases.set(node.name.text, targetName);
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return aliases;
+}
+
+// --- Identifier classification ---
+
+function isDeclarationName(node: ts.Identifier): boolean {
+  const parent = node.parent;
+  if (!parent) return false;
+  if (ts.isVariableDeclaration(parent) && parent.name === node) return true;
+  if (ts.isParameter(parent) && parent.name === node) return true;
+  if (ts.isFunctionDeclaration(parent) && parent.name === node) return true;
+  if (ts.isClassDeclaration(parent) && parent.name === node) return true;
+  if (ts.isInterfaceDeclaration(parent) && parent.name === node) return true;
+  if (ts.isTypeAliasDeclaration(parent) && parent.name === node) return true;
+  if (ts.isEnumDeclaration(parent) && parent.name === node) return true;
+  if (ts.isEnumMember(parent) && parent.name === node) return true;
+  if (ts.isMethodDeclaration(parent) && parent.name === node) return true;
+  if (ts.isMethodSignature(parent) && parent.name === node) return true;
+  if (ts.isPropertyDeclaration(parent) && parent.name === node) return true;
+  if (ts.isPropertySignature(parent) && parent.name === node) return true;
+  if (ts.isPropertyAssignment(parent) && parent.name === node) return true;
+  // ShorthandPropertyAssignment is intentionally NOT treated as a
+  // declaration: `{ requestAnimationFrame }` is a value-position
+  // read of the identifier, equivalent to
+  // `{ requestAnimationFrame: requestAnimationFrame }`.
+  if (ts.isBindingElement(parent) && parent.name === node) return true;
+  if (ts.isImportSpecifier(parent)) return true;
+  if (ts.isImportClause(parent) && parent.name === node) return true;
+  if (ts.isNamespaceImport(parent)) return true;
+  if (ts.isImportEqualsDeclaration(parent) && parent.name === node) return true;
+  if (ts.isExportSpecifier(parent)) return true;
+  if (ts.isLabeledStatement(parent) && parent.label === node) return true;
+  // Property-name positions: the `.name` of a PropertyAccess or
+  // QualifiedName is the key, not a value-position reference.
+  if (
+    (ts.isPropertyAccessExpression(parent) || ts.isQualifiedName(parent)) &&
+    'name' in parent &&
+    parent.name === node
+  ) {
+    return true;
+  }
+  return false;
+}
+
+function isInTypePosition(node: ts.Node): boolean {
+  let n: ts.Node | undefined = node.parent;
+  while (n) {
+    if (
+      ts.isTypeNode(n) ||
+      ts.isTypeAliasDeclaration(n) ||
+      ts.isInterfaceDeclaration(n) ||
+      ts.isTypeReferenceNode(n) ||
+      ts.isTypeLiteralNode(n)
+    ) {
+      return true;
+    }
+    n = n.parent;
+  }
+  return false;
+}
+
+// --- Comment / exemption ---
+
+function collectExemptedLines(sourceFile: ts.SourceFile): Set<number> {
+  const exempted = new Set<number>();
+  const text = sourceFile.text;
+  const scanner = ts.createScanner(
+    ts.ScriptTarget.Latest,
+    /*skipTrivia=*/ false,
+    ts.LanguageVariant.Standard,
+    text,
+  );
+  let token = scanner.scan();
+  while (token !== ts.SyntaxKind.EndOfFileToken) {
+    if (token === ts.SyntaxKind.SingleLineCommentTrivia) {
+      const tokenText = scanner.getTokenText();
+      if (EXEMPT_REGEX.test(tokenText)) {
+        const start = scanner.getTokenStart();
+        const { line } = sourceFile.getLineAndCharacterOfPosition(start);
+        exempted.add(line);
+      }
+    }
+    token = scanner.scan();
+  }
+  return exempted;
+}
+
+function lineText(sourceFile: ts.SourceFile, lineIndex0: number): string {
+  const lines = sourceFile.text.split('\n');
+  return lines[lineIndex0] ?? '';
+}
+
+// --- Scanner entry point ---
+
+function scanSourceForNonDeterminism(text: string, file: string): readonly SourceFinding[] {
+  const sourceFile = ts.createSourceFile(
+    file,
+    text,
+    ts.ScriptTarget.Latest,
+    /*setParentNodes=*/ true,
+  );
+  const exempted = collectExemptedLines(sourceFile);
+  const aliases = collectAliases(sourceFile);
+  const findings: SourceFinding[] = [];
+  const seen = new Set<string>(); // dedupe (node start + label)
+
+  const record = (node: ts.Node, label: string): void => {
+    const start = node.getStart(sourceFile);
+    const key = `${start}::${label}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    const { line } = sourceFile.getLineAndCharacterOfPosition(start);
+    if (exempted.has(line)) return;
+    findings.push({
+      file,
+      line: line + 1,
+      text: lineText(sourceFile, line).trim(),
+      label,
+    });
+  };
+
+  // Resolve a callee expression to its access path (with aliases /
+  // wrappers unwound). Used by no-arg `new Date()` / `Date()` and
+  // by Element.animate dot-call detection (the latter no longer
+  // needs it because we flag any read of `.animate`, but the helper
+  // is still useful for the Date constructor case).
+  const resolveCalleePath = (callee: ts.Expression): AccessPath | null => {
+    const inner = unwrap(callee);
+    if (ts.isIdentifier(inner)) {
+      const resolved = aliases.get(inner.text) ?? inner.text;
+      return { path: [resolved], originalRoot: inner.text };
+    }
+    if (ts.isPropertyAccessExpression(inner) || ts.isElementAccessExpression(inner)) {
+      return getAccessPath(inner, aliases);
+    }
+    return null;
+  };
+
+  // Check whether a path resolves to `[..globals.., Date]` (i.e., the
+  // `Date` constructor) — used for no-arg `new Date()` and `Date()`.
+  const isDatePath = (path: readonly string[]): boolean => {
+    let start = 0;
+    while (start < path.length && GLOBAL_ROOTS.has(path[start] ?? '')) {
+      start += 1;
+    }
+    return path.length - start === 1 && path[start] === 'Date';
+  };
+
+  const visit = (node: ts.Node): void => {
+    // 1. Property / element access chains. Detection covers:
+    //   (a) `[root, prop]` and `[..globals.., root, prop]` against
+    //       the FORBIDDEN_ROOT_PROPERTIES table.
+    //   (b) `[..globals.., globalIdent]` against the FORBIDDEN_GLOBAL_
+    //       IDENTIFIERS table — catches `window.localStorage`, etc.
+    //   (c) Forbidden leaf-name reads (`.animate`) regardless of root.
+    //   (d) `import.meta.env`.
+    //
+    // The outermost access wins for (a)/(b)/(d); nested sub-accesses
+    // are still visited but normally produce no match because their
+    // path is too short. Dedup via `seen` keeps a single outer match
+    // from being reported by both the outer and inner visits.
+    if (ts.isPropertyAccessExpression(node) || ts.isElementAccessExpression(node)) {
+      if (!isInTypePosition(node)) {
+        const access = getAccessPath(node, aliases);
+        if (access) {
+          const rootProp = matchRootPropertySurface(access.path);
+          if (rootProp) {
+            record(node, rootProp);
+          } else {
+            const wrappedGlobal = matchWrappedGlobalIdentifier(access.path);
+            if (wrappedGlobal) record(node, wrappedGlobal);
+            const importMeta = matchImportMetaEnv(access.path);
+            if (importMeta) record(node, importMeta);
+          }
+        }
+        // Leaf-name reads (Element.animate, etc.) — flag regardless
+        // of the root, because the surface is the named method/
+        // property itself.
+        const leafName = ts.isPropertyAccessExpression(node)
+          ? node.name.text
+          : ts.isStringLiteralLike(node.argumentExpression)
+            ? node.argumentExpression.text
+            : null;
+        if (leafName) {
+          const leafLabel = FORBIDDEN_LEAF_LABEL_BY_NAME.get(leafName);
+          if (leafLabel) record(node, leafLabel);
+        }
+      }
+    }
+
+    // 2. Bare identifier references (not declarations, not type
+    //    positions, not the `.name` of a PropertyAccess).
+    if (ts.isIdentifier(node) && !isDeclarationName(node) && !isInTypePosition(node)) {
+      const name = node.text;
+      const label = FORBIDDEN_GLOBAL_IDENTIFIER_LABEL_BY_NAME.get(name);
+      if (label) {
+        // Don't double-count `globalThis.setTimeout` — handled by
+        // the wrapped-global-identifier check above. The check here
+        // is for BARE identifier reads where the parent is not a
+        // PropertyAccess `.name`.
+        const parent = node.parent;
+        const isPropertyAccessName =
+          parent &&
+          (ts.isPropertyAccessExpression(parent) || ts.isQualifiedName(parent)) &&
+          'name' in parent &&
+          parent.name === node;
+        if (!isPropertyAccessName) {
+          record(node, label);
+        }
+      }
+    }
+
+    // 3. `new Date()` / `Date()` with zero arguments — covering
+    //    bare, global-wrapped, aliased, and parenthesized callees.
+    if (ts.isNewExpression(node) || ts.isCallExpression(node)) {
+      const hasNoArgs = !node.arguments || node.arguments.length === 0;
+      if (hasNoArgs) {
+        const callee = resolveCalleePath(node.expression);
+        if (callee && isDatePath(callee.path)) {
+          record(node, ts.isNewExpression(node) ? 'new Date() (no-arg)' : 'Date() (function call)');
+        }
+      }
+    }
+
+    // 4. Destructuring from a forbidden root. `const { random } =
+    //    Math;` is semantically equivalent to a `Math.random` read.
+    //    The initializer is unwrapped before identifier-matching so
+    //    `const { random } = (Math)` / `(Math as object)` are
+    //    caught alongside the bare form.
+    if (
+      ts.isVariableDeclaration(node) &&
+      node.initializer &&
+      ts.isObjectBindingPattern(node.name)
+    ) {
+      const init = unwrap(node.initializer);
+      if (ts.isIdentifier(init)) {
+        const resolved = aliases.get(init.text) ?? init.text;
+        if (FORBIDDEN_ROOTS.has(resolved)) {
+          for (const element of node.name.elements) {
+            const propName = element.propertyName ?? element.name;
+            if (!ts.isIdentifier(propName)) continue;
+            for (const surface of FORBIDDEN_ROOT_PROPERTIES) {
+              if (surface.root === resolved && surface.prop === propName.text) {
+                record(element, `${surface.label} (via destructuring)`);
+              }
+            }
+          }
+        }
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return findings;
+}
+
+// --- File system driver ---
+
+const REPO_ROOT = fileURLToPath(new URL('../..', import.meta.url));
+const SCAN_ROOT = join(REPO_ROOT, 'src');
+
+// `.ts` paths in `src/` that this scan skips. None today; the array
+// exists so a future generated or third-party include under `src/`
+// can be opted out explicitly. Test files don't live under `src/`,
+// so they don't need an exclude.
+const SCAN_EXCLUDES: readonly string[] = [];
+
+function isExcluded(absolutePath: string): boolean {
+  const rel = relative(REPO_ROOT, absolutePath);
+  return SCAN_EXCLUDES.some((ex) => rel === ex || rel.startsWith(`${ex}/`));
+}
+
+function walkTs(root: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(root)) {
+    if (entry.startsWith('.')) continue;
+    const full = join(root, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      out.push(...walkTs(full));
+    } else if (st.isFile() && entry.endsWith('.ts')) {
+      if (!isExcluded(full)) out.push(full);
+    }
+  }
+  return out;
+}
+
+// --- Tests ---
+
+describe('PUL-Q001 — screenshot determinism source scan', () => {
+  describe('scanner self-tests', () => {
+    describe('direct spellings', () => {
+      it.each([
+        ['Math.random', 'const x = Math.random();'],
+        ['Date.now', 'const t = Date.now();'],
+        ['new Date() (no-arg)', 'const d = new Date();'],
+        ['Date() (function call)', 'const s = Date();'],
+        ['performance.now', 'const t = performance.now();'],
+        ['crypto.getRandomValues', 'crypto.getRandomValues(new Uint8Array(4));'],
+        ['requestAnimationFrame', 'requestAnimationFrame(noop);'],
+        ['localStorage', 'localStorage.getItem("x");'],
+        ['sessionStorage', 'sessionStorage.getItem("x");'],
+        ['document.cookie', 'document.cookie;'],
+        ['history.state', 'const s = history.state;'],
+        ['process.env', 'const v = process.env.FOO;'],
+        ['process.argv', 'const a = process.argv[2];'],
+        ['import.meta.env', 'const v = import.meta.env.VITE_SEED;'],
+        ['setTimeout', 'setTimeout(noop, 0);'],
+        ['setInterval', 'setInterval(noop, 0);'],
+      ])('flags %s', (label, source) => {
+        const findings = scanSourceForNonDeterminism(source, 'fake.ts');
+        expect(findings.map((f) => f.label)).toContain(label);
+      });
+
+      it('flags Element.animate calls (direct dot-call)', () => {
+        const findings = scanSourceForNonDeterminism(
+          'declare const el: HTMLElement; el.animate([], { duration: 100 });',
+          'fake.ts',
+        );
+        expect(findings.map((f) => f.label)).toContain('Element.animate');
+      });
+
+      it('flags Element.animate reads (alias, not just calls)', () => {
+        // PUL-Q001 forbids `Element.animate` because it starts a
+        // wall-clock animation timeline. Reading the member to alias
+        // it is the same hazard — flag both forms.
+        const findings = scanSourceForNonDeterminism(
+          'declare const el: HTMLElement; const animateFn = el.animate;',
+          'fake.ts',
+        );
+        expect(findings.map((f) => f.label)).toContain('Element.animate');
+      });
+
+      it('flags Element.animate via bracket access', () => {
+        const findings = scanSourceForNonDeterminism(
+          `declare const el: HTMLElement; el['animate']([], { duration: 100 });`,
+          'fake.ts',
+        );
+        expect(findings.map((f) => f.label)).toContain('Element.animate');
+      });
+
+      it('flags Element.animate via optional chaining', () => {
+        const findings = scanSourceForNonDeterminism(
+          'declare const el: HTMLElement | null; el?.animate([]);',
+          'fake.ts',
+        );
+        expect(findings.map((f) => f.label)).toContain('Element.animate');
+      });
+    });
+
+    describe('global-wrapper forms (globalThis / window / self / global)', () => {
+      it.each([
+        ['globalThis.Math.random', 'globalThis.Math.random();', 'Math.random'],
+        ['window.localStorage', 'window.localStorage.getItem("x");', 'localStorage'],
+        ['self.setTimeout', 'self.setTimeout(noop, 0);', 'setTimeout'],
+        [
+          'global.requestAnimationFrame',
+          'global.requestAnimationFrame(noop);',
+          'requestAnimationFrame',
+        ],
+        [
+          'globalThis.crypto.getRandomValues',
+          'globalThis.crypto.getRandomValues(new Uint8Array(4));',
+          'crypto.getRandomValues',
+        ],
+        ['window.document.cookie', 'window.document.cookie;', 'document.cookie'],
+        ['globalThis.history.state', 'const s = globalThis.history.state;', 'history.state'],
+        ['globalThis.process.env', 'const v = globalThis.process.env.FOO;', 'process.env'],
+        ["globalThis['setInterval']", `globalThis['setInterval'](noop, 0);`, 'setInterval'],
+      ])('flags %s', (_label, source, expectedLabel) => {
+        const findings = scanSourceForNonDeterminism(source, 'fake.ts');
+        expect(findings.map((f) => f.label)).toContain(expectedLabel);
+      });
+
+      it('flags `new globalThis.Date()` (no-arg)', () => {
+        const findings = scanSourceForNonDeterminism('new globalThis.Date();', 'fake.ts');
+        expect(findings.map((f) => f.label)).toContain('new Date() (no-arg)');
+      });
+
+      it('flags `globalThis.Date()` (function-call form)', () => {
+        const findings = scanSourceForNonDeterminism('const s = globalThis.Date();', 'fake.ts');
+        expect(findings.map((f) => f.label)).toContain('Date() (function call)');
+      });
+    });
+
+    describe('aliased forms', () => {
+      it('flags `const m = Math; m.random()`', () => {
+        const findings = scanSourceForNonDeterminism(
+          'const m = Math; const r = m.random();',
+          'fake.ts',
+        );
+        expect(findings.map((f) => f.label)).toContain('Math.random');
+      });
+
+      it('flags `const perf = performance; perf.now()`', () => {
+        const findings = scanSourceForNonDeterminism(
+          'const perf = performance; const t = perf.now();',
+          'fake.ts',
+        );
+        expect(findings.map((f) => f.label)).toContain('performance.now');
+      });
+
+      it('flags `const rng = crypto; rng.getRandomValues(...)`', () => {
+        const findings = scanSourceForNonDeterminism(
+          'const rng = crypto; rng.getRandomValues(new Uint8Array(4));',
+          'fake.ts',
+        );
+        expect(findings.map((f) => f.label)).toContain('crypto.getRandomValues');
+      });
+
+      it('flags `const Clock = Date; new Clock()` (no-arg)', () => {
+        const findings = scanSourceForNonDeterminism(
+          'const Clock = Date; const d = new Clock();',
+          'fake.ts',
+        );
+        expect(findings.map((f) => f.label)).toContain('new Date() (no-arg)');
+      });
+
+      it('flags `const Clock = Date; Clock.now()`', () => {
+        const findings = scanSourceForNonDeterminism(
+          'const Clock = Date; const t = Clock.now();',
+          'fake.ts',
+        );
+        expect(findings.map((f) => f.label)).toContain('Date.now');
+      });
+
+      it('flags `const g = globalThis; g.Math.random()`', () => {
+        const findings = scanSourceForNonDeterminism(
+          'const g = globalThis; const r = g.Math.random();',
+          'fake.ts',
+        );
+        expect(findings.map((f) => f.label)).toContain('Math.random');
+      });
+    });
+
+    describe('TypeScript wrapper expressions', () => {
+      it.each([
+        ['(Math).random()', '(Math).random();', 'Math.random'],
+        ['(Date).now()', '(Date).now();', 'Date.now'],
+        [
+          '(performance as Performance).now()',
+          '(performance as Performance).now();',
+          'performance.now',
+        ],
+        [
+          '(globalThis as any).crypto.getRandomValues',
+          '(globalThis as any).crypto.getRandomValues(new Uint8Array(4));',
+          'crypto.getRandomValues',
+        ],
+        [
+          'performance!.now()',
+          'declare const performance: Performance | undefined; performance!.now();',
+          'performance.now',
+        ],
+        ['(Math satisfies object).random()', '(Math satisfies object).random();', 'Math.random'],
+        ['new (Date)()', 'const d = new (Date)();', 'new Date() (no-arg)'],
+      ])('unwraps %s', (_label, source, expectedLabel) => {
+        const findings = scanSourceForNonDeterminism(source, 'fake.ts');
+        expect(findings.map((f) => f.label)).toContain(expectedLabel);
+      });
+    });
+
+    describe('bracket access', () => {
+      it('flags `Date["now"]()`', () => {
+        const findings = scanSourceForNonDeterminism(`Date['now']();`, 'fake.ts');
+        expect(findings.map((f) => f.label)).toContain('Date.now');
+      });
+
+      it('flags `Math["random"]()`', () => {
+        const findings = scanSourceForNonDeterminism(`Math['random']();`, 'fake.ts');
+        expect(findings.map((f) => f.label)).toContain('Math.random');
+      });
+
+      it('flags `Date[`now`]()` (template-literal subscript)', () => {
+        const findings = scanSourceForNonDeterminism('Date[`now`]();', 'fake.ts');
+        expect(findings.map((f) => f.label)).toContain('Date.now');
+      });
+    });
+
+    describe('destructuring', () => {
+      it('flags `const { random } = Math; random();`', () => {
+        const findings = scanSourceForNonDeterminism(
+          'const { random } = Math; random();',
+          'fake.ts',
+        );
+        expect(findings.map((f) => f.label)).toContain('Math.random (via destructuring)');
+      });
+
+      it('flags `const { now } = Date; now();`', () => {
+        const findings = scanSourceForNonDeterminism('const { now } = Date; now();', 'fake.ts');
+        expect(findings.map((f) => f.label)).toContain('Date.now (via destructuring)');
+      });
+
+      it('flags destructuring through an alias (`const M = Math; const { random } = M;`)', () => {
+        const findings = scanSourceForNonDeterminism(
+          'const M = Math; const { random } = M;',
+          'fake.ts',
+        );
+        expect(findings.map((f) => f.label)).toContain('Math.random (via destructuring)');
+      });
+    });
+
+    describe('object shorthand', () => {
+      it('flags `{ localStorage }` shorthand read', () => {
+        // Object shorthand `{ requestAnimationFrame }` is equivalent
+        // to `{ requestAnimationFrame: requestAnimationFrame }` —
+        // the identifier is a value-position read, not a
+        // declaration.
+        const findings = scanSourceForNonDeterminism(
+          'const timers = { requestAnimationFrame };',
+          'fake.ts',
+        );
+        expect(findings.map((f) => f.label)).toContain('requestAnimationFrame');
+      });
+
+      it('flags `return { localStorage }` shorthand read', () => {
+        const findings = scanSourceForNonDeterminism(
+          'function pack() { return { localStorage }; }',
+          'fake.ts',
+        );
+        expect(findings.map((f) => f.label)).toContain('localStorage');
+      });
+    });
+
+    describe('non-global object graphs are NOT flagged (false-positive defense)', () => {
+      it.each([
+        // root-anchoring prevents these from triggering
+        [
+          'snapshot.history.state',
+          'declare const snapshot: { history: { state: number } }; const s = snapshot.history.state;',
+        ],
+        [
+          'fixture.process.env',
+          'declare const fixture: { process: { env: object } }; const e = fixture.process.env;',
+        ],
+        [
+          'mock.document.cookie',
+          'declare const mock: { document: { cookie: string } }; const c = mock.document.cookie;',
+        ],
+        [
+          'scene.crypto.getRandomValues',
+          'declare const scene: { crypto: { getRandomValues(buf: Uint8Array): void } }; scene.crypto.getRandomValues(new Uint8Array(4));',
+        ],
+      ])('does NOT flag %s (root is not an ambient global)', (_label, source) => {
+        const findings = scanSourceForNonDeterminism(source, 'fake.ts');
+        expect(findings).toEqual([]);
+      });
+    });
+
+    describe('whole-word semantics + lookalikes', () => {
+      it('does not flag whole-word lookalikes', () => {
+        const safe = `declare const myDate: { now: number };
+          declare function requestAnimationFrameLike(cb: () => void): void;
+          const a = myDate.now;
+          requestAnimationFrameLike(() => {});`;
+        const findings = scanSourceForNonDeterminism(safe, 'fake.ts');
+        expect(findings).toEqual([]);
+      });
+
+      it('does not flag `new Date(timestamp)` (argument-form is deterministic)', () => {
+        expect(scanSourceForNonDeterminism('const d = new Date(0);', 'fake.ts')).toEqual([]);
+        expect(scanSourceForNonDeterminism('const d = new Date(beatMs);', 'fake.ts')).toEqual([]);
+      });
+
+      it('does NOT flag computed bracket access (semantically opaque)', () => {
+        const findings = scanSourceForNonDeterminism(
+          'declare const propKey: string; Math[propKey];',
+          'fake.ts',
+        );
+        expect(findings).toEqual([]);
+      });
+    });
+
+    describe('type-position references are ignored', () => {
+      it('does not flag setTimeout used as a type member name', () => {
+        const findings = scanSourceForNonDeterminism(
+          'interface Timers { setTimeout(cb: () => void, ms: number): number; }',
+          'fake.ts',
+        );
+        expect(findings).toEqual([]);
+      });
+
+      it('does not flag identifier reads inside a type alias', () => {
+        const findings = scanSourceForNonDeterminism('type T = typeof setTimeout;', 'fake.ts');
+        // `typeof setTimeout` in a type alias is a type-position
+        // reference; it does not execute at runtime.
+        expect(findings).toEqual([]);
+      });
+    });
+
+    describe('comment / string handling', () => {
+      it('ignores forbidden vocabulary inside `//` line comments', () => {
+        const text = '// `Math.random`, `Date.now()`, and `localStorage` are forbidden.';
+        expect(scanSourceForNonDeterminism(text, 'fake.ts')).toEqual([]);
+      });
+
+      it('ignores forbidden vocabulary inside `/* … */` block comments (single line)', () => {
+        const text = '/* Math.random and Date.now are forbidden. */';
+        expect(scanSourceForNonDeterminism(text, 'fake.ts')).toEqual([]);
+      });
+
+      it('ignores forbidden vocabulary inside `/* … */` block comments spanning multiple lines', () => {
+        const text = ['/**', ' * Forbids Math.random and Date.now().', ' */', 'const x = 1;'].join(
+          '\n',
+        );
+        expect(scanSourceForNonDeterminism(text, 'fake.ts')).toEqual([]);
+      });
+
+      it('does not treat `//` inside a string literal as a comment', () => {
+        const text = `const url = 'foo://bar'; const t = Date.now();`;
+        const findings = scanSourceForNonDeterminism(text, 'fake.ts');
+        expect(findings.map((f) => f.label)).toContain('Date.now');
+      });
+    });
+
+    describe('exemption marker', () => {
+      it('respects an inline `// PUL-Q001-allow:` exemption on the same line', () => {
+        const findings = scanSourceForNonDeterminism(
+          'const t = Date.now(); // PUL-Q001-allow: bootstrap log timestamp, not captured',
+          'fake.ts',
+        );
+        expect(findings).toEqual([]);
+      });
+
+      it('does NOT honor an empty exemption rationale', () => {
+        const findings = scanSourceForNonDeterminism(
+          'const t = Date.now(); // PUL-Q001-allow:',
+          'fake.ts',
+        );
+        expect(findings.map((f) => f.label)).toContain('Date.now');
+      });
+
+      it('does NOT honor an exemption with only whitespace after the colon', () => {
+        const findings = scanSourceForNonDeterminism(
+          'const t = Date.now(); // PUL-Q001-allow:   ',
+          'fake.ts',
+        );
+        expect(findings.map((f) => f.label)).toContain('Date.now');
+      });
+
+      it('does NOT honor a marker hidden inside a string literal', () => {
+        const findings = scanSourceForNonDeterminism(
+          `const note = "// PUL-Q001-allow: hidden in a string"; const t = Date.now();`,
+          'fake.ts',
+        );
+        expect(findings.map((f) => f.label)).toContain('Date.now');
+      });
+
+      it('does NOT honor an exemption on a different line (line-scoped, not file-scoped)', () => {
+        const text = '// PUL-Q001-allow: see above\nconst t = Date.now();';
+        const findings = scanSourceForNonDeterminism(text, 'fake.ts');
+        expect(findings).toHaveLength(1);
+        expect(findings[0]?.line).toBe(2);
+      });
+
+      it('honors an exemption on a `// PUL-Q001-allow:` marker after the forbidden call on the same line', () => {
+        const findings = scanSourceForNonDeterminism(
+          'setTimeout(work, 0); // PUL-Q001-allow: navigation idle scheduling, not captured',
+          'fake.ts',
+        );
+        expect(findings).toEqual([]);
+      });
+    });
+
+    describe('reporting', () => {
+      it('reports line numbers (1-based) and the offending file path', () => {
+        const text = 'const a = 1;\nconst b = 2;\nconst t = Date.now();\nconst c = 3;';
+        const findings = scanSourceForNonDeterminism(text, 'src/runtime/example.ts');
+        expect(findings).toHaveLength(1);
+        expect(findings[0]?.line).toBe(3);
+        expect(findings[0]?.file).toBe('src/runtime/example.ts');
+      });
+
+      it('reports every distinct violation when a single line carries more than one', () => {
+        const findings = scanSourceForNonDeterminism(
+          'const r = Math.random() + Date.now();',
+          'fake.ts',
+        );
+        expect(findings.map((f) => f.label).sort()).toEqual(['Date.now', 'Math.random']);
+      });
+
+      it('reports findings across multiple lines independently', () => {
+        const text = ['const a = Math.random();', 'const t = Date.now();'].join('\n');
+        const findings = scanSourceForNonDeterminism(text, 'fake.ts');
+        expect(findings).toHaveLength(2);
+        expect(findings[0]?.line).toBe(1);
+        expect(findings[1]?.line).toBe(2);
+      });
+    });
+  });
+
+  describe('runtime tree (current code revision)', () => {
+    it('scan root `src/` exists and contains at least one .ts file', () => {
+      const st = statSync(SCAN_ROOT);
+      expect(st.isDirectory()).toBe(true);
+      const files = walkTs(SCAN_ROOT);
+      expect(files.length).toBeGreaterThan(0);
+    });
+
+    it.each([
+      ['src/runtime', join(SCAN_ROOT, 'runtime')],
+      ['src/scenes', join(SCAN_ROOT, 'scenes')],
+      ['src/compositions', join(SCAN_ROOT, 'compositions')],
+    ])('expected runtime subtree %s contains at least one .ts file', (label, root) => {
+      const files = walkTs(root);
+      expect(files.length, `${label} produced no .ts files`).toBeGreaterThan(0);
+    });
+
+    it('expected runtime entry `src/main.ts` exists', () => {
+      const st = statSync(join(SCAN_ROOT, 'main.ts'));
+      expect(st.isFile()).toBe(true);
+    });
+
+    it('contains no non-deterministic primitives across `src/**/*.ts`', () => {
+      const files = walkTs(SCAN_ROOT);
+      const findings: SourceFinding[] = [];
+      for (const file of files) {
+        const text = readFileSync(file, 'utf-8');
+        const rel = relative(REPO_ROOT, file);
+        findings.push(...scanSourceForNonDeterminism(text, rel));
+      }
+
+      const header =
+        'PUL-Q001 forbids the listed APIs in runtime source. Add a `// PUL-Q001-allow: <reason>` exemption on the same line if the use is intentional and deterministic in context.';
+      const detail = findings.map((f) => `  ${f.file}:${f.line}  ${f.label}  ${f.text}`).join('\n');
+      const message = findings.length === 0 ? '' : `${header}\n${detail}`;
+      expect(findings, message).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Documents the screenshot determinism contract (`mode=screenshot` SHALL produce byte-identical rendered output across reloads on the same engine/platform) in ADR-007 and `.gc/plan-rules.md`, and adds a TypeScript-AST-based structural-gate vitest suite that fails the build when forbidden non-deterministic primitives are introduced into `src/**/*.ts` without an inline `// PUL-Q001-allow: <reason>` exemption. PUL-Q001 stays DRAFT — the gap to ACTIVE is the scene-side deterministic-randomness convention (seed surface on `ctx`) plus an end-to-end byte-identical-capture test, the same gap ADR-021 records as condition 3 of PUL-F018's DRAFT → ACTIVE.

## Requirement UIDs

- `PUL-Q001`

## Related Issues

Closes #40

## ADR Impact

- ADR-007

## Changes

- Adds `### Screenshot determinism contract` to `docs/adrs/007-browser-workbench.md`: locks URL-only mode source, scene/composition reuse, GSAP-frozen frame, silent audio, declared assets/fonts before capture-ready signal, no wall-clock/RNG/storage/cookie/env/argv entropy, and no secret-leaking error envelopes.
- Adds the same constraints to `.gc/plan-rules.md` as mandatory plan rules so future `/implement` runs see them at planning time.
- Adds `tests/runtime/screenshot-determinism-source.test.ts` — an AST-based structural gate that walks every `.ts` file under `src/` via the TypeScript compiler API and flags `Math.random`, `Date.now`, `new Date()` (no-arg), bare `Date()`, `performance.now`, `crypto.getRandomValues`, `document.cookie`, `history.state`, `process.env`, `process.argv`, `import.meta.env`, `requestAnimationFrame`, `setTimeout`, `setInterval`, `localStorage`, `sessionStorage`, and `Element.animate`. Detection is semantic and root-anchored: direct spellings, global wrappers (`globalThis`/`window`/`self`/`global`), file-local aliases (`const m = Math`), TS expression wrappers (`(Math).random()`, `as`, `!`, `satisfies`), bracket access (`Date['now']`), template-literal subscripts, optional chaining, destructuring, and object-shorthand reads are all caught the same way. Non-global object graphs (`snapshot.history.state`, `fixture.process.env`) are not false-positive flagged. Inline exemption requires a non-empty rationale.
- Pins `@types/node` to `^22.18.0` (was `^25.7.0`) to match the repo's declared Node 22 engine.
- PUL-Q001 stays DRAFT (forward-looking). The diff DOCUMENTS the contract; the active capture-bundle delivery is gated on a scene-side deterministic-randomness convention plus an end-to-end byte-identical-capture test.

## Test Plan

- [x] `pnpm lint && pnpm typecheck && pnpm test` green locally (1109 tests, 80 new self-tests in the structural-gate suite).
- [x] Red-step verified end-to-end by injecting `_g.Math.random()` (alias), `(performance as Performance).now()` (TS wrapper), and `window.setTimeout(...)` (global wrapper) into `src/main.ts` — all three were flagged by the scanner; revert restored the green state.
- [x] Pre-push codex review ran three cycles (cap reached); every cycle's findings were fixed and recorded as decision-record comments on the issue thread. Cycle-4 verification skipped per maintainer authorization.

## Ground Control Checks

- [x] Pre-commit hooks pass (biome, typecheck, vitest)
- [x] Plan posted to issue #40 with `gc_post_implementation_plan`
- [x] Decision records posted for all three pre-push review cycles

## Traceability

- IMPLEMENTS: (none — forward-looking documentation pass)
- TESTS: PUL-Q001 ← tests/runtime/screenshot-determinism-source.test.ts (DOCUMENTS — PUL-Q001 stays DRAFT)

## Checklist

- [x] Code follows project coding standards
- [x] Changelog fragment added at `changelog.d/40.added.md`
- [x] Architectural docs updated (ADR-007 + plan-rules.md)