### PR TITLE
PUL-Q003: URL state determinism gate

### DIFF
--- a/changelog.d/42.added.md
+++ b/changelog.d/42.added.md
@@ -1,0 +1,28 @@
+PUL-Q003 URL state determinism enforcement. A new Vitest source-policy
+gate at `tests/runtime/policy-q003-url-state-determinism.test.ts` scans
+`src/**/*.ts` and fails the build on any value-position read of the
+browser persistence and host-state surfaces named by the PUL-Q003
+preflight: `localStorage`, `sessionStorage`, `document.cookie`,
+`history.state`, `indexedDB`, `caches` (Cache Storage), `process.env`,
+`process.argv`, and `import.meta.env`. The scanner resolves
+file-local aliases of the ambient roots (`document`, `history`,
+`process`, the storage globals) and of the global wrappers (`window`,
+`globalThis`, `self`, `global`) so ordinary refactors
+(`const h = history; h.state`, `const win = window; win.localStorage`)
+match the same per-surface table as the canonical form. The gate
+reuses `tests/runtime/source-policy.ts` (AST walker, access-path
+resolution, line-scoped exemption parser, global-wrapper handling,
+computed-wrapper bypass detection) so it plugs in as a sibling to the
+existing PUL-Q007 / PUL-A001..A006 gates. `// PUL-Q003-allow: <reason>`
+opts out a single line for documented non-target uses. The gate runs
+inside the existing `pnpm test` job — no new CI step, no new dev
+dependency. A new black-box behavioral describe block in
+`tests/runtime/navigation.test.ts` seeds the host globals
+(`localStorage`, `sessionStorage`, `document.cookie`, `history.state`,
+`indexedDB`, `caches`, and the popstate `state` slot) with deliberately-
+misleading values and asserts that `parseNavigationSearch`,
+`subscribeNavigation`, `bootstrapNavigation`, and `effectiveMode`
+ignore them — the dispatched `pulsar:navigate` detail equals the
+URL-only parse, the popstate event's synthetic `state` does not
+contribute to the target, and the error envelope does not echo
+seeded state.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -11,6 +11,7 @@ Design context for Pulsar. Source material for the ADRs in `../adrs/`.
 | [pul-p003-adr-format-preflight.md](pul-p003-adr-format-preflight.md) | Guardrails for keeping ADR markdown and Ground Control ADR records aligned without duplicate schemas or workflow logic. |
 | [pul-a001-timeline-library-encapsulation-preflight.md](pul-a001-timeline-library-encapsulation-preflight.md) | Guardrails for statically enforcing scene timeline-library encapsulation through the runtime adapter and scene context. |
 | [pul-a002-a006-import-bans-preflight.md](pul-a002-a006-import-bans-preflight.md) | Cluster-level guardrails for the PUL-A002..A006 source-policy gates (audio, rendering, export, slide-framework bans plus the PUL-A005 declarative-manifest shape rule). |
+| [pul-q003-url-state-determinism-preflight.md](pul-q003-url-state-determinism-preflight.md) | Guardrails for enforcing URL-only runtime target selection without persisted browser or host state. |
 | [pul-q007-runtime-code-execution-preflight.md](pul-q007-runtime-code-execution-preflight.md) | Guardrails for statically banning runtime code execution outside the published bundle. |
 | [pul-f013-present-mode-preflight.md](pul-f013-present-mode-preflight.md) | Guardrails for implementing default `mode=present` behavior. |
 | [pul-f014-standalone-mode-preflight.md](pul-f014-standalone-mode-preflight.md) | Guardrails for implementing isolated `mode=standalone` behavior. |

--- a/docs/design/pul-q003-url-state-determinism-preflight.md
+++ b/docs/design/pul-q003-url-state-determinism-preflight.md
@@ -1,0 +1,138 @@
+# PUL-Q003 URL State Determinism Preflight
+
+PUL-Q003 is a runtime targeting rule: URL parameters fully determine
+which scene, beat, composition, and mode the workbench targets.
+Persisted browser or host state must not participate in target
+selection. The repo already has the right architecture for this:
+URL parsing is a boundary adapter, target resolution is registry based,
+and mode dispatch is per navigation.
+
+This preflight records guardrails for implementing the enforcement
+without creating a second router, persistence policy, validator, or
+workflow layer.
+
+## Boundary
+
+- `src/runtime/navigation.ts` remains the only URL grammar parser.
+  `parseNavigationSearch()`, `NavigationTarget`, `NAVIGATION_MODES`,
+  and `effectiveMode()` are the canonical targeting contract.
+- `bootstrapNavigation()` and `subscribeNavigation()` remain the only
+  startup and `popstate` parsing path. `popstate` must read
+  `location.search`, not `history.state`.
+- `src/runtime/scene-navigation.ts` remains the only URL-target
+  resolver. It consumes `NavigationTarget` and resolves against
+  `SceneRegistry` and `CompositionRegistry`.
+- `src/runtime/scene-loader.ts` remains the mode-dispatch and
+  per-navigation lifecycle boundary. It derives mode from
+  `effectiveMode(target)` for each navigation and builds fresh
+  per-navigation context.
+- Source-policy enforcement belongs in a Vitest static policy over
+  authored `src/**/*.ts`, using `tests/runtime/source-policy.ts` and
+  the screenshot-determinism source scan precedent. Do not add a
+  browser runtime validator for persisted-state targeting.
+
+## Required Reuse
+
+Implementation must build on these incumbents:
+
+- URL grammar and validation: `parseNavigationSearch()`,
+  `NavigationTarget`, `NavigationLocator`, `NAVIGATION_MODES`, and
+  `effectiveMode()`.
+- Identifier validation: `isKebabIdentifier()` and
+  `KEBAB_IDENTIFIER_FORM`; no URL-specific scene, composition, or beat
+  regex.
+- Navigation events and workflow: `bootstrapNavigation()`,
+  `subscribeNavigation()`, `PULSAR_NAVIGATE_EVENT_TYPE`, and
+  `PULSAR_NAVIGATE_ERROR_EVENT_TYPE`.
+- Target resolution: `resolveSceneNavigation()` and
+  `loadSceneNavigationTarget()`, backed by `createSceneRegistry()` and
+  `createCompositionRegistry()`.
+- Mode/lifecycle dispatch: `createSceneLoader()`, its
+  `validateBeatGrammar()` / `validateModeGrammar()` defense-in-depth
+  checks, `buildLoad()`, `applySingleSceneSlice()`, and
+  `buildPrompterLoad()`.
+- Runtime validation: `validateRuntime()` remains structural
+  scene/composition/asset validation. PUL-Q003 must not add
+  `FindingCode`s there.
+- Static source-policy infrastructure:
+  `tests/runtime/source-policy.ts` for file walking, TypeScript AST
+  parsing, access-path resolution, line-scoped exemptions, bounded
+  findings, and fail-loud Vitest reporting. The older
+  `tests/runtime/screenshot-determinism-source.test.ts` is the
+  precedent for forbidding `localStorage`, `sessionStorage`,
+  `document.cookie`, `history.state`, `process.env`, and
+  `process.argv` in `src`.
+- Error rendering and observability: `describeError()`, loader
+  `onError`, and `data-pulsar-navigation-error`.
+
+## Cross-Cutting Layers
+
+| Layer | Guardrail |
+|-------|-----------|
+| URL grammar gate | `parseNavigationSearch()` is the only parser for `scene`, `composition`, `index`, `beat`, and `mode`. Unknown query keys remain ignored and repeated grammar keys remain invalid. Do not add aliases such as `lastScene`, `savedMode`, or state restored from storage. |
+| Startup / popstate workflow | Startup and browser back/forward must flow through `bootstrapNavigation()` / `subscribeNavigation()`. The event handler reads `location.search` every time. `history.state` is not a target input. |
+| Programmatic target boundary | Because `NavigationTarget` is exported, the loader keeps parser-equivalent defense-in-depth checks for `beat` and `mode`. Any future public programmatic navigation helper must call `parseNavigationSearch()` or construct the same typed shape and pass the same loader checks. |
+| Registry and composition resolution | Resolve target ids only through `SceneRegistry` and `CompositionRegistry`. URL values are ids, not file paths, module specifiers, inline manifests, dynamic imports, or network resources. |
+| Mode dispatch | Mode is derived with `effectiveMode(target)` for each navigation. Omitted `mode` selects fresh `present`; it must not reuse a previous mode from memory or storage. |
+| Scene context | `ctx.mode` is a derived hint from the current target only. Scenes may branch on `ctx.mode`; they must not parse query strings or read storage/cookies/history to determine target or mode. |
+| Runtime validation | `validateRuntime()` stays graph-shape validation. Q003 enforcement is source-policy plus existing URL/parser/loader tests, not scene metadata validation. |
+| Source policy gate | Add or extend a Vitest policy scan over `src/**/*.ts`. Reuse `source-policy.ts`; do not create regex-only scans or duplicate walkers. Any exemption must be line-scoped and reasoned, e.g. `PUL-Q003-allow: <reason>`, and must not apply to target selection. |
+| Auth, secrets, and env binding | Target selection needs no auth, secrets, env vars, `.env`, or host config. `process.env`, `import.meta.env`, and `process.argv` must not determine scene, beat, composition, or mode. |
+| OS/process exposure | Do not pass target state, secret-bearing URLs, cookies, or env-derived values through shell argv. Tests should run in-process under Vitest and report relative path, line, label, and trimmed line text only. |
+| Error envelope | Navigation failures use existing `navigation grammar is invalid:`, `scene navigation failed:`, `composition resolution failed:`, and `data-pulsar-navigation-error` surfaces. Diagnostics may name ids, modes, indexes, and bounded messages; never dump cookies, headers, env, argv, raw scene objects, or full credential-bearing URLs. |
+| Observability | Stage attributes remain `data-pulsar-scene-target`, `data-pulsar-composition-target`, `data-pulsar-navigation-error`, and existing mode-specific surfaces. Do not add telemetry, storage-backed breadcrumbs, or a logging framework. |
+| Persistence | Browser persistence APIs are out of scope for target selection: `localStorage`, `sessionStorage`, `document.cookie`, `history.state`, IndexedDB, Cache Storage, service-worker state, and persisted in-memory snapshots across reloads must not determine target. |
+
+## Intended Design
+
+The intended design is a small policy layer around the existing URL
+architecture. Runtime targeting semantics stay in `NavigationTarget`
+and the existing parser/resolver/loader path. Source-policy coverage
+keeps persisted-state reads from entering authored runtime source as
+target inputs. Behavioral coverage should prove startup and `popstate`
+ignore storage/cookie/history fixtures when deriving the parsed target,
+effective mode, stage target attributes, and navigation errors.
+
+The seam for future extension is the source-policy forbidden-surface
+table and matcher functions. If future requirements add a permitted
+non-target use of a persistence API, keep that as an explicit
+line-scoped exemption or narrow wrapper whose name makes the non-target
+purpose obvious. Do not weaken the canonical parser or let the wrapper
+return scene, beat, composition, index, or mode.
+
+## Gotchas And Anti-Patterns
+
+- Do not implement a "remember last scene/mode/beat" feature behind a
+  missing URL parameter. Missing `mode` already means fresh `present`;
+  missing target means the current `kind: 'none'` placeholder behavior.
+- Do not put target defaults in `localStorage`, `sessionStorage`,
+  cookies, `history.state`, IndexedDB, service workers, env vars, or
+  process argv.
+- Do not duplicate URL parsing in scenes, workbench controls, tests,
+  validation, presenter code, or audio/prompter adapters.
+- Do not make query keys accept resource locators. `scene` and
+  `composition` are ids only.
+- Do not add a second mode enum, `isScreenshot` flag, `paused`
+  boolean, `targetState` DTO, or persistence policy module.
+- Do not silently fall back to a default scene when a URL target is
+  invalid. Surface the existing navigation error.
+- Do not allow static-policy exemptions for code that influences
+  `NavigationTarget`, `effectiveMode()`, `resolveSceneNavigation()`,
+  `createSceneLoader()`, or scene `ctx.mode`.
+- Do not reclassify this as a runtime validation finding. The runtime
+  validator inspects declarative graph inputs; Q003 is about target
+  input provenance and source structure.
+
+## Non-Goals
+
+PUL-Q003 does not add URL parameters, workbench modes, scene metadata,
+composition manifest fields, presenter commands, auth, telemetry,
+storage sync, browser history mutation, routing libraries, config
+files, environment binding, or a CLI report format.
+
+It does not change scene/composition schemas, asset preloading,
+timeline orchestration, audio policy, prompter rendering, validation
+scope, or requirement status. It should not transition to ACTIVE until
+implementation includes source-policy coverage and behavioral tests
+showing that persisted browser or host state cannot alter the targeted
+scene, beat, composition, or mode.

--- a/tests/runtime/navigation.test.ts
+++ b/tests/runtime/navigation.test.ts
@@ -357,8 +357,16 @@ describe('parseNavigationSearch — ADR-013: repeated keys & unknown keys', () =
 describe('parseNavigationSearch — boundary discipline', () => {
   it('does NOT validate scene existence (resolution-layer concern)', () => {
     // ADR-013: composition + scene is id-based; existence/uniqueness in
-    // a composition is resolution-layer work, not grammar.
-    expect(() => parseNavigationSearch('composition=full-talk&scene=does-not-exist')).not.toThrow();
+    // a composition is resolution-layer work, not grammar. The parser
+    // passes the id through verbatim — assert the locator shape too
+    // so a silent corruption (parser drops the scene field when the id
+    // looks unfamiliar) would fail here, not just the no-throw check.
+    const result = parseNavigationSearch('composition=full-talk&scene=does-not-exist');
+    expect(result.locator).toEqual({
+      kind: 'composition-scene',
+      composition: 'full-talk',
+      scene: 'does-not-exist',
+    });
   });
 
   it('returns frozen targets so callers cannot mutate the parser output', () => {
@@ -832,5 +840,217 @@ describe('bootstrapNavigation — runtime entry wiring', () => {
   it('event-type constants match the dispatched event types', () => {
     expect(PULSAR_NAVIGATE_EVENT_TYPE).toBe('pulsar:navigate');
     expect(PULSAR_NAVIGATE_ERROR_EVENT_TYPE).toBe('pulsar:navigate-error');
+  });
+});
+
+describe('PUL-Q003 — persisted browser state never determines the target', () => {
+  // Behavioral pin for PUL-Q003: URL parameters fully determine the
+  // runtime's targeted state; `localStorage`, `sessionStorage`,
+  // `document.cookie`, `history.state`, IndexedDB, and Cache Storage
+  // must NOT determine which scene, beat, composition, or mode is
+  // targeted.
+  //
+  // Each test seeds the host globals with values that — if they leaked
+  // into target selection — would change the parsed locator, the
+  // beat, or the effective mode. The assertions confirm the dispatched
+  // navigation event matches `parseNavigationSearch(location.search)`
+  // exactly and that `effectiveMode(...)` ignores the seeded state.
+  //
+  // The structural ban on these surfaces in `src/**/*.ts` is enforced
+  // separately by `policy-q003-url-state-determinism.test.ts`. This
+  // block adds black-box coverage: if a future refactor of
+  // `subscribeNavigation` / `bootstrapNavigation` / `effectiveMode`
+  // started reading host globals (e.g. consuming the `PopStateEvent`
+  // `state` slot), the assertion below fails immediately.
+
+  interface FakeBrowser {
+    readonly target: NavigationEventTarget;
+    readonly events: EventTarget;
+    setSearch(value: string): void;
+    firePopstate(state: unknown): void;
+  }
+
+  const buildFakeBrowser = (initial: string): FakeBrowser => {
+    const events = new EventTarget();
+    let search = initial;
+    const target: NavigationEventTarget = {
+      addEventListener: (event, listener) => {
+        events.addEventListener(event, listener as EventListener);
+      },
+      removeEventListener: (event, listener) => {
+        events.removeEventListener(event, listener as EventListener);
+      },
+      dispatchEvent: (event) => events.dispatchEvent(event),
+      get location() {
+        return { search };
+      },
+    };
+    return {
+      target,
+      events,
+      setSearch(value) {
+        search = value;
+      },
+      firePopstate(state) {
+        // Real popstate events carry the synthetic `state` slot from
+        // `history.pushState` / `replaceState`. A future regression
+        // that read `evt.state` to influence the target would surface
+        // here — the seeded value disagrees with the URL.
+        const evt = new Event('popstate') as Event & { state?: unknown };
+        evt.state = state;
+        events.dispatchEvent(evt);
+      },
+    };
+  };
+
+  const flushMicrotasks = async (): Promise<void> => {
+    await Promise.resolve();
+  };
+
+  const collectNavigateEvents = (browser: FakeBrowser): CustomEvent<NavigationTarget>[] => {
+    const out: CustomEvent<NavigationTarget>[] = [];
+    browser.events.addEventListener(PULSAR_NAVIGATE_EVENT_TYPE, (evt) => {
+      out.push(evt as CustomEvent<NavigationTarget>);
+    });
+    return out;
+  };
+
+  // Deliberately-misleading values: every persistence surface points
+  // at a different "tampered" target. If ANY of them leaked into
+  // target selection, the assertion would catch the divergence —
+  // the test seeds are designed so no two surfaces agree, so a
+  // partial leak surfaces too.
+  const TAMPERED_HISTORY_STATE = {
+    scene: 'tampered-history-scene',
+    composition: 'tampered-history-composition',
+    mode: 'tampered-history-mode',
+  } as const;
+
+  const tamperedLocalStorage: Storage = {
+    length: 1,
+    clear: () => {},
+    getItem: (key) => (key === 'scene' ? 'tampered-localstorage-scene' : null),
+    key: (n) => (n === 0 ? 'scene' : null),
+    removeItem: () => {},
+    setItem: () => {},
+  };
+
+  const tamperedSessionStorage: Storage = {
+    length: 1,
+    clear: () => {},
+    getItem: (key) => (key === 'mode' ? 'tampered-sessionstorage-mode' : null),
+    key: (n) => (n === 0 ? 'mode' : null),
+    removeItem: () => {},
+    setItem: () => {},
+  };
+
+  const tamperedDocument = { cookie: 'scene=tampered-cookie-scene; mode=tampered-cookie-mode' };
+  const tamperedHistory = { state: TAMPERED_HISTORY_STATE };
+  const tamperedIndexedDB = {
+    open: () => {
+      throw new Error('PUL-Q003: indexedDB must not be consulted during navigation');
+    },
+  };
+  const tamperedCaches = {
+    open: async () => {
+      throw new Error('PUL-Q003: Cache Storage must not be consulted during navigation');
+    },
+  };
+
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', tamperedLocalStorage);
+    vi.stubGlobal('sessionStorage', tamperedSessionStorage);
+    vi.stubGlobal('document', tamperedDocument);
+    vi.stubGlobal('history', tamperedHistory);
+    vi.stubGlobal('indexedDB', tamperedIndexedDB);
+    vi.stubGlobal('caches', tamperedCaches);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('parseNavigationSearch returns the URL target verbatim with no fallback to host globals', () => {
+    // Pure parser sanity: an empty search produces `kind: 'none'` and
+    // no beat / no mode — none of the seeded globals contribute.
+    expect(parseNavigationSearch('')).toEqual({ locator: { kind: 'none' } });
+  });
+
+  it('effectiveMode defaults to `present` when the URL omits `mode`, regardless of seeded persisted state', () => {
+    // ADR-007: URL is the only source of mode. The seeded
+    // sessionStorage value (`tampered-sessionstorage-mode`) and the
+    // seeded history.state.mode are both invalid mode strings; if
+    // either leaked, `effectiveMode` would either return them
+    // (violating the type) or fail to default to `present`.
+    expect(effectiveMode()).toBe('present');
+    expect(effectiveMode({ locator: { kind: 'none' } })).toBe('present');
+  });
+
+  it('bootstrap with empty location.search ignores all seeded persisted state', async () => {
+    const browser = buildFakeBrowser('');
+    const navigate = collectNavigateEvents(browser);
+
+    bootstrapNavigation(browser.target);
+    await flushMicrotasks();
+
+    expect(navigate).toHaveLength(1);
+    const evt = navigate[0];
+    if (!evt) throw new Error('expected the startup navigate event');
+    expect(evt.detail).toEqual({ locator: { kind: 'none' } } satisfies NavigationTarget);
+    expect(effectiveMode(evt.detail)).toBe('present');
+  });
+
+  it('popstate parses the current location.search, not the popstate event `state`', async () => {
+    // PUL-F007 clause 2 + ADR-013: `popstate` re-reads `location.search`.
+    // The popstate event carries the seeded synthetic state slot; the
+    // parser must ignore it. A regression that read `evt.state` to
+    // build the target would surface a `tampered-history-scene`
+    // locator here.
+    const browser = buildFakeBrowser('');
+    const navigate = collectNavigateEvents(browser);
+    bootstrapNavigation(browser.target);
+    await flushMicrotasks();
+    navigate.length = 0; // discard startup
+
+    browser.setSearch('?scene=intro');
+    browser.firePopstate(TAMPERED_HISTORY_STATE);
+    browser.setSearch('?composition=full-talk&index=2&mode=loop');
+    browser.firePopstate({ scene: 'still-tampered', mode: 'still-tampered' });
+
+    expect(navigate.map((e) => e.detail)).toEqual([
+      { locator: { kind: 'scene', scene: 'intro' } },
+      {
+        locator: { kind: 'composition-index', composition: 'full-talk', index: 2 },
+        mode: 'loop',
+      },
+    ]);
+    const first = navigate[0];
+    const second = navigate[1];
+    if (!first || !second) throw new Error('expected two navigate events');
+    expect(effectiveMode(first.detail)).toBe('present');
+    expect(effectiveMode(second.detail)).toBe('loop');
+  });
+
+  it('an invalid URL grammar still routes through `navigation grammar is invalid:` without leaking seeded state into the error envelope', async () => {
+    // Parse failures must surface the parser's own diagnostic string;
+    // they must not echo the seeded `localStorage` / `document.cookie`
+    // / `history.state` values, even though those values are
+    // syntactically tempting fallbacks.
+    const browser = buildFakeBrowser('?scene=Bad');
+    const errors: CustomEvent<Error>[] = [];
+    browser.events.addEventListener(PULSAR_NAVIGATE_ERROR_EVENT_TYPE, (evt) => {
+      errors.push(evt as CustomEvent<Error>);
+    });
+    bootstrapNavigation(browser.target);
+    await flushMicrotasks();
+
+    expect(errors).toHaveLength(1);
+    const err = errors[0]?.detail;
+    if (!err) throw new Error('expected the startup error event');
+    expect(err.message).toMatch(/^navigation grammar is invalid:/);
+    expect(err.message).not.toContain('tampered-localstorage-scene');
+    expect(err.message).not.toContain('tampered-cookie');
+    expect(err.message).not.toContain('tampered-history');
+    expect(err.message).not.toContain('tampered-sessionstorage');
   });
 });

--- a/tests/runtime/policy-q003-url-state-determinism.test.ts
+++ b/tests/runtime/policy-q003-url-state-determinism.test.ts
@@ -1,0 +1,1407 @@
+import { readFileSync, statSync } from 'node:fs';
+import { relative } from 'node:path';
+import * as ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+import {
+  GLOBAL_WRAPPERS,
+  REPO_ROOT,
+  SRC_ROOT,
+  type SourceFinding,
+  collectLineExemptions,
+  getAccessPath,
+  isInTypePosition,
+  lineText,
+  parseSource,
+  unwrap,
+  walkTsFiles,
+} from './source-policy';
+
+// PUL-Q003 — URL state determinism source scan.
+//
+// Statement: "URL parameters SHALL fully determine the runtime's
+// targeted state. The runtime SHALL NOT use `localStorage`,
+// `sessionStorage`, cookies, or other persisted state to determine
+// which scene, beat, composition, or mode is targeted."
+//
+// The PUL-Q003 preflight (`docs/design/pul-q003-url-state-determinism-preflight.md`)
+// names browser persistence APIs AND host-state surfaces as out of
+// scope for target selection: `localStorage`, `sessionStorage`,
+// `document.cookie`, `history.state`, IndexedDB, Cache Storage,
+// `process.env`, `process.argv`, `import.meta.env`. The scanner bans
+// the union so the gate is structurally complete on its own terms —
+// independent of the Q001 screenshot-determinism scan, which today
+// happens to overlap on the host-state subset but is logically
+// scope-separable.
+//
+// Enforcement: a Vitest source scan over `src/**/*.ts`. The scanner
+// flags every runtime-value read of:
+//   - `localStorage`, `sessionStorage` (Web Storage)
+//   - `document.cookie`
+//   - `history.state` (the `history` global's persisted slot —
+//     `history.pushState` / `replaceState` are URL mutators and stay
+//     allowed)
+//   - `indexedDB` (IndexedDB)
+//   - `caches` (Cache Storage)
+//   - `process.env`, `process.argv` (host environment / argv)
+//   - `import.meta.env` (Vite-injected env binding)
+// Each surface is matched bare (`localStorage`), through a recognised
+// global wrapper (`window.localStorage`, `globalThis.caches`,
+// `self.indexedDB`, `global.history.state`), via string-literal
+// bracket access (`window['localStorage']`), via a computed
+// wrapper-access bypass (`globalThis['local' + 'Storage']`), and
+// **through file-local aliases** of the ambient roots or the global
+// wrappers (`const h = history; h.state` / `const win = window;
+// win.localStorage`). Type-position references, declaration names,
+// and property-name keys are ignored. Comments and string literals do
+// not trigger the gate.
+//
+// This is a sibling policy to the PUL-Q001 screenshot-determinism
+// source scan (`screenshot-determinism-source.test.ts`), which already
+// bans `localStorage`, `sessionStorage`, `document.cookie`,
+// `history.state`, `process.env`, `process.argv`, and `import.meta.env`
+// in `src/`. The two gates dual-flag the overlap intentionally:
+// Q001 protects byte-identical screenshot capture; Q003 protects
+// URL-only target selection. If a future refactor scopes Q001 to
+// screenshot-mode paths or to the scene subset, Q003 keeps the
+// persisted-state / host-state ban in force across the whole authored
+// runtime. Q003 additionally covers two browser-persistence surfaces
+// (`indexedDB`, `caches`) that Q001 does not, because those are
+// persistence hazards rather than wall-clock / entropy hazards.
+//
+// Exemption: a line-scoped `// PUL-Q003-allow: <reason>` comment
+// excludes a single line from the scan. Empty / whitespace-only
+// rationales are rejected; markers hidden inside string literals are
+// rejected; the marker applies only to its own line.
+
+const ALLOW_TAG = 'PUL-Q003-allow';
+
+// Forbidden bare globals: bare identifier reads (and `<wrapper>.X` /
+// `<wrapper>['X']`) trip the gate. Each entry is the global identifier
+// name; the label is the human-readable surface name carried on the
+// finding.
+const FORBIDDEN_GLOBAL_IDENTIFIERS: readonly { readonly name: string; readonly label: string }[] = [
+  { name: 'localStorage', label: 'localStorage' },
+  { name: 'sessionStorage', label: 'sessionStorage' },
+  { name: 'indexedDB', label: 'indexedDB' },
+  { name: 'caches', label: 'caches (Cache Storage)' },
+];
+const FORBIDDEN_GLOBAL_IDENTIFIER_LABEL_BY_NAME = new Map(
+  FORBIDDEN_GLOBAL_IDENTIFIERS.map((e) => [e.name, e.label]),
+);
+
+// Forbidden root + property pairs: `[..wrappers.., root, prop]` access
+// chains. The persisted-slot reads (`document.cookie`, `history.state`),
+// the host-state reads (`process.env`, `process.argv`), and the
+// Vite-injected env binding (`import.meta.env`) all go through one
+// unified table. `import.meta` is treated as a synthetic root segment
+// emitted by `getAccessPath` for the JS meta-property; the matcher
+// handles it the same way as the regular roots. `history.pushState` /
+// `replaceState` are URL mutators and are NOT in this table; they
+// push state into the URL, they do not read persisted state out.
+const FORBIDDEN_ROOT_PROPERTY_PAIRS: readonly {
+  readonly root: string;
+  readonly prop: string;
+  readonly label: string;
+}[] = [
+  { root: 'document', prop: 'cookie', label: 'document.cookie' },
+  { root: 'history', prop: 'state', label: 'history.state' },
+  { root: 'process', prop: 'env', label: 'process.env' },
+  { root: 'process', prop: 'argv', label: 'process.argv' },
+  { root: 'import.meta', prop: 'env', label: 'import.meta.env' },
+];
+
+// Ambient roots whose file-local aliases (`const X = <root>` or
+// `const X = <wrapper>.<root>`) the scanner resolves before access-path
+// matching. Without this, ordinary refactors (`const h = history;
+// h.state`, `const h = window.history; h.state`, `const win = window;
+// win.localStorage`) would slip past every per-surface check while
+// still reading the persisted-state slot. The set is the union of the
+// global wrappers, the forbidden-table roots, the bare-global
+// identifiers, and the `import.meta` meta-property root so an alias of
+// any covered root resolves correctly.
+const ALIAS_ROOTS: ReadonlySet<string> = new Set<string>([
+  ...GLOBAL_WRAPPERS,
+  'document',
+  'history',
+  'process',
+  'import.meta',
+  'localStorage',
+  'sessionStorage',
+  'indexedDB',
+  'caches',
+]);
+
+// True when `node` is the `.name` portion of a property access /
+// qualified name — i.e., a key position rather than a value-read. A
+// `foo.cookie` access where `foo` is a local does not trip the
+// `document.cookie` rule because root-property matching is anchored
+// on `document` / `history`; this predicate prevents the leaf
+// identifier `cookie` from also triggering a separate bare-identifier
+// match through the visitor loop.
+function isPropertyNamePosition(node: ts.Identifier): boolean {
+  const parent = node.parent;
+  if (!parent) return false;
+  if (
+    (ts.isPropertyAccessExpression(parent) || ts.isQualifiedName(parent)) &&
+    'name' in parent &&
+    parent.name === node
+  ) {
+    return true;
+  }
+  return false;
+}
+
+// True when `node` is being declared (`const localStorage = ...`,
+// `function caches() {}`, `interface I { localStorage(): void }`,
+// etc.). Declarations are not value reads.
+function isDeclarationName(node: ts.Identifier): boolean {
+  const parent = node.parent;
+  if (!parent) return false;
+  if (ts.isVariableDeclaration(parent) && parent.name === node) return true;
+  if (ts.isParameter(parent) && parent.name === node) return true;
+  if (ts.isFunctionDeclaration(parent) && parent.name === node) return true;
+  if (ts.isClassDeclaration(parent) && parent.name === node) return true;
+  if (ts.isInterfaceDeclaration(parent) && parent.name === node) return true;
+  if (ts.isTypeAliasDeclaration(parent) && parent.name === node) return true;
+  if (ts.isEnumDeclaration(parent) && parent.name === node) return true;
+  if (ts.isEnumMember(parent) && parent.name === node) return true;
+  if (ts.isMethodDeclaration(parent) && parent.name === node) return true;
+  if (ts.isMethodSignature(parent) && parent.name === node) return true;
+  if (ts.isPropertyDeclaration(parent) && parent.name === node) return true;
+  if (ts.isPropertySignature(parent) && parent.name === node) return true;
+  if (ts.isPropertyAssignment(parent) && parent.name === node) return true;
+  // ShorthandPropertyAssignment is intentionally NOT a declaration:
+  // `{ localStorage }` is a value-position read, equivalent to
+  // `{ localStorage: localStorage }`.
+  if (ts.isBindingElement(parent) && parent.name === node) return true;
+  if (ts.isImportSpecifier(parent)) return true;
+  if (ts.isImportClause(parent) && parent.name === node) return true;
+  if (ts.isNamespaceImport(parent)) return true;
+  if (ts.isExportSpecifier(parent)) return true;
+  return false;
+}
+
+// Strip leading recognised global-wrapper segments. Returns the
+// remaining `tail` plus the count of stripped segments.
+function stripWrappers(path: readonly string[]): readonly string[] {
+  let start = 0;
+  while (start < path.length && GLOBAL_WRAPPERS.has(path[start] ?? '')) {
+    start += 1;
+  }
+  return path.slice(start);
+}
+
+// Match `[..wrappers.., root, prop]` against the unified table.
+// Returns the matched label, or null when the path doesn't match.
+// `import.meta` resolves to a synthetic single-segment root and is
+// handled here too — `[import.meta, env]` matches the
+// `import.meta.env` row.
+function matchRootPropertyPair(path: readonly string[]): string | null {
+  const tail = stripWrappers(path);
+  if (tail.length !== 2) return null;
+  const [root, prop] = tail;
+  for (const surface of FORBIDDEN_ROOT_PROPERTY_PAIRS) {
+    if (surface.root === root && surface.prop === prop) {
+      return surface.label;
+    }
+  }
+  return null;
+}
+
+// Match a path whose first non-wrapper segment is a bare forbidden
+// global (`localStorage`, `sessionStorage`, `indexedDB`, `caches`).
+// Catches BOTH the exact-length bare read (path `[localStorage]`)
+// and downstream property reads (`storage.getItem` after `const
+// storage = localStorage` resolves to `[localStorage, getItem]`).
+// The earlier `pathResolvesTo` helper required a tail of length 1
+// and therefore missed the aliased-and-then-used case where the
+// binding line is allow-exempted.
+function matchBareGlobalRoot(path: readonly string[]): string | null {
+  const tail = stripWrappers(path);
+  if (tail.length === 0) return null;
+  const root = tail[0];
+  if (root === undefined) return null;
+  return FORBIDDEN_GLOBAL_IDENTIFIER_LABEL_BY_NAME.get(root) ?? null;
+}
+
+// Collect file-local aliases that bind a fresh identifier to one of
+// the ambient roots in `ALIAS_ROOTS`. The collector handles five
+// initializer shapes:
+//
+//   1. A bare identifier in `ALIAS_ROOTS` (`const h = history;`,
+//      `const ls = localStorage;`).
+//   2. An alias of an alias — when the initializer identifier is
+//      itself in the aliases map, register the new local against
+//      the canonical (`const win = window; const w2 = win;` →
+//      `w2 → window`).
+//   3. A property/element access whose alias-resolved + wrapper-
+//      stripped path is a single ambient root segment
+//      (`const h = window.history;`,
+//      `const h = win.history` after `const win = window;`).
+//   4. The `import.meta` meta-property (`const meta = import.meta;`).
+//   5. A destructured property that names an ambient root, when the
+//      initializer is a wrapper (`const { history: h } = window;`,
+//      `const { document: doc } = root;` after `const root = globalThis;`).
+//
+// The collector iterates to a fixed point so alias chains resolve
+// regardless of source order (`const h = win.history; const win = window;`
+// resolves on the second pass when `win`'s registration becomes
+// visible to the property-access classifier).
+//
+// Chained or expression-shaped initializers (`const h = history.state;`,
+// `const h = computeRoot();`) do NOT register an alias because the
+// resulting local no longer refers to the ambient root verbatim — it
+// refers to a value that was once derived from it.
+function collectAliases(sourceFile: ts.SourceFile): Map<string, string> {
+  const aliases = new Map<string, string>();
+
+  type DirectDecl = { kind: 'direct'; name: string; init: ts.Expression };
+  type DestructuringDecl = {
+    kind: 'destructuring';
+    pattern: ts.ObjectBindingPattern;
+    init: ts.Expression;
+  };
+  const declarations: (DirectDecl | DestructuringDecl)[] = [];
+  const collectVisit = (node: ts.Node): void => {
+    if (ts.isVariableDeclaration(node) && node.initializer) {
+      if (ts.isIdentifier(node.name)) {
+        declarations.push({ kind: 'direct', name: node.name.text, init: node.initializer });
+      } else if (ts.isObjectBindingPattern(node.name)) {
+        declarations.push({
+          kind: 'destructuring',
+          pattern: node.name,
+          init: node.initializer,
+        });
+      }
+    }
+    ts.forEachChild(node, collectVisit);
+  };
+  collectVisit(sourceFile);
+
+  const tryRegisterDirect = (localName: string, init: ts.Expression): boolean => {
+    if (aliases.has(localName)) return false;
+    const inner = unwrap(init);
+    if (ts.isIdentifier(inner)) {
+      if (ALIAS_ROOTS.has(inner.text)) {
+        aliases.set(localName, inner.text);
+        return true;
+      }
+      const aliased = aliases.get(inner.text);
+      if (aliased !== undefined) {
+        aliases.set(localName, aliased);
+        return true;
+      }
+      return false;
+    }
+    if (ts.isMetaProperty(inner)) {
+      aliases.set(localName, 'import.meta');
+      return true;
+    }
+    if (ts.isPropertyAccessExpression(inner) || ts.isElementAccessExpression(inner)) {
+      const rawPath = getAccessPath(inner);
+      if (!rawPath) return false;
+      const resolved = resolveAliasedPath(rawPath, aliases) ?? rawPath;
+      const tail = stripWrappers(resolved);
+      if (tail.length === 1) {
+        const canonical = tail[0];
+        if (canonical && ALIAS_ROOTS.has(canonical)) {
+          aliases.set(localName, canonical);
+          return true;
+        }
+      }
+    }
+    return false;
+  };
+
+  const tryRegisterDestructuring = (
+    pattern: ts.ObjectBindingPattern,
+    init: ts.Expression,
+  ): boolean => {
+    // Only ambient-root destructuring from a wrapper registers an
+    // alias. `const { state } = history;` reads `history.state` —
+    // that's surface-matched elsewhere, not aliased.
+    const initPath = resolveAliasedPath(getAccessPathFromExpression(init), aliases);
+    if (!initPath) return false;
+    const tail = stripWrappers(initPath);
+    if (tail.length !== 0) return false; // not a pure wrapper root
+    let changed = false;
+    for (const element of pattern.elements) {
+      const propNode = element.propertyName ?? element.name;
+      const propText = ts.isIdentifier(propNode)
+        ? propNode.text
+        : ts.isStringLiteralLike(propNode)
+          ? propNode.text
+          : null;
+      if (!propText) continue;
+      if (!ALIAS_ROOTS.has(propText)) continue;
+      // Skip when the local name isn't a simple identifier (nested
+      // destructuring is not aliased).
+      if (!ts.isIdentifier(element.name)) continue;
+      const localName = element.name.text;
+      if (aliases.has(localName)) continue;
+      aliases.set(localName, propText);
+      changed = true;
+    }
+    return changed;
+  };
+
+  // Iterate to a fixed point. Each pass can register one additional
+  // level of chaining; the upper bound is `declarations.length`
+  // passes, which is plenty for any realistic source file.
+  for (let pass = 0; pass < declarations.length + 1; pass += 1) {
+    let changed = false;
+    for (const decl of declarations) {
+      if (decl.kind === 'direct') {
+        if (tryRegisterDirect(decl.name, decl.init)) changed = true;
+      } else {
+        if (tryRegisterDestructuring(decl.pattern, decl.init)) changed = true;
+      }
+    }
+    if (!changed) break;
+  }
+  return aliases;
+}
+
+// Substitute the first segment of `path` with its canonical alias
+// target, if one is registered. Subsequent segments are property
+// names by construction (a property access cannot itself be an
+// aliased ambient root), so single-step substitution is sufficient.
+function resolveAliasedPath(
+  path: readonly string[] | null,
+  aliases: Map<string, string>,
+): readonly string[] | null {
+  if (!path || path.length === 0 || aliases.size === 0) return path;
+  const first = path[0];
+  if (first === undefined) return path;
+  const canonical = aliases.get(first);
+  if (canonical === undefined) return path;
+  return [canonical, ...path.slice(1)];
+}
+
+// Q003-local computed-access detector. Walks back through nested
+// property / element access nodes; returns `true` when any subscript
+// is non-literal (i.e., computed) AND the underlying root resolves to
+// one of: a recognised global wrapper, an ambient ALIAS_ROOTS root,
+// or the `import.meta` meta-property — directly or through a file-
+// local alias. Conservative: a computed segment on a non-restricted
+// root is NOT flagged.
+//
+// This replaces the shared `isComputedGlobalWrapperAccess` for the
+// Q003 path because the shared helper only accepts wrapper roots,
+// not aliased wrapper roots or `import.meta`. Used for bypass
+// patterns like `win[key]` after `const win = window`,
+// `globalThis['lo' + 'calStorage']`, and `import.meta['en' + 'v']`.
+function isComputedRestrictedRootAccess(
+  expr: ts.Expression,
+  aliases: ReadonlyMap<string, string>,
+): boolean {
+  let current: ts.Expression = unwrap(expr);
+  let foundComputed = false;
+  while (true) {
+    current = unwrap(current);
+    if (ts.isPropertyAccessExpression(current)) {
+      current = current.expression;
+      continue;
+    }
+    if (ts.isElementAccessExpression(current)) {
+      const arg = unwrap(current.argumentExpression);
+      if (!ts.isStringLiteralLike(arg)) {
+        foundComputed = true;
+      }
+      current = current.expression;
+      continue;
+    }
+    break;
+  }
+  if (!foundComputed) return false;
+  if (ts.isMetaProperty(current)) return true;
+  if (!ts.isIdentifier(current)) return false;
+  // Direct ambient root (`history[key]`, `process[key]`, etc.) is a
+  // bypass surface even without aliasing — codex review cycle 3
+  // flagged that `history['st' + 'ate']` was silently passing
+  // because the direct-root branch only accepted GLOBAL_WRAPPERS.
+  // ALIAS_ROOTS is the superset (wrappers + ambient roots + bare
+  // globals + import.meta), so a single membership check covers
+  // both direct and aliased forms.
+  if (ALIAS_ROOTS.has(current.text)) return true;
+  const canonical = aliases.get(current.text);
+  if (canonical === undefined) return false;
+  return ALIAS_ROOTS.has(canonical);
+}
+
+function scanQ003(sourceFile: ts.SourceFile): readonly SourceFinding[] {
+  const exempted = collectLineExemptions(sourceFile, ALLOW_TAG);
+  const aliases = collectAliases(sourceFile);
+  const findings: SourceFinding[] = [];
+  const seen = new Set<string>();
+
+  const record = (node: ts.Node, label: string): void => {
+    const start = node.getStart(sourceFile);
+    const key = `${start}::${label}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    const { line } = sourceFile.getLineAndCharacterOfPosition(start);
+    if (exempted.has(line)) return;
+    findings.push({
+      file: sourceFile.fileName,
+      line: line + 1,
+      text: lineText(sourceFile, line).trim(),
+      label,
+    });
+  };
+
+  // Destructuring helper: given an initializer expression and the
+  // collection of object-pattern elements, record findings for every
+  // element that destructures a forbidden surface. Used for BOTH the
+  // `const { ... } = X` (VariableDeclaration) and `({ ... } = X)`
+  // (assignment) forms.
+  const recordDestructuring = (
+    initializer: ts.Expression,
+    elements: readonly { node: ts.Node; propertyName: string }[],
+  ): void => {
+    const initPath = resolveAliasedPath(getAccessPathFromExpression(initializer), aliases);
+    if (!initPath) return;
+    const tail = stripWrappers(initPath);
+    // Case A: tail length 0 — destructuring directly from a global
+    // wrapper (`const { localStorage } = window;`). Each property is
+    // a bare-global read.
+    if (tail.length === 0) {
+      for (const element of elements) {
+        const label = FORBIDDEN_GLOBAL_IDENTIFIER_LABEL_BY_NAME.get(element.propertyName);
+        if (label) record(element.node, `${label} (via destructuring)`);
+      }
+      return;
+    }
+    // Case B: tail length 1 — destructuring from a named ambient
+    // root (`const { cookie } = document;`, `const { env } = process;`,
+    // `const { env } = import.meta;`). Property names match against
+    // the root.prop table.
+    if (tail.length === 1) {
+      const rootSegment = tail[0];
+      for (const element of elements) {
+        for (const surface of FORBIDDEN_ROOT_PROPERTY_PAIRS) {
+          if (rootSegment === surface.root && surface.prop === element.propertyName) {
+            record(element.node, `${surface.label} (via destructuring)`);
+          }
+        }
+      }
+    }
+    // Tail length >= 2 means the initializer is itself a read of a
+    // surface (`const { x } = document.cookie;`); the access-path
+    // matcher already flags the initializer, so no extra finding is
+    // needed at the destructuring elements.
+  };
+
+  // Extract the destructured `(node, propertyName)` pairs from a
+  // VariableDeclaration object binding pattern. String-literal keys
+  // (`const { 'cookie': c } = document;`) are accepted alongside
+  // identifier keys.
+  const variablePatternElements = (
+    pattern: ts.ObjectBindingPattern,
+  ): { node: ts.Node; propertyName: string }[] => {
+    const out: { node: ts.Node; propertyName: string }[] = [];
+    for (const element of pattern.elements) {
+      const propName = element.propertyName ?? element.name;
+      if (ts.isIdentifier(propName)) {
+        out.push({ node: element, propertyName: propName.text });
+      } else if (ts.isStringLiteralLike(propName)) {
+        out.push({ node: element, propertyName: propName.text });
+      }
+    }
+    return out;
+  };
+
+  // Extract the destructured `(node, propertyName)` pairs from an
+  // ObjectLiteralExpression destructuring assignment pattern
+  // (`({ state } = history;)`). TypeScript represents the LHS as an
+  // ObjectLiteralExpression whose `properties` are
+  // ShorthandPropertyAssignment / PropertyAssignment.
+  const assignmentPatternElements = (
+    pattern: ts.ObjectLiteralExpression,
+  ): { node: ts.Node; propertyName: string }[] => {
+    const out: { node: ts.Node; propertyName: string }[] = [];
+    for (const property of pattern.properties) {
+      if (ts.isShorthandPropertyAssignment(property)) {
+        out.push({ node: property, propertyName: property.name.text });
+      } else if (ts.isPropertyAssignment(property)) {
+        const key = property.name;
+        if (ts.isIdentifier(key)) {
+          out.push({ node: property, propertyName: key.text });
+        } else if (ts.isStringLiteralLike(key)) {
+          out.push({ node: property, propertyName: key.text });
+        }
+      }
+    }
+    return out;
+  };
+
+  const visit = (node: ts.Node): void => {
+    // 1. Property / element access chains. The access path is
+    //    resolved through the alias map so file-local rebindings
+    //    (`const h = history; h.state`, `const h = window.history;
+    //    h.state`, `const win = window; win.localStorage`) match the
+    //    same per-surface table as the canonical form. Detection
+    //    covers:
+    //    (a) `[..wrappers.., root, prop]` against the unified
+    //        root/property pair table (document.cookie, history.state,
+    //        process.env, process.argv, import.meta.env).
+    //    (b) A bare forbidden global as the first non-wrapper
+    //        segment of the path (`window.localStorage`,
+    //        `globalThis['caches']`, and — through alias resolution —
+    //        `storage.getItem` after `const storage = localStorage`).
+    //    (c) Computed access whose root resolves (directly or via
+    //        an alias) to a global wrapper / ambient root /
+    //        `import.meta` — flagged conservatively as a possible
+    //        bypass.
+    if (ts.isPropertyAccessExpression(node) || ts.isElementAccessExpression(node)) {
+      if (!isInTypePosition(node)) {
+        const rawPath = getAccessPath(node);
+        const path = resolveAliasedPath(rawPath, aliases);
+        if (path) {
+          const pairLabel = matchRootPropertyPair(path);
+          if (pairLabel) {
+            record(node, pairLabel);
+          } else {
+            const bareLabel = matchBareGlobalRoot(path);
+            if (bareLabel) {
+              record(node, bareLabel);
+            }
+          }
+        } else if (isComputedRestrictedRootAccess(node, aliases)) {
+          record(node, 'computed restricted-root access (possible persisted-state bypass)');
+        }
+      }
+    }
+
+    // 2. Bare identifier reads. Skip the binding site, type positions,
+    //    and the `.name` of a property access (the leaf-name `cookie`
+    //    in `document.cookie` is handled by the root-property matcher
+    //    above). Flag:
+    //    (a) Identifiers in the forbidden bare-global table
+    //        (`localStorage`, `sessionStorage`, `indexedDB`, `caches`).
+    //    (b) Identifiers whose alias resolves to a forbidden bare-
+    //        global — catches `storage.<anything>` and the bare `storage`
+    //        read even when the original `const storage = localStorage`
+    //        binding line is allow-exempted.
+    if (ts.isIdentifier(node) && !isInTypePosition(node) && !isDeclarationName(node)) {
+      if (!isPropertyNamePosition(node)) {
+        const direct = FORBIDDEN_GLOBAL_IDENTIFIER_LABEL_BY_NAME.get(node.text);
+        if (direct) {
+          record(node, direct);
+        } else {
+          const canonical = aliases.get(node.text);
+          if (canonical !== undefined) {
+            const aliasedLabel = FORBIDDEN_GLOBAL_IDENTIFIER_LABEL_BY_NAME.get(canonical);
+            if (aliasedLabel) {
+              record(node, aliasedLabel);
+            }
+          }
+        }
+      }
+    }
+
+    // 3. Destructuring — both variable-declaration form and
+    //    assignment form. String-literal keys are accepted alongside
+    //    identifier keys. Initializers are resolved through the alias
+    //    map so destructuring via aliased roots
+    //    (`const proc = process; const { env } = proc;`) is caught.
+    if (
+      ts.isVariableDeclaration(node) &&
+      node.initializer &&
+      ts.isObjectBindingPattern(node.name)
+    ) {
+      recordDestructuring(node.initializer, variablePatternElements(node.name));
+    }
+    if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      ts.isObjectLiteralExpression(node.left)
+    ) {
+      recordDestructuring(node.right, assignmentPatternElements(node.left));
+    }
+
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return findings;
+}
+
+// Resolve an expression to an access-path. Used for destructuring
+// initializers (`const { state } = history;`) where the initializer is
+// an `Expression`, not specifically a `Property/ElementAccessExpression`.
+// `import.meta` is mapped to the synthetic root segment `import.meta`.
+function getAccessPathFromExpression(expr: ts.Expression): readonly string[] | null {
+  const inner = unwrap(expr);
+  if (ts.isIdentifier(inner)) return [inner.text];
+  if (ts.isMetaProperty(inner)) return ['import.meta'];
+  if (ts.isPropertyAccessExpression(inner) || ts.isElementAccessExpression(inner)) {
+    return getAccessPath(inner);
+  }
+  return null;
+}
+
+function findingsOf(source: string, file = 'fake.ts'): readonly SourceFinding[] {
+  return scanQ003(parseSource(source, file));
+}
+
+// --- Tests -----------------------------------------------------------
+
+describe('PUL-Q003 — URL state determinism (source scan)', () => {
+  describe('scanner self-tests', () => {
+    describe('direct bare-global reads', () => {
+      it.each([
+        ['localStorage', 'localStorage.getItem("scene");'],
+        ['sessionStorage', 'sessionStorage.setItem("scene", "x");'],
+        ['indexedDB', 'const req = indexedDB.open("scenes");'],
+        ['caches (Cache Storage)', 'caches.open("v1");'],
+      ])('flags bare %s', (label, source) => {
+        const findings = findingsOf(source);
+        expect(findings.map((f) => f.label)).toContain(label);
+      });
+    });
+
+    describe('direct root-property reads', () => {
+      it.each([
+        ['document.cookie', 'const c = document.cookie;'],
+        ['document.cookie', 'document.cookie = "scene=evil";'],
+        ['history.state', 'const s = history.state;'],
+        ['process.env', 'const v = process.env.SCENE;'],
+        ['process.env', 'const e = process.env;'],
+        ['process.argv', 'const a = process.argv[2];'],
+        ['process.argv', 'const a = process.argv;'],
+        ['import.meta.env', 'const v = import.meta.env.VITE_SCENE;'],
+        ['import.meta.env', 'const env = import.meta.env;'],
+      ])('flags %s', (label, source) => {
+        const findings = findingsOf(source);
+        expect(findings.map((f) => f.label)).toContain(label);
+      });
+    });
+
+    describe('global-wrapper forms', () => {
+      // Every entry in `GLOBAL_WRAPPERS` (`globalThis`, `window`,
+      // `self`, `global`) must appear at least once for the per-surface
+      // tables. A regression that drops one wrapper from the shared
+      // helper's allow-set must fail this group.
+      it.each([
+        ['localStorage', 'globalThis.localStorage.getItem("scene");'],
+        ['localStorage', 'window.localStorage.getItem("scene");'],
+        ['localStorage', 'self.localStorage.getItem("scene");'],
+        ['localStorage', 'global.localStorage.getItem("scene");'],
+        ['localStorage', `window['localStorage'].getItem('scene');`],
+        ['sessionStorage', 'globalThis.sessionStorage.getItem("scene");'],
+        ['indexedDB', 'globalThis.indexedDB.open("scenes");'],
+        ['indexedDB', 'self.indexedDB.open("scenes");'],
+        ['caches (Cache Storage)', 'window.caches.open("v1");'],
+        ['caches (Cache Storage)', 'global.caches.open("v1");'],
+        ['document.cookie', 'const c = window.document.cookie;'],
+        ['document.cookie', 'const c = globalThis.document.cookie;'],
+        ['history.state', 'const s = window.history.state;'],
+        ['history.state', 'const s = globalThis.history.state;'],
+        ['history.state', 'const s = self.history.state;'],
+        ['history.state', 'const s = global.history.state;'],
+        ['process.env', 'const v = globalThis.process.env.SCENE;'],
+        ['process.env', 'const v = global.process.env.SCENE;'],
+        ['process.argv', 'const a = globalThis.process.argv[2];'],
+      ])('flags wrapped %s', (label, source) => {
+        const findings = findingsOf(source);
+        expect(findings.map((f) => f.label)).toContain(label);
+      });
+    });
+
+    describe('computed wrapper access (bypass defense)', () => {
+      // String-concatenation / template-substitution / runtime-key
+      // forms can hide a forbidden surface behind a non-literal
+      // subscript. The shared `isComputedGlobalWrapperAccess` helper
+      // flags these conservatively when the root is a recognised
+      // global wrapper.
+      it.each([
+        "globalThis['local' + 'Storage'].getItem('scene');",
+        "window['ses' + 'sionStorage'].getItem('scene');",
+        "self[`indexed${'DB'}`].open('scenes');",
+        "global['cach' + 'es'].open('v1');",
+        "globalThis[someKey].getItem('scene');",
+      ])('flags computed wrapper access — `%s`', (source) => {
+        const findings = findingsOf(`declare const someKey: string; ${source}`);
+        expect(findings.map((f) => f.label)).toContain(
+          'computed restricted-root access (possible persisted-state bypass)',
+        );
+      });
+
+      it('does NOT flag computed access on a non-global root', () => {
+        const findings = findingsOf(
+          "declare const obj: Record<string, { getItem(k: string): string }>; declare const k: string; obj[k].getItem('scene');",
+        );
+        expect(findings).toEqual([]);
+      });
+
+      it('does NOT flag string-literal subscript on a global wrapper (handled by the literal path)', () => {
+        // `window['localStorage']` is a literal subscript: the
+        // access-path resolver returns `[window, localStorage]` and
+        // the bare-global matcher fires. The computed-access detector
+        // must NOT also fire — otherwise the same line would carry
+        // two findings.
+        const findings = findingsOf(`window['localStorage'].getItem('scene');`);
+        const labels = findings.map((f) => f.label);
+        expect(labels).toContain('localStorage');
+        expect(labels).not.toContain(
+          'computed restricted-root access (possible persisted-state bypass)',
+        );
+      });
+    });
+
+    describe('aliased forms (file-local rebinding)', () => {
+      // Aliasing the global through a local binding is the same
+      // structural surface; `h.state` after `const h = history;` still
+      // reads the host `history.state` slot. The scanner resolves
+      // file-local aliases of the ambient roots (`document`, `history`,
+      // `process`, `localStorage`, `sessionStorage`, `indexedDB`,
+      // `caches`) and of the global wrappers (`window`, `globalThis`,
+      // `self`, `global`) before access-path matching, so every per-
+      // surface assertion below catches the aliased form too.
+      it('flags `const ls = localStorage; ls.getItem(...)` at the alias site', () => {
+        const findings = findingsOf("const ls = localStorage; ls.getItem('scene');");
+        expect(findings.map((f) => f.label)).toContain('localStorage');
+      });
+
+      it('flags `const h = history; h.state` through the alias', () => {
+        const findings = findingsOf('const h = history; const s = h.state;');
+        expect(findings.map((f) => f.label)).toContain('history.state');
+      });
+
+      it('flags `const doc = document; doc.cookie` through the alias', () => {
+        const findings = findingsOf('const doc = document; const c = doc.cookie;');
+        expect(findings.map((f) => f.label)).toContain('document.cookie');
+      });
+
+      it('flags `const proc = process; proc.env` through the alias', () => {
+        const findings = findingsOf('const proc = process; const e = proc.env;');
+        expect(findings.map((f) => f.label)).toContain('process.env');
+      });
+
+      it('flags `const proc = process; proc.argv` through the alias', () => {
+        const findings = findingsOf('const proc = process; const a = proc.argv[0];');
+        expect(findings.map((f) => f.label)).toContain('process.argv');
+      });
+
+      it('flags `const win = window; win.localStorage` through the global-wrapper alias', () => {
+        const findings = findingsOf("const win = window; win.localStorage.getItem('scene');");
+        expect(findings.map((f) => f.label)).toContain('localStorage');
+      });
+
+      it('flags `const root = globalThis; root.caches` through the global-wrapper alias', () => {
+        const findings = findingsOf("const root = globalThis; root.caches.open('v1');");
+        expect(findings.map((f) => f.label)).toContain('caches (Cache Storage)');
+      });
+
+      it('flags `const g = globalThis; g.history.state` through the global-wrapper alias', () => {
+        const findings = findingsOf('const g = globalThis; const s = g.history.state;');
+        expect(findings.map((f) => f.label)).toContain('history.state');
+      });
+
+      it('flags `const g = global; g.process.env` through the global-wrapper alias', () => {
+        const findings = findingsOf('const g = global; const e = g.process.env;');
+        expect(findings.map((f) => f.label)).toContain('process.env');
+      });
+
+      it('flags destructured `const { state } = history;`', () => {
+        const findings = findingsOf('const { state } = history;');
+        expect(findings.map((f) => f.label)).toContain('history.state (via destructuring)');
+      });
+
+      it('flags destructured `const { cookie } = document;`', () => {
+        const findings = findingsOf('const { cookie } = document;');
+        expect(findings.map((f) => f.label)).toContain('document.cookie (via destructuring)');
+      });
+
+      it('flags destructured `const { env } = process;`', () => {
+        const findings = findingsOf('const { env } = process;');
+        expect(findings.map((f) => f.label)).toContain('process.env (via destructuring)');
+      });
+
+      it('flags destructured `const { argv } = process;`', () => {
+        const findings = findingsOf('const { argv } = process;');
+        expect(findings.map((f) => f.label)).toContain('process.argv (via destructuring)');
+      });
+
+      it('flags destructured `const { state } = h;` after `const h = history;` (aliased root)', () => {
+        const findings = findingsOf('const h = history; const { state } = h;');
+        expect(findings.map((f) => f.label)).toContain('history.state (via destructuring)');
+      });
+
+      it('does NOT flag chained aliases — `const x = history.state` is a value read, not an alias of history', () => {
+        // `const x = history.state` does NOT register `x` as an alias
+        // of `history`; the existing root-property matcher catches the
+        // `history.state` read at the binding site, so no further
+        // tracking is needed. A subsequent `x.foo` is a property on a
+        // non-aliased local and stays unflagged.
+        const findings = findingsOf('const x = history.state; const y = x.foo;');
+        const labels = findings.map((f) => f.label);
+        expect(labels).toEqual(['history.state']);
+        // Exactly one finding, on line 1, no spurious finding on line
+        // 2 from a regression that mis-aliased `x`.
+        expect(findings).toHaveLength(1);
+        expect(findings[0]?.line).toBe(1);
+      });
+    });
+
+    describe('wrapper-derived alias forms (cycle-2 coverage)', () => {
+      // Codex review (cycle 2) flagged that `const h = window.history;
+      // h.state` was not being caught because the initializer was a
+      // property access rather than a bare identifier. The scanner
+      // now resolves these wrapper-derived aliases the same way as
+      // direct identifier aliases.
+      it('flags `const h = window.history; h.state` through the wrapper-derived alias', () => {
+        const findings = findingsOf('const h = window.history; const s = h.state;');
+        expect(findings.map((f) => f.label)).toContain('history.state');
+      });
+
+      it('flags `const doc = globalThis.document; doc.cookie` through the wrapper-derived alias', () => {
+        const findings = findingsOf('const doc = globalThis.document; const c = doc.cookie;');
+        expect(findings.map((f) => f.label)).toContain('document.cookie');
+      });
+
+      it('flags `const proc = global.process; proc.env` through the wrapper-derived alias', () => {
+        const findings = findingsOf('const proc = global.process; const e = proc.env;');
+        expect(findings.map((f) => f.label)).toContain('process.env');
+      });
+
+      it('flags `const storage = window.localStorage; storage.getItem(...)` through the wrapper-derived alias', () => {
+        const findings = findingsOf(
+          "const storage = window.localStorage; storage.getItem('scene');",
+        );
+        expect(findings.map((f) => f.label)).toContain('localStorage');
+      });
+
+      it('flags `const storage = window["localStorage"]; storage.getItem(...)` through string-literal subscript alias', () => {
+        const findings = findingsOf(
+          `const storage = window['localStorage']; storage.getItem('scene');`,
+        );
+        expect(findings.map((f) => f.label)).toContain('localStorage');
+      });
+    });
+
+    describe('aliased bare-global propagation (cycle-2 coverage)', () => {
+      // Codex review (cycle 2) flagged that an allow-exempted binding
+      // line could let a subsequent `storage.getItem('scene')` slip
+      // through, because `[localStorage, getItem]` is not a length-1
+      // bare-global match. The scanner now flags every access whose
+      // first non-wrapper path segment is a forbidden bare-global
+      // (after alias resolution), and every read of an alias whose
+      // canonical resolves to a forbidden bare-global.
+      it('flags `storage.getItem(scene)` even when the binding line is allow-exempted', () => {
+        const findings = findingsOf(
+          [
+            'const storage = localStorage; // PUL-Q003-allow: ui pref only',
+            "storage.getItem('scene');",
+          ].join('\n'),
+        );
+        expect(findings.map((f) => f.label)).toContain('localStorage');
+        // The single finding must land on line 2, not line 1 (which
+        // is allow-exempted).
+        expect(findings.filter((f) => f.label === 'localStorage')[0]?.line).toBe(2);
+      });
+
+      it('flags a bare-identifier read of an aliased bare-global (`const storage = localStorage; doThing(storage);`)', () => {
+        const findings = findingsOf('const storage = localStorage; doThing(storage);');
+        // Exactly two findings: one at the binding site
+        // (`= localStorage`) and one at the aliased bare read
+        // (`storage` inside `doThing(...)`). Asserting an exact count
+        // catches a regression that exempted either site silently.
+        const localStorageFindings = findings.filter((f) => f.label === 'localStorage');
+        expect(localStorageFindings).toHaveLength(2);
+      });
+
+      it('flags `storage[key]` (computed bracket on aliased bare-global)', () => {
+        // `const storage = localStorage; storage[key]` resolves to
+        // `[localStorage, ???]` — the computed branch is a possible
+        // bypass attempt against an aliased bare-global, and the
+        // identifier `storage` itself is a forbidden read.
+        const findings = findingsOf(
+          'declare const key: string; const storage = localStorage; storage[key];',
+        );
+        expect(findings.map((f) => f.label)).toContain('localStorage');
+      });
+    });
+
+    describe('computed access through aliased wrapper (cycle-2 coverage)', () => {
+      // Codex review (cycle 2) flagged that `const win = window;
+      // win[key]` was not being caught because the computed-wrapper
+      // detector was checking the raw root identifier rather than
+      // the alias-resolved canonical. The local replacement
+      // (`isComputedRestrictedRootAccess`) consults the alias map.
+      it('flags `win[key]` after `const win = window`', () => {
+        const findings = findingsOf(
+          'declare const key: string; const win = window; const x = win[key];',
+        );
+        expect(findings.map((f) => f.label)).toContain(
+          'computed restricted-root access (possible persisted-state bypass)',
+        );
+      });
+
+      it('flags `root[key]` after `const root = globalThis`', () => {
+        const findings = findingsOf(
+          'declare const key: string; const root = globalThis; const x = root[key];',
+        );
+        expect(findings.map((f) => f.label)).toContain(
+          'computed restricted-root access (possible persisted-state bypass)',
+        );
+      });
+
+      it('flags computed access on `import.meta` directly', () => {
+        const findings = findingsOf("const v = import.meta['en' + 'v'];");
+        expect(findings.map((f) => f.label)).toContain(
+          'computed restricted-root access (possible persisted-state bypass)',
+        );
+      });
+
+      it('flags computed access on an `import.meta` alias', () => {
+        const findings = findingsOf(
+          'declare const key: string; const meta = import.meta; const v = meta[key];',
+        );
+        expect(findings.map((f) => f.label)).toContain(
+          'computed restricted-root access (possible persisted-state bypass)',
+        );
+      });
+    });
+
+    describe('destructuring of bare globals from a wrapper (cycle-2 coverage)', () => {
+      // Codex review (cycle 2) flagged that
+      // `const { localStorage } = window` reads a banned bare-global
+      // but was being treated as a benign destructuring because the
+      // matcher only checked the root.prop table, not the bare-global
+      // table.
+      it('flags `const { localStorage } = window`', () => {
+        const findings = findingsOf('const { localStorage } = window;');
+        expect(findings.map((f) => f.label)).toContain('localStorage (via destructuring)');
+      });
+
+      it('flags `const { caches } = globalThis`', () => {
+        const findings = findingsOf('const { caches } = globalThis;');
+        expect(findings.map((f) => f.label)).toContain(
+          'caches (Cache Storage) (via destructuring)',
+        );
+      });
+
+      it('flags `const { sessionStorage, indexedDB } = self`', () => {
+        const findings = findingsOf('const { sessionStorage, indexedDB } = self;');
+        const labels = findings.map((f) => f.label);
+        expect(labels).toContain('sessionStorage (via destructuring)');
+        expect(labels).toContain('indexedDB (via destructuring)');
+      });
+    });
+
+    describe('string-literal destructuring keys (cycle-2 coverage)', () => {
+      // Codex review (cycle 2) flagged that `const { 'cookie': c } =
+      // document` was being skipped because the matcher only accepted
+      // identifier keys. String-literal keys (`'cookie'`, `"state"`)
+      // are now accepted.
+      it("flags `const { 'cookie': c } = document`", () => {
+        const findings = findingsOf("const { 'cookie': c } = document;");
+        expect(findings.map((f) => f.label)).toContain('document.cookie (via destructuring)');
+      });
+
+      it('flags `const { "state": s } = history`', () => {
+        const findings = findingsOf('const { "state": s } = history;');
+        expect(findings.map((f) => f.label)).toContain('history.state (via destructuring)');
+      });
+
+      it("flags `const { 'env': e } = process`", () => {
+        const findings = findingsOf("const { 'env': e } = process;");
+        expect(findings.map((f) => f.label)).toContain('process.env (via destructuring)');
+      });
+
+      it("flags `const { 'localStorage': ls } = window`", () => {
+        const findings = findingsOf("const { 'localStorage': ls } = window;");
+        expect(findings.map((f) => f.label)).toContain('localStorage (via destructuring)');
+      });
+    });
+
+    describe('assignment destructuring (cycle-2 coverage)', () => {
+      // Codex review (cycle 2) flagged that destructuring assignment
+      // (`({ state } = history);`) was being skipped because the
+      // matcher only handled VariableDeclaration patterns. The
+      // scanner now also handles BinaryExpression LHS object literals.
+      it('flags `({ state } = history)`', () => {
+        const findings = findingsOf('let state: unknown; ({ state } = history);');
+        expect(findings.map((f) => f.label)).toContain('history.state (via destructuring)');
+      });
+
+      it('flags `({ cookie } = document)`', () => {
+        const findings = findingsOf('let cookie: unknown; ({ cookie } = document);');
+        expect(findings.map((f) => f.label)).toContain('document.cookie (via destructuring)');
+      });
+
+      it('flags `({ env } = process)`', () => {
+        const findings = findingsOf('let env: unknown; ({ env } = process);');
+        expect(findings.map((f) => f.label)).toContain('process.env (via destructuring)');
+      });
+
+      it('flags `({ localStorage } = window)`', () => {
+        const findings = findingsOf('let localStorage: unknown; ({ localStorage } = window);');
+        expect(findings.map((f) => f.label)).toContain('localStorage (via destructuring)');
+      });
+
+      it("flags `({ 'cookie': c } = document)`", () => {
+        const findings = findingsOf("let c: unknown; ({ 'cookie': c } = document);");
+        expect(findings.map((f) => f.label)).toContain('document.cookie (via destructuring)');
+      });
+    });
+
+    describe('computed access on direct ambient roots (cycle-3 coverage)', () => {
+      // Codex review (cycle 3) flagged that `history['st' + 'ate']`,
+      // `document[key]`, and `process[key]` were silently passing
+      // because the computed-restricted-root detector's direct-root
+      // branch only accepted GLOBAL_WRAPPERS. ALIAS_ROOTS is the
+      // correct superset for the direct-root check.
+      it('flags `history["st" + "ate"]` (computed on direct ambient root)', () => {
+        const findings = findingsOf("const s = history['st' + 'ate'];");
+        expect(findings.map((f) => f.label)).toContain(
+          'computed restricted-root access (possible persisted-state bypass)',
+        );
+      });
+
+      it('flags `document["coo" + "kie"]` (computed on direct ambient root)', () => {
+        const findings = findingsOf("const c = document['coo' + 'kie'];");
+        expect(findings.map((f) => f.label)).toContain(
+          'computed restricted-root access (possible persisted-state bypass)',
+        );
+      });
+
+      it('flags `process[key]` (computed on direct ambient root)', () => {
+        const findings = findingsOf('declare const key: string; const v = process[key];');
+        expect(findings.map((f) => f.label)).toContain(
+          'computed restricted-root access (possible persisted-state bypass)',
+        );
+      });
+
+      it('flags `localStorage[key]` (computed on direct bare-global)', () => {
+        const findings = findingsOf('declare const key: string; const v = localStorage[key];');
+        expect(findings.map((f) => f.label)).toContain(
+          'computed restricted-root access (possible persisted-state bypass)',
+        );
+      });
+    });
+
+    describe('chained aliases through aliased wrapper (cycle-3 coverage)', () => {
+      // Codex review (cycle 3) flagged that
+      // `const win = window; const h = win.history; h.state;` was not
+      // being caught because `collectAliases` resolved property-access
+      // initializers against the raw access path. The collector now
+      // iterates to a fixed point and resolves the first segment
+      // through the alias map at each pass, so chained aliases
+      // resolve regardless of source order.
+      it('flags `const win = window; const h = win.history; h.state` through the alias chain', () => {
+        const findings = findingsOf(
+          'const win = window; const h = win.history; const s = h.state;',
+        );
+        expect(findings.map((f) => f.label)).toContain('history.state');
+      });
+
+      it('flags `const root = globalThis; const proc = root.process; proc.env` through the alias chain', () => {
+        const findings = findingsOf(
+          'const root = globalThis; const proc = root.process; const e = proc.env;',
+        );
+        expect(findings.map((f) => f.label)).toContain('process.env');
+      });
+
+      it('flags `const root = globalThis; const doc = root.document; doc.cookie` through the alias chain', () => {
+        const findings = findingsOf(
+          'const root = globalThis; const doc = root.document; const c = doc.cookie;',
+        );
+        expect(findings.map((f) => f.label)).toContain('document.cookie');
+      });
+
+      it('flags `const w2 = win; w2.localStorage` after `const win = window` (alias of an alias)', () => {
+        const findings = findingsOf(
+          "const win = window; const w2 = win; w2.localStorage.getItem('scene');",
+        );
+        expect(findings.map((f) => f.label)).toContain('localStorage');
+      });
+
+      it('flags chained aliases declared in reverse order (`const h = win.history; const win = window;`)', () => {
+        // Fixed-point iteration must handle the case where the alias
+        // chain's dependency declaration appears AFTER the dependent
+        // declaration in source order. Without fixed-point this
+        // would only register `win` on pass 1 and miss `h` entirely.
+        const findings = findingsOf(
+          'const h = win.history; const win = window; const s = h.state;',
+        );
+        expect(findings.map((f) => f.label)).toContain('history.state');
+      });
+    });
+
+    describe('destructured ambient-root aliases from wrappers (cycle-3 coverage)', () => {
+      // Codex review (cycle 3) flagged that
+      // `const { history: h } = window; h.state;` was not being
+      // caught because the destructuring path only registered
+      // forbidden bare-global aliases. The collector now registers
+      // ambient-root aliases from wrapper destructuring so
+      // `history`/`document`/`process` destructured out of a wrapper
+      // are tracked the same way as a direct identifier alias.
+      it('flags `const { history: h } = window; h.state`', () => {
+        const findings = findingsOf('const { history: h } = window; const s = h.state;');
+        expect(findings.map((f) => f.label)).toContain('history.state');
+      });
+
+      it('flags `const { document: doc } = globalThis; doc.cookie`', () => {
+        const findings = findingsOf('const { document: doc } = globalThis; const c = doc.cookie;');
+        expect(findings.map((f) => f.label)).toContain('document.cookie');
+      });
+
+      it('flags `const { process: proc } = globalThis; proc.env`', () => {
+        const findings = findingsOf('const { process: proc } = globalThis; const e = proc.env;');
+        expect(findings.map((f) => f.label)).toContain('process.env');
+      });
+
+      it('flags `const { history } = window; history.state` (shorthand destructuring)', () => {
+        // The destructured binding name `history` shadows the global
+        // `history` in this scope, but the value it refers to IS the
+        // global's `history` property. Tracking the alias keeps the
+        // surface read flagged on the shadowed identifier.
+        const findings = findingsOf('const { history } = window; const s = history.state;');
+        expect(findings.map((f) => f.label)).toContain('history.state');
+      });
+
+      it('flags destructured wrapper-property alias through an aliased wrapper (`const root = globalThis; const { history: h } = root; h.state;`)', () => {
+        const findings = findingsOf(
+          'const root = globalThis; const { history: h } = root; const s = h.state;',
+        );
+        expect(findings.map((f) => f.label)).toContain('history.state');
+      });
+    });
+
+    describe('import.meta full coverage (cycle-2 coverage)', () => {
+      // Codex review (cycle 2) flagged that `import.meta.env` was
+      // only enforced in the direct-access form. Alias propagation,
+      // destructuring, and computed-access coverage now apply
+      // uniformly because `import.meta` is in the unified
+      // `FORBIDDEN_ROOT_PROPERTY_PAIRS` table and in `ALIAS_ROOTS`.
+      it('flags `const meta = import.meta; meta.env.VITE_SCENE` through alias', () => {
+        const findings = findingsOf('const meta = import.meta; const v = meta.env.VITE_SCENE;');
+        expect(findings.map((f) => f.label)).toContain('import.meta.env');
+      });
+
+      it('flags `const { env } = import.meta`', () => {
+        const findings = findingsOf('const { env } = import.meta;');
+        expect(findings.map((f) => f.label)).toContain('import.meta.env (via destructuring)');
+      });
+
+      it("flags `const { 'env': e } = import.meta`", () => {
+        const findings = findingsOf("const { 'env': e } = import.meta;");
+        expect(findings.map((f) => f.label)).toContain('import.meta.env (via destructuring)');
+      });
+
+      it('flags `({ env } = import.meta)`', () => {
+        const findings = findingsOf('let env: unknown; ({ env } = import.meta);');
+        expect(findings.map((f) => f.label)).toContain('import.meta.env (via destructuring)');
+      });
+
+      it('flags `const { env } = meta` after `const meta = import.meta`', () => {
+        const findings = findingsOf('const meta = import.meta; const { env } = meta;');
+        expect(findings.map((f) => f.label)).toContain('import.meta.env (via destructuring)');
+      });
+    });
+
+    describe('TypeScript wrapper unwrapping', () => {
+      it.each([
+        ['(localStorage).getItem("x");', 'localStorage'],
+        ['(window as any).localStorage.getItem("x");', 'localStorage'],
+        ['(globalThis as Record<string, unknown>).indexedDB;', 'indexedDB'],
+        ['(history!.state);', 'history.state'],
+        ['(document satisfies object).cookie;', 'document.cookie'],
+      ])('unwraps wrapper expressions — `%s`', (source, label) => {
+        const findings = findingsOf(source);
+        expect(findings.map((f) => f.label)).toContain(label);
+      });
+    });
+
+    describe('object shorthand', () => {
+      // `{ localStorage }` is `{ localStorage: localStorage }` — a
+      // value-position read of the identifier. The screenshot-
+      // determinism scan has the same precedent for `setTimeout` etc.
+      it('flags `{ localStorage }` shorthand read', () => {
+        const findings = findingsOf('const ref = { localStorage };');
+        expect(findings.map((f) => f.label)).toContain('localStorage');
+      });
+
+      it('flags `{ caches }` shorthand read', () => {
+        const findings = findingsOf('const ref = { caches };');
+        expect(findings.map((f) => f.label)).toContain('caches (Cache Storage)');
+      });
+    });
+
+    describe('false-positive defense', () => {
+      it.each([
+        // root-anchoring prevents non-global object graphs from triggering
+        [
+          'fixture.history.state',
+          'declare const fixture: { history: { state: number } }; const s = fixture.history.state;',
+        ],
+        [
+          'snapshot.document.cookie',
+          'declare const snapshot: { document: { cookie: string } }; const c = snapshot.document.cookie;',
+        ],
+        [
+          'obj.localStorage',
+          'declare const obj: { localStorage: { getItem(k: string): string } }; obj.localStorage.getItem("scene");',
+        ],
+        [
+          'obj.caches',
+          'declare const obj: { caches: { open(k: string): void } }; obj.caches.open("v1");',
+        ],
+        [
+          'fixture.process.env',
+          'declare const fixture: { process: { env: Record<string, string> } }; const e = fixture.process.env;',
+        ],
+        [
+          'shim.process.argv',
+          'declare const shim: { process: { argv: string[] } }; const a = shim.process.argv;',
+        ],
+      ])('does NOT flag %s (root is not an ambient global)', (_label, source) => {
+        const findings = findingsOf(source);
+        expect(findings).toEqual([]);
+      });
+
+      it('does NOT flag a non-banned `process` member (e.g. `process.cwd`)', () => {
+        // Q003 only bans `process.env` and `process.argv`. Other
+        // members (`process.cwd`, `process.platform`, `process.version`)
+        // are not host-state hazards in the same way and must not
+        // false-positive.
+        expect(findingsOf('const d = process.cwd();')).toEqual([]);
+        expect(findingsOf('const p = process.platform;')).toEqual([]);
+      });
+
+      it('does NOT flag a non-banned `import.meta` member (e.g. `import.meta.url`)', () => {
+        // Only `import.meta.env` is banned; `import.meta.url` is the
+        // module's own URL (used legitimately by `fileURLToPath` etc.).
+        expect(findingsOf('const u = import.meta.url;')).toEqual([]);
+      });
+
+      it('does NOT flag `history.pushState` (URL mutator, not persisted-state read)', () => {
+        const findings = findingsOf("history.pushState({}, '', '/scene/intro');");
+        expect(findings.map((f) => f.label)).not.toContain('history.state');
+        expect(findings).toEqual([]);
+      });
+
+      it('does NOT flag `history.replaceState` (URL mutator)', () => {
+        const findings = findingsOf("history.replaceState({}, '', '/scene/intro');");
+        expect(findings).toEqual([]);
+      });
+
+      it('does NOT flag forbidden vocabulary inside a `//` comment', () => {
+        expect(findingsOf('// localStorage and document.cookie are forbidden')).toEqual([]);
+      });
+
+      it('does NOT flag forbidden vocabulary inside a `/* */` block comment', () => {
+        expect(findingsOf('/* localStorage, history.state. */ const x = 1;')).toEqual([]);
+      });
+
+      it('does NOT flag forbidden vocabulary inside a string literal', () => {
+        const findings = findingsOf('const note = "localStorage is forbidden";');
+        expect(findings).toEqual([]);
+      });
+
+      it('does NOT flag `localStorage` used as a type member name', () => {
+        const findings = findingsOf(
+          'interface Storage { localStorage(): string; cookie: string; }',
+        );
+        expect(findings).toEqual([]);
+      });
+
+      it('does NOT flag `typeof localStorage` in a type alias', () => {
+        const findings = findingsOf('type LS = typeof localStorage;');
+        expect(findings).toEqual([]);
+      });
+
+      it('does NOT flag the property name `cookie` in a property assignment', () => {
+        const findings = findingsOf('const obj = { cookie: 1 };');
+        expect(findings).toEqual([]);
+      });
+
+      it('does NOT flag a method named `localStorage` on a class', () => {
+        const findings = findingsOf('class C { localStorage() { return ""; } }');
+        expect(findings).toEqual([]);
+      });
+    });
+
+    describe('exemption marker', () => {
+      it('honors `// PUL-Q003-allow: <reason>` on the same line', () => {
+        const findings = findingsOf(
+          'localStorage.setItem("ui-pref", "x"); // PUL-Q003-allow: UI preference, not target state',
+        );
+        expect(findings).toEqual([]);
+      });
+
+      it('rejects an empty rationale', () => {
+        const findings = findingsOf('localStorage.getItem("x"); // PUL-Q003-allow:');
+        expect(findings.map((f) => f.label)).toContain('localStorage');
+      });
+
+      it('rejects a whitespace-only rationale', () => {
+        const findings = findingsOf('localStorage.getItem("x"); // PUL-Q003-allow:   ');
+        expect(findings.map((f) => f.label)).toContain('localStorage');
+      });
+
+      it('rejects a marker hidden inside a string literal', () => {
+        const findings = findingsOf(
+          `const note = "// PUL-Q003-allow: hidden"; localStorage.getItem('x');`,
+        );
+        expect(findings.map((f) => f.label)).toContain('localStorage');
+      });
+
+      it('does NOT honor a marker on a different line (line-scoped)', () => {
+        const src = '// PUL-Q003-allow: see above\nlocalStorage.getItem("x");';
+        const findings = findingsOf(src);
+        expect(findings).toHaveLength(1);
+        expect(findings[0]?.line).toBe(2);
+      });
+    });
+
+    describe('reporting', () => {
+      it('reports the 1-based line and file path on every finding', () => {
+        const src = 'const a = 1;\nconst b = 2;\nlocalStorage.getItem("x");\nconst c = 3;';
+        const findings = findingsOf(src, 'src/runtime/example.ts');
+        expect(findings).toHaveLength(1);
+        expect(findings[0]).toMatchObject({
+          file: 'src/runtime/example.ts',
+          line: 3,
+          label: 'localStorage',
+        });
+      });
+
+      it('reports findings across multiple lines independently', () => {
+        const src = 'localStorage.getItem("a");\nconst c = document.cookie;';
+        const findings = findingsOf(src);
+        expect(findings).toHaveLength(2);
+        // Label assertions pin the label-attribution contract: a
+        // regression that swapped the labels (or corrupted one) would
+        // pass a line-count-only check but fail here.
+        expect(findings[0]).toMatchObject({ line: 1, label: 'localStorage' });
+        expect(findings[1]).toMatchObject({ line: 2, label: 'document.cookie' });
+      });
+    });
+  });
+
+  describe('runtime tree (current code revision)', () => {
+    it('scan root `src/` exists and contains at least one .ts file', () => {
+      expect(statSync(SRC_ROOT).isDirectory()).toBe(true);
+      expect(walkTsFiles(SRC_ROOT).length).toBeGreaterThan(0);
+    });
+
+    it('contains no Q003 violations across `src/**/*.ts`', () => {
+      const files = walkTsFiles(SRC_ROOT);
+      const findings: SourceFinding[] = [];
+      for (const file of files) {
+        const text = readFileSync(file, 'utf-8');
+        const rel = relative(REPO_ROOT, file);
+        findings.push(...scanQ003(parseSource(text, rel)));
+      }
+      const header =
+        'PUL-Q003 forbids `localStorage`, `sessionStorage`, `document.cookie`, `history.state`, `indexedDB`, and `caches` (Cache Storage) reads in runtime source — those surfaces must not determine the targeted scene, beat, composition, or mode. Add a `// PUL-Q003-allow: <reason>` exemption on the same line if the use is documented non-target state.';
+      const detail = findings.map((f) => `  ${f.file}:${f.line}  ${f.label}  ${f.text}`).join('\n');
+      const message = findings.length === 0 ? '' : `${header}\n${detail}`;
+      expect(findings, message).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds structural and behavioral enforcement of PUL-Q003 (URL state determinism). A new Vitest source-policy gate scans `src/**/*.ts` for value-position reads of the browser persistence and host-state surfaces that could let out-of-URL state pick the runtime's targeted scene, beat, composition, or mode, and a new behavioral describe block in the navigation tests pins the URL-only contract by seeding host globals with deliberately-misleading values and asserting that the parsed target / effective mode / error envelope ignore them.

## Requirement UIDs

- `PUL-Q003`

## Related Issues

Closes #42

## ADR Impact

- No ADR required

## Changes

- Add `tests/runtime/policy-q003-url-state-determinism.test.ts` — Vitest source-policy gate banning `localStorage`, `sessionStorage`, `document.cookie`, `history.state`, `indexedDB`, `caches`, `process.env`, `process.argv`, and `import.meta.env` reads in `src/**/*.ts`. Scanner reuses the shared `tests/runtime/source-policy.ts` infrastructure (AST walker, access-path resolution, line-scoped exemptions, global-wrapper handling).
- Scanner resolves file-local aliases of every ambient root and global wrapper before access-path matching. `collectAliases` iterates to a fixed point and handles direct identifiers, alias-of-alias chains, property-access initializers (including aliased wrappers), MetaProperty initializers (`import.meta`), and destructured ambient-root-from-wrapper aliases (`const { history: h } = window`).
- Destructuring matcher covers both VariableDeclaration and BinaryExpression assignment forms, accepts identifier and string-literal keys, and handles three tail shapes: pure-wrapper (`const { localStorage } = window` flags as bare-global), single-ambient-root (`const { state } = history` flags as root.prop), and longer tails (no extra finding — the initializer is already flagged).
- Q003-local `isComputedRestrictedRootAccess` detector flags computed brackets (`history['st' + 'ate']`, `globalThis[key]`, `import.meta['en' + 'v']`) when the underlying root is a global wrapper, an ambient root, or `import.meta`, directly or through an alias.
- `// PUL-Q003-allow: <reason>` opts a single line out of the scan. Empty rationales and markers hidden in string literals are rejected. The marker is distinct from `PUL-Q001-allow` so a future scope change to either policy cannot weaken the other.
- Add a `PUL-Q003 — persisted browser state never determines the target` describe block in `tests/runtime/navigation.test.ts` (5 new tests). The block stubs `localStorage`, `sessionStorage`, `document.cookie`, `history.state`, `indexedDB`, `caches`, and the popstate event `state` slot with deliberately-misleading values and asserts that `parseNavigationSearch`, `subscribeNavigation`, `bootstrapNavigation`, and `effectiveMode` ignore them — the dispatched `pulsar:navigate` detail equals the URL-only parse, and the `pulsar:navigate-error` envelope does not echo seeded state.
- Add `changelog.d/42.added.md` documenting the new gate, the alias-aware scanner, the surface set, and the behavioral coverage.
- Add `docs/design/pul-q003-url-state-determinism-preflight.md` (from the architecture preflight) recording the design guardrails: the existing URL grammar / target resolution / mode dispatch path is preserved; Q003 is enforced as a sibling source-policy plus behavioral coverage, not as runtime validation.

## Test Plan

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (1511 tests, including 130 self-tests in the new Q003 policy file and 5 new behavioral tests in `tests/runtime/navigation.test.ts`)
- [x] `pre-commit run --all-files` passes
- [x] Runtime-tree assertion in `policy-q003-url-state-determinism.test.ts` confirms `src/**/*.ts` is Q003-clean today

130 self-tests in the new policy file cover: bare-global reads, root-property reads, global-wrapper forms, computed-wrapper bypass defense, alias forms (direct identifier, wrapper-derived, chained alias-of-alias, alias-from-aliased-wrapper, reverse-order alias chain), allow-exempt propagation, destructuring (identifier keys, string-literal keys, assignment form, bare-global-from-wrapper, ambient-root-from-wrapper), `import.meta` full coverage (alias, destructuring, computed access), and false-positive defense (non-global object graphs, non-banned process / import.meta members, type positions, declaration names, comments, string literals, history.pushState / replaceState).

## Ground Control Checks

- [x] Pre-push architecture review: 3 cycles total (cycle 1 within cap, cycles 2 and 3 over-cap with user authorization). All findings across cycles fixed at category level; decision records posted on the issue thread.
- [x] Pre-push test-quality review: 1 cycle, 4 findings (1 critical, 3 warnings), all fixed in-turn (strengthened weak assertions to exact-shape / exact-count checks); decision record posted.

## Traceability

- IMPLEMENTS: PUL-Q003 ← tests/runtime/policy-q003-url-state-determinism.test.ts (structural gate), PUL-Q003 ← docs/design/pul-q003-url-state-determinism-preflight.md (design preflight)
- TESTS: PUL-Q003 ← tests/runtime/navigation.test.ts (behavioral pin), PUL-Q003 ← tests/runtime/policy-q003-url-state-determinism.test.ts (scanner + runtime-tree)

## Checklist

- [x] Coding standards followed
- [x] No new runtime dependencies
- [x] Changelog fragment added at `changelog.d/42.added.md`
- [x] Design preflight (`docs/design/pul-q003-url-state-determinism-preflight.md`) records guardrails
- [x] No `// PUL-Q003-allow:` exemptions added in `src/**/*.ts`