### PR TITLE
fix(runtime): surface failing asset paths on preload failure (PUL-Q009)

### DIFF
--- a/changelog.d/48.added.md
+++ b/changelog.d/48.added.md
@@ -1,0 +1,14 @@
+PUL-Q009 asset failure surfacing. The scene loader's
+`data-pulsar-navigation-error` stage attribute and the `Error` it
+hands to the workbench `onError` sink now carry the failing scene id
+and every declared asset path on a preload failure. A new
+`describeErrorDetailed(value, options?)` helper in `src/runtime/error.ts`
+walks `Error.cause` and `AggregateError.errors[]` to a bounded depth
+(default 4) and branch count (default 10), composing existing message
+strings only — no response bodies, headers, cookies, stacks, scene
+objects, DOM, or auth values reach the public surface. Internal
+wrapping paths (resolver / preloader / audio) keep using the original
+`describeError` so their structural-test wording is unchanged. No
+change to the asset-preloader `AggregateError` shape, no change to
+ADR-028 scene lifecycle failure isolation, no change to lifecycle
+ordering: a preload throw still aborts before `create(ctx)` runs.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -15,6 +15,7 @@ Design context for Pulsar. Source material for the ADRs in `../adrs/`.
 | [pul-q004-resource-cleanup-preflight.md](pul-q004-resource-cleanup-preflight.md) | Guardrails for enforcing scene resource cleanup completeness through existing lifecycle, audio, timeline, presenter, and prompter boundaries. |
 | [pul-q005-validation-actionability-preflight.md](pul-q005-validation-actionability-preflight.md) | Guardrails for making runtime validation findings locate the offending declaration and failed condition without duplicating validation schemas or error systems. |
 | [pul-q007-runtime-code-execution-preflight.md](pul-q007-runtime-code-execution-preflight.md) | Guardrails for statically banning runtime code execution outside the published bundle. |
+| [pul-q009-asset-failure-surfacing-preflight.md](pul-q009-asset-failure-surfacing-preflight.md) | Guardrails for surfacing asset preload failures with scene and asset context before mounting. |
 | [pul-f013-present-mode-preflight.md](pul-f013-present-mode-preflight.md) | Guardrails for implementing default `mode=present` behavior. |
 | [pul-f014-standalone-mode-preflight.md](pul-f014-standalone-mode-preflight.md) | Guardrails for implementing isolated `mode=standalone` behavior. |
 | [pul-f015-loop-mode-preflight.md](pul-f015-loop-mode-preflight.md) | Guardrails for implementing repeated `mode=loop` scene-timeline playback. |

