### PR TITLE
added: PUL-Q010 master mute responsiveness gate

### DIFF
--- a/changelog.d/49.added.md
+++ b/changelog.d/49.added.md
@@ -1,0 +1,32 @@
+### Added
+
+- PUL-Q010 master mute responsiveness gate. The presenter master mute
+  path is now structurally pinned to silence within 100 milliseconds
+  of the accepted `'toggle-master-mute'` command at the controller
+  boundary.
+  - New PUL-Q010 tests at `tests/runtime/scene-loader-present.test.ts`
+    in the existing PUL-F025 describe block: synchronous observability
+    of the engine flip on the next statement after `emit()`, audio
+    handler runs before any runner-supplied subscriber on the same
+    controller emission, a slow runner busy-loop cannot delay the
+    engine flip, and a throwing runner subscriber does not prevent
+    the engine flip.
+  - New PUL-Q010 tests at `tests/runtime/audio.test.ts` in the
+    existing `createAudioService — master mute (ADR-004)` describe
+    block: `engine.setMasterMute(...)` is invoked synchronously from
+    `AudioService.mute(...)` with no microtask hop, and the
+    invocation happens regardless of whether playback is currently
+    active (snapshot-based assertion catches per-sound
+    `stop`/`fade`/`volume`/`loop`/`unload` regressions, not just
+    `stop`).
+  - New PUL-Q010 production-Howler-boundary test at
+    `tests/runtime/audio-engine.test.ts` proving
+    `createHowlerAudioEngine.setMasterMute(b)` forwards synchronously
+    to `Howler.mute(b)` — so a regression that left wrapper-local
+    state correct while skipping the actual Howler call (and thus
+    leaving active playback audible) cannot slip past fake-engine
+    coverage.
+  - ADR-004 amended with the PUL-Q010 latency-bound paragraph naming
+    the runtime seam where the bound is measured and the test files
+    that pin it. No production source change; the underlying mute
+    path was already synchronous.

--- a/docs/adrs/004-howler-audio-engine.md
+++ b/docs/adrs/004-howler-audio-engine.md
@@ -146,6 +146,35 @@ PUL-F024 lands the runtime side in `src/runtime/audio.ts`:
   `'audible'` is the default for every other mode. Future variations
   (export silence, ducking, bus volume, an audio-status UI) extend
   this same union rather than scattering branches across the runtime.
+- **PUL-Q010 latency bound (≤ 100 ms).** Master mute engagement under
+  PUL-F025 is bounded end to end: from the accepted
+  `'toggle-master-mute'` presenter command at the controller boundary
+  (`src/runtime/presenter.ts` `centralWrapped`) to
+  `AudioEngine.setMasterMute(...)` returning, the path is one
+  synchronous call chain — no `await`, `queueMicrotask`, timer, fade
+  interpolation, or runner hop. The loader-owned audio handler
+  (`src/runtime/scene-loader.ts` `buildPresenterPipe`) is subscribed to
+  the controller BEFORE the runner subscribes via
+  `input.presenter.subscribe(...)`, so it runs FIRST in the controller's
+  subscription-order fan-out and a slow or throwing runner subscriber
+  cannot push the engine flip past the bound. The per-subscriber
+  try/catch in `centralWrapped` keeps a throwing runner subscriber
+  from masking the audio flip. Tests pinning these properties live at
+  `tests/runtime/scene-loader-present.test.ts` (PUL-Q010 block in the
+  PUL-F025 describe — synchronous observability of the engine flip
+  on the next statement after `emit()`, ordering, slow-runner
+  immunity, throwing-runner isolation),
+  `tests/runtime/audio.test.ts` (PUL-Q010 block in the master-mute
+  describe — synchronous engine delegation with no per-sound
+  iteration on the mute path), and
+  `tests/runtime/audio-engine.test.ts` (PUL-Q010
+  production-Howler-boundary test —
+  `createHowlerAudioEngine.setMasterMute(b)` forwards synchronously
+  to `Howler.mute(b)`). The wall-clock budget collapses to
+  "synchronous" at this seam because a single synchronous call chain
+  costs sub-millisecond on any realistic V8; the structural
+  observability checks above are the gate of record. Detailed
+  guardrails: `docs/design/pul-q010-master-mute-responsiveness-preflight.md`.
 - Rehearsal (PUL-F026) lives entirely on this audio-service seam — not
   as a head-only timeline-runner hint, not as a slice truncation, not
   as a presenter command. Rehearsal preserves the same composition

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -18,6 +18,7 @@ Design context for Pulsar. Source material for the ADRs in `../adrs/`.
 | [pul-q007-runtime-code-execution-preflight.md](pul-q007-runtime-code-execution-preflight.md) | Guardrails for statically banning runtime code execution outside the published bundle. |
 | [pul-q008-dom-css-accessibility-preflight.md](pul-q008-dom-css-accessibility-preflight.md) | Guardrails for preserving native browser text selection, focus order, and ARIA semantics in DOM/CSS scenes. |
 | [pul-q009-asset-failure-surfacing-preflight.md](pul-q009-asset-failure-surfacing-preflight.md) | Guardrails for surfacing asset preload failures with scene and asset context before mounting. |
+| [pul-q010-master-mute-responsiveness-preflight.md](pul-q010-master-mute-responsiveness-preflight.md) | Guardrails for bounding master-mute latency without duplicating presenter or audio boundaries. |
 | [pul-f013-present-mode-preflight.md](pul-f013-present-mode-preflight.md) | Guardrails for implementing default `mode=present` behavior. |
 | [pul-f014-standalone-mode-preflight.md](pul-f014-standalone-mode-preflight.md) | Guardrails for implementing isolated `mode=standalone` behavior. |
 | [pul-f015-loop-mode-preflight.md](pul-f015-loop-mode-preflight.md) | Guardrails for implementing repeated `mode=loop` scene-timeline playback. |

--- a/docs/design/pul-q010-master-mute-responsiveness-preflight.md
+++ b/docs/design/pul-q010-master-mute-responsiveness-preflight.md
@@ -1,0 +1,126 @@
+# PUL-Q010 Master Mute Responsiveness Preflight
+
+PUL-Q010 adds a latency bound to the existing master-mute contract:
+engaging master mute must silence active audio playback within 100 ms.
+
+No new ADR is needed. ADR-004 already owns master mute as
+audio-engine runtime state, and the PUL-F025 preflight already fixes
+the command path through ADR-023's presenter seam. This note narrows
+the timing boundary so the implementation does not invent a second
+mute mechanism.
+
+## Boundary
+
+The timing path stays on the existing runtime path:
+
+- `src/runtime/presenter.ts` remains the only presenter command schema,
+  validator, controller, and abort-tied subscription boundary.
+- `src/runtime/scene-loader.ts` remains the only seam with both the
+  accepted `toggle-master-mute` command and the per-navigation
+  `AudioService`. The mute handler must stay a synchronous,
+  loader-owned subscriber.
+- `src/runtime/audio.ts` remains the only audio-engine boundary.
+  Silencing means `AudioService.mute(true)` delegates to
+  `AudioEngine.setMasterMute(true)` / `Howler.mute(true)`; it is not a
+  fade, stop, unload, remount, timeline pause, or scene cleanup.
+- `src/runtime/timeline.ts`, `src/runtime/composition-resolver.ts`, and
+  scene modules remain out of the mute timing path. They must not learn
+  responsiveness-specific state.
+
+Measure the runtime guarantee from the accepted presenter command
+arriving at the controller boundary to the audio engine master-mute
+call returning. Future UI/browser tests may include the workbench input
+event, but the canonical runtime seam is the accepted
+`toggle-master-mute` command, not an arbitrary DOM event.
+
+## Required Reuse
+
+Use the existing incumbents:
+
+- Presenter input: `PRESENTER_COMMAND_KINDS`, `isPresenterCommand`,
+  `PresenterCommandSource`, `PresenterController`, and
+  `createPresenterController`.
+- Mode scoping: `effectiveMode()`, `SceneLoaderOptions.presenterCommands`,
+  and the loader's present-only controller construction.
+- Audio boundary: `AudioService.mute()`, `AudioService.isMuted()`,
+  `AudioEngine.setMasterMute()`, `AudioEngine.isMasterMuted()`,
+  `createHowlerAudioEngine()`, and `noopAudioEngine`.
+- Error/diagnostic path: presenter controller handler isolation and the
+  loader `onError` sink. PUL-Q010 should not add an exception hierarchy,
+  telemetry framework, stage attribute, or command log.
+- Tests: extend the existing audio-service tests and
+  scene-loader-present seam tests. Any timing test must use a
+  deterministic fake engine/source for runtime latency and only use
+  browser/audio integration tests for Howler behavior where necessary.
+
+## Cross-Cutting Layers
+
+| Layer | Guardrail |
+|-------|-----------|
+| Presenter command validation | Only a validated `toggle-master-mute` command reaches the handler. Do not add `mute`, `unmute`, `master-mute`, or a second validator. |
+| Mode and URL grammar | The handler exists only under effective `present`. Do not add mute URL parameters, new modes, history state, storage keys, or persisted mute state. |
+| Audio engine boundary | The handler calls `audio.mute(!audio.isMuted())`. Howler remains hidden behind `createHowlerAudioEngine()`; active playback is silenced through engine master mute, not by iterating sounds in the loader. |
+| Lifecycle and cleanup | The handler must not abort navigation, call `cleanup(ctx)`, stop groups, unload sounds, rebuild services, or wait for resolver/timeline completion. |
+| Error envelope | Malformed commands and handler failures continue through the existing `onError` sink. Diagnostics must not include raw future remote payloads, source URLs, Howler handles, stacks, cookies, env, or scene objects. |
+| Config / env / OS exposure | No env vars, config files, CLI flags, process argv tokens, shell commands, cookies, localStorage, sessionStorage, or credentials are needed. |
+| Auth / remote input | No auth surface exists here. A future remote presenter bridge must authenticate before emitting into `PresenterCommandSource`; the controller still shape-checks every emitted command. |
+| Observability | CI assertions and existing `onError` diagnostics are sufficient. Do not add per-command logs or analytics for a latency requirement. |
+
+## Guardrails
+
+- The mute path must be synchronous and allocation-light: read current
+  engine state, flip it, return. Do not await, debounce, throttle,
+  schedule with timers, use animation frames, or defer behind runner
+  callbacks.
+- The loader-owned mute subscriber should remain independent of runner
+  subscribers. A slow or throwing runner handler must not sit before
+  the audio mute action on the critical path.
+- Do not implement the 100 ms bound with a fade duration. A fade is
+  audible during the fade and cannot prove "silence within 100 ms."
+- Do not re-check or iterate scene audio declarations at command time.
+  The command must work before any sound is registered and while audio
+  is already playing.
+- Preserve engine-level state. `stopAll()` and scene cleanup must not
+  reset master mute.
+- Post-abort commands remain inert through the existing presenter and
+  audio-service cleanup semantics.
+
+## Extensibility
+
+The extension seam is the presenter command payload plus the audio
+service. If a future requirement needs explicit target state, add a
+kind such as `set-master-mute` with a `muted: boolean` field to the
+same `PresenterCommand` discriminated union and validate it in
+`isPresenterCommand`. The timing-sensitive behavior still belongs
+behind `AudioService.mute()`, not in UI, runner, scene, timeline, or
+Howler-specific call sites.
+
+If future status UI needs latency reporting, add an injected monotonic
+clock/test seam at the presenter/audio boundary or a bounded workbench
+status surface. Do not use `Date.now()` in scene code, persistent
+storage, URL state, or source payload logs for this requirement.
+
+## Non-Goals
+
+PUL-Q010 should not implement visible mute UI, keyboard listeners,
+remote presenter protocol, auth, telemetry, persistence, volume buses,
+ducking, fade curves, per-scene mute, playback stopping, export audio,
+scrub cue gating, audio unlock, requirement status transition, or
+GitHub/Ground Control workflow automation.
+
+It should not change scene schemas, composition schemas, URL grammar,
+asset preload rules, audio source validation, resolver lifecycle,
+timeline transport, or presenter command source ownership.
+
+## Anti-Patterns
+
+- Adding a second mute controller, event bus, schema, validator, or
+  exception family.
+- Importing Howler outside `src/runtime/audio.ts` or reaching into
+  Howler from tests that can assert through `AudioEngine`.
+- Implementing silence by pause, fade, stop, unload, navigation abort,
+  scene remount, `cleanup(ctx)`, or timeline mutation.
+- Waiting for logs, UI state, unlock prompts, preloader work, runner
+  subscription delivery, or composition lifecycle before muting.
+- Persisting mute state in URL, history, storage, cookies, env, config,
+  or process argv.

--- a/tests/runtime/audio-engine.test.ts
+++ b/tests/runtime/audio-engine.test.ts
@@ -30,11 +30,23 @@ const config = (over: Partial<AudioSoundConfig> = {}): AudioSoundConfig => ({
 });
 
 describe('createHowlerAudioEngine (Howler boundary)', () => {
-  it('constructs a sound and forwards every handle method without throwing', () => {
+  it('constructs a sound and forwards every handle method, returning a valid play id', () => {
+    // The play id is a real number Howler hands out per `play()`
+    // call. The test-quality review (issue #49 cycle 1) named the
+    // risk of a regression where `wrapHowl.play` always returned
+    // `0` / `undefined` — Howler's `volume`/`loop`/`fade`/`stop`
+    // all special-case `undefined` playId to mean "all instances"
+    // so a broken play id would silently degrade per-play targeting
+    // without surfacing under `not.toThrow()`. Assert the play id
+    // is a non-negative number so a future regression that breaks
+    // the return type fails loud.
     const engine = createHowlerAudioEngine();
     const handle = engine.createSound(config());
+    const playId = handle.play();
+    expect(typeof playId).toBe('number');
+    expect(Number.isFinite(playId)).toBe(true);
+    expect(playId).toBeGreaterThanOrEqual(0);
     expect(() => {
-      const playId = handle.play();
       handle.volume(0.5, playId);
       handle.loop(true, playId);
       handle.fade(1, 0, 10, playId);
@@ -46,19 +58,36 @@ describe('createHowlerAudioEngine (Howler boundary)', () => {
     }).not.toThrow();
   });
 
-  it('supports a muted sound and a sprite map', () => {
+  it('supports a muted sound and a sprite map, returning a valid play id for sprite playback', () => {
+    // Same regression class as the play-id assertion above, applied
+    // to the sprite branch. A `wrapHowl.play` that dropped the
+    // sprite argument (`play: (sprite) => howl.play()`) would route
+    // to the no-sprite branch and the sprite test would still pass
+    // under `not.toThrow()`. Asserting the return type pins the
+    // sprite-forwarding path (test-quality review, issue #49
+    // cycle 1).
     const engine = createHowlerAudioEngine();
     const handle = engine.createSound(
       config({ muted: true, sprite: { hit: [0, 100], cheer: [200, 300, true] } }),
     );
+    const spriteId = handle.play('hit');
+    expect(typeof spriteId).toBe('number');
+    expect(Number.isFinite(spriteId)).toBe(true);
+    expect(spriteId).toBeGreaterThanOrEqual(0);
     expect(() => {
-      handle.play('hit');
       handle.stop();
       handle.unload();
     }).not.toThrow();
   });
 
-  it('round-trips master mute', () => {
+  it('round-trips wrapper-local isMasterMuted state (Howler.mute forwarding is asserted by the PUL-Q010 test below)', () => {
+    // This test only covers the wrapper's local `masterMuted`
+    // closure — `isMasterMuted()` reads the closure, not Howler's
+    // own state. A regression that removed `Howler.mute(...)` from
+    // `setMasterMute` would leave this test green. The PUL-Q010
+    // production-Howler-boundary test below pins the actual
+    // `Howler.mute(...)` forwarding (test-quality review, issue
+    // #49 cycle 1).
     const engine = createHowlerAudioEngine();
     expect(engine.isMasterMuted()).toBe(false);
     engine.setMasterMute(true);
@@ -67,18 +96,73 @@ describe('createHowlerAudioEngine (Howler boundary)', () => {
     expect(engine.isMasterMuted()).toBe(false);
   });
 
+  // PUL-Q010 — master mute responsiveness (≤ 100 ms).
+  //
+  // The user-visible guarantee is silence of active playback within
+  // 100 ms of engagement. The fake-engine tests at
+  // `audio.test.ts` PUL-Q010 + `scene-loader-present.test.ts`
+  // PUL-Q010 pin the loader → service → engine path structurally,
+  // but a regression that left `createHowlerAudioEngine.setMasterMute`
+  // still flipping wrapper-local state while skipping
+  // `Howler.mute(...)` — or deferring it past return — would leave
+  // active playback audible while every fake-engine test stayed
+  // green. This test anchors the production-Howler boundary
+  // (codex review cycle 1, class finding on issue 49) by spying on
+  // `Howler.mute` and asserting that `engine.setMasterMute(b)`
+  // forwards the call SYNCHRONOUSLY for both true and false.
+  it('PUL-Q010 — setMasterMute forwards synchronously to Howler.mute(...)', async () => {
+    const { Howler } = await import('howler');
+    const howlerHandle = Howler as unknown as { mute: (muted: boolean) => void };
+    const originalMute = howlerHandle.mute;
+    const muteCalls: boolean[] = [];
+    howlerHandle.mute = (muted: boolean): void => {
+      muteCalls.push(muted);
+    };
+    try {
+      const engine = createHowlerAudioEngine();
+      expect(muteCalls).toEqual([]);
+      engine.setMasterMute(true);
+      // No await between these two lines — a microtask-deferred
+      // implementation would observe `[]` here, not `[true]`.
+      expect(muteCalls).toEqual([true]);
+      engine.setMasterMute(false);
+      expect(muteCalls).toEqual([true, false]);
+    } finally {
+      howlerHandle.mute = originalMute;
+    }
+  });
+
   it('drives a full AudioService end-to-end over the real engine', () => {
+    // Test-quality review (issue #49 cycle 1) flagged the pre-fix
+    // version of this test as `not.toThrow()`-only with no state
+    // assertions on `mute()`, the disposal precondition, or the
+    // loaded/played sound. Added: disposal precondition before
+    // `stopAll()`; mute state assertions before and after
+    // `service.mute(true)`; engine-level mute observation through
+    // `engine.isMasterMuted()` so a no-op `mute()` regression
+    // surfaces at this seam.
     const engine = createHowlerAudioEngine();
     const service = createAudioService(engine, { signal: new AbortController().signal });
+    expect(service.isDisposed()).toBe(false);
     expect(() => {
       service.load('bed', { src: SILENT_WAV });
       service.play('bed', { loop: true, volume: 0.4, group: 'scene-a' });
       service.fade('bed', 0.4, 0, 20);
       service.stopGroup('scene-a');
-      service.mute(true);
+    }).not.toThrow();
+    expect(service.isMuted()).toBe(false);
+    service.mute(true);
+    expect(service.isMuted()).toBe(true);
+    expect(engine.isMasterMuted()).toBe(true);
+    expect(() => {
       service.stopAll();
     }).not.toThrow();
     expect(service.isDisposed()).toBe(true);
+    // Master mute persists across `stopAll` (engine-level runtime
+    // state, ADR-004); reset so this test does not leak mute state
+    // into other tests that share Howler's global engine in the
+    // same Vitest worker.
+    engine.setMasterMute(false);
   });
 
   // PUL-F030 / ADR-029: the engine's unlock operation is the

--- a/tests/runtime/audio.test.ts
+++ b/tests/runtime/audio.test.ts
@@ -17,7 +17,7 @@
 // here the engine is a deterministic in-process fake so every code
 // path of the service is asserted without a browser audio context.
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import {
   type AudioCueLogEntry,
   type AudioCueLogStopGroup,
@@ -537,6 +537,79 @@ describe('createAudioService — master mute (ADR-004)', () => {
     service.stopAll();
     expect(service.isMuted()).toBe(true);
   });
+
+  /* ---------------------------------------------------------------- *
+   *  PUL-Q010 — master mute responsiveness (≤ 100 ms)
+   *
+   *  PUL-Q010 statement: "Master mute SHALL silence active audio
+   *  playback within 100 milliseconds of being engaged."
+   *
+   *  The audio-service boundary is one leg of the runtime latency
+   *  path the loader-owned `'toggle-master-mute'` handler walks
+   *  (see `scene-loader-present.test.ts` PUL-Q010 block for the
+   *  end-to-end test). At THIS layer the bound translates to two
+   *  structural invariants that any regression toward async work
+   *  (debounce / queueMicrotask / setTimeout / fade-to-silence)
+   *  would break:
+   *
+   *  (1) `engine.setMasterMute(...)` is invoked SYNCHRONOUSLY on
+   *      the same call stack as `AudioService.mute(...)`. No
+   *      microtask gap, no scheduler hop, no fade interpolation.
+   *  (2) The invocation happens regardless of whether playback is
+   *      currently active — silencing an already-playing sound is
+   *      delegated to the engine's master-mute mechanism rather
+   *      than to per-sound iteration or fade scheduling.
+   * ---------------------------------------------------------------- */
+
+  it('PUL-Q010 — engine.setMasterMute is invoked synchronously from AudioService.mute (no microtask hop)', () => {
+    // The 100 ms bound collapses to "synchronous" at this layer
+    // because a single synchronous call costs sub-millisecond on
+    // any realistic V8. The only way to blow the bound here is to
+    // defer the engine call — `queueMicrotask`, `Promise.resolve()
+    // .then`, `setTimeout(..., 0)`, debounce, fade scheduling, etc.
+    // This test pins the synchronous contract by checking the
+    // engine's mute state on the very next statement after the
+    // service call (no `await`, no `await Promise.resolve()`).
+    const { fake, service } = buildService();
+    expect(fake.masterMuted()).toBe(false);
+    service.mute(true);
+    // No await between these two lines — a microtask-deferred
+    // implementation would see `false` here.
+    expect(fake.masterMuted()).toBe(true);
+    service.mute(false);
+    expect(fake.masterMuted()).toBe(false);
+  });
+
+  it('PUL-Q010 — engine.setMasterMute is invoked synchronously even while sounds are loaded and playing', () => {
+    // Pins the "active audio playback" clause: silencing an
+    // already-playing sound is delegated to the engine's master
+    // mute, not to iterating the registered sounds. A regression
+    // that re-implemented mute as `for (const sound of sounds)
+    // sound.handle.<stop|fade|volume|loop|unload>()` (or similar
+    // per-sound work) would silently break the engine-state
+    // contract — and the next `play()` after un-muting would no
+    // longer be inhibited by the engine, because the per-sound
+    // mute would be a snapshot rather than persistent runtime
+    // state. The assertion below snapshots the entire handle-call
+    // record before `mute(...)` and asserts that mute adds NO
+    // handle-level calls (codex review cycle 1: a `stop`-only
+    // filter would miss `fade` / `volume` / `loop` / `unload`
+    // regressions on the mute path).
+    const { fake, service } = buildService();
+    service.load('bed', { src: '/audio/bed.mp3' });
+    service.play('bed');
+    service.load('stinger', { src: '/audio/stinger.mp3' });
+    service.play('stinger');
+    expect(fake.masterMuted()).toBe(false);
+    const handleCallsBeforeMute = fake.calls.length;
+    service.mute(true);
+    expect(fake.masterMuted()).toBe(true);
+    // `mute(...)` MUST NOT add any per-sound handle calls — the
+    // path is purely engine-level. Any new entry in `fake.calls`
+    // (`stop` / `fade` / `volume` / `loop` / `unload`) would mean
+    // mute is iterating registered sounds.
+    expect(fake.calls.length).toBe(handleCallsBeforeMute);
+  });
 });
 
 /* -------------------------------------------------------------------- *
@@ -688,8 +761,27 @@ describe('createAudioService — lifecycle / cleanup (ADR-004)', () => {
  * -------------------------------------------------------------------- */
 
 describe('noopAudioEngine', () => {
-  it('produces handles whose methods do not throw and back a working service', () => {
+  // `noopAudioEngine` is a module-level singleton with mutable
+  // `masterMuted` state. Sharing it across tests in the same
+  // Vitest worker creates the same leak `scene-loader-present.test.ts`
+  // documents and avoids with its own `freshAudioEngine` helper.
+  // Test-quality review (issue #49 cycle 1) flagged the singleton
+  // hazard here. The `afterEach` below resets the singleton so any
+  // test that flips `mute(true)` on the noop engine and bails
+  // before unsetting it does not corrupt the baseline for later
+  // tests that observe `isMasterMuted()`.
+  afterEach(() => {
+    noopAudioEngine.setMasterMute(false);
+  });
+
+  it('produces handles whose methods do not throw, back a working service, and dispose cleanly', () => {
+    // Pre-fix: pure `not.toThrow()`. Post-fix: assert
+    // `isDisposed()` precondition and postcondition so a regression
+    // that broke `stopAll()`'s dispose flag (or that disposed the
+    // service early) surfaces here (test-quality review, issue #49
+    // cycle 1).
     const service = createAudioService(noopAudioEngine, { signal: liveSignal() });
+    expect(service.isDisposed()).toBe(false);
     service.load('bed', { src: '/audio/bed.mp3', sprite: { hit: [0, 100] } });
     expect(() => {
       service.play('bed', { sprite: 'hit', loop: true, volume: 0.5, group: 'scene-a' });
@@ -698,10 +790,14 @@ describe('noopAudioEngine', () => {
       service.stop('bed');
       service.stopAll();
     }).not.toThrow();
+    expect(service.isDisposed()).toBe(true);
   });
 
   it('round-trips master mute', () => {
     const service = createAudioService(noopAudioEngine, { signal: liveSignal() });
+    // The `afterEach` above resets the singleton, so the baseline
+    // here is always `false` regardless of prior-test mute state.
+    expect(service.isMuted()).toBe(false);
     service.mute(true);
     expect(service.isMuted()).toBe(true);
     service.mute(false);

--- a/tests/runtime/scene-loader-present.test.ts
+++ b/tests/runtime/scene-loader-present.test.ts
@@ -1797,5 +1797,261 @@ describe('createSceneLoader — present-mode & presenter seams (PUL-F008)', () =
       loader.dispose();
       await loader.idle();
     });
+
+    /* ---------------------------------------------------------------- *
+     *  PUL-Q010 — master mute responsiveness (≤ 100 ms)
+     *
+     *  PUL-Q010 statement: "Master mute SHALL silence active audio
+     *  playback within 100 milliseconds of being engaged."
+     *
+     *  Engagement is the accepted `'toggle-master-mute'` command at
+     *  the presenter controller boundary; silence is delivered by
+     *  the audio engine's master mute (`Howler.mute(true)` in the
+     *  production engine — see `audio.ts`). The runtime seam being
+     *  bounded is therefore:
+     *
+     *    source.emit({ kind: 'toggle-master-mute' })
+     *      → controller.centralWrapped (validation + fan-out)
+     *      → loader audio handler (`audio.mute(!audio.isMuted())`)
+     *      → engine.setMasterMute(...) returns.
+     *
+     *  The path is synchronous in production code: no `await`, no
+     *  `queueMicrotask`, no timer, no fade interpolation, no runner
+     *  hop. The tests below pin THAT property structurally so a
+     *  future regression toward async work or subscription-order
+     *  drift cannot blow the 100 ms bound silently. They use a
+     *  deterministic fake engine that records `performance.now()`
+     *  at each `setMasterMute` invocation and a shared `events[]`
+     *  sequence labeling each observable side-effect, so ordering
+     *  and wall-clock are both first-class assertions.
+     *
+     *  Companion audio-service-layer tests live in
+     *  `tests/runtime/audio.test.ts` PUL-Q010 block; together they
+     *  pin the full audio-side of the latency path.
+     * ---------------------------------------------------------------- */
+
+    /** Engine fake that records wall-clock + ordering for PUL-Q010. */
+    const instrumentedAudioEngine = (muteTimes: number[], events: string[]): AudioEngine => {
+      let muted = false;
+      const noopHandle = {
+        play: () => 0,
+        stop: () => undefined,
+        fade: () => undefined,
+        loop: () => undefined,
+        volume: () => undefined,
+        unload: () => undefined,
+      };
+      return {
+        createSound: () => noopHandle,
+        setMasterMute: (m: boolean) => {
+          muted = m;
+          muteTimes.push(performance.now());
+          events.push('audio-flip');
+        },
+        isMasterMuted: () => muted,
+        unlock: () => Promise.resolve(),
+      };
+    };
+
+    // PUL-Q010's 100 ms budget collapses to "synchronous" at the
+    // runtime seam: a single synchronous call chain
+    // (`source.emit` → controller fan-out → loader handler →
+    // `AudioService.mute` → `AudioEngine.setMasterMute`) costs
+    // sub-millisecond on any realistic V8, so the 100 ms wall-clock
+    // bound is satisfied by proving the path is synchronous. A
+    // wall-clock assertion would be both flaky (GC / OS pauses) and
+    // strictly weaker than the structural observability check below;
+    // see codex review cycle 1 on issue 49. The structural test is
+    // the gate of record.
+    it('PUL-Q010 — engine master mute is observable synchronously on the next statement after `emit`', async () => {
+      // The synchronous-path invariant: a microtask-deferred
+      // implementation (e.g., `queueMicrotask(() => audio.mute(...))`
+      // in the loader handler, or `Promise.resolve().then(...)` in
+      // the audio service) would leave the engine state unchanged
+      // on the very next line after `emit(...)`. Pinning this
+      // separately from the wall-clock test means a regression
+      // toward microtask deferral fails LOUD here even on a CI
+      // whose `performance.now()` granularity would still satisfy
+      // the 100 ms bound.
+      const engine = instrumentedAudioEngine([], []);
+      const m = mountPresent({ mode: 'present', engine });
+      await m.readyP;
+      expect(engine.isMasterMuted()).toBe(false);
+      m.fake.emit({ kind: 'toggle-master-mute' });
+      // No await between these two lines — a microtask-deferred
+      // implementation would see `false` here.
+      expect(engine.isMasterMuted()).toBe(true);
+      m.loader.dispose();
+      await m.loader.idle();
+    });
+
+    it('PUL-Q010 — the loader audio handler runs BEFORE any runner-supplied subscriber on the same emission', async () => {
+      // The preflight guardrail: "A slow or throwing runner handler
+      // must not sit before the audio mute action on the critical
+      // path." The controller fans subscribers out in subscription
+      // order; the loader subscribes the audio handler in
+      // `buildPresenterPipe` BEFORE the runner subscribes via
+      // `input.presenter.subscribe(...)`. A regression that moved
+      // the audio handler subscription into `runner(input)` (or
+      // any later seam) would put it AFTER the runner subscriber
+      // in the fan-out and a slow runner could delay the engine
+      // flip past 100 ms.
+      const muteTimes: number[] = [];
+      const events: string[] = [];
+      const engine = instrumentedAudioEngine(muteTimes, events);
+      const fake = buildFakeSource();
+      let runnerEntered: () => void = () => undefined;
+      const ready = new Promise<void>((resolve) => {
+        runnerEntered = resolve;
+      });
+      const sceneA = buildScene({ id: 'scene-a' });
+      const runner = (input: LegacyRunInput): Promise<void> => {
+        input.presenter?.subscribe((cmd) => {
+          if (cmd.kind === 'toggle-master-mute') events.push('runner-saw-cmd');
+        });
+        runnerEntered();
+        return new Promise<void>((resolve) => {
+          input.signal?.addEventListener('abort', () => resolve(), { once: true });
+        });
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: buildStage().element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        timeline: asTimeline(runner),
+        audioEngine: engine,
+        presenterCommands: fake.source,
+      });
+      void loader.handle({ locator: { kind: 'scene', scene: 'scene-a' }, mode: 'present' });
+      await ready;
+      fake.emit({ kind: 'toggle-master-mute' });
+      // The audio flip is the FIRST observable side-effect; the
+      // runner subscriber sees the command strictly after.
+      expect(events).toEqual(['audio-flip', 'runner-saw-cmd']);
+      loader.dispose();
+      await loader.idle();
+    });
+
+    it('PUL-Q010 — a slow runner subscriber cannot delay the engine flip past 100 ms', async () => {
+      // Strongest form of the handler-ordering invariant: even
+      // when the runner subscriber does a deliberate synchronous
+      // busy-loop, the engine flip has already happened BEFORE
+      // the loop starts — because the loader's audio handler is
+      // FIRST in the fan-out and its work (one boolean flip) is
+      // complete before control reaches the runner's handler.
+      // Asserted via ordering AND wall-clock: the
+      // `setMasterMute` timestamp is captured before the busy-
+      // loop's start timestamp, so a regression that pushed the
+      // audio handler after the runner would surface as either
+      // an inverted `events[]` order OR a `muteTimes[0]` reading
+      // AFTER the loop wall-clock.
+      const muteTimes: number[] = [];
+      const events: string[] = [];
+      const engine = instrumentedAudioEngine(muteTimes, events);
+      const fake = buildFakeSource();
+      let runnerEntered: () => void = () => undefined;
+      const ready = new Promise<void>((resolve) => {
+        runnerEntered = resolve;
+      });
+      const sceneA = buildScene({ id: 'scene-a' });
+      let busyStart = -1;
+      let busyEnd = -1;
+      const runner = (input: LegacyRunInput): Promise<void> => {
+        input.presenter?.subscribe((cmd) => {
+          if (cmd.kind !== 'toggle-master-mute') return;
+          busyStart = performance.now();
+          // Bounded busy loop: deliberately spin for ~5 ms so
+          // any "runner-runs-first" regression would put
+          // `muteTimes[0]` AT OR AFTER `busyEnd`.
+          while (performance.now() - busyStart < 5) {
+            // intentionally empty busy loop
+          }
+          busyEnd = performance.now();
+        });
+        runnerEntered();
+        return new Promise<void>((resolve) => {
+          input.signal?.addEventListener('abort', () => resolve(), { once: true });
+        });
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: buildStage().element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        timeline: asTimeline(runner),
+        audioEngine: engine,
+        presenterCommands: fake.source,
+      });
+      void loader.handle({ locator: { kind: 'scene', scene: 'scene-a' }, mode: 'present' });
+      await ready;
+      fake.emit({ kind: 'toggle-master-mute' });
+      expect(muteTimes).toHaveLength(1);
+      expect(busyStart).toBeGreaterThan(0);
+      expect(busyEnd).toBeGreaterThanOrEqual(busyStart);
+      // The engine flip happened strictly before the runner's
+      // busy loop started — a regression that put the runner
+      // first would have `muteTimes[0] >= busyEnd`.
+      const firstMuteTime = muteTimes[0] ?? Number.NaN;
+      expect(firstMuteTime).toBeLessThan(busyEnd);
+      // Even with the runner's deliberate ~5 ms spin in the
+      // same fan-out, the engine flip stayed comfortably under
+      // 100 ms because it ran first.
+      loader.dispose();
+      await loader.idle();
+    });
+
+    it('PUL-Q010 — a throwing runner subscriber does NOT prevent the engine flip', async () => {
+      // Per-subscriber isolation guarantee: the controller wraps
+      // each subscriber's handler in try/catch (presenter.ts
+      // `centralWrapped`). A runner subscriber that throws on
+      // `'toggle-master-mute'` cannot prevent the loader's audio
+      // handler (which already executed first per the ordering
+      // invariant above) from having flipped the engine. The
+      // throw is surfaced via the loader's `onError` sink.
+      const muteTimes: number[] = [];
+      const events: string[] = [];
+      const engine = instrumentedAudioEngine(muteTimes, events);
+      const fake = buildFakeSource();
+      const errors: unknown[] = [];
+      let runnerEntered: () => void = () => undefined;
+      const ready = new Promise<void>((resolve) => {
+        runnerEntered = resolve;
+      });
+      const sceneA = buildScene({ id: 'scene-a' });
+      const runner = (input: LegacyRunInput): Promise<void> => {
+        input.presenter?.subscribe((cmd) => {
+          if (cmd.kind === 'toggle-master-mute') throw new Error('runner subscriber boom');
+        });
+        runnerEntered();
+        return new Promise<void>((resolve) => {
+          input.signal?.addEventListener('abort', () => resolve(), { once: true });
+        });
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: buildStage().element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        timeline: asTimeline(runner),
+        audioEngine: engine,
+        presenterCommands: fake.source,
+        onError: (err) => errors.push(err),
+      });
+      void loader.handle({ locator: { kind: 'scene', scene: 'scene-a' }, mode: 'present' });
+      await ready;
+      fake.emit({ kind: 'toggle-master-mute' });
+      expect(engine.isMasterMuted()).toBe(true);
+      expect(muteTimes).toHaveLength(1);
+      const boomErrors = errors.filter(
+        (e) => e instanceof Error && /runner subscriber boom/.test(e.message),
+      );
+      expect(boomErrors).toHaveLength(1);
+      loader.dispose();
+      await loader.idle();
+    });
   });
 });


### PR DESCRIPTION
## Summary

Pin the PUL-Q010 master-mute responsiveness contract (≤ 100 ms from accepted `toggle-master-mute` command to engine flip) with structural tests at the audio-service boundary, the scene-loader presenter seam, and the production Howler boundary. The underlying runtime path was already synchronous — this PR adds the gates that catch any regression toward async work, subscription-order drift, or skipped Howler.mute forwarding before it ships.

## Requirement UIDs

- `PUL-Q010`

## Related Issues

Closes #49

## ADR Impact

- ADR-004 (amended)

## Changes

- Add 4 PUL-Q010 tests in `tests/runtime/scene-loader-present.test.ts` PUL-F025 describe: synchronous engine flip on next statement after `emit()`, audio handler runs before any runner-supplied subscriber, slow runner busy-loop cannot delay the engine flip, throwing runner subscriber cannot prevent the engine flip.
- Add 2 PUL-Q010 tests in `tests/runtime/audio.test.ts` master-mute describe: `engine.setMasterMute(...)` invoked synchronously from `AudioService.mute(...)` with no microtask hop; mute path adds zero per-sound handle calls even when sounds are loaded and playing.
- Add 1 PUL-Q010 production-Howler-boundary test in `tests/runtime/audio-engine.test.ts`: `createHowlerAudioEngine.setMasterMute(b)` forwards synchronously to `Howler.mute(b)` via monkey-patched spy.
- Strengthen 4 adjacent existing tests in `tests/runtime/audio-engine.test.ts` and `tests/runtime/audio.test.ts` per pre-push review: play-id return-type assertions on Howler `handle.play()` (no-sprite and sprite branches), `isDisposed()` precondition/postcondition on the end-to-end service test and the `noopAudioEngine` handle test, engine-level mute observation on the end-to-end service test, rename the wrapper-local master-mute test to disambiguate scope, and add an `afterEach` reset for the `noopAudioEngine` singleton so mute state cannot leak between tests sharing the Vitest worker.
- Amend ADR-004 (`docs/adrs/004-howler-audio-engine.md`) with a PUL-Q010 latency-bound paragraph naming the runtime seam where the bound is measured, the synchronous structural-test gate of record, and the three test files that pin it.
- Add `docs/design/pul-q010-master-mute-responsiveness-preflight.md` cataloging the boundary, required reuse, cross-cutting layers, guardrails, extensibility seam, non-goals, and anti-patterns.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

- `pnpm lint && pnpm typecheck && pnpm test` green (1816 tests passed; previous baseline 1809).
- Mutation pass run locally per the plan: each PUL-Q010 test was confirmed to fail when the production path was mutated (`queueMicrotask` in the loader handler, `queueMicrotask` in `AudioService.mute`, removed loader audio handler), then reverted before commit.
- Pre-push core review cycle 1: 3 findings (1 class, 2 one-off), all fixed in this commit, decision record on issue thread (https://github.com/KeplerOps/pulsar/issues/49#issuecomment-4472430835).
- Pre-push test-quality review cycle 1: 6 findings (1 class, 5 one-off), all fixed in this commit, decision record on issue thread (https://github.com/KeplerOps/pulsar/issues/49#issuecomment-4472463250).

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: PUL-Q010 ← src/runtime/scene-loader.ts (loader-owned audio handler), PUL-Q010 ← src/runtime/presenter.ts (synchronous controller fan-out), PUL-Q010 ← src/runtime/audio.ts (synchronous AudioService.mute / engine.setMasterMute), PUL-Q010 ← docs/adrs/004-howler-audio-engine.md (amended), PUL-Q010 ← docs/design/pul-q010-master-mute-responsiveness-preflight.md
- TESTS: PUL-Q010 ← tests/runtime/scene-loader-present.test.ts, PUL-Q010 ← tests/runtime/audio.test.ts, PUL-Q010 ← tests/runtime/audio-engine.test.ts

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/49.added.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed