### PR TITLE
feat: add PUL-F031 workbench chrome surface

### DIFF
--- a/changelog.d/77.added.md
+++ b/changelog.d/77.added.md
@@ -1,0 +1,41 @@
+### Added
+
+- PUL-F031 workbench chrome surface. The runtime now mounts a
+  workbench-owned chrome DOM root (`<div data-pulsar-chrome="surface">`)
+  as a sibling of `#stage` before the first navigation event, governed
+  by the active workbench mode, and persistent across scene navigations
+  within a composition.
+  - New `src/runtime/workbench-chrome.ts` factory
+    (`createDomWorkbenchChrome`) mirroring `audio-unlock-dom.ts`:
+    injected `mount` + `createSurface` hooks, exposes
+    `applyMode(NavigationMode)` and `dispose()`. The pure helper
+    `chromeVisibilityFor(mode)` is the chrome-specific visibility
+    policy — `standalone` and `screenshot` → `hidden`; every other
+    `NAVIGATION_MODES` member → `visible`.
+  - New `chrome?: WorkbenchChromeAdapter` option on
+    `SceneLoaderOptions`. The loader calls
+    `options.chrome?.applyMode(effectiveMode(target))` once per
+    navigation, after `validateModeGrammar` passes and before
+    `resolveSceneNavigation`, so chrome tracks the URL-addressed mode
+    even when target resolution fails. The single call site is
+    upstream of the resolver's per-scene loop — a multi-scene
+    composition under `mode=present` produces exactly one `applyMode`
+    call, the structural form of "chrome persists across scene
+    navigations within a composition." Parse-error events take the
+    `kind: 'error'` path and never reach chrome, so chrome state
+    survives malformed URLs unchanged.
+  - `src/main.ts` wires `createDomWorkbenchChrome` at workbench
+    bootstrap (before `bootstrapNavigation`) with
+    `role="complementary"` + `aria-label="workbench chrome"` ARIA
+    contract; HMR `dispose()` tears chrome down so re-evaluated entry
+    modules do not accumulate workbench chrome roots on `document.body`.
+  - New ADR-031 (Workbench Chrome Surface) and design preflight at
+    `docs/design/pul-f031-workbench-chrome-surface-preflight.md`.
+    PUL-F013 (ADR-016) facet table flips "Render full chrome" from
+    absent to delivered; PUL-F013 itself stays DRAFT pending the
+    remaining three facets (audio, GSAP runner, presenter input).
+  - 39 new unit tests across
+    `tests/runtime/workbench-chrome.test.ts` (factory + visibility
+    policy) and `tests/runtime/scene-loader-chrome.test.ts` (loader
+    dispatch ordering, single-call-per-composition persistence,
+    no-call-on-parse-error / no-call-on-forged-mode).

--- a/docs/adrs/016-workbench-mode-present.md
+++ b/docs/adrs/016-workbench-mode-present.md
@@ -30,7 +30,7 @@ not yet landed in this repo:
 
 | Facet | Surface that delivers it | Status |
 |-------|--------------------------|--------|
-| Render full chrome | Workbench-shell requirement (not yet drafted) | absent |
+| Render full chrome | PUL-F031 / ADR-031 workbench chrome surface | **delivered (structure)** — workbench-owned DOM root mounted by `src/runtime/workbench-chrome.ts`, mode-governed via `chromeVisibilityFor`. The chrome surface ships empty today; actual presenter UI content lands with the presenter-input facet (PUL-F020 / F021 / F025). |
 | Render audio | Audio service per ADR-004 (Howler.js); a future PUL-F* requirement will deliver the service | absent |
 | Render inter-scene transitions | GSAP timeline runner per ADR-003; the runner's adapter slot exists in `composition-resolver.ts` but the GSAP implementation has not landed | absent (placeholder runner in `src/main.ts`) |
 | Respond to presenter input | Presenter controls per PUL-F020 (advance / hold / skip), PUL-F021 (pause / resume), PUL-F025 (master mute) | absent |
@@ -179,6 +179,21 @@ When all four arrive, PUL-F013 transitions to ACTIVE and the issue
 ↔ requirement link upgrades from `DOCUMENTS` to `IMPLEMENTS`. Until
 then, treating this PR as satisfying PUL-F013 would be a
 traceability/status mismatch.
+
+## Update — 2026-05-18 (PUL-F031 lands)
+
+PUL-F031 ships the workbench chrome surface — see ADR-031. The
+"Render full chrome" facet in the table above is now structurally
+delivered: chrome is workbench-owned, mounted before the first
+navigation, mode-governed (`present` → visible; `standalone` /
+`screenshot` → hidden), and persistent across scene navigations
+within a composition. The chrome surface itself ships empty;
+PUL-F020 / F021 / F025 land the presenter controls that populate it.
+
+PUL-F013 STILL stays DRAFT. Three facets remain absent (audio,
+inter-scene transitions, presenter input). The ACTIVE bar is
+unchanged — every facet must land as a real rendering / input
+surface with end-to-end tests.
 
 ## Related ADRs
 

--- a/docs/adrs/031-workbench-chrome-surface.md
+++ b/docs/adrs/031-workbench-chrome-surface.md
@@ -1,0 +1,217 @@
+# ADR-031: Workbench Chrome Surface — Workbench-Owned, Mode-Governed, Persistent
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-18
+
+## Context
+
+PUL-F031 specifies the workbench chrome surface:
+
+> The runtime SHALL render a workbench chrome surface around the scene
+> stage. Chrome SHALL be workbench-owned, mounted before the first
+> scene navigation, and SHALL NOT be created or mutated by scene
+> modules. Chrome rendering SHALL be governed by the active workbench
+> mode: `mode=present` renders chrome fully; modes that explicitly
+> suppress chrome (e.g., `mode=standalone`, `mode=screenshot`) SHALL
+> hide it. Chrome SHALL persist across scene navigations within a
+> composition without being torn down between scenes.
+
+ADR-007 names the eight workbench modes and the URL-only-source
+invariant for mode selection. ADR-013 fixes the URL grammar boundary.
+ADR-014 fixes scene target resolution. ADR-016 (`present`), ADR-017
+(`standalone`), ADR-018 (`loop`), ADR-019 (`paused`), ADR-020
+(`scrub`), ADR-021 (`screenshot`), ADR-022 (`prompter`) record the
+mode-specific seams. PUL-A008 forbids scene modules from owning mode
+dispatch. PUL-F013 (ADR-016) names "render full chrome" as one of the
+four facets present-mode must deliver and explicitly leaves chrome to
+"a future workbench-shell requirement (not yet drafted)" — that
+requirement is PUL-F031.
+
+The question this ADR answers: where does the chrome surface live,
+how does it learn about workbench mode, and how does it persist
+across scene navigations without becoming a scene-lifecycle concern?
+
+## Decision
+
+Chrome is a **workbench-owned DOM root**, built at the runtime
+composition root (`src/main.ts`) before the first navigation event,
+governed by a single per-navigation `applyMode` call from the scene
+loader, and structurally inert to the resolver and scenes.
+
+### Boundary
+
+The chrome surface lives at two seams:
+
+- **`src/runtime/workbench-chrome.ts`** — a factory
+  (`createDomWorkbenchChrome`) that mounts the chrome DOM root,
+  exposes `applyMode(mode: NavigationMode): void` and `dispose():
+  void`, and contains the pure visibility policy
+  `chromeVisibilityFor(mode)`. The factory mirrors
+  `audio-unlock-dom.ts`: injected `mount` and `createSurface` hooks
+  keep every DOM behavior testable against fakes while production
+  `main.ts` supplies real `document.createElement` and the live mount
+  point.
+
+- **`src/runtime/scene-loader.ts`** — adds an optional `chrome?:
+  WorkbenchChromeAdapter` field on `SceneLoaderOptions`. In
+  `runTarget`, immediately after `validateModeGrammar(target)` passes
+  and BEFORE `resolveSceneNavigation`, the loader calls
+  `options.chrome?.applyMode(effectiveMode(target))`. The single call
+  site is upstream of the composition resolver's per-scene loop, so a
+  multi-scene composition produces exactly one `applyMode` call — the
+  structural form of "chrome SHALL persist across scene navigations
+  within a composition without being torn down between scenes."
+
+`src/main.ts` instantiates `createDomWorkbenchChrome({...})` BEFORE
+calling `bootstrapNavigation(globalThis)`, so the chrome surface exists
+before any navigation event can fire. The HMR `dispose()` hook tears
+chrome down so re-evaluated entry modules do not accumulate chrome
+surfaces.
+
+### Mode → visibility policy
+
+The pure helper `chromeVisibilityFor(mode: NavigationMode): 'visible'
+| 'hidden'` defines the policy:
+
+| Mode | Chrome |
+|------|--------|
+| `present` | visible |
+| `standalone` | **hidden** |
+| `screenshot` | **hidden** |
+| `loop` | visible |
+| `paused` | visible |
+| `scrub` | visible |
+| `prompter` | visible |
+| `rehearsal` | visible |
+
+PUL-F031's statement names only `standalone` and `screenshot` as
+chrome-suppressing modes. The PUL-F031 preflight records the
+remaining defaults: "Other modes keep their existing ADR-defined
+behavior unless their own requirement explicitly suppresses chrome."
+No requirement names chrome suppression for `loop`, `paused`,
+`scrub`, `prompter`, or `rehearsal`, so they default to visible.
+
+The seam is **chrome-specific**, not a generic `ModePolicy`. A future
+mode that needs compact / reviewer / presenter chrome variants
+extends the literal-union return type at this one helper. Per the
+ADR-016 / PUL-F013 precedent, generic mode-policy abstractions land
+when a second concrete consumer demands them, not speculatively.
+
+### What chrome IS NOT in this PR
+
+PUL-F031 delivers the **structural chrome surface and the visibility
+seam**, not chrome's visual content. The chrome surface ships empty
+today — actual presenter controls (PUL-F020 / F021 / F025), captions
+chrome, and audio chrome land as their own requirements. Per the
+PUL-F031 preflight non-goals: "PUL-F031 should not implement
+presenter controls, presenter command transport, audio chrome,
+inter-scene transitions, screenshot capture, prompter UI, a new
+workbench mode, a design system, persistence, authentication,
+telemetry, export behavior, or a generic mode-policy framework."
+
+### PUL-F013 coupling
+
+PUL-F013 (`mode=present` renders full chrome, audio, transitions, and
+responds to presenter input — ADR-016) lists four facets that ACTIVE
+requires. This PR delivers the first facet (chrome). The remaining
+three (audio service per ADR-004, GSAP runner per ADR-003, presenter
+input per PUL-F020 / F021 / F025) are independent surfaces. PUL-F013
+stays DRAFT — landing PUL-F031 satisfies one facet, not the full
+four-facet contract. The DRAFT → ACTIVE transition is gated on every
+facet landing.
+
+## Consequences
+
+### Positive
+
+- The structural defense for every PUL-F031 clause exists in code:
+  workbench ownership (factory is not exported into the scene
+  surface), bootstrap-time mount (`main.ts` calls the factory before
+  `bootstrapNavigation`), mode governance (`chromeVisibilityFor`
+  table), composition persistence (single `applyMode` call per
+  navigation, upstream of the resolver's per-scene loop).
+- The chrome adapter follows the existing inert-seam pattern
+  (`renderPrompter`, `presenterCommands`, `audioUnlockAdapter`).
+  Pre-PUL-F031 loader callers (Node tests, every existing loader
+  test suite) continue to work unchanged because the option is
+  optional.
+- The visibility policy is one pure function over `NavigationMode`,
+  exhaustive over `NAVIGATION_MODES`. Adding the ninth mode requires
+  an explicit case in the switch — the compiler forces the author to
+  decide chrome behavior for the new mode.
+- Chrome is mounted as a sibling of `#stage` on `document.body`. The
+  preflight invariant "Do not re-parent `#stage` in a way that breaks
+  loader ownership or lets scene cleanup clear chrome" is honored by
+  construction.
+- The `hidden` boolean IDL property (rather than CSS `display: none`)
+  keeps hidden chrome out of the accessibility tree and prevents
+  focus traps, satisfying the PUL-Q008 cross-cutting layer the
+  preflight names.
+
+### Negative
+
+- The chrome surface ships empty today. A reviewer expecting visible
+  presenter affordances will not see any — that content is owned by
+  PUL-F020 / F021 / F025 and lands when those requirements are
+  implemented. The DOM root is present and `data-pulsar-chrome` /
+  `data-pulsar-chrome-visibility` are addressable for downstream
+  styling and inspection.
+- Two new files (`workbench-chrome.ts`, two test files) plus a
+  single line at the loader's `runTarget` increase the loader's
+  optional-seam list to four (`renderPrompter`,
+  `presenterCommands`, `audioUnlockAdapter`, `chrome`). Each is
+  narrowly scoped and inert when absent, but the list is growing.
+  When a fifth lands, consider whether the loader's optional-seam
+  pattern should consolidate into a single "workbench surfaces"
+  argument bag.
+
+### Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| Future chrome content (presenter controls, captions chrome) gets bolted onto the chrome surface in a way that re-introduces scene-owned mode branches | PUL-A008 source policy continues to scan `src/scenes/**/*.ts` for mode-literal branches. Chrome content authors land their content at the runtime/workbench seam, not at the scene seam — same pattern as audio (PUL-F024), presenter (PUL-F025), and prompter (ADR-022). |
+| A future PR adds a generic `ModePolicy` abstraction by pulling `chromeVisibilityFor` alongside `audioOutputPolicyFor` into a shared table | The ADR-016 precedent: defer the abstraction until a third concrete consumer demands it. Two pure helpers in two files is not yet a pattern to extract. |
+| Hidden chrome under `standalone` / `screenshot` becomes a covert focus trap if a future presenter control inside the chrome surface acquires focus before visibility is applied | The chrome adapter sets `element.hidden = true` (HTML `hidden` IDL property), which removes the element and all descendants from the focus order and the accessibility tree. PUL-Q008's Playwright gate exercises the live workbench and will catch focus-order regressions for any visible chrome content the future delivers. |
+| A non-loader caller forges an invalid mode and calls `chrome.applyMode` directly | The chrome adapter re-validates against `NAVIGATION_MODES` and throws on unknown modes — defense in depth. The loader's `validateModeGrammar` already rejects forged modes before they reach chrome. |
+
+## Related ADRs
+
+- [ADR-003](003-gsap-timeline-engine.md) — the timeline runner is a
+  separate seam from chrome; chrome does not own timeline state.
+- [ADR-004](004-howler-audio-engine.md) — `ctx.audio` is the separate
+  seam through which audio chrome will flow when audio chrome lands;
+  this ADR does not deliver audio chrome.
+- [ADR-007](007-browser-workbench.md) — defines the eight workbench
+  modes and the URL-only-source invariant for mode selection.
+- [ADR-008](008-agent-native-authoring.md) — manifests-over-flow-
+  control underpins the workbench-owned, scene-opaque chrome ownership
+  choice.
+- [ADR-011](011-composition-resolver-orchestration.md) — the resolver
+  is mode-opaque and chrome-opaque. Chrome dispatch lives at the
+  loader, not inside the resolver.
+- [ADR-013](013-url-navigation-grammar-boundary.md) — the parser
+  preserves `mode` and forbids recovering it from any non-URL source.
+- [ADR-016](016-workbench-mode-present.md) — establishes the
+  present-mode boundary and lists "render full chrome" as the first
+  of four facets PUL-F013 ACTIVE requires. PUL-F031 delivers that
+  facet; PUL-F013 stays DRAFT until the remaining three land.
+- [ADR-017](017-workbench-mode-standalone.md) — names "surrounding
+  chrome suppressed" as a PUL-F014 ACTIVE precondition. PUL-F031's
+  `chromeVisibilityFor('standalone') === 'hidden'` satisfies that
+  precondition structurally.
+- [ADR-021](021-workbench-mode-screenshot.md) — screenshot-mode
+  determinism includes "all chrome hidden" as a visual invariant.
+  PUL-F031's `chromeVisibilityFor('screenshot') === 'hidden'`
+  satisfies it.
+- [ADR-022](022-workbench-mode-prompter.md) — prompter bypasses the
+  scene lifecycle; PUL-F031's chrome dispatch still fires under
+  `prompter` because the chrome surface is mode-governed, not
+  lifecycle-governed.
+- [ADR-029](029-present-mode-audio-unlock-gate.md) — the audio unlock
+  adapter's factory shape (`audio-unlock-dom.ts`) is the prior art
+  this ADR's `workbench-chrome.ts` factory mirrors.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -55,3 +55,5 @@ Each ADR includes:
 | [027](027-caption-timestamp-grammar.md) | Caption Timestamp Grammar — `at` Accepts a Millisecond Offset or a Beat Label, Validated at the Scene Schema Boundary | Accepted |
 | [028](028-scene-level-error-isolation.md) | Scene-Level Error Isolation | Accepted |
 | [029](029-present-mode-audio-unlock-gate.md) | Present-Mode Audio Unlock Gate Before Composition Start | Accepted |
+| [030](030-browser-support.md) | Browser Support Contract | Accepted |
+| [031](031-workbench-chrome-surface.md) | Workbench Chrome Surface — Workbench-Owned, Mode-Governed, Persistent | Accepted |

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -36,6 +36,7 @@ Design context for Pulsar. Source material for the ADRs in `../adrs/`.
 | [pul-f027-caption-metadata-prompter-preflight.md](pul-f027-caption-metadata-prompter-preflight.md) | Guardrails for widening caption metadata timing and keeping prompter content single-sourced. |
 | [pul-f028-validation-preflight.md](pul-f028-validation-preflight.md) | Guardrails for implementing structural runtime validation without duplicating schemas, registries, asset policy, or lifecycle logic. |
 | [pul-f030-audio-unlock-interaction-preflight.md](pul-f030-audio-unlock-interaction-preflight.md) | Guardrails for implementing present-mode audio unlock before an audio-declaring composition begins. |
+| [pul-f031-workbench-chrome-surface-preflight.md](pul-f031-workbench-chrome-surface-preflight.md) | Guardrails for implementing a persistent workbench-owned chrome surface around the scene stage. |
 
 Design docs are mutable. Decisions are captured as ADRs (immutable once
 accepted).

--- a/docs/design/pul-f031-workbench-chrome-surface-preflight.md
+++ b/docs/design/pul-f031-workbench-chrome-surface-preflight.md
@@ -1,0 +1,150 @@
+# PUL-F031 Workbench Chrome Surface Preflight
+
+PUL-F031 is a workbench-shell requirement. Chrome is persistent UI
+owned by the browser workbench around the scene stage. It is not a
+scene lifecycle hook, not scene metadata, not a workbench-mode system,
+and not a presenter-controls implementation.
+
+The implementation must land the smallest chrome surface that satisfies
+the requirement while reusing the existing URL, mode, lifecycle,
+diagnostic, validation, and source-policy boundaries.
+
+## Boundary
+
+Chrome belongs at the workbench bootstrap / loader boundary:
+
+- `src/main.ts` owns browser DOM bootstrapping. It already finds the
+  scene `#stage`, runs the runtime validation gate, builds registries,
+  wires adapters, creates the loader, and starts URL navigation.
+  Chrome must mount from this workbench-owned path before the first
+  navigation can activate a scene.
+- `src/runtime/navigation.ts` owns `mode=` parsing,
+  `NAVIGATION_MODES`, and `effectiveMode()`. Chrome visibility must
+  read the effective mode from this canonical boundary. Do not parse
+  `window.location`, duplicate the mode list, or add a second query
+  key.
+- `src/runtime/scene-loader.ts` owns serialized navigation,
+  per-navigation mode validation, stage diagnostics, abort, cleanup,
+  presenter scoping, audio policy, and lifecycle handoff. Chrome must
+  not bypass or replace that queue.
+- `src/runtime/scene-navigation.ts` owns target resolution and
+  composition slicing. If chrome displays target context, it should
+  consume bounded identifiers or existing read-only metadata from the
+  resolved target path; it must not re-resolve targets, mutate
+  registries, or flatten composition context.
+- `src/runtime/composition-resolver.ts` remains mode-opaque and
+  chrome-opaque. It must not mount, hide, update, or tear down
+  workbench chrome.
+- Scene modules own only scene content under `ctx.stage`. They must not
+  create, query, retain, style, hide, or mutate chrome nodes.
+
+Chrome persistence is structural: mount one workbench-owned controller
+or DOM root for the workbench session, then update its visibility /
+content across navigations. Scene `cleanup(ctx)` and resolver cleanup
+must not remove chrome.
+
+## Required Reuse
+
+Implementation must build on these canonical incumbents:
+
+- URL and mode grammar: `parseNavigationSearch()`,
+  `NAVIGATION_MODES`, `NavigationMode`, and `effectiveMode()` in
+  `src/runtime/navigation.ts`.
+- Loader orchestration: `createSceneLoader()`, its serialized queue,
+  `validateModeGrammar()` defense-in-depth, one per-navigation
+  `AbortController`, and existing stage diagnostic attributes.
+- Navigation resolution: `resolveSceneNavigation()` and
+  `loadSceneNavigationTarget()` for scene/composition identity and
+  range / behavior preservation.
+- Scene/composition schemas and registries:
+  `assertSceneModule()`, `createSceneRegistry()`,
+  `assertCompositionManifest()`, `createCompositionRegistry()`, and
+  the canonical `src/workbench-graph.ts` declarations.
+- Runtime validation: `validateRuntime()` /
+  `assertNoValidationFindings()` must still run before navigation and
+  before any scene lifecycle effect. Chrome must not add a parallel
+  graph validator or schema.
+- Error and observability: `describeErrorDetailed()`,
+  `formatSceneContext()`, `data-pulsar-navigation-error`,
+  `data-pulsar-scene-target`, `data-pulsar-composition-target`,
+  `data-pulsar-scene-failures`, and the loader `onError` sink.
+- Existing mode guardrails: ADR-007, ADR-013, ADR-014, ADR-016,
+  ADR-017, ADR-021, and
+  `docs/design/pul-a008-mode-dispatch-core-preflight.md`.
+- Source-policy tests: especially
+  `tests/runtime/policy-a008-mode-dispatch.test.ts`; scene modules
+  must remain barred from mode dispatch except narrow allowed
+  scene-owned hints.
+
+Do not create duplicate schemas, duplicate validators, duplicate mode
+enums, duplicate exception hierarchies, or a generic `ModePolicy`.
+
+## Cross-Cutting Layers
+
+| Layer | Guardrail |
+|-------|-----------|
+| URL grammar / public input | Only `mode=<NAVIGATION_MODES member>` controls chrome visibility. Unknown and repeated `mode` values keep failing through the existing navigation grammar envelope. Unknown query keys must not influence chrome. |
+| Programmatic navigation | Hand-built targets still pass the loader's mode defense before chrome state is trusted. Do not let a forged string reach chrome as an unchecked mode. |
+| Source of truth | Omitted `mode` derives to `present` through `effectiveMode()` on every navigation. Do not recover mode from localStorage, sessionStorage, cookies, `history.state`, previous in-memory state, env vars, argv, files, or host config. |
+| DOM ownership | Chrome nodes are outside scene ownership. Scenes receive `ctx.stage`; they do not receive a chrome handle, selector, event bus, or mutation API. Scene cleanup must be incapable of tearing down chrome. |
+| Scene/composition schema | Do not add `chrome`, `hideChrome`, `standaloneChrome`, or similar fields to scene modules or composition manifests. Existing scene metadata may be read for display only if it has already passed the canonical schema. |
+| Resolver lifecycle | The resolver stays chrome-opaque. Chrome visibility and content updates belong before/around loader dispatch, not in `resolveComposition()` or lifecycle hooks. |
+| Error envelope | Chrome-related failures use the existing `onError` / `data-pulsar-navigation-error` surface and bounded messages. Do not serialize raw scene objects, DOM nodes, stacks, full URLs with credentials, headers, cookies, env, auth values, or asset payloads. |
+| Asset security | Chrome must not turn query values into paths, dynamic imports, style URLs, or network requests. Workbench-owned chrome assets, if any, are static bundled workbench assets, not scene-declared or query-derived assets. |
+| Validation | The existing runtime validation remains about scene/composition graph structure. Chrome must not be represented as a fake scene or manifest entry to satisfy validation. |
+| Accessibility / DOM-CSS | Chrome must preserve browser text selection, focus order, and ARIA semantics per the existing DOM/CSS accessibility preflight and Playwright gate. Hidden chrome in suppressing modes must not trap focus or cover the stage. |
+| Observability | Stage attributes continue to describe navigation target and errors. Chrome may render bounded target/status text derived from the same canonical data but must not become the source of truth for navigation state. |
+| OS / config exposure | No chrome mode, target, token, or user URL belongs in process argv, environment bindings, browser storage, cookies, or local files. A future export/screenshot wrapper may load a URL; the runtime still receives mode through the URL grammar. |
+
+## Visibility Seam
+
+The required extensibility seam is chrome-specific, not generic mode
+policy. A small workbench-owned visibility decision should map
+`NavigationMode` to a literal chrome state such as visible/hidden.
+
+The initial policy is:
+
+- `present` renders full chrome.
+- `standalone` hides chrome.
+- `screenshot` hides chrome.
+- Other modes keep their existing ADR-defined behavior unless their
+  own requirement explicitly suppresses chrome.
+
+Keep this decision parameterized at the chrome adapter boundary so a
+future mode can request hidden, compact, reviewer, or presenter chrome
+without editing scene modules, registries, composition manifests,
+resolver logic, or the URL parser beyond adding the mode itself.
+
+## Gotchas And Anti-Patterns
+
+- Mounting chrome from a scene `create(ctx)` hook or removing it from
+  a scene `cleanup(ctx)` hook.
+- Passing `ctx.chrome`, a global chrome controller, or a chrome DOM
+  selector to scene modules.
+- Treating CSS hiding after scene lifecycle effects as ownership:
+  `standalone` and `screenshot` must not depend on scene code to hide
+  workbench UI.
+- Duplicating `NAVIGATION_MODES` or implementing a local
+  `isChromeMode()` over string literals in scene code.
+- Encoding chrome behavior in composition `behavior`, fake transition
+  scenes, sentinel manifest entries, or scene metadata fields.
+- Re-parenting `#stage` in a way that breaks the loader's stage handle
+  or lets scene cleanup clear chrome.
+- Making chrome persistence depend on composition resolver mount/run/
+  cleanup phases.
+- Using browser storage to remember whether chrome was hidden.
+- Logging high-volume chrome telemetry or dumping raw target objects
+  for visible status text.
+
+## Non-Goals
+
+PUL-F031 should not implement presenter controls, presenter command
+transport, audio chrome, inter-scene transitions, screenshot capture,
+prompter UI, a new workbench mode, a design system, persistence,
+authentication, telemetry, export behavior, or a generic mode-policy
+framework.
+
+It should not transition PUL-F013 to ACTIVE by itself unless the full
+PUL-F013 statement is satisfied at the same time: chrome, audio,
+inter-scene transitions, and presenter input all rendered / accepted
+end to end under `mode=present` with their own tests and traceability.

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,6 +39,7 @@ import { createSceneRegistry } from './runtime/registry';
 import { type WorkbenchSceneCtx, createSceneLoader } from './runtime/scene-loader';
 import { createGsapCompositionTimeline, createTimelineEngine } from './runtime/timeline';
 import { assertNoValidationFindings, validateRuntime } from './runtime/validation';
+import { createDomWorkbenchChrome } from './runtime/workbench-chrome';
 import { WORKBENCH_COMPOSITIONS, WORKBENCH_SCENES } from './workbench-graph';
 
 const stage = document.querySelector('#stage');
@@ -212,6 +213,31 @@ const audioUnlockAdapter = createDomAudioUnlockAdapter({
   },
 });
 
+// PUL-F031 / ADR-031: workbench chrome surface. The chrome controller
+// is workbench-owned, mounted as a sibling of `#stage` BEFORE
+// `bootstrapNavigation()` registers its listeners, and persists across
+// scene navigations within a composition. The loader (above) calls
+// `chrome.applyMode(effectiveMode(target))` once per navigation; this
+// factory flips the `hidden` boolean + `data-pulsar-chrome-visibility`
+// attribute on the same element instance, so persistence is structural.
+// The chrome surface ships empty today — actual chrome content
+// (presenter controls per PUL-F020 / F021 / F025, captions chrome,
+// audio chrome) lands as those surfaces' own requirements. ARIA
+// `role="complementary"` + `aria-label` keeps the chrome region
+// announced without interfering with the scene's focus order
+// (PUL-Q008). Mounting on `document.body` keeps `#stage` ownership
+// untouched (preflight: do not re-parent `#stage`).
+const chrome = createDomWorkbenchChrome({
+  mount: (element) => document.body.appendChild(element as unknown as Node),
+  createSurface: () => {
+    const surface = document.createElement('div');
+    surface.dataset.pulsarChrome = 'surface';
+    surface.setAttribute('role', 'complementary');
+    surface.setAttribute('aria-label', 'workbench chrome');
+    return surface;
+  },
+});
+
 const loader = createSceneLoader({
   scenes: sceneRegistry,
   compositions: compositionRegistry,
@@ -222,6 +248,7 @@ const loader = createSceneLoader({
   audioEngine,
   renderPrompter,
   audioUnlockAdapter,
+  chrome,
 });
 
 const onNavigate = (event: Event): void => {
@@ -247,4 +274,7 @@ import.meta.hot?.dispose(() => {
   globalThis.removeEventListener(PULSAR_NAVIGATE_EVENT_TYPE, onNavigate);
   globalThis.removeEventListener(PULSAR_NAVIGATE_ERROR_EVENT_TYPE, onNavigateError);
   loader.dispose();
+  // PUL-F031 / ADR-031: remove the chrome surface so HMR re-evaluation
+  // does not accumulate workbench chrome roots on `document.body`.
+  chrome.dispose();
 });

--- a/src/runtime/scene-loader.ts
+++ b/src/runtime/scene-loader.ts
@@ -316,6 +316,49 @@ export interface SceneLoaderOptions {
    *    a workbench-bootstrap defect, not an inert seam.
    */
   readonly audioUnlockAdapter?: AudioUnlockAdapter;
+  /**
+   * PUL-F031 / ADR-031: workbench-supplied chrome controller. The
+   * loader calls `chrome.applyMode(effectiveMode(target))` once per
+   * navigation, immediately after mode-grammar validation passes and
+   * BEFORE scene resolution / lifecycle work, so chrome visibility
+   * tracks the addressed workbench mode (`present` → visible;
+   * `standalone` / `screenshot` → hidden; other modes → visible per
+   * preflight policy) and a present-mode composition does not flash
+   * an un-chromed frame.
+   *
+   * Chrome is workbench-owned and built at bootstrap by
+   * `src/runtime/workbench-chrome.ts`. The loader's seam is
+   * intentionally narrow: one call per navigation with the URL-derived
+   * mode. The chrome controller itself decides what "visible" /
+   * "hidden" mean structurally (DOM `hidden` attribute, visibility
+   * data attribute) — the loader does not know.
+   *
+   * Optional: a workbench bootstrap that has not wired chrome yet
+   * (Node tests, pre-PUL-F031 bootstraps) omits the field and the
+   * seam is structurally inert, the same inert-seam pattern
+   * {@link renderPrompter} / {@link presenterCommands} /
+   * {@link audioUnlockAdapter} follow.
+   *
+   * The chrome surface persists across scene navigations within a
+   * composition because the loader's single call site is upstream of
+   * the resolver's per-scene loop — a multi-scene composition under
+   * `mode=present` produces exactly one `applyMode('present')` call.
+   * Per ADR-007 / ADR-016 / PUL-A008, chrome state is workbench-owned
+   * and scenes never see a chrome handle.
+   */
+  readonly chrome?: WorkbenchChromeAdapter;
+}
+
+/**
+ * PUL-F031 / ADR-031: workbench-supplied chrome controller surface.
+ * The loader only needs the one operation — apply a validated mode
+ * to chrome — so the interface stays narrow. The full chrome
+ * controller lives in {@link import('./workbench-chrome').WorkbenchChromeController}
+ * with a `dispose()` method the workbench (not the loader) calls on
+ * HMR teardown.
+ */
+export interface WorkbenchChromeAdapter {
+  applyMode(mode: NavigationMode): void;
 }
 
 /**
@@ -1412,14 +1455,68 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
     }
   };
 
-  const runOnce = async (event: NavigationEvent, myGen: number): Promise<void> => {
+  /**
+   * PUL-F031 / ADR-031: dispatch the workbench chrome surface for a
+   * target event synchronously, returning any thrown error so the
+   * caller can surface it after stage-attr reset.
+   *
+   * Called from {@link enqueue} BEFORE the queue serializes the event,
+   * because chrome is workbench-owned and outside the scene-lifecycle
+   * serialization invariant — flipping `present` → `standalone` /
+   * `screenshot` MUST hide chrome immediately rather than waiting for
+   * the prior load's `cleanup(ctx)` to drain (codex review, cycle 1,
+   * one-off "suppressing-mode chrome updates wait for old cleanup").
+   * The mode is re-validated through {@link validateModeGrammar} so a
+   * forged `NavigationTarget` (non-parser caller) never reaches the
+   * chrome adapter; `runTarget` will surface the same validation
+   * error downstream so the operator sees one consistent diagnostic.
+   *
+   * Synchronous adapter throws (codex review, cycle 1, one-off
+   * "chrome adapter failures bypass the loader error envelope") are
+   * caught and routed through the same {@link surfaceError} envelope
+   * as every other navigation diagnostic. `runOnce` defers the
+   * surface until after `resetStageAttrs()` so the
+   * `data-pulsar-navigation-error` attribute survives the post-abort
+   * reset, AND skips the lifecycle for the failing event because
+   * chrome is in an unknown state.
+   */
+  const dispatchChrome = (target: NavigationTarget): Error | null => {
+    if (options.chrome === undefined) return null;
+    if (validateModeGrammar(target) !== null) return null;
+    try {
+      options.chrome.applyMode(effectiveMode(target));
+      return null;
+    } catch (err) {
+      return err instanceof Error ? err : new Error(String(err));
+    }
+  };
+
+  const runOnce = async (
+    event: NavigationEvent,
+    myGen: number,
+    chromeErr: Error | null,
+  ): Promise<void> => {
     // Drop superseded events before doing any visible work — both at
     // entry (handle → handle race) and after the abort-and-await yield
-    // (slow cleanup observed by another enqueue).
+    // (slow cleanup observed by another enqueue). A chrome error from
+    // a superseded enqueue is intentionally dropped here: the newer
+    // event has already dispatched chrome (possibly successfully), so
+    // the older error is moot.
     if (myGen !== generation || disposed) return;
     await abortAndAwait();
     if (myGen !== generation || disposed) return;
     resetStageAttrs();
+
+    if (chromeErr !== null) {
+      // Chrome dispatch failed at enqueue — surface through the same
+      // envelope as grammar / resolution failures AND skip the
+      // lifecycle for this event. Chrome is in an unknown state;
+      // running scene lifecycle around an unsynchronized chrome
+      // surface would compound the workbench bootstrap defect rather
+      // than recover from it.
+      surfaceError(chromeErr);
+      return;
+    }
 
     if (event.kind === 'error') {
       surfaceError(event.err);
@@ -1430,6 +1527,14 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
 
   const enqueue = (event: NavigationEvent): Promise<void> => {
     if (disposed) return pending;
+    // PUL-F031 / ADR-031: dispatch chrome SYNCHRONOUSLY at enqueue,
+    // BEFORE the queue serializes. Workbench chrome is outside the
+    // scene-lifecycle serialization invariant — a mode flip (present
+    // → standalone) hides chrome immediately rather than waiting for
+    // the prior load's cleanup. Errors are captured and forwarded to
+    // `runOnce`, which surfaces them after `resetStageAttrs()` (so
+    // the diagnostic attr is not wiped) and bails the lifecycle.
+    const chromeErr = event.kind === 'target' ? dispatchChrome(event.target) : null;
     // Eagerly abort any in-flight load so the queued event can
     // proceed past `await load.settled` immediately. Without this, a
     // popstate-fired re-navigation would wait for the current load to
@@ -1438,8 +1543,8 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
     if (inFlight !== null) inFlight.controller.abort();
     const myGen = ++generation;
     pending = pending.then(
-      () => runOnce(event, myGen),
-      () => runOnce(event, myGen),
+      () => runOnce(event, myGen, chromeErr),
+      () => runOnce(event, myGen, chromeErr),
     );
     return pending;
   };

--- a/src/runtime/workbench-chrome.ts
+++ b/src/runtime/workbench-chrome.ts
@@ -1,0 +1,172 @@
+// Workbench-owned chrome surface — PUL-F031 / ADR-031.
+//
+// `src/main.ts` (the production browser bootstrap) builds a chrome DOM
+// root next to the scene `#stage` and wires this factory's controller
+// into the scene loader via `SceneLoaderOptions.chrome`. The loader
+// calls `applyMode(effectiveMode(target))` once per navigation, before
+// any lifecycle work, so chrome visibility tracks the addressed
+// workbench mode without scenes ever owning chrome state.
+//
+// Per ADR-007 / ADR-016 / the PUL-F031 preflight:
+//   - Chrome is workbench-owned. Scenes receive `ctx.stage`, never a
+//     chrome handle, selector, or event bus.
+//   - Chrome is mounted ONCE at workbench bootstrap, before the first
+//     navigation event. Persistence across scene navigations is
+//     structural — `applyMode` only flips visibility on the existing
+//     element; it never re-mounts or re-creates the surface.
+//   - The chrome visibility decision is a chrome-specific policy, not
+//     a generic `ModePolicy`. A future mode that needs compact /
+//     reviewer / presenter chrome variants extends the literal-union
+//     return type at this one helper, not by editing scenes,
+//     manifests, the resolver, or the URL parser beyond adding the
+//     mode itself.
+//
+// The factory shape (mirroring `audio-unlock-dom.ts`) keeps every
+// observable DOM behavior — mount-once, visibility flip, dispose
+// removal — testable against fakes while production `main.ts` supplies
+// real `document.createElement` and the live mount point.
+
+import { NAVIGATION_MODES, type NavigationMode } from './navigation';
+
+/**
+ * Minimal `HTMLElement`-like surface the chrome adapter writes to.
+ * Production `main.ts` passes a real `HTMLElement`; tests pass a fake.
+ * The chrome surface only needs `setAttribute` / `removeAttribute` /
+ * the boolean `hidden` IDL property / `remove()` — everything else
+ * (children, layout, content) is the workbench's own concern and is
+ * out of scope for PUL-F031's structural defense.
+ */
+export interface WorkbenchChromeElement {
+  setAttribute(name: string, value: string): void;
+  removeAttribute(name: string): void;
+  hidden: boolean;
+  remove(): void;
+}
+
+/**
+ * Mount callback the factory invokes to attach the chrome surface to
+ * the workbench. Decoupling the mount from a specific `Element` /
+ * `appendChild` shape lets the production wiring stay compatible with
+ * the real DOM (`(el) => document.body.appendChild(el as unknown as
+ * Node)`) while tests pass a fake that records the appended element —
+ * without forcing the factory to know about `Node` or jsdom.
+ */
+export type WorkbenchChromeMount = (element: WorkbenchChromeElement) => void;
+
+/**
+ * Inputs to {@link createDomWorkbenchChrome}.
+ *
+ *  - `mount` attaches the chrome surface to the workbench. Called
+ *    exactly once, during factory construction — chrome MUST exist
+ *    before the first navigation event fires.
+ *  - `createSurface` builds the chrome DOM root. Called exactly once,
+ *    during factory construction. Production `main.ts` builds a
+ *    `<div data-pulsar-chrome="surface" role="complementary"
+ *    aria-label="workbench chrome">`; tests build a minimal fake.
+ */
+export interface WorkbenchChromeHost {
+  readonly mount: WorkbenchChromeMount;
+  readonly createSurface: () => WorkbenchChromeElement;
+}
+
+/**
+ * Returned by {@link createDomWorkbenchChrome}. The workbench wires the
+ * controller into `SceneLoaderOptions.chrome`; the loader calls
+ * `applyMode` once per navigation. `dispose()` removes the chrome
+ * surface from the workbench and silences any subsequent `applyMode`
+ * calls — invoked from the workbench bootstrap's HMR cleanup so a
+ * re-evaluated entry module does not accumulate chrome surfaces.
+ */
+export interface WorkbenchChromeController {
+  /**
+   * Apply the effective workbench mode to the chrome surface. Maps the
+   * mode through {@link chromeVisibilityFor} and updates the
+   * `data-pulsar-chrome-visibility` attribute plus the boolean `hidden`
+   * IDL property. Inert post-dispose.
+   */
+  applyMode(mode: NavigationMode): void;
+  /**
+   * Tear down the chrome surface. Removes the element from the
+   * workbench and makes subsequent `applyMode` calls no-ops.
+   * Idempotent: a second `dispose()` does not re-remove or throw.
+   */
+  dispose(): void;
+}
+
+/**
+ * Pure mapping from workbench mode to chrome visibility.
+ *
+ * PUL-F031 statement: chrome SHALL be governed by the active mode —
+ * `present` renders chrome fully; modes that explicitly suppress
+ * chrome (`standalone`, `screenshot`) SHALL hide it.
+ *
+ * Preflight policy: "Other modes keep their existing ADR-defined
+ * behavior unless their own requirement explicitly suppresses chrome."
+ * No requirement names chrome suppression for `loop`, `paused`,
+ * `scrub`, `prompter`, or `rehearsal`, so they default to visible.
+ *
+ * The exhaustive `switch` over `NavigationMode` is the extensibility
+ * seam the preflight names: a future mode that needs compact /
+ * reviewer / presenter chrome variants extends the literal union here
+ * (and updates the gate test), not by editing scenes, manifests, or
+ * the resolver.
+ */
+export function chromeVisibilityFor(mode: NavigationMode): 'visible' | 'hidden' {
+  switch (mode) {
+    case 'standalone':
+    case 'screenshot':
+      return 'hidden';
+    case 'present':
+    case 'loop':
+    case 'paused':
+    case 'scrub':
+    case 'prompter':
+    case 'rehearsal':
+      return 'visible';
+  }
+}
+
+const VISIBILITY_ATTR = 'data-pulsar-chrome-visibility';
+
+/**
+ * Build a {@link WorkbenchChromeController} backed by a DOM-shaped
+ * chrome surface.
+ *
+ * Construction is eager:
+ *   1. `createSurface()` is called exactly once to build the chrome
+ *      DOM root.
+ *   2. `mount(element)` attaches it to the workbench.
+ *
+ * Both run synchronously before this function returns, so chrome
+ * exists before the workbench bootstrap calls `bootstrapNavigation()`
+ * — the "mounted before the first scene navigation" clause of
+ * PUL-F031 is satisfied structurally by call order in `main.ts`.
+ *
+ * `applyMode` flips visibility on the same element instance every
+ * call — the chrome surface is never re-created or re-mounted, which
+ * is how "chrome SHALL persist across scene navigations within a
+ * composition" is honored structurally.
+ */
+export function createDomWorkbenchChrome(host: WorkbenchChromeHost): WorkbenchChromeController {
+  const element = host.createSurface();
+  host.mount(element);
+  let disposed = false;
+  return {
+    applyMode(mode: NavigationMode): void {
+      if (disposed) return;
+      if (!(NAVIGATION_MODES as readonly string[]).includes(mode)) {
+        throw new Error(
+          `workbench chrome: unknown mode "${String(mode)}" — allowed: ${NAVIGATION_MODES.join(', ')}`,
+        );
+      }
+      const visibility = chromeVisibilityFor(mode);
+      element.setAttribute(VISIBILITY_ATTR, visibility);
+      element.hidden = visibility === 'hidden';
+    },
+    dispose(): void {
+      if (disposed) return;
+      disposed = true;
+      element.remove();
+    },
+  };
+}

--- a/tests/runtime/scene-loader-chrome.test.ts
+++ b/tests/runtime/scene-loader-chrome.test.ts
@@ -1,0 +1,480 @@
+// Tests for the loader → chrome dispatch seam — PUL-F031 / ADR-031.
+//
+// The chrome controller is workbench-owned and built by `main.ts`; the
+// loader's only job is to call `chrome.applyMode(effectiveMode(target))`
+// once per navigation, before any lifecycle work, so chrome visibility
+// tracks the addressed workbench mode. These tests pin that seam:
+//
+//   - Called exactly once per navigation with the effective mode.
+//   - Called BEFORE `scene.create(ctx)` so chrome is in place when
+//     the first frame paints.
+//   - Called ONCE for a multi-scene composition (not once per scene)
+//     — pins the "persists across scene navigations within a
+//     composition" clause structurally.
+//   - Called with the URL-derived mode even when target resolution
+//     fails (a `?scene=nonexistent&mode=standalone` URL still
+//     suppresses chrome because the user asked).
+//   - NOT called on parse-error events (chrome state persists across
+//     malformed URLs).
+//   - NOT called when `validateModeGrammar` rejects a hand-built
+//     forged mode (the URL is invalid; chrome state is preserved).
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  type AudioService,
+  type CompositionTimelineAdapter,
+  type NavigationMode,
+  type NavigationTarget,
+  type SceneModule,
+  type WorkbenchSceneCtx,
+  buildScene,
+  buildStage,
+  compositionTarget,
+  createCompositionRegistry,
+  createSceneLoader,
+  createSceneRegistry,
+  gsap,
+  noneTarget,
+  noopTimeline,
+  sceneTarget,
+  stubCtx,
+} from './scene-loader.helpers';
+
+interface RecordingChrome {
+  readonly chrome: { applyMode(mode: NavigationMode): void };
+  readonly calls: readonly NavigationMode[];
+}
+
+const recordingChrome = (): RecordingChrome => {
+  const calls: NavigationMode[] = [];
+  return {
+    calls,
+    chrome: {
+      applyMode: (mode) => {
+        calls.push(mode);
+      },
+    },
+  };
+};
+
+describe('createSceneLoader — chrome dispatch (PUL-F031 / ADR-031)', () => {
+  it('calls chrome.applyMode exactly once per navigation with the effective mode', async () => {
+    const rec = recordingChrome();
+    const scene = buildScene({ id: 'scene-a' });
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([scene]),
+      compositions: createCompositionRegistry([]),
+      stage: buildStage().element,
+      buildCtx: stubCtx,
+      createPreloader: () => () => undefined,
+      timeline: noopTimeline,
+      chrome: rec.chrome,
+    });
+
+    await loader.handle({ locator: { kind: 'scene', scene: 'scene-a' }, mode: 'present' });
+    expect(rec.calls).toEqual(['present']);
+  });
+
+  it('defaults to present when mode is absent (matches effectiveMode)', async () => {
+    const rec = recordingChrome();
+    const scene = buildScene({ id: 'scene-a' });
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([scene]),
+      compositions: createCompositionRegistry([]),
+      stage: buildStage().element,
+      buildCtx: stubCtx,
+      createPreloader: () => () => undefined,
+      timeline: noopTimeline,
+      chrome: rec.chrome,
+    });
+
+    await loader.handle(sceneTarget('scene-a'));
+    expect(rec.calls).toEqual(['present']);
+  });
+
+  it.each([
+    ['standalone'],
+    ['screenshot'],
+    ['loop'],
+    ['paused'],
+    ['scrub'],
+    ['rehearsal'],
+  ] as const)("forwards mode='%s' to chrome.applyMode", async (mode) => {
+    const rec = recordingChrome();
+    const scene = buildScene({ id: 'scene-a' });
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([scene]),
+      compositions: createCompositionRegistry([]),
+      stage: buildStage().element,
+      buildCtx: stubCtx,
+      createPreloader: () => () => undefined,
+      timeline: noopTimeline,
+      chrome: rec.chrome,
+    });
+
+    await loader.handle({ locator: { kind: 'scene', scene: 'scene-a' }, mode });
+    expect(rec.calls).toEqual([mode]);
+  });
+
+  it("forwards mode='prompter' even though the resolver lifecycle is bypassed", async () => {
+    // mode=prompter bypasses scene lifecycle entirely, but chrome
+    // still tracks the URL-addressed mode (preflight: the chrome
+    // policy is mode-driven, not lifecycle-driven).
+    const rec = recordingChrome();
+    const scene = buildScene({ id: 'scene-a' });
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([scene]),
+      compositions: createCompositionRegistry([]),
+      stage: buildStage().element,
+      buildCtx: stubCtx,
+      createPreloader: () => () => undefined,
+      timeline: noopTimeline,
+      chrome: rec.chrome,
+    });
+
+    await loader.handle({ locator: { kind: 'scene', scene: 'scene-a' }, mode: 'prompter' });
+    expect(rec.calls).toEqual(['prompter']);
+  });
+
+  it('calls chrome.applyMode for a `kind: "none"` target (mode still applies even without a scene)', async () => {
+    const rec = recordingChrome();
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([]),
+      compositions: createCompositionRegistry([]),
+      stage: buildStage().element,
+      buildCtx: stubCtx,
+      createPreloader: () => () => undefined,
+      timeline: noopTimeline,
+      chrome: rec.chrome,
+    });
+
+    await loader.handle(noneTarget);
+    expect(rec.calls).toEqual(['present']);
+  });
+
+  it('calls chrome.applyMode BEFORE scene.create(ctx) so chrome is in place when the first frame paints', async () => {
+    const log: string[] = [];
+    const chrome = {
+      applyMode: (mode: NavigationMode) => {
+        log.push(`chrome:${mode}`);
+      },
+    };
+    const scene = buildScene({
+      id: 'scene-a',
+      create: () => {
+        log.push('create:scene-a');
+      },
+      timeline: () => {
+        log.push('timeline:scene-a');
+        return null;
+      },
+      cleanup: () => {
+        log.push('cleanup:scene-a');
+      },
+    });
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([scene]),
+      compositions: createCompositionRegistry([]),
+      stage: buildStage().element,
+      buildCtx: stubCtx,
+      createPreloader: () => () => undefined,
+      timeline: noopTimeline,
+      chrome,
+    });
+
+    await loader.handle({ locator: { kind: 'scene', scene: 'scene-a' }, mode: 'present' });
+    // Pin the exact ordering — chrome MUST flip visibility before
+    // create runs, so a present-mode composition does not flash an
+    // un-chromed frame.
+    expect(log).toEqual([
+      'chrome:present',
+      'create:scene-a',
+      'timeline:scene-a',
+      'cleanup:scene-a',
+    ]);
+  });
+
+  it('calls chrome.applyMode ONCE for a multi-scene composition navigation (persists across scene transitions)', async () => {
+    // PUL-F031 clause: chrome SHALL persist across scene navigations
+    // within a composition without being torn down between scenes.
+    // Structural pin: the loader's dispatch point is upstream of the
+    // resolver's per-scene loop, so a 3-scene composition under
+    // present produces exactly ONE applyMode call.
+    const rec = recordingChrome();
+    const scenes: SceneModule[] = [
+      buildScene({ id: 'scene-a' }),
+      buildScene({ id: 'scene-b' }),
+      buildScene({ id: 'scene-c' }),
+    ];
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry(scenes),
+      compositions: createCompositionRegistry([
+        { id: 'full-talk', manifest: ['scene-a', 'scene-b', 'scene-c'] },
+      ]),
+      stage: buildStage().element,
+      buildCtx: stubCtx,
+      createPreloader: () => () => undefined,
+      timeline: noopTimeline,
+      chrome: rec.chrome,
+    });
+
+    await loader.handle(compositionTarget('full-talk'));
+    expect(rec.calls).toEqual(['present']);
+  });
+
+  it('receives ordered applyMode calls when two sequential navigations flip the mode', async () => {
+    const rec = recordingChrome();
+    const sceneA = buildScene({ id: 'scene-a' });
+    const sceneB = buildScene({ id: 'scene-b' });
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([sceneA, sceneB]),
+      compositions: createCompositionRegistry([]),
+      stage: buildStage().element,
+      buildCtx: stubCtx,
+      createPreloader: () => () => undefined,
+      timeline: noopTimeline,
+      chrome: rec.chrome,
+    });
+
+    await loader.handle({ locator: { kind: 'scene', scene: 'scene-a' }, mode: 'present' });
+    await loader.handle({ locator: { kind: 'scene', scene: 'scene-b' }, mode: 'standalone' });
+    expect(rec.calls).toEqual(['present', 'standalone']);
+  });
+
+  it('applies the URL-addressed mode even when resolution fails (chrome reflects user intent)', async () => {
+    // A `?scene=nonexistent&mode=standalone` URL should still
+    // suppress chrome — the user asked for standalone. The chrome
+    // call lives upstream of resolveSceneNavigation, so the
+    // resolution failure does not skip the chrome flip.
+    const rec = recordingChrome();
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([]),
+      compositions: createCompositionRegistry([]),
+      stage: buildStage().element,
+      buildCtx: stubCtx,
+      createPreloader: () => () => undefined,
+      timeline: noopTimeline,
+      chrome: rec.chrome,
+      onError: () => undefined,
+    });
+
+    await loader.handle({
+      locator: { kind: 'scene', scene: 'nonexistent' },
+      mode: 'standalone',
+    });
+    expect(rec.calls).toEqual(['standalone']);
+  });
+
+  it('does NOT call chrome.applyMode on the parse-error path (chrome persists across malformed URLs)', async () => {
+    const rec = recordingChrome();
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([]),
+      compositions: createCompositionRegistry([]),
+      stage: buildStage().element,
+      buildCtx: stubCtx,
+      createPreloader: () => () => undefined,
+      timeline: noopTimeline,
+      chrome: rec.chrome,
+      onError: () => undefined,
+    });
+
+    loader.handleError(new Error('navigation grammar is invalid: bogus'));
+    await loader.idle();
+    expect(rec.calls).toEqual([]);
+  });
+
+  it('does NOT call chrome.applyMode when validateModeGrammar rejects a hand-built forged mode', async () => {
+    // Defense in depth: a non-parser caller that constructs a
+    // NavigationTarget with a forged mode trips validateModeGrammar
+    // BEFORE chrome would apply. The chrome contract requires a
+    // valid NavigationMode; we MUST NOT apply an invalid mode to
+    // chrome (which would then throw and contaminate the navigation
+    // error path).
+    const rec = recordingChrome();
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([]),
+      compositions: createCompositionRegistry([]),
+      stage: buildStage().element,
+      buildCtx: stubCtx,
+      createPreloader: () => () => undefined,
+      timeline: noopTimeline,
+      chrome: rec.chrome,
+      onError: () => undefined,
+    });
+
+    await loader.handle({
+      locator: { kind: 'scene', scene: 'whatever' },
+      mode: 'made-up-mode' as unknown as NavigationMode,
+    });
+    expect(rec.calls).toEqual([]);
+  });
+
+  it('flips chrome visibility immediately on a superseding navigation, without waiting for the prior loadʼs cleanup (codex review, cycle 1)', async () => {
+    // PUL-F031 clause: chrome is workbench-owned and outside the
+    // scene-lifecycle serialization invariant. A navigation that
+    // flips mode (visible → hidden) MUST hide chrome BEFORE the
+    // prior load's `cleanup(ctx)` drains — otherwise a slow
+    // present-mode cleanup would leave chrome visible while the user
+    // already navigated to standalone / screenshot.
+    let releaseFirstCleanup: () => void = () => undefined;
+    const firstCleanupBlocker = new Promise<void>((resolve) => {
+      releaseFirstCleanup = resolve;
+    });
+    const log: { event: string; mode?: NavigationMode }[] = [];
+    const chrome = {
+      applyMode: (mode: NavigationMode) => {
+        log.push({ event: 'chrome', mode });
+      },
+    };
+    const sceneA = buildScene({
+      id: 'scene-a',
+      cleanup: () => {
+        log.push({ event: 'cleanup:scene-a' });
+        // Holds cleanup until the test releases it — pins that the
+        // SECOND navigation's chrome flip does NOT wait for this.
+        return firstCleanupBlocker;
+      },
+    });
+    const sceneB = buildScene({
+      id: 'scene-b',
+      create: () => {
+        log.push({ event: 'create:scene-b' });
+      },
+    });
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([sceneA, sceneB]),
+      compositions: createCompositionRegistry([]),
+      stage: buildStage().element,
+      buildCtx: stubCtx,
+      createPreloader: () => () => undefined,
+      timeline: noopTimeline,
+      chrome,
+      onError: () => undefined,
+    });
+
+    // First navigation: present-mode scene-a starts. Cleanup will
+    // hang on the blocker until we release it.
+    const first = loader.handle({
+      locator: { kind: 'scene', scene: 'scene-a' },
+      mode: 'present',
+    });
+    // Wait for first navigation's chrome dispatch to happen so the
+    // second call's eagerness is observable.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(log.filter((entry) => entry.event === 'chrome').map((e) => e.mode)).toEqual(['present']);
+
+    // Second navigation: standalone — should hide chrome immediately,
+    // BEFORE scene-a's cleanup drains.
+    const second = loader.handle({
+      locator: { kind: 'scene', scene: 'scene-b' },
+      mode: 'standalone',
+    });
+    // Yield so the synchronous chrome dispatch in `runOnce` runs even
+    // though the queue's `pending.then(...)` is still waiting for
+    // scene-a's cleanup.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    // The chrome dispatch for the second navigation MUST have fired
+    // before scene-a's cleanup released — that is the structural
+    // form of "chrome is workbench-owned, outside scene cleanup."
+    const chromeCalls = log.filter((entry) => entry.event === 'chrome').map((e) => e.mode);
+    expect(chromeCalls).toEqual(['present', 'standalone']);
+
+    // Release the first navigation's cleanup so both promises can
+    // settle and the test does not hang.
+    releaseFirstCleanup();
+    await first;
+    await second;
+  });
+
+  it('surfaces a chrome adapter throw through onError + data-pulsar-navigation-error and skips lifecycle for that event (codex review, cycle 1)', async () => {
+    // PUL-F031 preflight error-envelope clause: chrome-related
+    // failures use the existing onError / data-pulsar-navigation-
+    // error surface. A synchronous adapter throw is a workbench
+    // bootstrap defect; the loader MUST route it through the same
+    // envelope as a grammar failure, and MUST NOT then run scene
+    // lifecycle around an unsynchronized chrome surface.
+    const errors: unknown[] = [];
+    let createRan = false;
+    const stage = buildStage();
+    const scene = buildScene({
+      id: 'scene-a',
+      create: () => {
+        createRan = true;
+      },
+    });
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([scene]),
+      compositions: createCompositionRegistry([]),
+      stage: stage.element,
+      buildCtx: stubCtx,
+      createPreloader: () => () => undefined,
+      timeline: noopTimeline,
+      chrome: {
+        applyMode: () => {
+          throw new Error('chrome adapter exploded');
+        },
+      },
+      onError: (err) => errors.push(err),
+    });
+
+    await loader.handle({ locator: { kind: 'scene', scene: 'scene-a' }, mode: 'present' });
+
+    // The error must reach onError.
+    expect(errors).toHaveLength(1);
+    expect((errors[0] as Error).message).toContain('chrome adapter exploded');
+    // The stage attribute must reflect the navigation failure — the
+    // post-reset surface is the durable diagnostic.
+    expect(stage.attrs.get('data-pulsar-navigation-error')).toContain('chrome adapter exploded');
+    // The lifecycle MUST NOT have run — chrome is in an unknown
+    // state, and proceeding would compound the bootstrap defect.
+    expect(createRan).toBe(false);
+    // Stage's scene/composition attrs must NOT be set — runTarget
+    // never ran.
+    expect(stage.attrs.has('data-pulsar-scene-target')).toBe(false);
+  });
+
+  it('is inert when no chrome adapter is supplied (preserves the existing optional-seam pattern)', async () => {
+    // Mirrors the existing renderPrompter / presenterCommands /
+    // audioUnlockAdapter ergonomics: a loader that has not yet wired
+    // chrome (e.g. Node tests, pre-chrome workbench bootstraps) MUST
+    // NOT throw when the navigation fires AND must still run the
+    // full lifecycle. Asserting only `resolves.toBeUndefined()` would
+    // pass even if a regression silently skipped `runTarget` for
+    // `chrome === undefined` (test-quality review, cycle 1).
+    let createRan = false;
+    let timelineRan = false;
+    let cleanupRan = false;
+    const scene = buildScene({
+      id: 'scene-a',
+      create: () => {
+        createRan = true;
+      },
+      timeline: () => {
+        timelineRan = true;
+        return null;
+      },
+      cleanup: () => {
+        cleanupRan = true;
+      },
+    });
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([scene]),
+      compositions: createCompositionRegistry([]),
+      stage: buildStage().element,
+      buildCtx: stubCtx,
+      createPreloader: () => () => undefined,
+      timeline: noopTimeline,
+      // chrome intentionally omitted
+    });
+
+    await expect(
+      loader.handle({ locator: { kind: 'scene', scene: 'scene-a' }, mode: 'present' }),
+    ).resolves.toBeUndefined();
+    // Pin that the full lifecycle ran — the inert-seam contract is
+    // "chrome absence does not break the rest of the pipeline."
+    expect(createRan).toBe(true);
+    expect(timelineRan).toBe(true);
+    expect(cleanupRan).toBe(true);
+  });
+});

--- a/tests/runtime/workbench-chrome.test.ts
+++ b/tests/runtime/workbench-chrome.test.ts
@@ -1,0 +1,208 @@
+// Tests for the workbench-owned chrome surface — PUL-F031 / ADR-031.
+//
+// Mirrors the `audio-unlock-dom` factory pattern (PUL-F030 / ADR-029):
+// the factory takes injected `mount` + `createSurface` hooks so the
+// chrome contract (mount once at construction, flip visibility on
+// `applyMode`, no DOM writes after `dispose`) is testable against
+// fakes while `main.ts` supplies real `document.createElement` and the
+// production mount.
+
+import { describe, expect, it } from 'vitest';
+
+import { NAVIGATION_MODES, type NavigationMode } from '../../src/runtime/navigation';
+import {
+  type WorkbenchChromeElement,
+  chromeVisibilityFor,
+  createDomWorkbenchChrome,
+} from '../../src/runtime/workbench-chrome';
+
+interface FakeChromeElement extends WorkbenchChromeElement {
+  readonly attrs: ReadonlyMap<string, string>;
+  readonly isHidden: () => boolean;
+  readonly removeCount: () => number;
+}
+
+const buildFakeElement = (): FakeChromeElement => {
+  const attrs = new Map<string, string>();
+  let hidden = false;
+  let removeCount = 0;
+  return {
+    setAttribute: (name, value) => attrs.set(name, value),
+    removeAttribute: (name) => attrs.delete(name),
+    set hidden(value: boolean) {
+      hidden = value;
+    },
+    get hidden(): boolean {
+      return hidden;
+    },
+    remove: () => {
+      removeCount += 1;
+    },
+    attrs,
+    isHidden: () => hidden,
+    removeCount: () => removeCount,
+  };
+};
+
+describe('chromeVisibilityFor (PUL-F031)', () => {
+  it.each([['standalone'], ['screenshot']] as const)(
+    "maps mode='%s' to 'hidden' (requirement statement: chrome SHALL hide)",
+    (mode) => {
+      expect(chromeVisibilityFor(mode)).toBe('hidden');
+    },
+  );
+
+  it.each([['present'], ['loop'], ['paused'], ['scrub'], ['prompter'], ['rehearsal']] as const)(
+    "maps mode='%s' to 'visible' (statement only names standalone/screenshot as hidden)",
+    (mode) => {
+      expect(chromeVisibilityFor(mode)).toBe('visible');
+    },
+  );
+
+  it('covers every NAVIGATION_MODES member', () => {
+    // Future-proofing: when ADR-007 adds a ninth mode the helper MUST
+    // either return a literal visibility for it (extending the table
+    // above) or the policy file forces the author to think about it.
+    // A missing case would default to TypeScript `never` and surface
+    // here.
+    for (const mode of NAVIGATION_MODES) {
+      const visibility = chromeVisibilityFor(mode);
+      expect(['visible', 'hidden']).toContain(visibility);
+    }
+  });
+});
+
+describe('createDomWorkbenchChrome (PUL-F031 / ADR-031)', () => {
+  it('mounts the chrome surface synchronously on construction (before the first navigation can fire)', () => {
+    const mounted: WorkbenchChromeElement[] = [];
+    const element = buildFakeElement();
+    createDomWorkbenchChrome({
+      mount: (el) => {
+        mounted.push(el);
+      },
+      createSurface: () => element,
+    });
+    expect(mounted).toHaveLength(1);
+    expect(mounted[0]).toBe(element);
+  });
+
+  it("applyMode('present') marks chrome visible (data-pulsar-chrome-visibility=visible, hidden=false)", () => {
+    const element = buildFakeElement();
+    const chrome = createDomWorkbenchChrome({
+      mount: () => undefined,
+      createSurface: () => element,
+    });
+    chrome.applyMode('present');
+    expect(element.attrs.get('data-pulsar-chrome-visibility')).toBe('visible');
+    expect(element.isHidden()).toBe(false);
+  });
+
+  it.each([['standalone'], ['screenshot']] as const)(
+    "applyMode('%s') hides chrome (data-pulsar-chrome-visibility=hidden + hidden=true)",
+    (mode) => {
+      const element = buildFakeElement();
+      const chrome = createDomWorkbenchChrome({
+        mount: () => undefined,
+        createSurface: () => element,
+      });
+      chrome.applyMode(mode);
+      expect(element.attrs.get('data-pulsar-chrome-visibility')).toBe('hidden');
+      expect(element.isHidden()).toBe(true);
+    },
+  );
+
+  it.each([['loop'], ['paused'], ['scrub'], ['prompter'], ['rehearsal']] as const)(
+    "applyMode('%s') leaves chrome visible (other modes default to visible per preflight)",
+    (mode) => {
+      const element = buildFakeElement();
+      const chrome = createDomWorkbenchChrome({
+        mount: () => undefined,
+        createSurface: () => element,
+      });
+      chrome.applyMode(mode);
+      expect(element.attrs.get('data-pulsar-chrome-visibility')).toBe('visible');
+      expect(element.isHidden()).toBe(false);
+    },
+  );
+
+  it('toggles deterministically across multiple applyMode calls (persistence across navigations)', () => {
+    // PUL-F031 clause: chrome SHALL persist across scene navigations
+    // within a composition without being torn down between scenes.
+    // Persistence is structural — the element is the same instance,
+    // just with visibility flipped — so toggling MUST NOT recreate or
+    // re-mount the surface.
+    let mountCalls = 0;
+    let createSurfaceCalls = 0;
+    const element = buildFakeElement();
+    const chrome = createDomWorkbenchChrome({
+      mount: () => {
+        mountCalls += 1;
+      },
+      createSurface: () => {
+        createSurfaceCalls += 1;
+        return element;
+      },
+    });
+    chrome.applyMode('present');
+    expect(element.isHidden()).toBe(false);
+    chrome.applyMode('standalone');
+    expect(element.isHidden()).toBe(true);
+    chrome.applyMode('screenshot');
+    expect(element.isHidden()).toBe(true);
+    chrome.applyMode('present');
+    expect(element.isHidden()).toBe(false);
+    // The same element instance — never re-created or re-mounted.
+    expect(mountCalls).toBe(1);
+    expect(createSurfaceCalls).toBe(1);
+    expect(element.removeCount()).toBe(0);
+  });
+
+  it('dispose removes the element from the workbench and silences subsequent applyMode calls', () => {
+    const element = buildFakeElement();
+    const chrome = createDomWorkbenchChrome({
+      mount: () => undefined,
+      createSurface: () => element,
+    });
+    chrome.applyMode('present');
+    expect(element.attrs.get('data-pulsar-chrome-visibility')).toBe('visible');
+    chrome.dispose();
+    expect(element.removeCount()).toBe(1);
+
+    // Post-dispose applyMode MUST be inert — no DOM writes, no
+    // throws. Capture the attrs snapshot to assert nothing changed.
+    const snapshot = new Map(element.attrs);
+    const hiddenSnapshot = element.isHidden();
+    chrome.applyMode('screenshot');
+    expect(new Map(element.attrs)).toEqual(snapshot);
+    expect(element.isHidden()).toBe(hiddenSnapshot);
+  });
+
+  it('dispose is idempotent — calling it twice does not throw or double-remove', () => {
+    const element = buildFakeElement();
+    const chrome = createDomWorkbenchChrome({
+      mount: () => undefined,
+      createSurface: () => element,
+    });
+    chrome.dispose();
+    chrome.dispose();
+    // Element removed exactly once — a second remove would be a
+    // workbench teardown bug (HMR cleanup runs more than once).
+    expect(element.removeCount()).toBe(1);
+  });
+
+  it('applyMode validates the mode against NAVIGATION_MODES (defense in depth against a forged mode)', () => {
+    // The loader already validates `target.mode` via
+    // `validateModeGrammar` before calling chrome.applyMode, but
+    // chrome is exported and a non-loader caller could pass a forged
+    // string. Treat that as a programming error rather than silently
+    // applying an unknown visibility.
+    const element = buildFakeElement();
+    const chrome = createDomWorkbenchChrome({
+      mount: () => undefined,
+      createSurface: () => element,
+    });
+    expect(() => chrome.applyMode('unknown-mode' as unknown as NavigationMode)).toThrow(
+      /workbench chrome: unknown mode/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Land PUL-F031 workbench chrome surface: a workbench-owned DOM root mounted next to #stage at bootstrap, with visibility governed by the active workbench mode (`present`/`loop`/`paused`/`scrub`/`prompter`/`rehearsal` → visible; `standalone`/`screenshot` → hidden), and persistent across scene navigations within a composition. Chrome dispatch is decoupled from the lifecycle queue so a mode flip hides chrome immediately rather than waiting for the prior load's cleanup. Chrome content itself ships empty — presenter UI is owned by PUL-F020 / F021 / F025 — but the structural surface, the mode-governance seam, and the persistence invariant are all delivered with executable tests.

## Requirement UIDs

- `PUL-F031`

## Related Issues

Closes #77

## ADR Impact

- ADR-031
- ADR-016 (amended)

## Changes

- New `src/runtime/workbench-chrome.ts` factory (`createDomWorkbenchChrome`) mirroring the audio-unlock-dom pattern: injected `mount` + `createSurface` hooks, exposes `applyMode(NavigationMode)` and `dispose()`. The pure `chromeVisibilityFor(mode)` helper is the chrome-specific visibility policy.
- Loader integration: optional `chrome?: WorkbenchChromeAdapter` on `SceneLoaderOptions`. Dispatched SYNCHRONOUSLY at `enqueue` (not inside `runTarget`) so a mode flip hides chrome immediately even while the prior scene's cleanup is still draining. Errors are forwarded to `runOnce`, surfaced through the same envelope as grammar/resolution failures after `resetStageAttrs()`, and the lifecycle is skipped for the failing event.
- `src/main.ts` wires `createDomWorkbenchChrome` at workbench bootstrap (before `bootstrapNavigation`) with `role="complementary"` + `aria-label="workbench chrome"`; HMR `dispose()` tears chrome down so re-evaluated entry modules do not accumulate workbench chrome roots.
- New ADR-031 (Workbench Chrome Surface) and amendment to ADR-016 flipping the PUL-F013 present-mode facet table's 'Render full chrome' from absent to delivered (structure). PUL-F013 stays DRAFT pending the other three facets.
- 41 new unit tests across `tests/runtime/workbench-chrome.test.ts` (factory + visibility policy) and `tests/runtime/scene-loader-chrome.test.ts` (dispatch ordering, single-call-per-composition persistence, no-call on parse error / forged mode, eager dispatch under blocked prior cleanup, chrome-throw error envelope, inert-seam lifecycle pin).

## Test Plan

- [x] Unit tests pass (`pnpm test`)
- [x] `pnpm lint && pnpm typecheck && pnpm test` clean
- [x] `pre-commit run --all-files` clean

## Traceability

- IMPLEMENTS: PUL-F031 ← src/runtime/workbench-chrome.ts, PUL-F031 ← src/runtime/scene-loader.ts, PUL-F031 ← src/main.ts, PUL-F031 ← docs/adrs/031-workbench-chrome-surface.md
- TESTS: PUL-F031 ← tests/runtime/workbench-chrome.test.ts, PUL-F031 ← tests/runtime/scene-loader-chrome.test.ts

## Checklist

- [x] Code follows project coding standards
- [x] Changelog fragment added at `changelog.d/77.added.md`
- [x] Architectural docs updated (ADR-031 added, ADR-016 amended)