--- a/docs/design/pul-q009-asset-failure-surfacing-preflight.md
+++ b/docs/design/pul-q009-asset-failure-surfacing-preflight.md
@@ -1,0 +1,126 @@
+# PUL-Q009 Asset Failure Surfacing Preflight
+
+PUL-Q009 requires asset preload failures to surface with the scene id
+and asset path before the scene mounts. The repository already has the
+right ownership split: `scene.assets` is the asset inventory,
+`createAssetPreloader()` fetches and aggregates per-asset failures,
+`resolveComposition()` awaits preload before `create(ctx)`, and
+`createSceneLoader()` owns the browser-visible diagnostic surface.
+
+This requirement should close the diagnostic gap at those seams. It is
+not a new asset subsystem, scene lifecycle failure type, validation
+schema, logger, retry policy, or workflow.
+
+## Boundary
+
+- `src/runtime/scene.ts` remains the scene metadata contract.
+  Implementations must read `SceneModule.assets`; do not add a second
+  asset declaration field.
+- `src/runtime/asset-preloader.ts` remains the fetch, URL-resolution,
+  scheme-validation, redirect-validation, stream-drain, and per-asset
+  failure aggregation boundary.
+- `src/runtime/composition-resolver.ts` remains the lifecycle
+  orchestrator. Preload is still awaited before `create(ctx)`, and a
+  preload failure remains composition-wide rather than a PUL-F029
+  scene lifecycle failure.
+- `src/runtime/scene-loader.ts` remains the browser/workbench
+  diagnostic boundary via `onError` and
+  `data-pulsar-navigation-error`.
+- `src/runtime/error.ts` remains the shared unknown-error rendering
+  home. Any cause/AggregateError rendering needed for asset diagnostics
+  belongs there or behind a helper exported from there, not as local
+  recursive string code in the loader, resolver, or preloader.
+
+## Required Reuse
+
+Implementation must build on these incumbents:
+
+- Scene asset inventory: `SceneModule.assets` and `assertSceneModule()`.
+- Asset policy and fetch semantics: `createAssetPreloader()`,
+  `resolveAssetUrl()`, `DEFAULT_ALLOWED_SCHEMES`,
+  `AssetPreloaderOptions.baseUrl`, `AssetPreloaderOptions.allowedSchemes`,
+  `AssetPreloaderOptions.fetch`, and `AssetPreloaderOptions.init`.
+- Lifecycle ordering: `AssetPreloader`, `preloadScene()`,
+  `resolveComposition()`, `loadSceneNavigationTarget()`, and the
+  loader's per-navigation `createPreloader(signal)` seam.
+- Error and diagnostic style: `Error`, `AggregateError`, `Error.cause`,
+  `describeError()`, loader `onError`, and
+  `data-pulsar-navigation-error`.
+- Existing test surfaces:
+  `tests/runtime/asset-preloader.test.ts`,
+  `tests/runtime/composition-resolver.test.ts`,
+  `tests/runtime/scene-navigation.test.ts`, and
+  `tests/runtime/scene-loader*.test.ts`.
+
+## Cross-Cutting Layers
+
+| Layer | Guardrail |
+|-------|-----------|
+| Scene schema gate | `assertSceneModule()` already guarantees `assets` is an array of strings. Do not introduce `AssetManifest`, asset DTOs, or duplicate scene validation for PUL-Q009. |
+| Asset URL policy | Use `resolveAssetUrl()` and the existing `baseUrl` / `allowedSchemes` behavior. The requirement is about surfacing failures, not widening allowed schemes, adding file access, or probing paths outside the preloader. |
+| Fetch boundary | Keep `fetch` injection and `init.signal` forwarding. Abort-driven preload cancellation must keep its current semantics and must not be reported as a stale navigation error after supersession. |
+| Redirect and scheme security | Preserve up-front scheme validation and post-redirect re-validation. Do not bypass the preloader with `<link rel=preload>`, `Image()`, Howler, or browser cache heuristics that cannot surface a precise per-asset failure. |
+| Credential handling | `init.headers` still flows to every asset URL. Do not add credentials, auth headers, cookies, or token-bearing query construction to satisfy this requirement. If a caller needs credentialed preload, it must stay behind a custom `fetch` or future origin policy. |
+| Resolver lifecycle | Preload failures remain composition-wide and must abort before `create(ctx)`. They must not flow through `onSceneFailed`, `data-pulsar-scene-failures`, presenter recovery, or scene cleanup for the not-yet-mounted scene. Already-mounted prior scenes still clean up through the resolver. |
+| Error envelope | Public diagnostics must include the scene id and failing declared asset path. They may include the resolved URL when the preloader already has it. Do not dump raw `Response` objects, request headers, cookies, authorization values, full stacks, scene objects, captions, DOM nodes, or serialized causes. |
+| Observability | Browser surfacing stays `onError` plus `data-pulsar-navigation-error`. No telemetry stream, persistent error history, localStorage, cookies, or new logging framework. |
+| Runtime validation | `validateRuntime()` may continue to catch unresolvable URL shapes through `resolveAssetUrl()`, but PUL-Q009 is runtime preload failure surfacing. Do not reclassify HTTP/network failures as structural validation findings. |
+| OS/process exposure | Asset paths and credential-bearing URLs must not be passed through process argv, shell commands, env vars, or generated command lines. Tests should use injected fake fetches in process. |
+
+## Intended Design
+
+The intended design is a narrow diagnostic rendering improvement over
+the existing `AggregateError` chain. `createAssetPreloader()` already
+throws `AggregateError` with scene id in the top message and
+asset-scoped entries in declaration order. `resolveComposition()`
+already preserves that object as `Error.cause` while adding scene
+context. The browser-facing diagnostic should render enough of that
+chain to expose each failing declared asset path alongside the scene
+id before any `create(ctx)` call occurs.
+
+Keep the output bounded and deterministic. Multiple failing assets
+should remain distinguishable and declaration ordered. A single
+failure should keep the same structural path as multiple failures; do
+not special-case it into a bare error.
+
+The extensibility seam is a shared diagnostic renderer in
+`src/runtime/error.ts`: it can later gain redaction, truncation,
+structured-error formatting, or AggregateError-depth limits without
+rewriting loader, resolver, asset, audio, and validation code. Keep the
+renderer parameterized enough for public surfaces to request bounded
+cause/AggregateError detail while internal wrappers can continue to
+use concise `describeError()` where appropriate.
+
+## Gotchas And Anti-Patterns
+
+- Do not create `AssetLoadError`, `SceneAssetFailure`, or a parallel
+  exception hierarchy. The repo already uses `AggregateError` plus
+  `Error.cause` for this path.
+- Do not solve surfacing by changing the scene schema or adding asset
+  ids. The requirement names the declared asset path.
+- Do not swallow `AggregateError.errors` at the loader boundary; that
+  is where the failing asset path currently lives.
+- Do not classify preload failure as a scene lifecycle failure. ADR-028
+  deliberately reserves `onSceneFailed` for `create`, `timeline`, and
+  `cleanup`.
+- Do not mount a placeholder scene, run `create(ctx)`, or call scene
+  cleanup for the scene whose preload failed. The failure must surface
+  before mount.
+- Do not fetch assets in validation or add a CI/network probe to
+  satisfy runtime surfacing.
+- Do not add retry, fallback URL, partial-success mount, decode-complete
+  image/font/audio handling, or cache warming policy under PUL-Q009.
+- Do not include headers, cookies, auth values, stacks, DOM, captions,
+  or raw cause serialization in public diagnostics.
+
+## Non-Goals
+
+PUL-Q009 does not add asset retries, fallback assets, host allowlists,
+credential policy, offline file access, decode-complete semantics,
+validation-network checks, telemetry, persistence, new URL parameters,
+new workbench modes, scene recovery UI, presenter commands, or a new
+logging system.
+
+It does not change composition manifest shape, scene metadata shape,
+registry behavior, navigation grammar, timeline orchestration, audio
+source policy, or ADR-028 scene lifecycle failure isolation.

--- a/src/runtime/error.ts
+++ b/src/runtime/error.ts
@@ -15,6 +15,120 @@
  * `null`, `undefined`) is coerced via `String(...)` so the message
  * is still well-defined for non-Error throws (`throw 'boom'`,
  * `Promise.reject(undefined)`, etc.).
+ *
+ * `describeError` is the **internal wrap** renderer: every resolver /
+ * preloader / audio wrapping `Error` uses this to keep the wrapping
+ * message terse and stable (so the existing structural tests that
+ * pattern-match the wrapping wording keep working). Browser-visible
+ * surfaces — `data-pulsar-navigation-error`, the `Error` passed to a
+ * workbench `onError` sink — call {@link describeErrorDetailed}
+ * instead, which walks `Error.cause` and `AggregateError.errors[]` so
+ * the per-asset failure messages buried inside a preload throw
+ * (PUL-Q009) reach the operator.
  */
 export const describeError = (value: unknown): string =>
   value instanceof Error ? value.message : String(value);
+
+/**
+ * Options for {@link describeErrorDetailed}. Both knobs default to
+ * values that surface every per-asset failure of a typical scene
+ * (multiple-asset compositions) while keeping the rendered string
+ * bounded enough for a DOM attribute.
+ */
+export interface DescribeErrorDetailedOptions {
+  /**
+   * Maximum walk depth into `Error.cause` and `AggregateError.errors`.
+   * `0` collapses to {@link describeError} (no cause, no children).
+   * Each cause hop AND each aggregate child consumes one unit of
+   * depth. Default `4` covers `loader → resolver → preloader →
+   * per-asset` chains without unbounded recursion.
+   */
+  readonly maxDepth?: number;
+  /**
+   * Maximum aggregate children rendered before a `…+N more` suffix
+   * truncates the rest. Default is unbounded so PUL-Q009 surfaces
+   * EVERY failing declared asset path on the public diagnostic
+   * surface — a static `scene.assets` list is bounded by the scene
+   * schema, so the realistic per-aggregate width is small (a few
+   * dozen at most) and truncating by default would silently drop
+   * paths beyond the cap. Pass an explicit positive integer when a
+   * caller has a separate bound (e.g. a UI that wants a one-line
+   * preview); pass `Number.POSITIVE_INFINITY` to be explicit about
+   * "render every child."
+   */
+  readonly maxBranches?: number;
+}
+
+const DEFAULT_MAX_DEPTH = 4;
+const DEFAULT_MAX_BRANCHES = Number.POSITIVE_INFINITY;
+
+/**
+ * Public-surface renderer for an unknown error-ish value.
+ *
+ * Walks `Error.cause` and `AggregateError.errors[]` to a bounded depth
+ * and width, producing a single-line summary suitable for a stage
+ * attribute or an `onError(err)` handler. Composes existing
+ * `.message` strings only — never inspects `stack`, headers, cookies,
+ * request init, scene objects, DOM, or response bodies — so the
+ * bounded payload is whatever upstream messages chose to surface.
+ *
+ * Output shape:
+ *  - plain `Error` / non-Error value → same as {@link describeError}.
+ *  - `Error` with a `cause` → `<message> — cause: <cause-rendered>`.
+ *  - `AggregateError` → `<message> [<child1>; <child2>; …]`.
+ *  - aggregate with > `maxBranches` children → `…+N more` suffix.
+ *  - cyclic cause chains terminate via a per-walk visited set.
+ *
+ * The renderer is PUL-Q009's diagnostic seam: it surfaces the failing
+ * scene id (already in the resolver's wrapping message) AND the
+ * per-asset paths (in `cause.errors[].message` from
+ * `createAssetPreloader`) at the existing
+ * `data-pulsar-navigation-error` / `onError` boundary, without
+ * touching the lifecycle ordering invariants in
+ * `composition-resolver.ts` or the AggregateError shape in
+ * `asset-preloader.ts`.
+ */
+export function describeErrorDetailed(
+  value: unknown,
+  options: DescribeErrorDetailedOptions = {},
+): string {
+  const maxDepth = options.maxDepth ?? DEFAULT_MAX_DEPTH;
+  const maxBranches = options.maxBranches ?? DEFAULT_MAX_BRANCHES;
+  const visited = new WeakSet<object>();
+  return render(value, maxDepth, maxBranches, visited);
+}
+
+function render(
+  value: unknown,
+  depth: number,
+  maxBranches: number,
+  visited: WeakSet<object>,
+): string {
+  if (!(value instanceof Error)) return String(value);
+  if (visited.has(value)) return value.message;
+  visited.add(value);
+  let out = value.message;
+  if (depth <= 0) return out;
+  if (value instanceof AggregateError && value.errors.length > 0) {
+    out += ` ${renderBranches(value.errors, depth - 1, maxBranches, visited)}`;
+  }
+  const cause = (value as Error & { cause?: unknown }).cause;
+  if (cause !== undefined && cause !== null) {
+    out += ` — cause: ${render(cause, depth - 1, maxBranches, visited)}`;
+  }
+  return out;
+}
+
+function renderBranches(
+  errors: readonly unknown[],
+  depth: number,
+  maxBranches: number,
+  visited: WeakSet<object>,
+): string {
+  const shown = errors
+    .slice(0, maxBranches)
+    .map((child) => render(child, depth, maxBranches, visited));
+  const remaining = errors.length - shown.length;
+  if (remaining > 0) shown.push(`…+${remaining} more`);
+  return `[${shown.join('; ')}]`;
+}

--- a/src/runtime/scene-loader.ts
+++ b/src/runtime/scene-loader.ts
@@ -43,7 +43,7 @@ import type {
   CompositionTimelineAdapter,
   SceneFailureEvent,
 } from './composition-resolver';
-import { describeError, describeErrorDetailed } from './error';
+import { describeErrorDetailed } from './error';
 import { KEBAB_IDENTIFIER_FORM, isKebabIdentifier } from './identifier';
 import {
   NAVIGATION_MODES,
@@ -624,7 +624,7 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
         }
       }
       // Public diagnostic: scene id + phase + composition context +
-      // mode + describeError rendering. Wrapped in an `Error` so
+      // mode + the resolver-rendered `event.message`. Wrapped in an `Error` so
       // existing `onError` consumers that call `err.message` keep
       // working. `event.cause` deliberately stays inside the resolver
       // — the loader never publishes it (ADR-028's "no raw causes"

--- a/src/runtime/scene-loader.ts
+++ b/src/runtime/scene-loader.ts
@@ -43,7 +43,7 @@ import type {
   CompositionTimelineAdapter,
   SceneFailureEvent,
 } from './composition-resolver';
-import { describeError } from './error';
+import { describeError, describeErrorDetailed } from './error';
 import { KEBAB_IDENTIFIER_FORM, isKebabIdentifier } from './identifier';
 import {
   NAVIGATION_MODES,
@@ -655,8 +655,19 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
   };
 
   const surfaceError = (err: unknown): void => {
-    onError(err);
-    setStageAttr(ATTR_ERROR, describeError(err));
+    // PUL-Q009: render the public-surface diagnostic through the
+    // bounded multi-cause walker so a preload failure (resolver wrap
+    // around an asset-preloader AggregateError) surfaces the scene id
+    // AND every failing declared asset path on `data-pulsar-navigation-error`
+    // and in `onError`'s argument. When the walker has nothing extra
+    // to add (a plain Error whose `.message` is already the full
+    // story), pass the original through so consumers comparing error
+    // identity / .message wording see no change.
+    const rendered = describeErrorDetailed(err);
+    const surfaced =
+      err instanceof Error && err.message === rendered ? err : new Error(rendered, { cause: err });
+    onError(surfaced);
+    setStageAttr(ATTR_ERROR, rendered);
   };
 
   /**

--- a/tests/runtime/error.test.ts
+++ b/tests/runtime/error.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+
+import { describeError, describeErrorDetailed } from '../../src/runtime/error';
+
+describe('describeError', () => {
+  it('returns the .message for an Error instance', () => {
+    expect(describeError(new Error('boom'))).toBe('boom');
+  });
+
+  it('coerces non-Error values via String()', () => {
+    expect(describeError('boom')).toBe('boom');
+    expect(describeError(42)).toBe('42');
+    expect(describeError(undefined)).toBe('undefined');
+    expect(describeError(null)).toBe('null');
+    expect(describeError({ toString: () => 'object' })).toBe('object');
+  });
+});
+
+describe('describeErrorDetailed (PUL-Q009 public-surface renderer)', () => {
+  it('matches describeError for a plain Error', () => {
+    expect(describeErrorDetailed(new Error('boom'))).toBe('boom');
+  });
+
+  it('matches describeError for non-Error values', () => {
+    expect(describeErrorDetailed('boom')).toBe('boom');
+    expect(describeErrorDetailed(undefined)).toBe('undefined');
+  });
+
+  it('renders AggregateError children in declaration order joined with "; "', () => {
+    const aggregate = new AggregateError(
+      [new Error('asset "/a.png": 404 Not Found'), new Error('asset "/b.json": 500 oops')],
+      'composition asset preload failed: scene "intro"',
+    );
+    expect(describeErrorDetailed(aggregate)).toBe(
+      'composition asset preload failed: scene "intro" [asset "/a.png": 404 Not Found; asset "/b.json": 500 oops]',
+    );
+  });
+
+  it('walks Error.cause and appends with " — cause: " prefix', () => {
+    const inner = new Error('inner detail');
+    const outer = new Error('outer wrap', { cause: inner });
+    expect(describeErrorDetailed(outer)).toBe('outer wrap — cause: inner detail');
+  });
+
+  it('walks a cause chain into an AggregateError so wrapped preload failures surface every asset path', () => {
+    const aggregate = new AggregateError(
+      [new Error('asset "/missing.png": 404 Not Found'), new Error('asset "/broken.json": 500')],
+      'composition asset preload failed: scene "intro"',
+    );
+    const wrapped = new Error(
+      'composition resolution failed: scene "intro" preloadAssets threw: composition asset preload failed: scene "intro"',
+      { cause: aggregate },
+    );
+    expect(describeErrorDetailed(wrapped)).toBe(
+      'composition resolution failed: scene "intro" preloadAssets threw: composition asset preload failed: scene "intro" — cause: composition asset preload failed: scene "intro" [asset "/missing.png": 404 Not Found; asset "/broken.json": 500]',
+    );
+  });
+
+  it('renders every aggregate child by default (PUL-Q009: every failing asset path surfaces)', () => {
+    // PUL-Q009 says "the runtime SHALL surface the failure with the
+    // scene id and asset path"; for a scene that declares many failing
+    // assets, "asset path" means every failing path. The default
+    // rendering MUST therefore not silently truncate — even when
+    // maxBranches is unset the operator sees every declared path.
+    const children = Array.from({ length: 25 }, (_, i) => new Error(`asset "/a${i}": 404`));
+    const aggregate = new AggregateError(children, 'preload failed');
+    const out = describeErrorDetailed(aggregate);
+    for (let i = 0; i < children.length; i += 1) {
+      expect(out).toContain(`asset "/a${i}": 404`);
+    }
+    // And no "…+N more" suffix on the default path.
+    expect(out).not.toContain('more');
+  });
+
+  it('truncates AggregateError branches beyond maxBranches with a "…+N more" suffix', () => {
+    const children = Array.from({ length: 12 }, (_, i) => new Error(`asset "/a${i}": 404`));
+    const aggregate = new AggregateError(children, 'preload failed');
+    expect(describeErrorDetailed(aggregate, { maxBranches: 3 })).toBe(
+      'preload failed [asset "/a0": 404; asset "/a1": 404; asset "/a2": 404; …+9 more]',
+    );
+  });
+
+  it('respects maxDepth: depth 0 collapses to describeError (no cause / no children walked)', () => {
+    const aggregate = new AggregateError([new Error('child')], 'outer');
+    expect(describeErrorDetailed(aggregate, { maxDepth: 0 })).toBe('outer');
+    const wrapped = new Error('wrap', { cause: new Error('cause') });
+    expect(describeErrorDetailed(wrapped, { maxDepth: 0 })).toBe('wrap');
+  });
+
+  it('renders nested AggregateError within depth budget and truncates beyond it', () => {
+    const innerAggregate = new AggregateError([new Error('leaf-1'), new Error('leaf-2')], 'inner');
+    const outerAggregate = new AggregateError([innerAggregate, new Error('sibling')], 'outer');
+    expect(describeErrorDetailed(outerAggregate)).toBe('outer [inner [leaf-1; leaf-2]; sibling]');
+    // Limit recursion: only the outer aggregate's children get walked,
+    // the inner one collapses to its own message.
+    expect(describeErrorDetailed(outerAggregate, { maxDepth: 1 })).toBe('outer [inner; sibling]');
+  });
+
+  it('terminates on a cyclic cause chain via the WeakSet cycle guard, not just the depth bound', () => {
+    // Pass an unbounded maxDepth so only the WeakSet cycle guard can
+    // stop the walk. The default depth-4 bound would shield the
+    // regression: a missing visited-set would still terminate at
+    // depth 0 and the assertion would silently pass.
+    const a = new Error('a');
+    const b = new Error('b', { cause: a });
+    (a as Error & { cause?: unknown }).cause = b;
+    const out = describeErrorDetailed(a, { maxDepth: Number.POSITIVE_INFINITY });
+    expect(out.startsWith('a — cause: b')).toBe(true);
+    expect(out.length).toBeLessThan(200);
+  });
+});

--- a/tests/runtime/scene-loader.test.ts
+++ b/tests/runtime/scene-loader.test.ts
@@ -791,7 +791,12 @@ describe('createSceneLoader — navigation, errors & abort (PUL-F008)', () => {
 
       // The cleanup failure on `broken` MUST have surfaced through
       // `onError` (the loader's `onSceneFailed` handler routes there).
-      expect(captured.length).toBeGreaterThanOrEqual(1);
+      // Exactly one onError call: the pure-abort wrapper is suppressed
+      // by `isPureAbort` (scene-loader.ts:418-424), so the cleanup
+      // failure is the only event reaching the workbench logger. The
+      // earlier `>= 1` assertion let a future regression that double-
+      // fires the abort through `onError` pass silently.
+      expect(captured).toHaveLength(1);
       const cleanupError = captured.find(
         (e) => e instanceof Error && /cleanup boom/.test((e as Error).message),
       );
@@ -830,6 +835,73 @@ describe('createSceneLoader — navigation, errors & abort (PUL-F008)', () => {
       // already-loaded scene.
       expect(stage.attrs.get('data-pulsar-navigation-error')).toBe('preloader factory blew up');
       expect(stage.attrs.has('data-pulsar-scene-target')).toBe(false);
+    });
+
+    it('surfaces the scene id and every failing asset path BEFORE mounting the scene (PUL-Q009)', async () => {
+      // PUL-Q009: when an asset declared by a scene fails to load
+      // during preload, the runtime SHALL surface the failure with the
+      // scene id and asset path before mounting the scene. The preload
+      // throw path already names the scene id in the resolver wrapper;
+      // the asset paths live in the AggregateError's per-asset
+      // `errors[]`. The browser-visible surface (onError + the stage
+      // attribute) MUST carry both so an operator does not see a
+      // generic "preload failed" line for a multi-asset failure.
+      const captured: unknown[] = [];
+      const stage = buildStage();
+      const createSpy = vi.fn();
+      const intro = buildScene({
+        id: 'intro',
+        assets: ['/missing.png', '/broken.json'],
+        create: createSpy,
+      });
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([intro]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        // Mimic the exact AggregateError shape `createAssetPreloader`
+        // produces (asset-preloader.ts: per-asset Errors whose
+        // `.message` carries the declared path, wrapped under a
+        // composition-scoped aggregate message).
+        createPreloader: () => () =>
+          Promise.reject(
+            new AggregateError(
+              [
+                new Error('asset "/missing.png": 404 Not Found'),
+                new Error('asset "/broken.json": 500 Internal Server Error'),
+              ],
+              'composition asset preload failed: scene "intro"',
+            ),
+          ),
+        timeline: noopTimeline,
+        onError: (err) => {
+          captured.push(err);
+        },
+      });
+
+      await loader.handle(sceneTarget('intro'));
+
+      // Clause "before mounting the scene": create(ctx) MUST NOT have
+      // been called for the scene whose preload failed.
+      expect(createSpy).not.toHaveBeenCalled();
+
+      // onError fires with an Error whose message carries the scene id
+      // AND every failing asset path.
+      expect(captured).toHaveLength(1);
+      const surfaced = captured[0] as Error;
+      expect(surfaced).toBeInstanceOf(Error);
+      expect(surfaced.message).toContain('scene "intro"');
+      expect(surfaced.message).toContain('asset "/missing.png"');
+      expect(surfaced.message).toContain('asset "/broken.json"');
+
+      // The stage attribute (data-pulsar-navigation-error) carries the
+      // same content so screenshot tooling / agents inspecting the DOM
+      // see the same diagnostic the workbench logger gets.
+      const stageMsg = stage.attrs.get('data-pulsar-navigation-error');
+      expect(stageMsg).toBeDefined();
+      expect(stageMsg).toContain('scene "intro"');
+      expect(stageMsg).toContain('asset "/missing.png"');
+      expect(stageMsg).toContain('asset "/broken.json"');
     });
 
     it('handle() after dispose() is a no-op', async () => {


### PR DESCRIPTION
## Summary

PUL-Q009: surface the failing scene id AND every declared asset path on the public diagnostic surface when an asset preload throws, before the scene mounts.

## Requirement UIDs

- `PUL-Q009`

## Related Issues

Closes #48

## ADR Impact

- No ADR required

## Changes

- Add `describeErrorDetailed` in `src/runtime/error.ts` — a bounded walker over `Error.cause` and `AggregateError.errors[]` that composes existing `.message` strings only (no headers, cookies, stacks, scene objects, DOM, response bodies). Branch default is unbounded so PUL-Q009's 'every failing asset path' contract holds; depth default 4 covers loader → resolver → preloader → per-asset chains. WeakSet cycle guard protects pathological self-referential causes.
- Wire `src/runtime/scene-loader.ts` `surfaceError` to render `data-pulsar-navigation-error` and `onError`'s Error argument via the new helper; pass through the original Error when the walker has nothing extra to add so existing error-identity tests stay green.
- Leave internal wraps in resolver / preloader / audio on the original `describeError` so structural-test wording is unchanged.
- Add a focused test suite at `tests/runtime/error.test.ts` covering plain Errors, AggregateError children, cause walks, nested aggregates, depth/branch bounds, cycle termination, and the PUL-Q009 'every failing asset path' default-rendering invariant.
- Add a scene-loader test that injects an AggregateError-shaped preload throw and asserts (a) `create(ctx)` is never called (clause 'before mounting the scene'), (b) `onError` fires with an Error message carrying scene id + both failing asset paths, (c) `data-pulsar-navigation-error` carries the same content.
- Tighten the pre-existing 'cleanup failures even when aborted' test to `toHaveLength(1)` (was `>= 1`).
- Preflight design note `docs/design/pul-q009-asset-failure-surfacing-preflight.md` plus index entry.

## Test Plan

- [x] Unit tests pass (`pnpm test`)
- [x] Lint + typecheck pass (`pnpm lint`, `pnpm typecheck`)
- [x] No coverage regression

Full local gate green: `pnpm lint`, `pnpm typecheck`, `pnpm test` (1683 tests).

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: PUL-Q009 ← src/runtime/error.ts, PUL-Q009 ← src/runtime/scene-loader.ts
- TESTS: PUL-Q009 ← tests/runtime/error.test.ts, PUL-Q009 ← tests/runtime/scene-loader.test.ts

## Checklist

- [x] Code follows project coding standards
- [x] Changelog fragment added at `changelog.d/48.added.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed