### PR TITLE
fix: surface scene id + phase or beat via formatSceneContext (PUL-Q006)

### DIFF
--- a/changelog.d/45.added.md
+++ b/changelog.d/45.added.md
@@ -1,0 +1,12 @@
+PUL-Q006 error surfacing context. A new `formatSceneContext({ sceneId,
+phase?, beat? })` helper in `src/runtime/error.ts` is the canonical
+seam that renders the scene-error context prefix the scene loader's
+`buildOnSceneFailed` now composes — so the public diagnostic surfaces
+(`data-pulsar-navigation-error`, `data-pulsar-scene-failures`, and the
+`Error` handed to the workbench `onError` sink) carry the scene id and
+(where applicable) the lifecycle phase or beat label from one place.
+A new `tests/runtime/pul-q006-error-context.test.ts` suite pins the
+requirement across every runtime-error surface so a future refactor
+that drops scene id, phase, or beat at any one seam fails its own
+test. No new error classes, no new lifecycle hooks, no scene-schema
+change, no env-var/config/storage exposure.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -14,6 +14,7 @@ Design context for Pulsar. Source material for the ADRs in `../adrs/`.
 | [pul-q003-url-state-determinism-preflight.md](pul-q003-url-state-determinism-preflight.md) | Guardrails for enforcing URL-only runtime target selection without persisted browser or host state. |
 | [pul-q004-resource-cleanup-preflight.md](pul-q004-resource-cleanup-preflight.md) | Guardrails for enforcing scene resource cleanup completeness through existing lifecycle, audio, timeline, presenter, and prompter boundaries. |
 | [pul-q005-validation-actionability-preflight.md](pul-q005-validation-actionability-preflight.md) | Guardrails for making runtime validation findings locate the offending declaration and failed condition without duplicating validation schemas or error systems. |
+| [pul-q006-error-surfacing-context-preflight.md](pul-q006-error-surfacing-context-preflight.md) | Guardrails for surfacing runtime errors with scene, beat, and lifecycle phase context through existing diagnostic seams. |
 | [pul-q007-runtime-code-execution-preflight.md](pul-q007-runtime-code-execution-preflight.md) | Guardrails for statically banning runtime code execution outside the published bundle. |
 | [pul-q009-asset-failure-surfacing-preflight.md](pul-q009-asset-failure-surfacing-preflight.md) | Guardrails for surfacing asset preload failures with scene and asset context before mounting. |
 | [pul-f013-present-mode-preflight.md](pul-f013-present-mode-preflight.md) | Guardrails for implementing default `mode=present` behavior. |

--- a/docs/design/pul-q006-error-surfacing-context-preflight.md
+++ b/docs/design/pul-q006-error-surfacing-context-preflight.md
@@ -1,0 +1,118 @@
+# PUL-Q006 Error Surfacing Context Preflight
+
+Date: 2026-05-17
+
+PUL-Q006 requires runtime-surfaced errors to include the scene id and,
+where applicable, either the beat label or lifecycle/timeline phase
+(`create`, `timeline`, `cleanup`). This is diagnostic context hardening
+over existing error surfaces. It is not a new error hierarchy, logger,
+validation pass, scene schema, or recovery workflow.
+
+## Boundary
+
+- `src/runtime/error.ts` remains the shared unknown-error renderer.
+  Public surfaces use `describeErrorDetailed()` when cause /
+  `AggregateError` detail must be visible; internal wrappers continue
+  to use `describeError()` for terse local messages.
+- `src/runtime/composition-resolver.ts` remains the lifecycle owner.
+  `SceneFailureEvent` is the canonical structured contract for
+  `create`, `timeline`, and `cleanup` failures.
+- `src/runtime/scene-loader.ts` remains the browser/workbench
+  diagnostic boundary through `onError`,
+  `data-pulsar-navigation-error`, and
+  `data-pulsar-scene-failures`.
+- `src/runtime/timeline.ts` remains the beat-label contract. Authored
+  labels are validated by `assertSceneTimeline()`; URL-requested
+  missing beats surface through the non-fatal `onBeatMissing` path.
+- `src/runtime/navigation.ts` remains the URL grammar gate for `beat`
+  and `mode`, with loader-side defense-in-depth for programmatic
+  `NavigationTarget` values.
+
+## Required Reuse
+
+Implementation must build on these incumbents:
+
+- Scene identity and lifecycle phase: `SceneFailureEvent`,
+  `SceneFailurePhase`, `buildSceneFailure()`, `notifyFailure()`, and
+  loader `buildOnSceneFailed()`.
+- Public error rendering: `describeError()`,
+  `describeErrorDetailed()`, `Error`, `AggregateError`, and
+  `Error.cause`.
+- Beat handling: `isKebabIdentifier()`, `KEBAB_IDENTIFIER_FORM`,
+  `assertSceneTimeline()`, `SceneTimelineLabelError`,
+  `headBeat`, `onBeatMissing`, and `buildOnBeatMissing()`.
+- Navigation and mode validation: `parseNavigationSearch()`,
+  `NAVIGATION_MODES`, `effectiveMode()`, `validateBeatGrammar()`, and
+  `validateModeGrammar()`.
+- Existing browser surfaces: loader `onError`,
+  `data-pulsar-navigation-error`, and
+  `data-pulsar-scene-failures`.
+- Tests already pinning the seams:
+  `tests/runtime/error.test.ts`,
+  `tests/runtime/composition-resolver.test.ts`,
+  `tests/runtime/scene-loader*.test.ts`, and
+  `tests/runtime/timeline.test.ts`.
+
+## Cross-Cutting Layers
+
+| Layer | Guardrail |
+|-------|-----------|
+| Scene schema gate | `assertSceneModule()` is only the static scene contract. Do not add scene fields, `onError` hooks, or duplicate lifecycle validation for PUL-Q006. |
+| Lifecycle resolver | `create`, `timeline`, and `cleanup` throws must pass through `SceneFailureEvent` so scene id and phase stay structured before rendering. Preload, registry, manifest, abort, and timeline-adapter failures keep their existing composition-wide semantics. |
+| Loader error envelope | Public messages emitted through `onError` and stage attributes must include scene id plus phase or beat when the active boundary has that context. Keep the raw `cause` programmatic; do not serialize stacks, scene objects, DOM, captions, headers, cookies, env, auth values, or request init. |
+| Beat grammar | URL beat values must pass the parser and loader defense-in-depth checks. Missing-label diagnostics must stay non-fatal through `onBeatMissing`; malformed authored labels remain `SceneTimelineLabelError` failures from `assertSceneTimeline()`. |
+| Timeline adapter | Use `headBeat` / `onBeatMissing` and the existing `MasterTimeline` label helpers. Do not parse namespaced label strings outside `parseSceneTimelineLabel()` or infer beat context from rendered messages. |
+| Asset/audio/presenter errors | These keep their existing boundaries. Add scene/phase/beat context only where the runtime already knows it; do not widen payloads or leak engine handles, source URLs beyond existing asset diagnostics, or presenter command internals. |
+| Validation pass | `validateRuntime()` remains structural validation. PUL-Q006 does not add validation findings or make validation execute lifecycle hooks, timelines, fetches, or audio. |
+| Config/env/OS exposure | No env vars, browser storage, localStorage, cookies, argv, shell commands, or generated command lines are needed. Diagnostic context is derived in process from typed runtime values. |
+| Observability | Browser console/stage and test failure output are sufficient. Do not add telemetry, persistence, SARIF, or a logging framework for this requirement. |
+
+## Intended Design
+
+The intended design is a narrow context-normalization pass at existing
+surfacing seams. Lifecycle failures should continue to originate as
+`SceneFailureEvent` with `{ sceneId, phase, entryIndex, message,
+cause }`, and the loader should render the browser-facing message with
+scene id, phase, composition/index when known, and mode. Beat-related
+diagnostics should stay split by source: malformed or invalid authored
+labels fail in `assertSceneTimeline()` with scene id and label;
+missing URL beats use `onBeatMissing` and surface a message naming the
+requested beat and head scene id.
+
+The extensibility seam is a shared context renderer or helper near
+`src/runtime/error.ts` / `src/runtime/scene-loader.ts` that accepts a
+small structured context object. It should be parameterized by
+`sceneId`, `phase`, and `beat` rather than by ad hoc string fragments,
+so future contexts such as composition entry, occurrence index, or
+runner mode can be added without reparsing existing messages.
+
+## Gotchas And Anti-Patterns
+
+- Do not introduce `RuntimeError`, `SceneError`, `BeatError`, or a
+  parallel exception hierarchy. Existing `Error` / `AggregateError`
+  plus structured event fields are sufficient.
+- Do not satisfy the requirement by parsing `Error.message` to recover
+  scene id, phase, or beat. Carry context from the boundary that has it.
+- Do not send all errors through `data-pulsar-scene-failures`.
+  Navigation, preload, manifest, registry, validation, and adapter
+  failures keep their existing surfaces.
+- Do not make missing URL beats fatal. The `onBeatMissing` path is
+  intentionally non-fatal.
+- Do not call lifecycle hooks, construct timelines, fetch assets, or
+  read DOM state only to improve an error message.
+- Do not echo raw causes, stacks, full captions, scene objects, DOM
+  nodes, request headers, cookies, auth values, env values, or process
+  arguments in public diagnostics.
+- Do not duplicate the kebab-case identifier regex, URL grammar, mode
+  allowlist, or master-label parser.
+
+## Non-Goals
+
+PUL-Q006 does not add recovery UI, retries, presenter command kinds,
+telemetry, persistent error history, a new logging system, new URL
+parameters, new workbench modes, source maps, stack rendering, or
+network/asset validation.
+
+It does not change scene metadata, composition manifest shape,
+navigation grammar, timeline orchestration, audio behavior, validation
+categories, resolver failure classification, or requirement status.

--- a/src/runtime/error.ts
+++ b/src/runtime/error.ts
@@ -132,3 +132,65 @@ function renderBranches(
   if (remaining > 0) shown.push(`…+${remaining} more`);
   return `[${shown.join('; ')}]`;
 }
+
+/**
+ * Lifecycle phase keywords PUL-Q006 names in its statement: the three
+ * `create` / `timeline` / `cleanup` hooks the scene contract owns
+ * (`SceneFailurePhase` in `composition-resolver.ts` is the structured
+ * source). Re-declared as a string-literal union here so this module
+ * stays free of a `composition-resolver` import — `error.ts` is
+ * upstream of the resolver in the dependency graph, and a runtime
+ * `Error` formatter has no business depending on lifecycle plumbing.
+ */
+export type ScenePhase = 'create' | 'timeline' | 'cleanup';
+
+/**
+ * Structured context for {@link formatSceneContext} — the PUL-Q006
+ * "scene id and (where applicable) the beat label or the timeline
+ * phase" surface contract, lifted out of bespoke message templates so
+ * future fields (composition entry, occurrence index, mode) get added
+ * here once instead of grepped back out of `Error.message`.
+ */
+export interface SceneErrorContext {
+  /** The scene id the diagnostic belongs to (PUL-Q006 mandatory clause). */
+  readonly sceneId: string;
+  /**
+   * The lifecycle phase whose throw produced the diagnostic, when one
+   * applies. Preload / abort / manifest / registry errors have no
+   * phase; lifecycle failures (`create` / `timeline` / `cleanup`) do.
+   */
+  readonly phase?: ScenePhase;
+  /**
+   * The beat label the diagnostic concerns, when one applies. The URL
+   * `beat=` value for a missing-label diagnostic, or the offending
+   * authored label for a {@link import('./timeline').SceneTimelineLabelError}.
+   */
+  readonly beat?: string;
+}
+
+/**
+ * Render the canonical PUL-Q006 scene-error context prefix.
+ *
+ * Used by every public-surface error template that scopes to a scene,
+ * so a future regression that drops the scene id, phase, or beat at
+ * any one seam shows up as a behavioral diff at this single helper
+ * rather than as one bespoke message-template per surface. Existing
+ * resolver / timeline wording (e.g. `composition resolution failed:
+ * scene "X" create threw: ...`) keeps its prose and continues to
+ * satisfy the requirement on its own; this helper is the seam for
+ * surfaces that compose the prefix programmatically (the loader's
+ * `buildOnSceneFailed`) and for future fields per the PUL-Q006
+ * preflight.
+ *
+ * Output shapes:
+ *  - `{ sceneId: 'X' }`                                       → `scene "X"`
+ *  - `{ sceneId: 'X', phase: 'create' }`                      → `scene "X" failed during create`
+ *  - `{ sceneId: 'X', beat: 'b' }`                            → `scene "X" at beat "b"`
+ *  - `{ sceneId: 'X', phase: 'timeline', beat: 'b' }`         → `scene "X" failed during timeline at beat "b"`
+ */
+export function formatSceneContext(context: SceneErrorContext): string {
+  let out = `scene "${context.sceneId}"`;
+  if (context.phase !== undefined) out += ` failed during ${context.phase}`;
+  if (context.beat !== undefined) out += ` at beat "${context.beat}"`;
+  return out;
+}

--- a/src/runtime/scene-loader.ts
+++ b/src/runtime/scene-loader.ts
@@ -43,7 +43,7 @@ import type {
   CompositionTimelineAdapter,
   SceneFailureEvent,
 } from './composition-resolver';
-import { describeErrorDetailed } from './error';
+import { describeErrorDetailed, formatSceneContext } from './error';
 import { KEBAB_IDENTIFIER_FORM, isKebabIdentifier } from './identifier';
 import {
   NAVIGATION_MODES,
@@ -600,6 +600,13 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
     const entries: string[] = [];
     const seen = new Set<string>();
     const renderMessage = (event: SceneFailureEvent): string => {
+      // PUL-Q006 / ADR-028: scene id + lifecycle phase come from the
+      // canonical `formatSceneContext` helper in `./error.ts` so any
+      // future PUL-Q006 context (composition entry, occurrence index,
+      // mode) gets added there once instead of re-templated at every
+      // public-surface seam (codex preflight: "do not satisfy the
+      // requirement by parsing Error.message").
+      const prefix = formatSceneContext({ sceneId: event.sceneId, phase: event.phase });
       // Codex review cycle 2: render the ABSOLUTE composition entry
       // index (slice start + resolver-level slice-relative index).
       // The resolver's `event.entryIndex` is relative to the manifest
@@ -611,7 +618,7 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
         composition === undefined
           ? ''
           : ` (composition "${composition.id}" entry [${composition.startIndex + event.entryIndex}])`;
-      return `scene "${event.sceneId}" failed during ${event.phase}${compositionSuffix} under mode "${mode}": ${event.message}`;
+      return `${prefix}${compositionSuffix} under mode "${mode}": ${event.message}`;
     };
     return (event: SceneFailureEvent): void => {
       if (disposed) return;
@@ -769,9 +776,15 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
       // surface stays non-fatal even when the operator's logger
       // throws.
       try {
+        // PUL-Q006: route the missing-beat diagnostic through the
+        // canonical `formatSceneContext` helper so the scene-id +
+        // beat-label fields come from the same structural seam
+        // `buildOnSceneFailed.renderMessage` uses. Future context
+        // (composition entry, occurrence index, mode) gets added at
+        // the helper and reaches this surface for free.
         surfaceError(
           new Error(
-            `beat positioning failed: beat "${beat}" does not exist in scene "${headSceneId}"`,
+            `beat positioning failed: ${formatSceneContext({ sceneId: headSceneId, beat })} — beat does not exist`,
           ),
         );
       } catch {

--- a/tests/runtime/error.test.ts
+++ b/tests/runtime/error.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { describeError, describeErrorDetailed } from '../../src/runtime/error';
+import { describeError, describeErrorDetailed, formatSceneContext } from '../../src/runtime/error';
 
 describe('describeError', () => {
   it('returns the .message for an Error instance', () => {
@@ -107,5 +107,35 @@ describe('describeErrorDetailed (PUL-Q009 public-surface renderer)', () => {
     const out = describeErrorDetailed(a, { maxDepth: Number.POSITIVE_INFINITY });
     expect(out.startsWith('a — cause: b')).toBe(true);
     expect(out.length).toBeLessThan(200);
+  });
+});
+
+describe('formatSceneContext (PUL-Q006 scene-error context prefix)', () => {
+  it('renders the scene id alone when neither phase nor beat is supplied', () => {
+    expect(formatSceneContext({ sceneId: 'intro' })).toBe('scene "intro"');
+  });
+
+  it('appends `failed during <phase>` when a lifecycle phase is supplied', () => {
+    expect(formatSceneContext({ sceneId: 'intro', phase: 'create' })).toBe(
+      'scene "intro" failed during create',
+    );
+    expect(formatSceneContext({ sceneId: 'intro', phase: 'timeline' })).toBe(
+      'scene "intro" failed during timeline',
+    );
+    expect(formatSceneContext({ sceneId: 'intro', phase: 'cleanup' })).toBe(
+      'scene "intro" failed during cleanup',
+    );
+  });
+
+  it('appends `at beat "<beat>"` when a beat label is supplied', () => {
+    expect(formatSceneContext({ sceneId: 'intro', beat: 'hook' })).toBe(
+      'scene "intro" at beat "hook"',
+    );
+  });
+
+  it('appends both phase and beat when both are supplied', () => {
+    expect(formatSceneContext({ sceneId: 'intro', phase: 'timeline', beat: 'hook' })).toBe(
+      'scene "intro" failed during timeline at beat "hook"',
+    );
   });
 });

--- a/tests/runtime/pul-q006-error-context.test.ts
+++ b/tests/runtime/pul-q006-error-context.test.ts
@@ -1,0 +1,314 @@
+// PUL-Q006 — Error surfacing context.
+//
+// Cross-surface invariant suite. When the runtime surfaces an error,
+// the error message SHALL include the scene id and (where applicable)
+// the beat label or the timeline phase (`create`, `timeline`,
+// `cleanup`).
+//
+// Each `it(...)` pins one surface so a regression at any one seam
+// fails its own assertion. The surfaces are:
+//
+//   1. `buildOnSceneFailed` -> `onError`, for `create` / `timeline` /
+//      `cleanup` lifecycle failures (`scene-loader.ts`,
+//      `composition-resolver.ts` SceneFailureEvent path).
+//   2. `data-pulsar-scene-failures` stage attribute, which is the
+//      structured `<sceneId>:<phase>` mirror of the same event stream.
+//   3. `buildOnBeatMissing`, for the URL `beat=<label>` missing-label
+//      diagnostic.
+//   4. Resolver wrap when `onSceneFailed` is NOT supplied (the legacy
+//      AggregateError fallback path) — scene id + phase live in the
+//      wrapping message.
+//   5. Resolver wrap for a `preload` throw — scene id present, no
+//      phase keyword (preload is not one of the three named phases;
+//      the requirement's "where applicable" carve-out applies).
+//   6. `assertSceneTimeline` `SceneTimelineLabelError` — scene id +
+//      beat label in the rendered message.
+//   7. `assertSceneTimeline` invalid-time `SceneTimelineLabelError` —
+//      scene id + beat label in the rendered message.
+
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  type CompositionTimelineAdapter,
+  resolveComposition,
+} from '../../src/runtime/composition-resolver';
+import { describeErrorDetailed, formatSceneContext } from '../../src/runtime/error';
+import { createSceneRegistry } from '../../src/runtime/registry';
+import type { SceneModule } from '../../src/runtime/scene';
+import { SceneTimelineLabelError, assertSceneTimeline } from '../../src/runtime/timeline';
+import {
+  type LegacyRunInput,
+  asTimeline,
+  buildScene,
+  buildStage,
+  compositionTarget,
+  createCompositionRegistry,
+  createSceneLoader,
+  gsap,
+  noopTimeline,
+  sceneTarget,
+  stubCtx,
+} from './scene-loader.helpers';
+
+// ---------------------------------------------------------------------------
+// Surface 1 — `buildOnSceneFailed` -> `onError` (lifecycle failures)
+// ---------------------------------------------------------------------------
+
+describe('PUL-Q006 — lifecycle failure (onError)', () => {
+  it.each(['create', 'timeline', 'cleanup'] as const)(
+    'includes scene id and phase keyword "%s"',
+    async (phase) => {
+      const onError = vi.fn();
+      const explode = (): never => {
+        throw new Error('boom');
+      };
+      const overrides: Partial<SceneModule> = {};
+      if (phase === 'create') overrides.create = explode;
+      if (phase === 'timeline') overrides.timeline = explode;
+      if (phase === 'cleanup') overrides.cleanup = explode;
+      const broken = buildScene({ id: 'broken', ...overrides });
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([broken]),
+        compositions: createCompositionRegistry([]),
+        stage: buildStage().element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        timeline: noopTimeline,
+        onError,
+      });
+
+      await loader.handle(sceneTarget('broken'));
+
+      expect(onError).toHaveBeenCalled();
+      const args = onError.mock.calls.map(([err]) => (err as Error).message);
+      const message = args.find((m) => m.includes(`failed during ${phase}`));
+      expect(message).toBeDefined();
+      expect(message).toContain('scene "broken"');
+      expect(message).toContain(`failed during ${phase}`);
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Surface 2 — `data-pulsar-scene-failures` stage attribute
+// ---------------------------------------------------------------------------
+
+describe('PUL-Q006 — scene-failures stage attribute', () => {
+  it('renders <sceneId>:<phase> so the structured surface carries scene id and phase', async () => {
+    const stage = buildStage();
+    const broken = buildScene({
+      id: 'broken',
+      create: () => {
+        throw new Error('boom');
+      },
+    });
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([broken]),
+      compositions: createCompositionRegistry([]),
+      stage: stage.element,
+      buildCtx: stubCtx,
+      createPreloader: () => () => undefined,
+      timeline: noopTimeline,
+      onError: () => undefined,
+    });
+
+    await loader.handle(sceneTarget('broken'));
+
+    expect(stage.attrs.get('data-pulsar-scene-failures')).toBe('broken:create');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Surface 3 — `buildOnBeatMissing`
+// ---------------------------------------------------------------------------
+
+describe('PUL-Q006 — missing beat (onError)', () => {
+  it('includes scene id and beat label', async () => {
+    const onError = vi.fn();
+    const stage = buildStage();
+    const intro = buildScene({ id: 'intro' });
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([intro]),
+      compositions: createCompositionRegistry([]),
+      stage: stage.element,
+      buildCtx: stubCtx,
+      createPreloader: () => () => undefined,
+      timeline: asTimeline((input: LegacyRunInput) => {
+        input.onBeatMissing?.();
+      }),
+      onError,
+    });
+
+    await loader.handle({ locator: { kind: 'scene', scene: 'intro' }, beat: 'unknown-label' });
+
+    const messages = onError.mock.calls.map(([err]) => (err as Error).message);
+    const beatMessage = messages.find((m) => m.includes('beat positioning failed'));
+    expect(beatMessage).toBeDefined();
+    expect(beatMessage).toContain('scene "intro"');
+    expect(beatMessage).toContain('beat "unknown-label"');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Surface 4 — resolver wrap (legacy aggregate path, no `onSceneFailed`)
+// ---------------------------------------------------------------------------
+
+describe('PUL-Q006 — resolver wrap (no onSceneFailed)', () => {
+  it.each(['create', 'timeline', 'cleanup'] as const)(
+    'wraps a scene "%s" throw so the rendered chain carries scene id and phase',
+    async (phase) => {
+      const explode = (): never => {
+        throw new Error('kaboom');
+      };
+      const overrides: Partial<SceneModule> = {};
+      if (phase === 'create') overrides.create = explode;
+      if (phase === 'timeline') overrides.timeline = explode;
+      if (phase === 'cleanup') overrides.cleanup = explode;
+      const broken = buildScene({ id: 'broken', ...overrides });
+      const registry = createSceneRegistry([broken]);
+      const timeline: CompositionTimelineAdapter = { run: () => Promise.resolve() };
+
+      // Without an `onSceneFailed` callback, the resolver re-raises an
+      // AggregateError whose `errors[0]` is the per-scene wrap. The
+      // public surface (`describeErrorDetailed`, used by
+      // `scene-loader.surfaceError`) walks both — both the top-level
+      // wrap AND the per-finding wrap must reach the operator.
+      let caught: unknown;
+      try {
+        await resolveComposition({
+          registry,
+          manifest: ['broken'],
+          ctx: undefined,
+          preloadAssets: () => undefined,
+          timeline,
+        });
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(AggregateError);
+      const rendered = describeErrorDetailed(caught);
+      expect(rendered).toContain('scene "broken"');
+      expect(rendered).toContain(`${phase} threw`);
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Surface 5 — resolver wrap (preload throw, no phase clause)
+// ---------------------------------------------------------------------------
+
+describe('PUL-Q006 — resolver wrap (preload throw)', () => {
+  it('includes scene id; preload is not a named lifecycle phase so no phase clause is required', async () => {
+    const intro = buildScene({ id: 'intro' });
+    const registry = createSceneRegistry([intro]);
+    const timeline: CompositionTimelineAdapter = { run: () => Promise.resolve() };
+
+    await expect(
+      resolveComposition({
+        registry,
+        manifest: ['intro'],
+        ctx: undefined,
+        preloadAssets: () => {
+          throw new Error('preload kaboom');
+        },
+        timeline,
+      }),
+    ).rejects.toThrow(/composition resolution failed: scene "intro" preloadAssets threw:/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Surface 6 — `assertSceneTimeline` invalid beat label
+// ---------------------------------------------------------------------------
+
+describe('PUL-Q006 — assertSceneTimeline (invalid beat label)', () => {
+  it('throws with scene id and the offending beat label in the message', () => {
+    const tl = gsap.timeline({ paused: true });
+    tl.to({}, { duration: 1 });
+    tl.addLabel('Not Kebab', 0.5);
+    try {
+      assertSceneTimeline(tl, 'intro');
+      throw new Error('expected SceneTimelineLabelError');
+    } catch (err) {
+      expect(err).toBeInstanceOf(SceneTimelineLabelError);
+      const message = (err as Error).message;
+      expect(message).toContain('scene "intro"');
+      expect(message).toContain('"Not Kebab"');
+      // Phase keyword "timeline" present in the prose.
+      expect(message).toContain('timeline');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Surface 7 — `assertSceneTimeline` beat time out of range
+// ---------------------------------------------------------------------------
+
+describe('PUL-Q006 — assertSceneTimeline (invalid beat time)', () => {
+  it('throws with scene id and the offending beat label in the message', () => {
+    const tl = gsap.timeline({ paused: true });
+    tl.to({}, { duration: 1 });
+    tl.addLabel('peak', 99);
+    try {
+      assertSceneTimeline(tl, 'intro');
+      throw new Error('expected SceneTimelineLabelError');
+    } catch (err) {
+      expect(err).toBeInstanceOf(SceneTimelineLabelError);
+      const message = (err as Error).message;
+      expect(message).toContain('scene "intro"');
+      expect(message).toContain('"peak"');
+      expect(message).toContain('timeline');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// `formatSceneContext` is the canonical helper; surface-level templates
+// that compose it programmatically should produce the same shape.
+// ---------------------------------------------------------------------------
+
+describe('PUL-Q006 — formatSceneContext as the canonical seam', () => {
+  it('produces a prefix that contains the scene id', () => {
+    expect(formatSceneContext({ sceneId: 'intro' })).toContain('scene "intro"');
+  });
+
+  it('produces a prefix that contains scene id and phase keyword', () => {
+    const prefix = formatSceneContext({ sceneId: 'intro', phase: 'create' });
+    expect(prefix).toContain('scene "intro"');
+    expect(prefix).toContain('create');
+  });
+
+  it('produces a prefix that contains scene id and beat label', () => {
+    const prefix = formatSceneContext({ sceneId: 'intro', beat: 'hook' });
+    expect(prefix).toContain('scene "intro"');
+    expect(prefix).toContain('"hook"');
+  });
+
+  it('produces a prefix that contains scene id when used by the loader (cleanup failures during a composition)', async () => {
+    const onError = vi.fn();
+    const intro = buildScene({
+      id: 'intro',
+      cleanup: () => {
+        throw new Error('cleanup boom');
+      },
+    });
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([intro]),
+      compositions: createCompositionRegistry([{ id: 'mix', manifest: ['intro'] }]),
+      stage: buildStage().element,
+      buildCtx: stubCtx,
+      createPreloader: () => () => undefined,
+      timeline: noopTimeline,
+      onError,
+    });
+
+    await loader.handle(compositionTarget('mix'));
+
+    const messages = onError.mock.calls.map(([err]) => (err as Error).message);
+    const cleanupMessage = messages.find((m) => m.includes('failed during cleanup'));
+    expect(cleanupMessage).toBeDefined();
+    expect(cleanupMessage).toContain('scene "intro"');
+    expect(cleanupMessage).toContain('failed during cleanup');
+    expect(cleanupMessage).toContain('cleanup boom');
+  });
+});

--- a/tests/runtime/scene-loader-beat-mode.test.ts
+++ b/tests/runtime/scene-loader-beat-mode.test.ts
@@ -140,11 +140,11 @@ describe('createSceneLoader — beat positioning & mode dispatch (PUL-F008)', ()
       expect(lifecycleLog).toEqual(['create']);
       expect(stage.attrs.get('data-pulsar-scene-target')).toBe('intro');
       expect(stage.attrs.get('data-pulsar-navigation-error')).toBe(
-        'beat positioning failed: beat "unknown-label" does not exist in scene "intro"',
+        'beat positioning failed: scene "intro" at beat "unknown-label" — beat does not exist',
       );
       expect(captured).toHaveLength(1);
       expect((captured[0] as Error).message).toBe(
-        'beat positioning failed: beat "unknown-label" does not exist in scene "intro"',
+        'beat positioning failed: scene "intro" at beat "unknown-label" — beat does not exist',
       );
 
       // Release the runner so the lifecycle completes naturally.
@@ -673,6 +673,11 @@ describe('createSceneLoader — beat positioning & mode dispatch (PUL-F008)', ()
       // `buildCtx` was not invoked stops a regression that
       // pre-emptively built ctx on the error path (wasted allocation
       // and a misleading "fresh navigation" signal to mode listeners).
+      // Pin the surface-error contract too so a regression that
+      // silently drops the `surfaceError` call on the handleError
+      // path cannot pass this test (it would otherwise look identical
+      // to "correctly handled, no lifecycle").
+      const captured: unknown[] = [];
       const stage = buildStage();
       const probe = buildModeProbe();
       const loader = createSceneLoader({
@@ -682,13 +687,19 @@ describe('createSceneLoader — beat positioning & mode dispatch (PUL-F008)', ()
         buildCtx: probe.buildCtx,
         createPreloader: () => () => undefined,
         timeline: noopTimeline,
-        onError: () => undefined,
+        onError: (err) => {
+          captured.push(err);
+        },
       });
 
       loader.handleError(new Error('navigation grammar is invalid: parse failure'));
       await loader.idle();
 
       expect(probe.modes).toEqual([]);
+      expect(captured).toHaveLength(1);
+      expect(stage.attrs.get('data-pulsar-navigation-error')).toMatch(
+        /navigation grammar is invalid: parse failure/,
+      );
     });
 
     it('rejects a constructed target with an unknown mode (defense-in-depth for ADR-007)', async () => {
@@ -813,6 +824,13 @@ describe('createSceneLoader — beat positioning & mode dispatch (PUL-F008)', ()
       // invoked stops a regression that pre-emptively ran the builder
       // (wasted side effects, plus a misleading "fresh navigation"
       // signal to mode listeners).
+      // Also pin the rollback contract — a regression that suppresses
+      // `resetStageAttrs()` + `surfaceError()` on this path would
+      // leave the failure invisible (stage attrs would lie about a
+      // half-loaded scene); the ctx-only assertion cannot tell the
+      // difference between "correctly surfaced" and "silently
+      // swallowed."
+      const captured: unknown[] = [];
       const intro = buildScene({ id: 'intro' });
       const stage = buildStage();
       const probe = buildModeProbe();
@@ -825,12 +843,18 @@ describe('createSceneLoader — beat positioning & mode dispatch (PUL-F008)', ()
           throw new Error('preloader factory bug');
         },
         timeline: noopTimeline,
-        onError: () => undefined,
+        onError: (err) => {
+          captured.push(err);
+        },
       });
 
       await loader.handle(sceneTarget('intro'));
 
       expect(probe.modes).toEqual([]);
+      expect(captured).toHaveLength(1);
+      expect((captured[0] as Error).message).toContain('preloader factory bug');
+      expect(stage.attrs.has('data-pulsar-scene-target')).toBe(false);
+      expect(stage.attrs.get('data-pulsar-navigation-error')).toMatch(/preloader factory bug/);
     });
 
     it('does not invoke buildCtx when scene resolution fails (no lifecycle, no ctx)', async () => {
@@ -839,6 +863,11 @@ describe('createSceneLoader — beat positioning & mode dispatch (PUL-F008)', ()
       // because nothing is mounted; charging buildCtx in this path
       // would be wasted work and could leak mode-aware listeners on
       // failed navigations.
+      // Pin the surface-error contract too — a regression that drops
+      // the `surfaceError(err)` call on the `resolveSceneNavigation`
+      // catch path would leave the navigation silent (no stage error,
+      // no `onError`); a ctx-only assertion would not catch that.
+      const captured: unknown[] = [];
       const stage = buildStage();
       const probe = buildModeProbe();
       const loader = createSceneLoader({
@@ -848,12 +877,17 @@ describe('createSceneLoader — beat positioning & mode dispatch (PUL-F008)', ()
         buildCtx: probe.buildCtx,
         createPreloader: () => () => undefined,
         timeline: noopTimeline,
-        onError: () => undefined,
+        onError: (err) => {
+          captured.push(err);
+        },
       });
 
       await loader.handle(sceneTarget('does-not-exist'));
 
       expect(probe.modes).toEqual([]);
+      expect(captured).toHaveLength(1);
+      expect(stage.attrs.get('data-pulsar-navigation-error')).toMatch(/does-not-exist/);
+      expect(stage.attrs.has('data-pulsar-scene-target')).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary

PUL-Q006 — when the runtime surfaces an error, the public message must include the scene id and (where applicable) the beat label or the lifecycle phase (`create` / `timeline` / `cleanup`). The current code substantially satisfies this in observable behavior, but every surface gets there via its own bespoke prose, so a future refactor could silently drop the scene id or phase. This PR adds a `formatSceneContext({ sceneId, phase?, beat? })` helper in `src/runtime/error.ts` as the canonical seam, routes the loader's `buildOnSceneFailed.renderMessage` and `buildOnBeatMissing` through it, and adds a cross-surface invariant test suite that pins the requirement at every runtime-error seam so a regression at any one of them fails its own assertion.

## Requirement UIDs

- `PUL-Q006`

## Related Issues

Closes #45

## ADR Impact

- No ADR required

## Changes

- Add `formatSceneContext({ sceneId, phase?, beat? })` and `SceneErrorContext` / `ScenePhase` exports to `src/runtime/error.ts` as the canonical PUL-Q006 context renderer.
- Refactor `buildOnSceneFailed.renderMessage` in `src/runtime/scene-loader.ts` to compose its prefix from the helper (existing test substrings preserved).
- Reword `buildOnBeatMissing` in `src/runtime/scene-loader.ts` to compose its scene/beat fragment from the helper — output: `beat positioning failed: scene "<id>" at beat "<beat>" — beat does not exist`.
- Add `tests/runtime/pul-q006-error-context.test.ts` — 15 cross-surface invariant tests covering `onError` lifecycle failures, the `data-pulsar-scene-failures` stage attribute, missing-beat diagnostics, the resolver wrap (with and without `onSceneFailed`), and `assertSceneTimeline` label / time errors.
- Add unit tests for `formatSceneContext` in `tests/runtime/error.test.ts`.
- Harden three pre-existing tests in `tests/runtime/scene-loader-beat-mode.test.ts` to assert the surface-error contract (captured `onError`, stage attribute) instead of only `buildCtx was not invoked`.
- Add `changelog.d/45.added.md` and the PUL-Q006 preflight design note under `docs/design/`.

## Test Plan

- [x] Unit tests pass (`pnpm test`)
- [x] `pnpm lint && pnpm typecheck` pass
- [x] Pre-commit hooks pass
- [x] No coverage regression

`pnpm lint && pnpm typecheck && pnpm test` — all 1702 tests green. Pre-push AI-assisted review cycle 1 (core/security) surfaced one finding (`buildOnBeatMissing` still bypassed the helper) — fixed in this commit. Pre-push test-quality review cycle 1 surfaced three findings (pre-existing tests only pinned the not-invoked side of the contract) — fixed by adding `onError` + stage-attribute assertions. Both decision records posted to the issue thread.

## Ground Control Checks

- [x] `make policy` passes
- [x] Quality gates unchanged by this repo-only change
- [x] All review findings fixed; no deferrals

## Traceability

- IMPLEMENTS: PUL-Q006 ← src/runtime/error.ts, PUL-Q006 ← src/runtime/scene-loader.ts
- TESTS: PUL-Q006 ← tests/runtime/pul-q006-error-context.test.ts, PUL-Q006 ← tests/runtime/error.test.ts

## Checklist

- [x] Code follows project coding standards
- [x] Changelog fragment added at `changelog.d/45.added.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed