### PR TITLE
feat: add vertical-slice demo composition (issue 98)

### DIFF
--- a/changelog.d/98.added.md
+++ b/changelog.d/98.added.md
@@ -1,0 +1,27 @@
+Issue 98 — first authored vertical-slice demo. Three real scenes
+under `src/scenes/` (`demo-title.ts`, `demo-feature.ts`, `demo-outro.ts`)
+arranged into a new `demo` composition under `src/compositions/demo.ts`
+and registered through `src/workbench-graph.ts` (single source of
+truth for both `src/main.ts` and the PUL-P002 CI gate). The slice
+exercises the runtime seams together end-to-end: each scene returns a
+real GSAP timeline via `ctx.gsap` with named beats (`title-in`,
+`subtitle-in`, `feature-reveal`, `outro-out`); captions reference
+those beats by label and flow through `buildPrompterScript()` under
+`mode=prompter`; the feature scene declares and consumes a real
+same-origin static asset (`/assets/demo/pulsar-mark.svg`, committed
+under `public/assets/demo/`) so the preloader, the Vite production
+asset surface, and the scene's `<img>` element all participate in the
+slice. Audio is intentionally not wired on the first pass (the
+preflight makes it optional and the asset-policy decision is out of
+scope for this PR). Reachable in the workbench via
+`?composition=demo` (any mode the runtime supports) and
+`?composition=demo&scene=demo-feature&beat=feature-reveal` for
+named-beat seek. New Vitest boundary coverage at
+`tests/runtime/demo-composition.test.ts` and new Playwright coverage
+at `tests-e2e/demo-composition.spec.ts` (chromium / firefox / webkit
+matrix) — the e2e spec fetches the asset path directly to prove the
+committed public asset is actually served by `pnpm preview`. No new
+ADR, scene schema, composition schema, URL grammar, mode, validator
+finding code, runtime abstraction, or workflow added; the existing
+`workbench-graph.test.ts` automatically PUL-F028-validates the new
+scenes and composition with zero findings.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -9,6 +9,7 @@ Design context for Pulsar. Source material for the ADRs in `../adrs/`.
 | [issue-090-complexity-gate-preflight.md](issue-090-complexity-gate-preflight.md) | Guardrails for hardening the existing Biome lint gate with one per-function cognitive-complexity rule. |
 | [issue-091-towncrier-fragments-preflight.md](issue-091-towncrier-fragments-preflight.md) | Guardrails for adopting Towncrier-managed changelog fragments without duplicating release workflow logic. |
 | [issue-097-browser-runtime-smoke-preflight.md](issue-097-browser-runtime-smoke-preflight.md) | Guardrails for expanding browser runtime smoke coverage through the existing Playwright workbench gate. |
+| [issue-098-vertical-slice-demo-preflight.md](issue-098-vertical-slice-demo-preflight.md) | Guardrails for adding authored demo scenes that exercise composition, timeline, captions, assets, and workbench routing through existing runtime seams. |
 | [positioning-and-landscape.md](positioning-and-landscape.md) | Category, adjacent OSS projects, differentiation, strategic risks. |
 | [pul-p002-validation-ci-preflight.md](pul-p002-validation-ci-preflight.md) | Guardrails for gating pull-request CI on the canonical runtime validation pass. |
 | [pul-p003-adr-format-preflight.md](pul-p003-adr-format-preflight.md) | Guardrails for keeping ADR markdown and Ground Control ADR records aligned without duplicate schemas or workflow logic. |

--- a/docs/design/issue-098-vertical-slice-demo-preflight.md
+++ b/docs/design/issue-098-vertical-slice-demo-preflight.md
@@ -1,0 +1,164 @@
+# Issue 98 Vertical-Slice Demo Scenes Preflight
+
+Date: 2026-05-18
+
+Issue 98 asks for authored demo content that exercises the existing
+runtime seams together. It is not a new scene schema, workbench mode,
+asset pipeline, prompter source, router, timeline engine, audio engine,
+or browser workflow.
+
+No new ADR is needed. Existing ADRs already decide the boundaries:
+scene metadata and compositions (ADR-002), GSAP behind `ctx.gsap`
+(ADR-003 / ADR-025 / ADR-026), audio behind `ctx.audio` (ADR-004 /
+ADR-029), DOM/CSS as the default surface (ADR-005), URL workbench
+navigation (ADR-007 / ADR-013 / ADR-014), asset preload (ADR-012),
+prompter mode (ADR-022), validation (ADR-008), scene-level isolation
+(ADR-028), browser support (ADR-030), and workbench chrome (ADR-031).
+
+## Boundary
+
+- Add dedicated demo scene modules under `src/scenes/`. Existing
+  fixture scenes are not the demo and should not be counted as the
+  issue's authored vertical slice.
+- Wire the demo through a declarative composition under
+  `src/compositions/` and register it from `src/workbench-graph.ts`.
+  The workbench URL should address the existing composition grammar,
+  for example `?composition=<demo-id>&mode=<mode>`.
+- Keep `src/runtime/` untouched unless the demo reveals an actual
+  runtime bug. A demo scene should consume runtime seams; it should not
+  define new cross-cutting seams.
+- Keep the default composition's current semantics unless the issue
+  explicitly changes the default route. The demo only needs to be
+  reachable by URL.
+
+## Required Reuse
+
+- Scene schema and validation: `SceneModule`, `Caption`,
+  `assertSceneModule()`, `sceneDeclaresAudio()`, and
+  `createSceneRegistry()`.
+- Composition schema and lookup: `CompositionManifest`,
+  `assertCompositionManifest()`, `createCompositionRegistry()`,
+  `entryId()`, and `findUnregisteredEntries()`.
+- Canonical app graph and validation gate: `WORKBENCH_SCENES`,
+  `WORKBENCH_COMPOSITIONS`, `validateRuntime()`,
+  `assertNoValidationFindings()`, and
+  `tests/runtime/workbench-graph.test.ts`.
+- Timeline seam: `ctx.gsap.timeline()`, GSAP labels as named beats,
+  `assertSceneTimeline()`, `composeMasterTimeline()`,
+  `MasterTimeline`, `sceneTimelineLabel()`, and
+  `createGsapCompositionTimeline()`. Scenes must not import `gsap`.
+- Prompter seam: `scene.captions`, `buildPrompterScript()`,
+  `PrompterScript`, `PrompterRenderer`, and loader `mode=prompter`
+  lifecycle bypass. Do not add prompter-only text or scripts.
+- Asset and audio policy: `scene.assets`, `scene.audio`,
+  `createAssetPreloader()`, `resolveAssetUrl()`,
+  `DEFAULT_ALLOWED_SCHEMES`, `createAudioService()`, and `ctx.audio`.
+  Scenes must not import Howler or construct `Audio` /
+  `HTMLAudioElement`.
+- DOM authoring: use the injected `ctx.stage` and
+  `ctx.stage.ownerDocument` pattern already used by fixture scenes.
+  Cleanup removes scene-owned nodes, listeners, timers, and any
+  scene-local style nodes.
+- Diagnostics: loader `onError`, `data-pulsar-navigation-error`,
+  `data-pulsar-validation-failed`, `data-pulsar-scene-target`,
+  `data-pulsar-composition-target`, and existing error helpers.
+- Workflow: `pnpm test`, `pnpm typecheck`, `pnpm lint`, and
+  `pnpm test:browsers` through the existing Vitest, Biome, Vite, and
+  Playwright configs. Source/test implementation should add a
+  Towncrier fragment; this preflight note alone does not require one.
+
+## Cross-Cutting Layers
+
+| Layer | Guardrail |
+|-------|-----------|
+| URL grammar | Use `parseNavigationSearch()` grammar only: `scene`, `composition`, `index`, `beat`, and `mode`. The demo URL names ids; it must not carry file paths, module specifiers, inline manifests, asset URLs, or script payloads. |
+| Workbench graph validation | Register demo scenes and the demo composition once in `src/workbench-graph.ts`; boot and CI validation must see the same graph. Do not add a test-only registry path or bypass `validateRuntime()`. |
+| Scene schema gate | Every demo scene satisfies `SceneModule` exactly. Captions use `Caption.at` as a non-negative integer or kebab beat label; audio entries, if any, must be members of `scene.assets`. Do not add duplicate DTOs or local validators. |
+| Composition schema gate | The demo composition remains a static `CompositionManifest`. Do not build it with functions, conditionals, env vars, or runtime discovery. The existing PUL-A005 policy gate should continue to classify it as declarative. |
+| Identifier grammar | Scene ids, composition id, beat labels, sound ids, and audio groups use the shared kebab-case rule. Do not copy the regex or invent a relaxed demo-only grammar. |
+| Timeline validation | Named beats are GSAP labels on the scene timeline returned by `timeline(ctx)`. They must be finite, non-negative, within the scene timeline duration, and kebab-case. Do not add a `beats` field to scene metadata. |
+| Prompter data path | Caption acceptance is proven by routing a scene or composition through `mode=prompter` / `buildPrompterScript()`. The prompter path must not mount scene DOM, run timelines, preload assets, or read a second script source. |
+| Asset security | Demo assets should be committed static same-origin assets, preferably served from Vite's public asset surface and referenced with root-relative paths such as `/assets/...`. Avoid `http:`, `https:`, `data:`, `blob:`, `file:`, and protocol-relative URLs unless a specific asset-policy decision is recorded. |
+| Fetch/preload | Asset preload remains `createAssetPreloader({ init: { signal } })` through the loader. Do not preload by constructing `Image`, `<link>`, Howler, or scene-local fetches that bypass resolver ordering and error surfacing. |
+| Audio policy | Audio is optional. If included, declare sources in both `scene.assets` and `scene.audio`, call `ctx.audio.load()` / `play()` from lifecycle or timeline callbacks, and test through the existing unlock/rehearsal/silent policies. Do not add composition-level audio manifests or direct media elements. |
+| Source-policy security | Existing source scans must keep passing: no scene `gsap` imports, no scene Howler imports or `Audio()` construction, no dynamic remote imports, no `eval` / `Function`, no parallel caption source, and no imperative composition dispatch. |
+| Error envelope | Demo failures should surface through existing validation, navigation, resolver, asset, audio, and scene-failure envelopes. Do not log raw scene objects, full scripts, DOM nodes, headers, cookies, env, auth values, or stacks as public diagnostics. |
+| Config/env/OS exposure | The demo needs no auth, secrets, `.env`, `process.env`, `import.meta.env`, `process.argv`, cookies, localStorage, sessionStorage, or history-state fallback. Do not put asset paths or demo selection behind shell flags or secret-bearing URLs. |
+| Persistence/observability | URL remains the only workbench target/mode source. Observability stays DOM attributes, Playwright artifacts, and bounded `onError` diagnostics; no telemetry, analytics, browser storage, or persistent cue logs. |
+
+## Extensibility
+
+The extension seam is the demo composition id plus its manifest. A
+future shorter demo, trailer demo, or alternate ordering should be a
+new composition manifest or a manifest edit, not runtime routing logic
+or scene-level flow control.
+
+Keep per-scene constants for repeated beat names, selectors, and asset
+paths. Promote a shared scene helper only when multiple demo scenes
+need the same non-trivial DOM/context narrowing; do not introduce a
+demo framework on the first pass.
+
+Asset location should be parameterized by a stable same-origin path
+prefix if a scene uses more than one asset. That keeps future asset
+replacement local to the scene metadata and DOM authoring without
+changing the preloader, Vite config, or URL grammar.
+
+## Gotchas
+
+- `assets/` at repo root is not automatically a production Vite static
+  surface. Root-relative demo asset URLs must resolve in `pnpm build`
+  + `pnpm preview`, not only under the dev server.
+- Relative assets with no `baseUrl` pass static scheme validation by
+  design; a browser/e2e check or fetch-backed runtime test should prove
+  the committed path is actually served.
+- Present-mode composition with declared audio triggers the audio
+  unlock gate. Browser tests must satisfy the user gesture flow or use
+  a mode whose audio policy is intentionally silent/logged.
+- `mode=prompter` intentionally bypasses preload, `create`, `timeline`,
+  and `cleanup`. Use it to prove caption aggregation, not visual scene
+  rendering or asset preload.
+- `mode=loop`, `paused`, `scrub`, `screenshot`, and `standalone`
+  truncate composition execution to the head scene. Use `mode=present`
+  or a runtime-boundary composition test when the full demo sequence
+  must run end to end.
+- Composition slices cannot currently repeat the same scene id because
+  activation context is scene-id scoped. Do not repeat demo scene ids
+  in the composition until per-entry activation contexts exist.
+- Existing fixture scenes are intentionally narrow testing surfaces;
+  folding them into the demo would blur fixture coverage with authored
+  demo content.
+
+## Tests
+
+Coverage should sit at runtime boundaries, not inside scene internals:
+
+- A registered-graph validation assertion should stay covered by
+  `tests/runtime/workbench-graph.test.ts`.
+- Add runtime-boundary coverage that resolves the demo composition and
+  observes preload, timeline segments, named beats, captions via
+  `buildPrompterScript()` or a `renderPrompter` spy, and cleanup through
+  existing loader/resolver seams.
+- Playwright is available. Add browser coverage under `tests-e2e/` for
+  at least the reachable demo URL and the public observables needed to
+  prove it mounted without validation/navigation errors and rendered
+  meaningful DOM.
+
+Do not add Puppeteer/Selenium, a second browser command, baseline image
+management, or test-only runtime attributes when existing observables
+or scene-owned `data-pulsar-*` markers can prove the behavior.
+
+## Non-Goals
+
+Issue 98 does not require polished presentation content, new runtime
+features, new workbench modes, presenter UI, visible prompter UI,
+caption editing, export support, dependency upgrades, a new styling
+system, new asset policy, audio mixing, remote asset hosting,
+telemetry, persistence, accessibility expansion beyond existing DOM
+contracts, or requirement status/traceability transitions.
+
+It should not change scene metadata shape, composition manifest shape,
+URL grammar, validation finding codes, exception hierarchy, logging
+framework, navigation lifecycle, asset preloader semantics, audio
+source policy, timeline adapter semantics, browser matrix, or CI
+workflow topology unless the implementation uncovers a real runtime
+defect that must be fixed separately.

--- a/package.json
+++ b/package.json
@@ -36,5 +36,10 @@
   "dependencies": {
     "gsap": "^3.15.0",
     "howler": "^2.2.4"
+  },
+  "pnpm": {
+    "overrides": {
+      "brace-expansion@^5": ">=5.0.6"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  brace-expansion@^5: '>=5.0.6'
+
 importers:
 
   .:
@@ -520,8 +523,8 @@ packages:
   brace-expansion@2.1.0:
     resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   cac@6.7.14:
@@ -1264,7 +1267,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -1428,7 +1431,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimatch@9.0.9:
     dependencies:

--- a/public/assets/demo/pulsar-mark.svg
+++ b/public/assets/demo/pulsar-mark.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" role="img" aria-label="Pulsar mark">
+  <title>Pulsar mark</title>
+  <rect width="200" height="200" fill="#0b1020" />
+  <circle cx="100" cy="100" r="58" fill="none" stroke="#7df5ff" stroke-width="6" />
+  <circle cx="100" cy="100" r="14" fill="#7df5ff" />
+  <line x1="100" y1="20" x2="100" y2="180" stroke="#7df5ff" stroke-width="3" />
+  <line x1="20" y1="100" x2="180" y2="100" stroke="#7df5ff" stroke-width="3" />
+</svg>

--- a/src/compositions/demo.ts
+++ b/src/compositions/demo.ts
@@ -1,0 +1,20 @@
+// Issue 98 — vertical-slice demo composition.
+//
+// A static three-scene manifest that arranges the demo scenes into a
+// composition reachable at `?composition=demo` in the workbench. The
+// manifest is a plain `readonly` array of bare scene-id strings so the
+// PUL-A005 declarative-composition source-policy gate continues to
+// classify it as declarative, the same way it classifies
+// `defaultComposition` in `./default.ts`.
+//
+// Per the codex preflight at
+// `docs/design/issue-098-vertical-slice-demo-preflight.md`: future
+// variants (a short cut, a trailer, an alternate ordering) are a new
+// manifest under `src/compositions/`, not a runtime change or a
+// scene-side flag.
+
+import type { CompositionManifest } from '../runtime/composition';
+
+export const DEMO_COMPOSITION_ID = 'demo';
+
+export const demoComposition: CompositionManifest = ['demo-title', 'demo-feature', 'demo-outro'];

--- a/src/scenes/demo-feature.ts
+++ b/src/scenes/demo-feature.ts
@@ -1,0 +1,199 @@
+// Issue 98 — vertical-slice demo: feature-highlight scene.
+//
+// The second scene in the demo composition. This one declares a real
+// static asset (an SVG mark committed under `public/assets/demo/`),
+// which Vite's default public-asset surface serves at the root path
+// under both `pnpm dev` and `pnpm build` + `pnpm preview`. The
+// preflight at `docs/design/issue-098-vertical-slice-demo-preflight.md`
+// is binding: same-origin asset, no `http://` / `https://` / `data:` /
+// `blob:` URL, no audio (asset-policy decision the issue does not
+// require). The Playwright spec at
+// `tests-e2e/demo-composition.spec.ts` HEAD-fetches the asset URL so
+// "the committed path is actually served" is a runtime check, not just
+// a static-validation pass.
+
+import { NAVIGATION_MODES } from '../runtime/navigation';
+import type { SceneModule } from '../runtime/scene';
+import type { WorkbenchSceneCtx } from '../runtime/scene-loader';
+
+// Exported so the unit + e2e tests assert against ONE constant rather
+// than each duplicating the literal path. A future asset replacement
+// is a one-line edit here.
+export const DEMO_FEATURE_ASSET_URL = '/assets/demo/pulsar-mark.svg';
+
+const ROOT_ATTR = 'data-pulsar-demo-scene';
+const ROOT_VALUE = 'demo-feature';
+const STATE_ATTR = 'data-pulsar-demo-state';
+// See `demo-title.ts` for the rationale on the activation marker —
+// timeline-owned activation keeps the demo composition sequential
+// even though the resolver mounts every scene's root up front.
+const ACTIVE_ATTR = 'data-pulsar-demo-active';
+const FEATURE_IMG_ATTR = 'data-pulsar-demo-feature-img';
+
+const BEAT_FEATURE_REVEAL = 'feature-reveal';
+
+const HEADLINE_TEXT = 'Composition over slides.';
+const BODY_TEXT =
+  'Scenes carry their own timelines, captions, assets, and audio. Compositions arrange them.';
+
+interface FixtureDomElement {
+  setAttribute(name: string, value: string): void;
+  appendChild?(node: unknown): unknown;
+  textContent?: string;
+}
+
+interface FixtureDomFactory {
+  createElement(tag: string): FixtureDomElement;
+}
+
+interface FixtureStageElement {
+  setAttribute(name: string, value: string): void;
+  removeAttribute(name: string): void;
+  appendChild?(node: unknown): unknown;
+  querySelector?(selector: string): {
+    setAttribute?(name: string, value: string): void;
+    remove?(): void;
+  } | null;
+  readonly ownerDocument?: FixtureDomFactory | null;
+}
+
+interface DemoCtx {
+  readonly stage: FixtureStageElement | null;
+  readonly mode: WorkbenchSceneCtx['mode'];
+  readonly gsap: WorkbenchSceneCtx['gsap'];
+}
+
+const isStageShape = (stage: unknown): stage is FixtureStageElement | null => {
+  if (stage === null) return true;
+  if (typeof stage !== 'object') return false;
+  const candidate = stage as Partial<Record<'setAttribute' | 'removeAttribute', unknown>>;
+  return (
+    typeof candidate.setAttribute === 'function' && typeof candidate.removeAttribute === 'function'
+  );
+};
+
+const isGsapShape = (gsap: unknown): gsap is WorkbenchSceneCtx['gsap'] => {
+  if (gsap === null || typeof gsap !== 'object') return false;
+  return typeof (gsap as { timeline?: unknown }).timeline === 'function';
+};
+
+const isDemoCtx = (value: unknown): value is DemoCtx => {
+  if (typeof value !== 'object' || value === null) return false;
+  if (!('stage' in value) || !('mode' in value) || !('gsap' in value)) return false;
+  const { stage, mode, gsap } = value;
+  if (!isStageShape(stage)) return false;
+  if (typeof mode !== 'string' || !(NAVIGATION_MODES as readonly string[]).includes(mode)) {
+    return false;
+  }
+  return isGsapShape(gsap);
+};
+
+const findRoot = (
+  stage: FixtureStageElement,
+): {
+  setAttribute?(name: string, value: string): void;
+  remove?(): void;
+} | null => {
+  if (typeof stage.querySelector !== 'function') return null;
+  return stage.querySelector(`[${ROOT_ATTR}="${ROOT_VALUE}"]`);
+};
+
+const setActive = (
+  root: {
+    setAttribute?(name: string, value: string): void;
+  } | null,
+  active: boolean,
+): void => {
+  if (root === null || typeof root.setAttribute !== 'function') return;
+  root.setAttribute(ACTIVE_ATTR, active ? 'true' : 'false');
+  root.setAttribute('style', active ? '' : 'display: none;');
+};
+
+export const demoFeatureScene: SceneModule = {
+  id: 'demo-feature',
+  title: 'Demo — feature highlight',
+  // See `demo-title.ts` for the rationale: `null` until the timeline
+  // becomes authoritative for prompter / export consumers.
+  duration: null,
+  tags: ['demo'],
+  assets: [DEMO_FEATURE_ASSET_URL],
+  captions: [
+    { at: 0, text: HEADLINE_TEXT },
+    { at: BEAT_FEATURE_REVEAL, text: BODY_TEXT },
+  ],
+  audio: [],
+  defaultNext: 'demo-outro',
+  standalone: false,
+  trailerSafe: true,
+  create: (ctx: unknown) => {
+    if (!isDemoCtx(ctx)) return;
+    const stage = ctx.stage;
+    if (stage === null) return;
+    if (typeof stage.appendChild !== 'function') return;
+    const ownerDoc = stage.ownerDocument;
+    if (ownerDoc === undefined || ownerDoc === null) return;
+    if (typeof ownerDoc.createElement !== 'function') return;
+
+    const root = ownerDoc.createElement('section');
+    root.setAttribute(ROOT_ATTR, ROOT_VALUE);
+    root.setAttribute(STATE_ATTR, 'mounted');
+    // Initially inactive — see demo-title.ts for the rationale.
+    root.setAttribute(ACTIVE_ATTR, 'false');
+    root.setAttribute('style', 'display: none;');
+    if (typeof root.appendChild === 'function') {
+      const heading = ownerDoc.createElement('h2');
+      heading.setAttribute('data-pulsar-demo-headline', '');
+      heading.textContent = HEADLINE_TEXT;
+      root.appendChild(heading);
+
+      // The preloader (PUL-F005) has already warmed `assets[0]` when
+      // this hook runs; the <img> just points at the same URL.
+      const img = ownerDoc.createElement('img');
+      img.setAttribute(FEATURE_IMG_ATTR, '');
+      img.setAttribute('src', DEMO_FEATURE_ASSET_URL);
+      img.setAttribute('alt', 'Pulsar mark');
+      root.appendChild(img);
+
+      const body = ownerDoc.createElement('p');
+      body.setAttribute('data-pulsar-demo-body', '');
+      body.textContent = BODY_TEXT;
+      root.appendChild(body);
+    }
+    stage.appendChild(root);
+  },
+  timeline: (ctx: unknown) => {
+    if (!isDemoCtx(ctx)) return null;
+    const stage = ctx.stage;
+    if (stage === null) return null;
+    const root = findRoot(stage);
+    const tl = ctx.gsap.timeline();
+    tl.call(() => setActive(root, true));
+    tl.to({}, { duration: 1 });
+    tl.addLabel(BEAT_FEATURE_REVEAL, 1);
+    // Trailing mutation rides on the last tween's `onComplete` — see
+    // `src/scenes/demo-title.ts` for the rationale (last-entry master
+    // boundary race).
+    tl.to(
+      {},
+      {
+        duration: 1,
+        onComplete: () => {
+          if (root !== null && typeof root.setAttribute === 'function') {
+            root.setAttribute(STATE_ATTR, 'ran');
+          }
+          setActive(root, false);
+        },
+      },
+    );
+    return tl;
+  },
+  cleanup: (ctx: unknown) => {
+    if (!isDemoCtx(ctx)) return;
+    const stage = ctx.stage;
+    if (stage === null) return;
+    const root = findRoot(stage);
+    if (root !== null && typeof root.remove === 'function') {
+      root.remove();
+    }
+  },
+};

--- a/src/scenes/demo-feature.ts
+++ b/src/scenes/demo-feature.ts
@@ -22,8 +22,6 @@ import { buildDemoTimeline, cleanupDemoRoot, mountDemoRoot } from './demo-shared
 export const DEMO_FEATURE_ASSET_URL = '/assets/demo/pulsar-mark.svg';
 
 const ROOT_VALUE = 'demo-feature';
-const FEATURE_IMG_ATTR = 'data-pulsar-demo-feature-img';
-
 const BEAT_FEATURE_REVEAL = 'feature-reveal';
 
 const HEADLINE_TEXT = 'Composition over slides.';
@@ -49,20 +47,22 @@ export const demoFeatureScene: SceneModule = {
   create: (ctx: unknown) => {
     mountDemoRoot(ctx, ROOT_VALUE, (root, ownerDoc) => {
       const heading = ownerDoc.createElement('h2');
-      heading.setAttribute('data-pulsar-demo-headline', '');
+      // `dataset.pulsarDemoX = ''` is the idiomatic data-* surface —
+      // see `demo-title.ts` for the rationale.
+      if (heading.dataset !== undefined) heading.dataset.pulsarDemoHeadline = '';
       heading.textContent = HEADLINE_TEXT;
       root.appendChild?.(heading);
 
       // The preloader (PUL-F005) has already warmed `assets[0]` when
       // this hook runs; the <img> just points at the same URL.
       const img = ownerDoc.createElement('img');
-      img.setAttribute(FEATURE_IMG_ATTR, '');
+      if (img.dataset !== undefined) img.dataset.pulsarDemoFeatureImg = '';
       img.setAttribute('src', DEMO_FEATURE_ASSET_URL);
       img.setAttribute('alt', 'Pulsar mark');
       root.appendChild?.(img);
 
       const body = ownerDoc.createElement('p');
-      body.setAttribute('data-pulsar-demo-body', '');
+      if (body.dataset !== undefined) body.dataset.pulsarDemoBody = '';
       body.textContent = BODY_TEXT;
       root.appendChild?.(body);
     });

--- a/src/scenes/demo-feature.ts
+++ b/src/scenes/demo-feature.ts
@@ -10,17 +10,11 @@
 // require). The Playwright spec at
 // `tests-e2e/demo-composition.spec.ts` HEAD-fetches the asset URL so
 // "the committed path is actually served" is a runtime check, not just
-// a static-validation pass. Shared defensive helpers (ctx predicate,
-// activation flip, scene-root query) live in `./demo-shared.ts`.
+// a static-validation pass. The shared lifecycle envelope lives in
+// `./demo-shared.ts`; per-scene constants stay here.
 
 import type { SceneModule } from '../runtime/scene';
-import {
-  DEMO_ACTIVE_ATTR,
-  DEMO_ROOT_ATTR,
-  findDemoRoot,
-  isDemoCtx,
-  setDemoActive,
-} from './demo-shared';
+import { buildDemoTimeline, cleanupDemoRoot, mountDemoRoot } from './demo-shared';
 
 // Exported so the unit + e2e tests assert against ONE constant rather
 // than each duplicating the literal path. A future asset replacement
@@ -28,7 +22,6 @@ import {
 export const DEMO_FEATURE_ASSET_URL = '/assets/demo/pulsar-mark.svg';
 
 const ROOT_VALUE = 'demo-feature';
-const STATE_ATTR = 'data-pulsar-demo-state';
 const FEATURE_IMG_ATTR = 'data-pulsar-demo-feature-img';
 
 const BEAT_FEATURE_REVEAL = 'feature-reveal';
@@ -54,24 +47,11 @@ export const demoFeatureScene: SceneModule = {
   standalone: false,
   trailerSafe: true,
   create: (ctx: unknown) => {
-    if (!isDemoCtx(ctx)) return;
-    const stage = ctx.stage;
-    if (stage === null) return;
-    if (typeof stage.appendChild !== 'function') return;
-    const ownerDoc = stage.ownerDocument;
-    if (ownerDoc === undefined || ownerDoc === null) return;
-    if (typeof ownerDoc.createElement !== 'function') return;
-
-    const root = ownerDoc.createElement('section');
-    root.setAttribute(DEMO_ROOT_ATTR, ROOT_VALUE);
-    root.setAttribute(STATE_ATTR, 'mounted');
-    root.setAttribute(DEMO_ACTIVE_ATTR, 'false');
-    root.setAttribute('style', 'display: none;');
-    if (typeof root.appendChild === 'function') {
+    mountDemoRoot(ctx, ROOT_VALUE, (root, ownerDoc) => {
       const heading = ownerDoc.createElement('h2');
       heading.setAttribute('data-pulsar-demo-headline', '');
       heading.textContent = HEADLINE_TEXT;
-      root.appendChild(heading);
+      root.appendChild?.(heading);
 
       // The preloader (PUL-F005) has already warmed `assets[0]` when
       // this hook runs; the <img> just points at the same URL.
@@ -79,45 +59,23 @@ export const demoFeatureScene: SceneModule = {
       img.setAttribute(FEATURE_IMG_ATTR, '');
       img.setAttribute('src', DEMO_FEATURE_ASSET_URL);
       img.setAttribute('alt', 'Pulsar mark');
-      root.appendChild(img);
+      root.appendChild?.(img);
 
       const body = ownerDoc.createElement('p');
       body.setAttribute('data-pulsar-demo-body', '');
       body.textContent = BODY_TEXT;
-      root.appendChild(body);
-    }
-    stage.appendChild(root);
+      root.appendChild?.(body);
+    });
   },
-  timeline: (ctx: unknown) => {
-    if (!isDemoCtx(ctx)) return null;
-    const stage = ctx.stage;
-    if (stage === null) return null;
-    const root = findDemoRoot(stage, ROOT_VALUE);
-    const tl = ctx.gsap.timeline();
-    tl.call(() => setDemoActive(root, true));
-    tl.to({}, { duration: 1 });
-    tl.addLabel(BEAT_FEATURE_REVEAL, 1);
-    tl.to(
-      {},
-      {
-        duration: 1,
-        onComplete: () => {
-          if (root !== null && typeof root.setAttribute === 'function') {
-            root.setAttribute(STATE_ATTR, 'ran');
-          }
-          setDemoActive(root, false);
-        },
+  timeline: (ctx: unknown) =>
+    buildDemoTimeline(
+      ctx,
+      ROOT_VALUE,
+      (tl) => {
+        tl.to({}, { duration: 1 });
+        tl.addLabel(BEAT_FEATURE_REVEAL, 1);
       },
-    );
-    return tl;
-  },
-  cleanup: (ctx: unknown) => {
-    if (!isDemoCtx(ctx)) return;
-    const stage = ctx.stage;
-    if (stage === null) return;
-    const root = findDemoRoot(stage, ROOT_VALUE);
-    if (root !== null && typeof root.remove === 'function') {
-      root.remove();
-    }
-  },
+      1,
+    ),
+  cleanup: cleanupDemoRoot(ROOT_VALUE),
 };

--- a/src/scenes/demo-feature.ts
+++ b/src/scenes/demo-feature.ts
@@ -10,24 +10,25 @@
 // require). The Playwright spec at
 // `tests-e2e/demo-composition.spec.ts` HEAD-fetches the asset URL so
 // "the committed path is actually served" is a runtime check, not just
-// a static-validation pass.
+// a static-validation pass. Shared defensive helpers (ctx predicate,
+// activation flip, scene-root query) live in `./demo-shared.ts`.
 
-import { NAVIGATION_MODES } from '../runtime/navigation';
 import type { SceneModule } from '../runtime/scene';
-import type { WorkbenchSceneCtx } from '../runtime/scene-loader';
+import {
+  DEMO_ACTIVE_ATTR,
+  DEMO_ROOT_ATTR,
+  findDemoRoot,
+  isDemoCtx,
+  setDemoActive,
+} from './demo-shared';
 
 // Exported so the unit + e2e tests assert against ONE constant rather
 // than each duplicating the literal path. A future asset replacement
 // is a one-line edit here.
 export const DEMO_FEATURE_ASSET_URL = '/assets/demo/pulsar-mark.svg';
 
-const ROOT_ATTR = 'data-pulsar-demo-scene';
 const ROOT_VALUE = 'demo-feature';
 const STATE_ATTR = 'data-pulsar-demo-state';
-// See `demo-title.ts` for the rationale on the activation marker —
-// timeline-owned activation keeps the demo composition sequential
-// even though the resolver mounts every scene's root up front.
-const ACTIVE_ATTR = 'data-pulsar-demo-active';
 const FEATURE_IMG_ATTR = 'data-pulsar-demo-feature-img';
 
 const BEAT_FEATURE_REVEAL = 'feature-reveal';
@@ -35,79 +36,6 @@ const BEAT_FEATURE_REVEAL = 'feature-reveal';
 const HEADLINE_TEXT = 'Composition over slides.';
 const BODY_TEXT =
   'Scenes carry their own timelines, captions, assets, and audio. Compositions arrange them.';
-
-interface FixtureDomElement {
-  setAttribute(name: string, value: string): void;
-  appendChild?(node: unknown): unknown;
-  textContent?: string;
-}
-
-interface FixtureDomFactory {
-  createElement(tag: string): FixtureDomElement;
-}
-
-interface FixtureStageElement {
-  setAttribute(name: string, value: string): void;
-  removeAttribute(name: string): void;
-  appendChild?(node: unknown): unknown;
-  querySelector?(selector: string): {
-    setAttribute?(name: string, value: string): void;
-    remove?(): void;
-  } | null;
-  readonly ownerDocument?: FixtureDomFactory | null;
-}
-
-interface DemoCtx {
-  readonly stage: FixtureStageElement | null;
-  readonly mode: WorkbenchSceneCtx['mode'];
-  readonly gsap: WorkbenchSceneCtx['gsap'];
-}
-
-const isStageShape = (stage: unknown): stage is FixtureStageElement | null => {
-  if (stage === null) return true;
-  if (typeof stage !== 'object') return false;
-  const candidate = stage as Partial<Record<'setAttribute' | 'removeAttribute', unknown>>;
-  return (
-    typeof candidate.setAttribute === 'function' && typeof candidate.removeAttribute === 'function'
-  );
-};
-
-const isGsapShape = (gsap: unknown): gsap is WorkbenchSceneCtx['gsap'] => {
-  if (gsap === null || typeof gsap !== 'object') return false;
-  return typeof (gsap as { timeline?: unknown }).timeline === 'function';
-};
-
-const isDemoCtx = (value: unknown): value is DemoCtx => {
-  if (typeof value !== 'object' || value === null) return false;
-  if (!('stage' in value) || !('mode' in value) || !('gsap' in value)) return false;
-  const { stage, mode, gsap } = value;
-  if (!isStageShape(stage)) return false;
-  if (typeof mode !== 'string' || !(NAVIGATION_MODES as readonly string[]).includes(mode)) {
-    return false;
-  }
-  return isGsapShape(gsap);
-};
-
-const findRoot = (
-  stage: FixtureStageElement,
-): {
-  setAttribute?(name: string, value: string): void;
-  remove?(): void;
-} | null => {
-  if (typeof stage.querySelector !== 'function') return null;
-  return stage.querySelector(`[${ROOT_ATTR}="${ROOT_VALUE}"]`);
-};
-
-const setActive = (
-  root: {
-    setAttribute?(name: string, value: string): void;
-  } | null,
-  active: boolean,
-): void => {
-  if (root === null || typeof root.setAttribute !== 'function') return;
-  root.setAttribute(ACTIVE_ATTR, active ? 'true' : 'false');
-  root.setAttribute('style', active ? '' : 'display: none;');
-};
 
 export const demoFeatureScene: SceneModule = {
   id: 'demo-feature',
@@ -135,10 +63,9 @@ export const demoFeatureScene: SceneModule = {
     if (typeof ownerDoc.createElement !== 'function') return;
 
     const root = ownerDoc.createElement('section');
-    root.setAttribute(ROOT_ATTR, ROOT_VALUE);
+    root.setAttribute(DEMO_ROOT_ATTR, ROOT_VALUE);
     root.setAttribute(STATE_ATTR, 'mounted');
-    // Initially inactive — see demo-title.ts for the rationale.
-    root.setAttribute(ACTIVE_ATTR, 'false');
+    root.setAttribute(DEMO_ACTIVE_ATTR, 'false');
     root.setAttribute('style', 'display: none;');
     if (typeof root.appendChild === 'function') {
       const heading = ownerDoc.createElement('h2');
@@ -165,14 +92,11 @@ export const demoFeatureScene: SceneModule = {
     if (!isDemoCtx(ctx)) return null;
     const stage = ctx.stage;
     if (stage === null) return null;
-    const root = findRoot(stage);
+    const root = findDemoRoot(stage, ROOT_VALUE);
     const tl = ctx.gsap.timeline();
-    tl.call(() => setActive(root, true));
+    tl.call(() => setDemoActive(root, true));
     tl.to({}, { duration: 1 });
     tl.addLabel(BEAT_FEATURE_REVEAL, 1);
-    // Trailing mutation rides on the last tween's `onComplete` — see
-    // `src/scenes/demo-title.ts` for the rationale (last-entry master
-    // boundary race).
     tl.to(
       {},
       {
@@ -181,7 +105,7 @@ export const demoFeatureScene: SceneModule = {
           if (root !== null && typeof root.setAttribute === 'function') {
             root.setAttribute(STATE_ATTR, 'ran');
           }
-          setActive(root, false);
+          setDemoActive(root, false);
         },
       },
     );
@@ -191,7 +115,7 @@ export const demoFeatureScene: SceneModule = {
     if (!isDemoCtx(ctx)) return;
     const stage = ctx.stage;
     if (stage === null) return;
-    const root = findRoot(stage);
+    const root = findDemoRoot(stage, ROOT_VALUE);
     if (root !== null && typeof root.remove === 'function') {
       root.remove();
     }

--- a/src/scenes/demo-outro.ts
+++ b/src/scenes/demo-outro.ts
@@ -31,11 +31,13 @@ export const demoOutroScene: SceneModule = {
   create: (ctx: unknown) => {
     mountDemoRoot(ctx, ROOT_VALUE, (root, ownerDoc) => {
       const heading = ownerDoc.createElement('h2');
-      heading.setAttribute('data-pulsar-demo-headline', '');
+      // `dataset.pulsarDemoX = ''` is the idiomatic data-* surface —
+      // see `demo-title.ts` for the rationale.
+      if (heading.dataset !== undefined) heading.dataset.pulsarDemoHeadline = '';
       heading.textContent = HEADLINE_TEXT;
       root.appendChild?.(heading);
       const body = ownerDoc.createElement('p');
-      body.setAttribute('data-pulsar-demo-body', '');
+      if (body.dataset !== undefined) body.dataset.pulsarDemoBody = '';
       body.textContent = BODY_TEXT;
       root.appendChild?.(body);
     });

--- a/src/scenes/demo-outro.ts
+++ b/src/scenes/demo-outro.ts
@@ -1,0 +1,171 @@
+// Issue 98 — vertical-slice demo: closing card.
+//
+// The third (and final) scene in the demo composition. A short
+// authored close — one named GSAP beat (`outro-out`), one caption
+// anchored to it, no assets, no audio. Same defensive ctx-narrowing
+// + ownerDocument allocation pattern as the other two demo scenes.
+
+import { NAVIGATION_MODES } from '../runtime/navigation';
+import type { SceneModule } from '../runtime/scene';
+import type { WorkbenchSceneCtx } from '../runtime/scene-loader';
+
+const ROOT_ATTR = 'data-pulsar-demo-scene';
+const ROOT_VALUE = 'demo-outro';
+const STATE_ATTR = 'data-pulsar-demo-state';
+// See `demo-title.ts` for the rationale on timeline-owned activation.
+const ACTIVE_ATTR = 'data-pulsar-demo-active';
+
+const BEAT_OUTRO_OUT = 'outro-out';
+
+const HEADLINE_TEXT = 'Thanks for watching.';
+const BODY_TEXT = 'Reuse these scenes in another composition, or stretch them with new ones.';
+
+interface FixtureDomElement {
+  setAttribute(name: string, value: string): void;
+  appendChild?(node: unknown): unknown;
+  textContent?: string;
+}
+
+interface FixtureDomFactory {
+  createElement(tag: string): FixtureDomElement;
+}
+
+interface FixtureStageElement {
+  setAttribute(name: string, value: string): void;
+  removeAttribute(name: string): void;
+  appendChild?(node: unknown): unknown;
+  querySelector?(selector: string): {
+    setAttribute?(name: string, value: string): void;
+    remove?(): void;
+  } | null;
+  readonly ownerDocument?: FixtureDomFactory | null;
+}
+
+interface DemoCtx {
+  readonly stage: FixtureStageElement | null;
+  readonly mode: WorkbenchSceneCtx['mode'];
+  readonly gsap: WorkbenchSceneCtx['gsap'];
+}
+
+const isStageShape = (stage: unknown): stage is FixtureStageElement | null => {
+  if (stage === null) return true;
+  if (typeof stage !== 'object') return false;
+  const candidate = stage as Partial<Record<'setAttribute' | 'removeAttribute', unknown>>;
+  return (
+    typeof candidate.setAttribute === 'function' && typeof candidate.removeAttribute === 'function'
+  );
+};
+
+const isGsapShape = (gsap: unknown): gsap is WorkbenchSceneCtx['gsap'] => {
+  if (gsap === null || typeof gsap !== 'object') return false;
+  return typeof (gsap as { timeline?: unknown }).timeline === 'function';
+};
+
+const isDemoCtx = (value: unknown): value is DemoCtx => {
+  if (typeof value !== 'object' || value === null) return false;
+  if (!('stage' in value) || !('mode' in value) || !('gsap' in value)) return false;
+  const { stage, mode, gsap } = value;
+  if (!isStageShape(stage)) return false;
+  if (typeof mode !== 'string' || !(NAVIGATION_MODES as readonly string[]).includes(mode)) {
+    return false;
+  }
+  return isGsapShape(gsap);
+};
+
+const findRoot = (
+  stage: FixtureStageElement,
+): {
+  setAttribute?(name: string, value: string): void;
+  remove?(): void;
+} | null => {
+  if (typeof stage.querySelector !== 'function') return null;
+  return stage.querySelector(`[${ROOT_ATTR}="${ROOT_VALUE}"]`);
+};
+
+const setActive = (
+  root: {
+    setAttribute?(name: string, value: string): void;
+  } | null,
+  active: boolean,
+): void => {
+  if (root === null || typeof root.setAttribute !== 'function') return;
+  root.setAttribute(ACTIVE_ATTR, active ? 'true' : 'false');
+  root.setAttribute('style', active ? '' : 'display: none;');
+};
+
+export const demoOutroScene: SceneModule = {
+  id: 'demo-outro',
+  title: 'Demo — outro',
+  // See `demo-title.ts` for the rationale: `null` until the timeline
+  // becomes authoritative for prompter / export consumers.
+  duration: null,
+  tags: ['demo'],
+  assets: [],
+  captions: [{ at: BEAT_OUTRO_OUT, text: HEADLINE_TEXT }],
+  audio: [],
+  defaultNext: null,
+  standalone: false,
+  trailerSafe: true,
+  create: (ctx: unknown) => {
+    if (!isDemoCtx(ctx)) return;
+    const stage = ctx.stage;
+    if (stage === null) return;
+    if (typeof stage.appendChild !== 'function') return;
+    const ownerDoc = stage.ownerDocument;
+    if (ownerDoc === undefined || ownerDoc === null) return;
+    if (typeof ownerDoc.createElement !== 'function') return;
+
+    const root = ownerDoc.createElement('section');
+    root.setAttribute(ROOT_ATTR, ROOT_VALUE);
+    root.setAttribute(STATE_ATTR, 'mounted');
+    // Initially inactive — see demo-title.ts for the rationale.
+    root.setAttribute(ACTIVE_ATTR, 'false');
+    root.setAttribute('style', 'display: none;');
+    if (typeof root.appendChild === 'function') {
+      const heading = ownerDoc.createElement('h2');
+      heading.setAttribute('data-pulsar-demo-headline', '');
+      heading.textContent = HEADLINE_TEXT;
+      root.appendChild(heading);
+      const body = ownerDoc.createElement('p');
+      body.setAttribute('data-pulsar-demo-body', '');
+      body.textContent = BODY_TEXT;
+      root.appendChild(body);
+    }
+    stage.appendChild(root);
+  },
+  timeline: (ctx: unknown) => {
+    if (!isDemoCtx(ctx)) return null;
+    const stage = ctx.stage;
+    if (stage === null) return null;
+    const root = findRoot(stage);
+    const tl = ctx.gsap.timeline();
+    tl.call(() => setActive(root, true));
+    tl.to({}, { duration: 1 });
+    tl.addLabel(BEAT_OUTRO_OUT, 1);
+    // Trailing mutation rides on the last tween's `onComplete` — see
+    // `src/scenes/demo-title.ts` for the rationale (last-entry master
+    // boundary race).
+    tl.to(
+      {},
+      {
+        duration: 0.5,
+        onComplete: () => {
+          if (root !== null && typeof root.setAttribute === 'function') {
+            root.setAttribute(STATE_ATTR, 'ran');
+          }
+          setActive(root, false);
+        },
+      },
+    );
+    return tl;
+  },
+  cleanup: (ctx: unknown) => {
+    if (!isDemoCtx(ctx)) return;
+    const stage = ctx.stage;
+    if (stage === null) return;
+    const root = findRoot(stage);
+    if (root !== null && typeof root.remove === 'function') {
+      root.remove();
+    }
+  },
+};

--- a/src/scenes/demo-outro.ts
+++ b/src/scenes/demo-outro.ts
@@ -2,21 +2,14 @@
 //
 // The third (and final) scene in the demo composition. A short
 // authored close — one named GSAP beat (`outro-out`), one caption
-// anchored to it, no assets, no audio. Shared defensive helpers
-// (ctx predicate, activation flip, scene-root query) live in
-// `./demo-shared.ts`.
+// anchored to it, no assets, no audio. The shared lifecycle
+// envelope lives in `./demo-shared.ts`; per-scene constants stay
+// here.
 
 import type { SceneModule } from '../runtime/scene';
-import {
-  DEMO_ACTIVE_ATTR,
-  DEMO_ROOT_ATTR,
-  findDemoRoot,
-  isDemoCtx,
-  setDemoActive,
-} from './demo-shared';
+import { buildDemoTimeline, cleanupDemoRoot, mountDemoRoot } from './demo-shared';
 
 const ROOT_VALUE = 'demo-outro';
-const STATE_ATTR = 'data-pulsar-demo-state';
 const BEAT_OUTRO_OUT = 'outro-out';
 
 const HEADLINE_TEXT = 'Thanks for watching.';
@@ -36,61 +29,26 @@ export const demoOutroScene: SceneModule = {
   standalone: false,
   trailerSafe: true,
   create: (ctx: unknown) => {
-    if (!isDemoCtx(ctx)) return;
-    const stage = ctx.stage;
-    if (stage === null) return;
-    if (typeof stage.appendChild !== 'function') return;
-    const ownerDoc = stage.ownerDocument;
-    if (ownerDoc === undefined || ownerDoc === null) return;
-    if (typeof ownerDoc.createElement !== 'function') return;
-
-    const root = ownerDoc.createElement('section');
-    root.setAttribute(DEMO_ROOT_ATTR, ROOT_VALUE);
-    root.setAttribute(STATE_ATTR, 'mounted');
-    root.setAttribute(DEMO_ACTIVE_ATTR, 'false');
-    root.setAttribute('style', 'display: none;');
-    if (typeof root.appendChild === 'function') {
+    mountDemoRoot(ctx, ROOT_VALUE, (root, ownerDoc) => {
       const heading = ownerDoc.createElement('h2');
       heading.setAttribute('data-pulsar-demo-headline', '');
       heading.textContent = HEADLINE_TEXT;
-      root.appendChild(heading);
+      root.appendChild?.(heading);
       const body = ownerDoc.createElement('p');
       body.setAttribute('data-pulsar-demo-body', '');
       body.textContent = BODY_TEXT;
-      root.appendChild(body);
-    }
-    stage.appendChild(root);
+      root.appendChild?.(body);
+    });
   },
-  timeline: (ctx: unknown) => {
-    if (!isDemoCtx(ctx)) return null;
-    const stage = ctx.stage;
-    if (stage === null) return null;
-    const root = findDemoRoot(stage, ROOT_VALUE);
-    const tl = ctx.gsap.timeline();
-    tl.call(() => setDemoActive(root, true));
-    tl.to({}, { duration: 1 });
-    tl.addLabel(BEAT_OUTRO_OUT, 1);
-    tl.to(
-      {},
-      {
-        duration: 0.5,
-        onComplete: () => {
-          if (root !== null && typeof root.setAttribute === 'function') {
-            root.setAttribute(STATE_ATTR, 'ran');
-          }
-          setDemoActive(root, false);
-        },
+  timeline: (ctx: unknown) =>
+    buildDemoTimeline(
+      ctx,
+      ROOT_VALUE,
+      (tl) => {
+        tl.to({}, { duration: 1 });
+        tl.addLabel(BEAT_OUTRO_OUT, 1);
       },
-    );
-    return tl;
-  },
-  cleanup: (ctx: unknown) => {
-    if (!isDemoCtx(ctx)) return;
-    const stage = ctx.stage;
-    if (stage === null) return;
-    const root = findDemoRoot(stage, ROOT_VALUE);
-    if (root !== null && typeof root.remove === 'function') {
-      root.remove();
-    }
-  },
+      0.5,
+    ),
+  cleanup: cleanupDemoRoot(ROOT_VALUE),
 };

--- a/src/scenes/demo-outro.ts
+++ b/src/scenes/demo-outro.ts
@@ -2,96 +2,25 @@
 //
 // The third (and final) scene in the demo composition. A short
 // authored close — one named GSAP beat (`outro-out`), one caption
-// anchored to it, no assets, no audio. Same defensive ctx-narrowing
-// + ownerDocument allocation pattern as the other two demo scenes.
+// anchored to it, no assets, no audio. Shared defensive helpers
+// (ctx predicate, activation flip, scene-root query) live in
+// `./demo-shared.ts`.
 
-import { NAVIGATION_MODES } from '../runtime/navigation';
 import type { SceneModule } from '../runtime/scene';
-import type { WorkbenchSceneCtx } from '../runtime/scene-loader';
+import {
+  DEMO_ACTIVE_ATTR,
+  DEMO_ROOT_ATTR,
+  findDemoRoot,
+  isDemoCtx,
+  setDemoActive,
+} from './demo-shared';
 
-const ROOT_ATTR = 'data-pulsar-demo-scene';
 const ROOT_VALUE = 'demo-outro';
 const STATE_ATTR = 'data-pulsar-demo-state';
-// See `demo-title.ts` for the rationale on timeline-owned activation.
-const ACTIVE_ATTR = 'data-pulsar-demo-active';
-
 const BEAT_OUTRO_OUT = 'outro-out';
 
 const HEADLINE_TEXT = 'Thanks for watching.';
 const BODY_TEXT = 'Reuse these scenes in another composition, or stretch them with new ones.';
-
-interface FixtureDomElement {
-  setAttribute(name: string, value: string): void;
-  appendChild?(node: unknown): unknown;
-  textContent?: string;
-}
-
-interface FixtureDomFactory {
-  createElement(tag: string): FixtureDomElement;
-}
-
-interface FixtureStageElement {
-  setAttribute(name: string, value: string): void;
-  removeAttribute(name: string): void;
-  appendChild?(node: unknown): unknown;
-  querySelector?(selector: string): {
-    setAttribute?(name: string, value: string): void;
-    remove?(): void;
-  } | null;
-  readonly ownerDocument?: FixtureDomFactory | null;
-}
-
-interface DemoCtx {
-  readonly stage: FixtureStageElement | null;
-  readonly mode: WorkbenchSceneCtx['mode'];
-  readonly gsap: WorkbenchSceneCtx['gsap'];
-}
-
-const isStageShape = (stage: unknown): stage is FixtureStageElement | null => {
-  if (stage === null) return true;
-  if (typeof stage !== 'object') return false;
-  const candidate = stage as Partial<Record<'setAttribute' | 'removeAttribute', unknown>>;
-  return (
-    typeof candidate.setAttribute === 'function' && typeof candidate.removeAttribute === 'function'
-  );
-};
-
-const isGsapShape = (gsap: unknown): gsap is WorkbenchSceneCtx['gsap'] => {
-  if (gsap === null || typeof gsap !== 'object') return false;
-  return typeof (gsap as { timeline?: unknown }).timeline === 'function';
-};
-
-const isDemoCtx = (value: unknown): value is DemoCtx => {
-  if (typeof value !== 'object' || value === null) return false;
-  if (!('stage' in value) || !('mode' in value) || !('gsap' in value)) return false;
-  const { stage, mode, gsap } = value;
-  if (!isStageShape(stage)) return false;
-  if (typeof mode !== 'string' || !(NAVIGATION_MODES as readonly string[]).includes(mode)) {
-    return false;
-  }
-  return isGsapShape(gsap);
-};
-
-const findRoot = (
-  stage: FixtureStageElement,
-): {
-  setAttribute?(name: string, value: string): void;
-  remove?(): void;
-} | null => {
-  if (typeof stage.querySelector !== 'function') return null;
-  return stage.querySelector(`[${ROOT_ATTR}="${ROOT_VALUE}"]`);
-};
-
-const setActive = (
-  root: {
-    setAttribute?(name: string, value: string): void;
-  } | null,
-  active: boolean,
-): void => {
-  if (root === null || typeof root.setAttribute !== 'function') return;
-  root.setAttribute(ACTIVE_ATTR, active ? 'true' : 'false');
-  root.setAttribute('style', active ? '' : 'display: none;');
-};
 
 export const demoOutroScene: SceneModule = {
   id: 'demo-outro',
@@ -116,10 +45,9 @@ export const demoOutroScene: SceneModule = {
     if (typeof ownerDoc.createElement !== 'function') return;
 
     const root = ownerDoc.createElement('section');
-    root.setAttribute(ROOT_ATTR, ROOT_VALUE);
+    root.setAttribute(DEMO_ROOT_ATTR, ROOT_VALUE);
     root.setAttribute(STATE_ATTR, 'mounted');
-    // Initially inactive — see demo-title.ts for the rationale.
-    root.setAttribute(ACTIVE_ATTR, 'false');
+    root.setAttribute(DEMO_ACTIVE_ATTR, 'false');
     root.setAttribute('style', 'display: none;');
     if (typeof root.appendChild === 'function') {
       const heading = ownerDoc.createElement('h2');
@@ -137,14 +65,11 @@ export const demoOutroScene: SceneModule = {
     if (!isDemoCtx(ctx)) return null;
     const stage = ctx.stage;
     if (stage === null) return null;
-    const root = findRoot(stage);
+    const root = findDemoRoot(stage, ROOT_VALUE);
     const tl = ctx.gsap.timeline();
-    tl.call(() => setActive(root, true));
+    tl.call(() => setDemoActive(root, true));
     tl.to({}, { duration: 1 });
     tl.addLabel(BEAT_OUTRO_OUT, 1);
-    // Trailing mutation rides on the last tween's `onComplete` — see
-    // `src/scenes/demo-title.ts` for the rationale (last-entry master
-    // boundary race).
     tl.to(
       {},
       {
@@ -153,7 +78,7 @@ export const demoOutroScene: SceneModule = {
           if (root !== null && typeof root.setAttribute === 'function') {
             root.setAttribute(STATE_ATTR, 'ran');
           }
-          setActive(root, false);
+          setDemoActive(root, false);
         },
       },
     );
@@ -163,7 +88,7 @@ export const demoOutroScene: SceneModule = {
     if (!isDemoCtx(ctx)) return;
     const stage = ctx.stage;
     if (stage === null) return;
-    const root = findRoot(stage);
+    const root = findDemoRoot(stage, ROOT_VALUE);
     if (root !== null && typeof root.remove === 'function') {
       root.remove();
     }

--- a/src/scenes/demo-shared.ts
+++ b/src/scenes/demo-shared.ts
@@ -28,13 +28,23 @@ import type { WorkbenchSceneCtx } from '../runtime/scene-loader';
 /**
  * The minimal shape the demo lifecycle hooks need from any element
  * they allocate via `ctx.stage.ownerDocument.createElement`. The
- * `appendChild` / `textContent` members are optional so off-DOM test
- * harnesses can supply bare records without those fields.
+ * `appendChild` / `textContent` / `dataset` members are optional so
+ * off-DOM test harnesses can supply bare records without them.
+ *
+ * `dataset` mirrors `HTMLElement.dataset` — the idiomatic surface
+ * for `data-*` attributes the demo scenes use to mark their authored
+ * children. Sonar's `prefer-dataset` rule prefers it over
+ * `setAttribute('data-...', '')` and the test stub
+ * (`tests/runtime/demo-composition.test.ts`) accordingly proxies
+ * dataset writes back into the same attribute-bag `setAttribute`
+ * uses, so demo unit tests stay agnostic of which surface authored
+ * the attribute.
  */
 export interface DemoDomElement {
   setAttribute(name: string, value: string): void;
   appendChild?(node: unknown): unknown;
   textContent?: string;
+  dataset?: Record<string, string>;
 }
 
 /** The factory `ctx.stage.ownerDocument` exposes to the demo scenes. */

--- a/src/scenes/demo-shared.ts
+++ b/src/scenes/demo-shared.ts
@@ -164,3 +164,121 @@ export const findDemoRoot = (
   if (typeof stage.querySelector !== 'function') return null;
   return stage.querySelector(`[${DEMO_ROOT_ATTR}="${rootValue}"]`);
 };
+
+/** Per-scene state attribute every demo scene flips through `mounted` → `ran`. */
+export const DEMO_STATE_ATTR = 'data-pulsar-demo-state';
+
+/**
+ * Mount the empty scene root with the canonical demo markers and
+ * call the supplied `buildChildren` callback to author scene-
+ * specific children inside it. Returns `null` (silent no-op) when
+ * the ctx is malformed, the stage cannot append, or the owner
+ * document cannot create elements — same defensive contract the
+ * existing fixture scenes use.
+ *
+ * The scene-specific content is the only thing the callback owns;
+ * the marker attributes (`DEMO_ROOT_ATTR`, `DEMO_STATE_ATTR`,
+ * `DEMO_ACTIVE_ATTR`) and the initial inactive-state inline
+ * `display: none;` are written here so every demo scene gets them
+ * identically — the preflight's "no demo framework" rule is honored
+ * by keeping per-scene constants in the scene file and pushing only
+ * the marker boilerplate down here.
+ */
+export const mountDemoRoot = (
+  ctx: unknown,
+  rootValue: string,
+  buildChildren: (root: DemoDomElement, ownerDoc: DemoDomFactory) => void,
+): void => {
+  if (!isDemoCtx(ctx)) return;
+  const stage = ctx.stage;
+  if (stage === null) return;
+  if (typeof stage.appendChild !== 'function') return;
+  const ownerDoc = stage.ownerDocument;
+  if (ownerDoc === undefined || ownerDoc === null) return;
+  if (typeof ownerDoc.createElement !== 'function') return;
+
+  const root = ownerDoc.createElement('section');
+  root.setAttribute(DEMO_ROOT_ATTR, rootValue);
+  root.setAttribute(DEMO_STATE_ATTR, 'mounted');
+  // Initially inactive: the resolver mounts every scene in the slice
+  // before any timeline runs, so a visible-on-create root would
+  // render alongside every sibling scene. Activation flips to true
+  // inside the scene's own timeline segment via `setDemoActive`.
+  root.setAttribute(DEMO_ACTIVE_ATTR, 'false');
+  root.setAttribute('style', 'display: none;');
+  if (typeof root.appendChild === 'function') {
+    buildChildren(root, ownerDoc);
+  }
+  stage.appendChild(root);
+};
+
+/**
+ * Build a scene's GSAP timeline with the activation/deactivation
+ * envelope every demo scene shares. The scene-specific GSAP segments
+ * (named beats, tween durations, intermediate `tl.to({}, ...)` calls)
+ * are authored inside the `buildSegments` callback; the prefix
+ * `tl.call(() => setDemoActive(root, true))` and the suffix tween
+ * whose `onComplete` writes `data-pulsar-demo-state="ran"` and flips
+ * activation back to false live here.
+ *
+ * The suffix is a tween's `onComplete` rather than a trailing
+ * `tl.call(...)` because the last entry in a composition slice has
+ * its child timeline end at master `duration()`; a callback
+ * registered at that exact position races the master's `onComplete`
+ * and may be skipped on the final tick.
+ *
+ * `suffixDuration` controls how long the deactivation tween lasts;
+ * scenes pick a number that matches their visual close (e.g., 1s
+ * for title/feature, 0.5s for outro).
+ *
+ * Returns `null` (silent no-op, same as the existing fixture
+ * scenes) when the ctx is malformed or the stage is absent.
+ */
+export const buildDemoTimeline = (
+  ctx: unknown,
+  rootValue: string,
+  buildSegments: (
+    tl: ReturnType<WorkbenchSceneCtx['gsap']['timeline']>,
+    root: ReturnType<typeof findDemoRoot>,
+  ) => void,
+  suffixDuration: number,
+): ReturnType<WorkbenchSceneCtx['gsap']['timeline']> | null => {
+  if (!isDemoCtx(ctx)) return null;
+  const stage = ctx.stage;
+  if (stage === null) return null;
+  const root = findDemoRoot(stage, rootValue);
+  const tl = ctx.gsap.timeline();
+  tl.call(() => setDemoActive(root, true));
+  buildSegments(tl, root);
+  tl.to(
+    {},
+    {
+      duration: suffixDuration,
+      onComplete: () => {
+        if (root !== null && typeof root.setAttribute === 'function') {
+          root.setAttribute(DEMO_STATE_ATTR, 'ran');
+        }
+        setDemoActive(root, false);
+      },
+    },
+  );
+  return tl;
+};
+
+/**
+ * Build a cleanup lifecycle hook that removes the scene root keyed
+ * by `rootValue`. Every demo scene's cleanup is structurally
+ * identical (find by attribute, remove if attached), so the factory
+ * removes the per-scene boilerplate entirely.
+ */
+export const cleanupDemoRoot =
+  (rootValue: string) =>
+  (ctx: unknown): void => {
+    if (!isDemoCtx(ctx)) return;
+    const stage = ctx.stage;
+    if (stage === null) return;
+    const root = findDemoRoot(stage, rootValue);
+    if (root !== null && typeof root.remove === 'function') {
+      root.remove();
+    }
+  };

--- a/src/scenes/demo-shared.ts
+++ b/src/scenes/demo-shared.ts
@@ -1,0 +1,166 @@
+// Issue 98 — shared helpers for the vertical-slice demo scenes.
+//
+// The codex preflight at
+// `docs/design/issue-098-vertical-slice-demo-preflight.md` is
+// explicit: "Promote a shared scene helper only when multiple demo
+// scenes need the same non-trivial DOM/context narrowing; do not
+// introduce a demo framework on the first pass." The three demo
+// scenes (`demo-title.ts`, `demo-feature.ts`, `demo-outro.ts`) each
+// need the same defensive ctx-narrowing predicate, the same
+// timeline-owned activation helper, and the same root-finding query;
+// keeping the helpers inline in each scene was triggering Sonar's
+// duplicated-lines gate (32% on the diff under the 3% bar) AND was
+// the kind of copy-paste drift the preflight names. Extracting THESE
+// helpers — and nothing else — is the minimum shared surface that
+// closes the duplication without becoming a "demo framework": per-
+// scene constants (beat names, selectors, asset paths, copy text)
+// still live next to the scene that owns them, and each scene's
+// lifecycle hooks are still authored in the scene file.
+//
+// This module is intentionally NOT a runtime abstraction: it does
+// not extend the scene schema, the composition model, or the
+// validator. The runtime sees only `SceneModule` instances; this
+// file is authoring infrastructure for the three demo scenes.
+
+import { NAVIGATION_MODES } from '../runtime/navigation';
+import type { WorkbenchSceneCtx } from '../runtime/scene-loader';
+
+/**
+ * The minimal shape the demo lifecycle hooks need from any element
+ * they allocate via `ctx.stage.ownerDocument.createElement`. The
+ * `appendChild` / `textContent` members are optional so off-DOM test
+ * harnesses can supply bare records without those fields.
+ */
+export interface DemoDomElement {
+  setAttribute(name: string, value: string): void;
+  appendChild?(node: unknown): unknown;
+  textContent?: string;
+}
+
+/** The factory `ctx.stage.ownerDocument` exposes to the demo scenes. */
+export interface DemoDomFactory {
+  createElement(tag: string): DemoDomElement;
+}
+
+/**
+ * The stage subset the demo scenes use. Matches the
+ * `FixtureStageElement` shape `browser-support-fixture.ts` and
+ * `dom-css-accessibility-fixture.ts` declare locally, with the
+ * `setAttribute?` extension on the queryselector result so the
+ * timeline-owned activation pattern can mutate found nodes.
+ */
+export interface DemoStageElement {
+  setAttribute(name: string, value: string): void;
+  removeAttribute(name: string): void;
+  appendChild?(node: unknown): unknown;
+  querySelector?(selector: string): {
+    setAttribute?(name: string, value: string): void;
+    remove?(): void;
+  } | null;
+  readonly ownerDocument?: DemoDomFactory | null;
+}
+
+/**
+ * The ctx narrowing every demo scene uses. Reading three of
+ * `WorkbenchSceneCtx`'s fields (`stage`, `mode`, `gsap`); a
+ * malformed ctx (no stage, unknown mode, non-gsap engine) is a
+ * silent no-op — same defensive pattern the existing fixture scenes
+ * use.
+ */
+export interface DemoCtx {
+  readonly stage: DemoStageElement | null;
+  readonly mode: WorkbenchSceneCtx['mode'];
+  readonly gsap: WorkbenchSceneCtx['gsap'];
+}
+
+const isStageShape = (stage: unknown): stage is DemoStageElement | null => {
+  if (stage === null) return true;
+  if (typeof stage !== 'object') return false;
+  const candidate = stage as Partial<Record<'setAttribute' | 'removeAttribute', unknown>>;
+  return (
+    typeof candidate.setAttribute === 'function' && typeof candidate.removeAttribute === 'function'
+  );
+};
+
+const isGsapShape = (gsap: unknown): gsap is WorkbenchSceneCtx['gsap'] => {
+  if (gsap === null || typeof gsap !== 'object') return false;
+  return typeof (gsap as { timeline?: unknown }).timeline === 'function';
+};
+
+/**
+ * Identical narrowing predicate every demo scene uses. Returns true
+ * iff `value` exposes `stage` / `mode` / `gsap` with the documented
+ * shapes; lifecycle hooks treat a `false` return as a silent no-op
+ * to match the existing fixture scenes' defensive contract.
+ */
+export const isDemoCtx = (value: unknown): value is DemoCtx => {
+  if (typeof value !== 'object' || value === null) return false;
+  if (!('stage' in value) || !('mode' in value) || !('gsap' in value)) return false;
+  const { stage, mode, gsap } = value;
+  if (!isStageShape(stage)) return false;
+  if (typeof mode !== 'string' || !(NAVIGATION_MODES as readonly string[]).includes(mode)) {
+    return false;
+  }
+  return isGsapShape(gsap);
+};
+
+/**
+ * The DOM marker every demo scene root carries. Per-scene constants
+ * stay scene-local (each scene defines its own `ROOT_VALUE` so the
+ * scene id and the marker value share one source of truth in that
+ * file); the attribute name is shared because the e2e spec queries
+ * by `[data-pulsar-demo-scene="<id>"]` regardless of which scene
+ * mounted the root.
+ */
+export const DEMO_ROOT_ATTR = 'data-pulsar-demo-scene';
+
+/**
+ * The activation marker every demo scene's timeline flips at the
+ * start and end of its own segment. The composition resolver mounts
+ * every scene's root BEFORE the master timeline runs (PUL-F004 /
+ * ADR-025), so a scene that is visible from `create(ctx)` would
+ * render simultaneously with every other scene. Setting this marker
+ * to `"false"` (and the inline `display: none;` companion below) in
+ * `create(ctx)` and flipping to `"true"` inside the scene's own
+ * timeline segment keeps the composition sequential.
+ */
+export const DEMO_ACTIVE_ATTR = 'data-pulsar-demo-active';
+
+/**
+ * Flip a scene root's `data-pulsar-demo-active` marker AND its
+ * inline `display` style in one call so the start-of-segment and
+ * end-of-segment activation/deactivation stays symmetric.
+ *
+ * `null` root is a no-op (off-DOM test harness path matching the
+ * existing fixture scenes' silent-on-missing contract). Inline
+ * `style` mutation instead of relying on production CSS, because the
+ * workbench currently ships no CSS and relying on an external rule
+ * would leave the demo visually layered even when the marker said
+ * "inactive".
+ */
+export const setDemoActive = (
+  root: {
+    setAttribute?(name: string, value: string): void;
+  } | null,
+  active: boolean,
+): void => {
+  if (root === null || typeof root.setAttribute !== 'function') return;
+  root.setAttribute(DEMO_ACTIVE_ATTR, active ? 'true' : 'false');
+  root.setAttribute('style', active ? '' : 'display: none;');
+};
+
+/**
+ * Locate a scene's root via `[data-pulsar-demo-scene="<rootValue>"]`.
+ * Returns `null` when the stage does not expose `querySelector` (off-
+ * DOM test harness path).
+ */
+export const findDemoRoot = (
+  stage: DemoStageElement,
+  rootValue: string,
+): {
+  setAttribute?(name: string, value: string): void;
+  remove?(): void;
+} | null => {
+  if (typeof stage.querySelector !== 'function') return null;
+  return stage.querySelector(`[${DEMO_ROOT_ATTR}="${rootValue}"]`);
+};

--- a/src/scenes/demo-title.ts
+++ b/src/scenes/demo-title.ts
@@ -9,118 +9,26 @@
 // binding: this scene reuses `ctx.gsap`, `ctx.stage.ownerDocument`,
 // the existing scene schema, and the existing identifier grammar; it
 // adds no new ADR, mode, asset pipeline, audio engine, or runtime
-// abstraction.
+// abstraction. Shared defensive helpers (the ctx predicate, the
+// activation marker flip, the scene-root query) live in
+// `./demo-shared.ts` — see that file's header for the rationale.
 
-import { NAVIGATION_MODES } from '../runtime/navigation';
 import type { SceneModule } from '../runtime/scene';
-import type { WorkbenchSceneCtx } from '../runtime/scene-loader';
+import {
+  DEMO_ACTIVE_ATTR,
+  DEMO_ROOT_ATTR,
+  findDemoRoot,
+  isDemoCtx,
+  setDemoActive,
+} from './demo-shared';
 
-// Stable DOM marker shared by all three demo scenes; the e2e spec
-// asserts the scene root mounts so blank-stage regressions surface
-// as a layout-or-mount problem rather than a failure to compile the
-// scene. Per-scene constants so each scene owns its own attribute
-// key — the preflight is explicit about avoiding a "demo framework"
-// on the first pass.
-const ROOT_ATTR = 'data-pulsar-demo-scene';
 const ROOT_VALUE = 'demo-title';
 const STATE_ATTR = 'data-pulsar-demo-state';
-// Timeline-owned activation marker. The composition resolver mounts
-// every scene's root before the master timeline runs (ADR-025), so a
-// scene that is visible from `create(ctx)` would render alongside
-// every other scene at once. The activation marker AND the inline
-// `display` style are flipped from `false` / `none` to `true` / `''`
-// by a `tl.call(...)` at the start of this scene's timeline segment
-// and back at its end. Result: only the currently-playing scene is
-// active, which is what a sequential composition is supposed to look
-// like. Per-scene constant so each scene owns its own marker.
-const ACTIVE_ATTR = 'data-pulsar-demo-active';
-
 const BEAT_TITLE_IN = 'title-in';
 const BEAT_SUBTITLE_IN = 'subtitle-in';
 
 const TITLE_TEXT = 'Pulsar';
 const SUBTITLE_TEXT = 'A scene-and-composition runtime for cinematic browser presentations.';
-
-interface FixtureDomElement {
-  setAttribute(name: string, value: string): void;
-  appendChild?(node: unknown): unknown;
-  textContent?: string;
-}
-
-interface FixtureDomFactory {
-  createElement(tag: string): FixtureDomElement;
-}
-
-interface FixtureStageElement {
-  setAttribute(name: string, value: string): void;
-  removeAttribute(name: string): void;
-  appendChild?(node: unknown): unknown;
-  querySelector?(selector: string): {
-    setAttribute?(name: string, value: string): void;
-    remove?(): void;
-  } | null;
-  readonly ownerDocument?: FixtureDomFactory | null;
-}
-
-interface DemoCtx {
-  readonly stage: FixtureStageElement | null;
-  readonly mode: WorkbenchSceneCtx['mode'];
-  readonly gsap: WorkbenchSceneCtx['gsap'];
-}
-
-const isStageShape = (stage: unknown): stage is FixtureStageElement | null => {
-  if (stage === null) return true;
-  if (typeof stage !== 'object') return false;
-  const candidate = stage as Partial<Record<'setAttribute' | 'removeAttribute', unknown>>;
-  return (
-    typeof candidate.setAttribute === 'function' && typeof candidate.removeAttribute === 'function'
-  );
-};
-
-const isGsapShape = (gsap: unknown): gsap is WorkbenchSceneCtx['gsap'] => {
-  if (gsap === null || typeof gsap !== 'object') return false;
-  return typeof (gsap as { timeline?: unknown }).timeline === 'function';
-};
-
-const isDemoCtx = (value: unknown): value is DemoCtx => {
-  if (typeof value !== 'object' || value === null) return false;
-  if (!('stage' in value) || !('mode' in value) || !('gsap' in value)) return false;
-  const { stage, mode, gsap } = value;
-  if (!isStageShape(stage)) return false;
-  if (typeof mode !== 'string' || !(NAVIGATION_MODES as readonly string[]).includes(mode)) {
-    return false;
-  }
-  return isGsapShape(gsap);
-};
-
-const findRoot = (
-  stage: FixtureStageElement,
-): {
-  setAttribute?(name: string, value: string): void;
-  remove?(): void;
-} | null => {
-  if (typeof stage.querySelector !== 'function') return null;
-  return stage.querySelector(`[${ROOT_ATTR}="${ROOT_VALUE}"]`);
-};
-
-// Flip the scene root's activation marker + inline display style in
-// one place so the start-of-segment and end-of-segment `tl.call(...)`s
-// stay symmetric. `null` root is a no-op (off-DOM test harness) so
-// these are safe to invoke unconditionally.
-const setActive = (
-  root: {
-    setAttribute?(name: string, value: string): void;
-  } | null,
-  active: boolean,
-): void => {
-  if (root === null || typeof root.setAttribute !== 'function') return;
-  root.setAttribute(ACTIVE_ATTR, active ? 'true' : 'false');
-  // Inline-style activation rather than relying on production CSS,
-  // because the workbench currently ships no CSS — relying on an
-  // external rule would leave the demo visually layered even when the
-  // marker said "inactive". Inline keeps the demo self-contained.
-  root.setAttribute('style', active ? '' : 'display: none;');
-};
 
 export const demoTitleScene: SceneModule = {
   id: 'demo-title',
@@ -155,13 +63,13 @@ export const demoTitleScene: SceneModule = {
     if (typeof ownerDoc.createElement !== 'function') return;
 
     const root = ownerDoc.createElement('section');
-    root.setAttribute(ROOT_ATTR, ROOT_VALUE);
+    root.setAttribute(DEMO_ROOT_ATTR, ROOT_VALUE);
     root.setAttribute(STATE_ATTR, 'mounted');
     // Initially inactive: the resolver mounts every scene in the
     // slice before any timeline runs, so a visible-on-create root
     // would render alongside every sibling scene. Activation flips
     // to true inside the scene's own timeline segment.
-    root.setAttribute(ACTIVE_ATTR, 'false');
+    root.setAttribute(DEMO_ACTIVE_ATTR, 'false');
     root.setAttribute('style', 'display: none;');
     if (typeof root.appendChild === 'function') {
       const title = ownerDoc.createElement('h1');
@@ -179,32 +87,22 @@ export const demoTitleScene: SceneModule = {
     if (!isDemoCtx(ctx)) return null;
     const stage = ctx.stage;
     if (stage === null) return null;
-    const root = findRoot(stage);
+    const root = findDemoRoot(stage, ROOT_VALUE);
     // GSAP labels are the named beats the URL / prompter / future
     // beat-seek surface address. We add them on the scene's own
     // timeline so `composeMasterTimeline` translates them into
     // `scene("demo-title").label("title-in")` master labels per
-    // `sceneTimelineLabel` in `src/runtime/timeline.ts`.
-    //
-    // Timeline-owned activation: the first `tl.call(...)` flips the
-    // root from inactive to active (visible); the trailing
-    // `tl.call(...)` flips it back. Wrapping the work in `tl.call`
-    // (rather than `tl.set` on the element) keeps the test stub —
-    // which is not a real DOM element — happy.
+    // `sceneTimelineLabel` in `src/runtime/timeline.ts`. The trailing
+    // mutation rides on the last tween's `onComplete` rather than a
+    // post-tween `tl.call(...)` because the last entry in a
+    // composition slice has its child timeline end at master
+    // duration, and a callback at that exact position races the
+    // master's `onComplete` and may be skipped.
     const tl = ctx.gsap.timeline();
-    tl.call(() => setActive(root, true));
+    tl.call(() => setDemoActive(root, true));
     tl.addLabel(BEAT_TITLE_IN, 0);
     tl.to({}, { duration: 1 });
     tl.addLabel(BEAT_SUBTITLE_IN, 1);
-    // Pin the terminal mutation to a tween's `onComplete` rather than
-    // a trailing `tl.call(...)`: when a scene is the LAST entry in the
-    // composition slice its child timeline ends at master time
-    // `master.duration()`, and a callback registered at that exact
-    // position races the master's `onComplete` and may be skipped on
-    // the final tick. A tween's `onComplete` fires when the tween
-    // itself ends, which is what every other scene timeline in this
-    // runtime relies on — see the browser-support fixture's
-    // terminating `tl.call` after a non-trailing `.to`.
     tl.to(
       {},
       {
@@ -213,7 +111,7 @@ export const demoTitleScene: SceneModule = {
           if (root !== null && typeof root.setAttribute === 'function') {
             root.setAttribute(STATE_ATTR, 'ran');
           }
-          setActive(root, false);
+          setDemoActive(root, false);
         },
       },
     );
@@ -223,7 +121,7 @@ export const demoTitleScene: SceneModule = {
     if (!isDemoCtx(ctx)) return;
     const stage = ctx.stage;
     if (stage === null) return;
-    const root = findRoot(stage);
+    const root = findDemoRoot(stage, ROOT_VALUE);
     if (root !== null && typeof root.remove === 'function') {
       root.remove();
     }

--- a/src/scenes/demo-title.ts
+++ b/src/scenes/demo-title.ts
@@ -50,11 +50,15 @@ export const demoTitleScene: SceneModule = {
   create: (ctx: unknown) => {
     mountDemoRoot(ctx, ROOT_VALUE, (root, ownerDoc) => {
       const title = ownerDoc.createElement('h1');
-      title.setAttribute('data-pulsar-demo-title', '');
+      // `dataset.pulsarDemoTitle = ''` is the idiomatic surface for
+      // `data-*` attributes — Sonar's prefer-dataset rule flags
+      // `setAttribute('data-...', '')` and the test stub mirrors
+      // dataset writes so this stays test-compatible.
+      if (title.dataset !== undefined) title.dataset.pulsarDemoTitle = '';
       title.textContent = TITLE_TEXT;
       root.appendChild?.(title);
       const subtitle = ownerDoc.createElement('p');
-      subtitle.setAttribute('data-pulsar-demo-subtitle', '');
+      if (subtitle.dataset !== undefined) subtitle.dataset.pulsarDemoSubtitle = '';
       subtitle.textContent = SUBTITLE_TEXT;
       root.appendChild?.(subtitle);
     });

--- a/src/scenes/demo-title.ts
+++ b/src/scenes/demo-title.ts
@@ -9,21 +9,17 @@
 // binding: this scene reuses `ctx.gsap`, `ctx.stage.ownerDocument`,
 // the existing scene schema, and the existing identifier grammar; it
 // adds no new ADR, mode, asset pipeline, audio engine, or runtime
-// abstraction. Shared defensive helpers (the ctx predicate, the
-// activation marker flip, the scene-root query) live in
-// `./demo-shared.ts` — see that file's header for the rationale.
+// abstraction. The lifecycle envelope (defensive ctx narrowing, root
+// mount with the activation marker, the activation/deactivation
+// timeline wrap, cleanup) lives in `./demo-shared.ts` — see that
+// file's header for the rationale. Per-scene constants (beat names,
+// copy text) stay here per the preflight's "no demo framework on
+// first pass" rule.
 
 import type { SceneModule } from '../runtime/scene';
-import {
-  DEMO_ACTIVE_ATTR,
-  DEMO_ROOT_ATTR,
-  findDemoRoot,
-  isDemoCtx,
-  setDemoActive,
-} from './demo-shared';
+import { buildDemoTimeline, cleanupDemoRoot, mountDemoRoot } from './demo-shared';
 
 const ROOT_VALUE = 'demo-title';
-const STATE_ATTR = 'data-pulsar-demo-state';
 const BEAT_TITLE_IN = 'title-in';
 const BEAT_SUBTITLE_IN = 'subtitle-in';
 
@@ -37,8 +33,6 @@ export const demoTitleScene: SceneModule = {
   // `timeline(ctx)` constructs, and PUL-F001 / ADR-002 explicitly
   // treats a divergence between `duration` metadata and the actual
   // GSAP timeline as a drift risk for prompter / export consumers.
-  // Promoting this to an authoritative integer is a follow-up if /
-  // when scene authoring needs scrub-bar metadata.
   duration: null,
   tags: ['demo'],
   assets: [],
@@ -54,76 +48,33 @@ export const demoTitleScene: SceneModule = {
   standalone: true,
   trailerSafe: true,
   create: (ctx: unknown) => {
-    if (!isDemoCtx(ctx)) return;
-    const stage = ctx.stage;
-    if (stage === null) return;
-    if (typeof stage.appendChild !== 'function') return;
-    const ownerDoc = stage.ownerDocument;
-    if (ownerDoc === undefined || ownerDoc === null) return;
-    if (typeof ownerDoc.createElement !== 'function') return;
-
-    const root = ownerDoc.createElement('section');
-    root.setAttribute(DEMO_ROOT_ATTR, ROOT_VALUE);
-    root.setAttribute(STATE_ATTR, 'mounted');
-    // Initially inactive: the resolver mounts every scene in the
-    // slice before any timeline runs, so a visible-on-create root
-    // would render alongside every sibling scene. Activation flips
-    // to true inside the scene's own timeline segment.
-    root.setAttribute(DEMO_ACTIVE_ATTR, 'false');
-    root.setAttribute('style', 'display: none;');
-    if (typeof root.appendChild === 'function') {
+    mountDemoRoot(ctx, ROOT_VALUE, (root, ownerDoc) => {
       const title = ownerDoc.createElement('h1');
       title.setAttribute('data-pulsar-demo-title', '');
       title.textContent = TITLE_TEXT;
-      root.appendChild(title);
+      root.appendChild?.(title);
       const subtitle = ownerDoc.createElement('p');
       subtitle.setAttribute('data-pulsar-demo-subtitle', '');
       subtitle.textContent = SUBTITLE_TEXT;
-      root.appendChild(subtitle);
-    }
-    stage.appendChild(root);
+      root.appendChild?.(subtitle);
+    });
   },
-  timeline: (ctx: unknown) => {
-    if (!isDemoCtx(ctx)) return null;
-    const stage = ctx.stage;
-    if (stage === null) return null;
-    const root = findDemoRoot(stage, ROOT_VALUE);
-    // GSAP labels are the named beats the URL / prompter / future
-    // beat-seek surface address. We add them on the scene's own
-    // timeline so `composeMasterTimeline` translates them into
-    // `scene("demo-title").label("title-in")` master labels per
-    // `sceneTimelineLabel` in `src/runtime/timeline.ts`. The trailing
-    // mutation rides on the last tween's `onComplete` rather than a
-    // post-tween `tl.call(...)` because the last entry in a
-    // composition slice has its child timeline end at master
-    // duration, and a callback at that exact position races the
-    // master's `onComplete` and may be skipped.
-    const tl = ctx.gsap.timeline();
-    tl.call(() => setDemoActive(root, true));
-    tl.addLabel(BEAT_TITLE_IN, 0);
-    tl.to({}, { duration: 1 });
-    tl.addLabel(BEAT_SUBTITLE_IN, 1);
-    tl.to(
-      {},
-      {
-        duration: 1,
-        onComplete: () => {
-          if (root !== null && typeof root.setAttribute === 'function') {
-            root.setAttribute(STATE_ATTR, 'ran');
-          }
-          setDemoActive(root, false);
-        },
+  timeline: (ctx: unknown) =>
+    buildDemoTimeline(
+      ctx,
+      ROOT_VALUE,
+      (tl) => {
+        // GSAP labels are the named beats the URL / prompter / future
+        // beat-seek surface address. `composeMasterTimeline`
+        // translates each label into a `sceneTimelineLabel`-namespaced
+        // master label per `src/runtime/timeline.ts`. The leading
+        // activation call and the trailing deactivation tween are
+        // owned by `buildDemoTimeline`.
+        tl.addLabel(BEAT_TITLE_IN, 0);
+        tl.to({}, { duration: 1 });
+        tl.addLabel(BEAT_SUBTITLE_IN, 1);
       },
-    );
-    return tl;
-  },
-  cleanup: (ctx: unknown) => {
-    if (!isDemoCtx(ctx)) return;
-    const stage = ctx.stage;
-    if (stage === null) return;
-    const root = findDemoRoot(stage, ROOT_VALUE);
-    if (root !== null && typeof root.remove === 'function') {
-      root.remove();
-    }
-  },
+      1,
+    ),
+  cleanup: cleanupDemoRoot(ROOT_VALUE),
 };

--- a/src/scenes/demo-title.ts
+++ b/src/scenes/demo-title.ts
@@ -1,0 +1,231 @@
+// Issue 98 — vertical-slice demo: title-card scene.
+//
+// The demo composition (`src/compositions/demo.ts`) wires this scene
+// first. It opens the slice with a heading and a subtitle, fading
+// each in on a named GSAP beat so reviewers can verify the timeline
+// engine, the prompter caption path, and the URL beat-seek surface
+// against authored content rather than a fixture. The codex preflight
+// at `docs/design/issue-098-vertical-slice-demo-preflight.md` is
+// binding: this scene reuses `ctx.gsap`, `ctx.stage.ownerDocument`,
+// the existing scene schema, and the existing identifier grammar; it
+// adds no new ADR, mode, asset pipeline, audio engine, or runtime
+// abstraction.
+
+import { NAVIGATION_MODES } from '../runtime/navigation';
+import type { SceneModule } from '../runtime/scene';
+import type { WorkbenchSceneCtx } from '../runtime/scene-loader';
+
+// Stable DOM marker shared by all three demo scenes; the e2e spec
+// asserts the scene root mounts so blank-stage regressions surface
+// as a layout-or-mount problem rather than a failure to compile the
+// scene. Per-scene constants so each scene owns its own attribute
+// key — the preflight is explicit about avoiding a "demo framework"
+// on the first pass.
+const ROOT_ATTR = 'data-pulsar-demo-scene';
+const ROOT_VALUE = 'demo-title';
+const STATE_ATTR = 'data-pulsar-demo-state';
+// Timeline-owned activation marker. The composition resolver mounts
+// every scene's root before the master timeline runs (ADR-025), so a
+// scene that is visible from `create(ctx)` would render alongside
+// every other scene at once. The activation marker AND the inline
+// `display` style are flipped from `false` / `none` to `true` / `''`
+// by a `tl.call(...)` at the start of this scene's timeline segment
+// and back at its end. Result: only the currently-playing scene is
+// active, which is what a sequential composition is supposed to look
+// like. Per-scene constant so each scene owns its own marker.
+const ACTIVE_ATTR = 'data-pulsar-demo-active';
+
+const BEAT_TITLE_IN = 'title-in';
+const BEAT_SUBTITLE_IN = 'subtitle-in';
+
+const TITLE_TEXT = 'Pulsar';
+const SUBTITLE_TEXT = 'A scene-and-composition runtime for cinematic browser presentations.';
+
+interface FixtureDomElement {
+  setAttribute(name: string, value: string): void;
+  appendChild?(node: unknown): unknown;
+  textContent?: string;
+}
+
+interface FixtureDomFactory {
+  createElement(tag: string): FixtureDomElement;
+}
+
+interface FixtureStageElement {
+  setAttribute(name: string, value: string): void;
+  removeAttribute(name: string): void;
+  appendChild?(node: unknown): unknown;
+  querySelector?(selector: string): {
+    setAttribute?(name: string, value: string): void;
+    remove?(): void;
+  } | null;
+  readonly ownerDocument?: FixtureDomFactory | null;
+}
+
+interface DemoCtx {
+  readonly stage: FixtureStageElement | null;
+  readonly mode: WorkbenchSceneCtx['mode'];
+  readonly gsap: WorkbenchSceneCtx['gsap'];
+}
+
+const isStageShape = (stage: unknown): stage is FixtureStageElement | null => {
+  if (stage === null) return true;
+  if (typeof stage !== 'object') return false;
+  const candidate = stage as Partial<Record<'setAttribute' | 'removeAttribute', unknown>>;
+  return (
+    typeof candidate.setAttribute === 'function' && typeof candidate.removeAttribute === 'function'
+  );
+};
+
+const isGsapShape = (gsap: unknown): gsap is WorkbenchSceneCtx['gsap'] => {
+  if (gsap === null || typeof gsap !== 'object') return false;
+  return typeof (gsap as { timeline?: unknown }).timeline === 'function';
+};
+
+const isDemoCtx = (value: unknown): value is DemoCtx => {
+  if (typeof value !== 'object' || value === null) return false;
+  if (!('stage' in value) || !('mode' in value) || !('gsap' in value)) return false;
+  const { stage, mode, gsap } = value;
+  if (!isStageShape(stage)) return false;
+  if (typeof mode !== 'string' || !(NAVIGATION_MODES as readonly string[]).includes(mode)) {
+    return false;
+  }
+  return isGsapShape(gsap);
+};
+
+const findRoot = (
+  stage: FixtureStageElement,
+): {
+  setAttribute?(name: string, value: string): void;
+  remove?(): void;
+} | null => {
+  if (typeof stage.querySelector !== 'function') return null;
+  return stage.querySelector(`[${ROOT_ATTR}="${ROOT_VALUE}"]`);
+};
+
+// Flip the scene root's activation marker + inline display style in
+// one place so the start-of-segment and end-of-segment `tl.call(...)`s
+// stay symmetric. `null` root is a no-op (off-DOM test harness) so
+// these are safe to invoke unconditionally.
+const setActive = (
+  root: {
+    setAttribute?(name: string, value: string): void;
+  } | null,
+  active: boolean,
+): void => {
+  if (root === null || typeof root.setAttribute !== 'function') return;
+  root.setAttribute(ACTIVE_ATTR, active ? 'true' : 'false');
+  // Inline-style activation rather than relying on production CSS,
+  // because the workbench currently ships no CSS — relying on an
+  // external rule would leave the demo visually layered even when the
+  // marker said "inactive". Inline keeps the demo self-contained.
+  root.setAttribute('style', active ? '' : 'display: none;');
+};
+
+export const demoTitleScene: SceneModule = {
+  id: 'demo-title',
+  title: 'Demo — title card',
+  // `null` is honest: the scene's playable length is whatever
+  // `timeline(ctx)` constructs, and PUL-F001 / ADR-002 explicitly
+  // treats a divergence between `duration` metadata and the actual
+  // GSAP timeline as a drift risk for prompter / export consumers.
+  // Promoting this to an authoritative integer is a follow-up if /
+  // when scene authoring needs scrub-bar metadata.
+  duration: null,
+  tags: ['demo'],
+  assets: [],
+  // Caption `at` labels are kebab-case and resolve against the GSAP
+  // labels added in `timeline(ctx)`; the shared identifier grammar
+  // (ADR-008 #1) covers both.
+  captions: [
+    { at: BEAT_TITLE_IN, text: TITLE_TEXT },
+    { at: BEAT_SUBTITLE_IN, text: SUBTITLE_TEXT },
+  ],
+  audio: [],
+  defaultNext: 'demo-feature',
+  standalone: true,
+  trailerSafe: true,
+  create: (ctx: unknown) => {
+    if (!isDemoCtx(ctx)) return;
+    const stage = ctx.stage;
+    if (stage === null) return;
+    if (typeof stage.appendChild !== 'function') return;
+    const ownerDoc = stage.ownerDocument;
+    if (ownerDoc === undefined || ownerDoc === null) return;
+    if (typeof ownerDoc.createElement !== 'function') return;
+
+    const root = ownerDoc.createElement('section');
+    root.setAttribute(ROOT_ATTR, ROOT_VALUE);
+    root.setAttribute(STATE_ATTR, 'mounted');
+    // Initially inactive: the resolver mounts every scene in the
+    // slice before any timeline runs, so a visible-on-create root
+    // would render alongside every sibling scene. Activation flips
+    // to true inside the scene's own timeline segment.
+    root.setAttribute(ACTIVE_ATTR, 'false');
+    root.setAttribute('style', 'display: none;');
+    if (typeof root.appendChild === 'function') {
+      const title = ownerDoc.createElement('h1');
+      title.setAttribute('data-pulsar-demo-title', '');
+      title.textContent = TITLE_TEXT;
+      root.appendChild(title);
+      const subtitle = ownerDoc.createElement('p');
+      subtitle.setAttribute('data-pulsar-demo-subtitle', '');
+      subtitle.textContent = SUBTITLE_TEXT;
+      root.appendChild(subtitle);
+    }
+    stage.appendChild(root);
+  },
+  timeline: (ctx: unknown) => {
+    if (!isDemoCtx(ctx)) return null;
+    const stage = ctx.stage;
+    if (stage === null) return null;
+    const root = findRoot(stage);
+    // GSAP labels are the named beats the URL / prompter / future
+    // beat-seek surface address. We add them on the scene's own
+    // timeline so `composeMasterTimeline` translates them into
+    // `scene("demo-title").label("title-in")` master labels per
+    // `sceneTimelineLabel` in `src/runtime/timeline.ts`.
+    //
+    // Timeline-owned activation: the first `tl.call(...)` flips the
+    // root from inactive to active (visible); the trailing
+    // `tl.call(...)` flips it back. Wrapping the work in `tl.call`
+    // (rather than `tl.set` on the element) keeps the test stub —
+    // which is not a real DOM element — happy.
+    const tl = ctx.gsap.timeline();
+    tl.call(() => setActive(root, true));
+    tl.addLabel(BEAT_TITLE_IN, 0);
+    tl.to({}, { duration: 1 });
+    tl.addLabel(BEAT_SUBTITLE_IN, 1);
+    // Pin the terminal mutation to a tween's `onComplete` rather than
+    // a trailing `tl.call(...)`: when a scene is the LAST entry in the
+    // composition slice its child timeline ends at master time
+    // `master.duration()`, and a callback registered at that exact
+    // position races the master's `onComplete` and may be skipped on
+    // the final tick. A tween's `onComplete` fires when the tween
+    // itself ends, which is what every other scene timeline in this
+    // runtime relies on — see the browser-support fixture's
+    // terminating `tl.call` after a non-trailing `.to`.
+    tl.to(
+      {},
+      {
+        duration: 1,
+        onComplete: () => {
+          if (root !== null && typeof root.setAttribute === 'function') {
+            root.setAttribute(STATE_ATTR, 'ran');
+          }
+          setActive(root, false);
+        },
+      },
+    );
+    return tl;
+  },
+  cleanup: (ctx: unknown) => {
+    if (!isDemoCtx(ctx)) return;
+    const stage = ctx.stage;
+    if (stage === null) return;
+    const root = findRoot(stage);
+    if (root !== null && typeof root.remove === 'function') {
+      root.remove();
+    }
+  },
+};

--- a/src/workbench-graph.ts
+++ b/src/workbench-graph.ts
@@ -31,9 +31,13 @@
 // literal at compile time.
 
 import { DEFAULT_COMPOSITION_ID, defaultComposition } from './compositions/default';
+import { DEMO_COMPOSITION_ID, demoComposition } from './compositions/demo';
 import type { CompositionRegistryEntry } from './runtime/composition-registry';
 import type { SceneModule } from './runtime/scene';
 import { browserSupportFixtureScene } from './scenes/browser-support-fixture';
+import { demoFeatureScene } from './scenes/demo-feature';
+import { demoOutroScene } from './scenes/demo-outro';
+import { demoTitleScene } from './scenes/demo-title';
 import { domCssAccessibilityFixtureScene } from './scenes/dom-css-accessibility-fixture';
 import { placeholderScene } from './scenes/placeholder';
 
@@ -49,12 +53,22 @@ import { placeholderScene } from './scenes/placeholder';
 // (`tests-e2e/dom-css-accessibility.spec.ts`) can boot it via
 // `?scene=dom-css-accessibility-fixture`. It is not part of the
 // default composition.
+//
+// Issue 98: the three authored demo scenes are registered together
+// and arranged by the `demo` composition. Reachable at
+// `?composition=demo` in the workbench; the e2e spec at
+// `tests-e2e/demo-composition.spec.ts` boots them and verifies the
+// declared static asset is actually served by the production build.
 export const WORKBENCH_SCENES: readonly SceneModule[] = [
   placeholderScene,
   browserSupportFixtureScene,
   domCssAccessibilityFixtureScene,
+  demoTitleScene,
+  demoFeatureScene,
+  demoOutroScene,
 ];
 
 export const WORKBENCH_COMPOSITIONS: readonly CompositionRegistryEntry[] = [
   { id: DEFAULT_COMPOSITION_ID, manifest: defaultComposition },
+  { id: DEMO_COMPOSITION_ID, manifest: demoComposition },
 ];

--- a/tests-e2e/demo-composition.spec.ts
+++ b/tests-e2e/demo-composition.spec.ts
@@ -1,0 +1,265 @@
+import { expect, test } from '@playwright/test';
+
+// Issue 98 — demo composition browser/e2e coverage.
+//
+// This spec runs in every Playwright project declared in
+// `playwright.config.ts` (chromium / firefox / webkit — same matrix
+// as the PUL-Q002 / ADR-030 browser-support gate and the issue 97
+// runtime-smoke suite). It boots the demo composition through the
+// existing workbench URL grammar (`?composition=demo&mode=paused`)
+// against the production build (`pnpm preview`) and verifies:
+//
+//   1. The URL resolves: `data-pulsar-composition-target="demo"` and
+//      `data-pulsar-scene-target="demo-title"` appear on `#stage`,
+//      validation/navigation error attributes do NOT, and the scene
+//      lifecycle reaches the `timeline` phase.
+//
+//   2. The demo composition's declared static asset is actually
+//      served by the production build. The codex preflight at
+//      `docs/design/issue-098-vertical-slice-demo-preflight.md` is
+//      explicit that bare root-relative asset paths bypass the
+//      preloader's scheme validation, so a browser/e2e check or
+//      fetch-backed runtime test is the only way to prove
+//      "the committed path is actually served" — without this
+//      assertion a future deletion of `public/assets/demo/` would
+//      ship silently because the static validation pass cannot
+//      catch it. We HEAD the asset URL via `page.request` (no DOM
+//      involvement) and check the response is 200 with an SVG
+//      content type.
+//
+//   3. The feature scene's `<img>` element loads the declared asset:
+//      under `?composition=demo&scene=demo-feature&mode=paused` the
+//      slice mounts the feature scene, its `<img data-pulsar-demo-
+//      feature-img>` is attached as a descendant of `#stage` with
+//      the documented `src`, and its `naturalWidth` is non-zero
+//      (proves the browser actually loaded the resource, not just
+//      that the element exists). The PUL-F031 chrome surface is
+//      asserted visible under `mode=paused` per the existing chrome
+//      visibility map.
+//
+// CSS injection: the production build ships no CSS yet, so
+// `#stage` and the demo `<img>` need positive layout dimensions for
+// the bounding-box check to be meaningful. We inject the same
+// minimal harness stylesheet pattern `tests-e2e/runtime-smoke.spec.ts`
+// uses (page-local, via `page.addStyleTag()`, no committed
+// baselines, no production CSS changed).
+//
+// Scope per the preflight: reuse the existing observables and
+// browser project matrix; do not add baseline snapshots, new
+// runtime attributes, or scene/composition/registry surfaces beyond
+// what issue 98 wires.
+
+const COMPOSITION_PAUSED = '/?composition=demo&mode=paused';
+const FEATURE_SCENE_PAUSED = '/?composition=demo&scene=demo-feature&mode=paused';
+const ASSET_PATH = '/assets/demo/pulsar-mark.svg';
+
+const DEMO_TEST_CSS = `
+  html, body { margin: 0; padding: 0; background: #ffffff; }
+  body { min-height: 100vh; }
+  #stage {
+    display: block;
+    width: 100%;
+    height: 100vh;
+    background: #ffffff;
+  }
+  [data-pulsar-demo-feature-img] {
+    display: block;
+    width: 200px;
+    height: 200px;
+  }
+`;
+
+test.describe('issue 98 — demo composition reachable and served', () => {
+  test('boots ?composition=demo&mode=paused and resolves the demo slice head', async ({ page }) => {
+    const errors: string[] = [];
+    page.on('pageerror', (err) => errors.push(`pageerror: ${err.message}`));
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') errors.push(`console.error: ${msg.text()}`);
+    });
+
+    await page.goto(COMPOSITION_PAUSED);
+    await page.addStyleTag({ content: DEMO_TEST_CSS });
+
+    const stage = page.locator('#stage');
+    await expect(stage, 'the workbench stage element must mount').toBeAttached();
+    await expect(
+      stage,
+      'PUL-F028 boot validation must succeed (no data-pulsar-validation-failed)',
+    ).not.toHaveAttribute('data-pulsar-validation-failed', /.*/);
+    await expect(
+      stage,
+      'the URL grammar parser must accept ?composition=demo&mode=paused (no data-pulsar-navigation-error)',
+    ).not.toHaveAttribute('data-pulsar-navigation-error', /.*/);
+    await expect(
+      stage,
+      'the loader must write data-pulsar-composition-target for the resolved demo composition',
+    ).toHaveAttribute('data-pulsar-composition-target', 'demo');
+    await expect(
+      stage,
+      "the resolver must mount the demo composition's first scene (demo-title)",
+    ).toHaveAttribute('data-pulsar-scene-target', 'demo-title');
+
+    // The demo scenes intentionally do NOT write `data-pulsar-scene-
+    // lifecycle` — that marker is a per-scene authoring convention the
+    // placeholder / dom-css-accessibility-fixture scenes happen to use,
+    // not a runtime guarantee. The loader-emitted `data-pulsar-scene-
+    // target` (asserted above) proves the resolver mounted the right
+    // scene; the scene-root locator below proves `create(ctx)` ran
+    // end-to-end and produced the expected DOM. Asserting only what
+    // each scene actually emits keeps this spec honest if a future
+    // demo scene picks different private DOM markers.
+    const root = page.locator('[data-pulsar-demo-scene="demo-title"]');
+    await expect(
+      root,
+      'the demo-title scene root must mount as a descendant of #stage',
+    ).toBeAttached();
+    await expect(
+      root.locator('[data-pulsar-demo-title]'),
+      'the demo-title heading must mount inside the scene root',
+    ).toBeAttached();
+
+    const chrome = page.locator('[data-pulsar-chrome="surface"]');
+    await expect(chrome, 'PUL-F031 chrome surface must mount').toBeAttached();
+    await expect(chrome, 'mode=paused must keep chrome visible').toHaveAttribute(
+      'data-pulsar-chrome-visibility',
+      'visible',
+    );
+
+    expect(errors, 'no uncaught exceptions or console errors during boot').toEqual([]);
+  });
+
+  test('the declared static asset path is served by the production build', async ({ page }) => {
+    // HEAD the asset directly through Playwright's request context.
+    // The production build (Vite preview, port 4173) serves
+    // `public/assets/demo/pulsar-mark.svg` at the root path
+    // `/assets/demo/pulsar-mark.svg`. Without this check, a future
+    // deletion of `public/assets/demo/` would ship silently because
+    // the workbench-graph validator pass accepts bare root-relative
+    // paths without contacting any server.
+    const response = await page.request.get(ASSET_PATH);
+    expect(response.status(), 'static asset must be served by the production build').toBe(200);
+    const contentType = response.headers()['content-type'] ?? '';
+    expect(contentType, 'static asset must be served with an SVG content type').toMatch(
+      /image\/svg\+xml/,
+    );
+    const body = await response.body();
+    expect(body.byteLength, 'static asset must have non-zero body').toBeGreaterThan(0);
+  });
+
+  test('demo-feature scene mounts its <img> element pointing at the served asset', async ({
+    page,
+  }) => {
+    const errors: string[] = [];
+    page.on('pageerror', (err) => errors.push(`pageerror: ${err.message}`));
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') errors.push(`console.error: ${msg.text()}`);
+    });
+
+    await page.goto(FEATURE_SCENE_PAUSED);
+    await page.addStyleTag({ content: DEMO_TEST_CSS });
+
+    const stage = page.locator('#stage');
+    await expect(stage).toBeAttached();
+    await expect(stage).not.toHaveAttribute('data-pulsar-validation-failed', /.*/);
+    await expect(stage).not.toHaveAttribute('data-pulsar-navigation-error', /.*/);
+    await expect(
+      stage,
+      'addressing a member scene must mount it as the slice head',
+    ).toHaveAttribute('data-pulsar-scene-target', 'demo-feature');
+
+    const root = stage.locator('[data-pulsar-demo-scene="demo-feature"]');
+    await expect(
+      root,
+      'the demo-feature scene root must mount as a descendant of #stage',
+    ).toBeAttached();
+
+    const img = root.locator('[data-pulsar-demo-feature-img]');
+    await expect(
+      img,
+      'the feature image must mount as a descendant of the scene root',
+    ).toBeAttached();
+    await expect(img, 'the feature image must point at the declared asset URL').toHaveAttribute(
+      'src',
+      ASSET_PATH,
+    );
+
+    // `naturalWidth > 0` proves the browser actually decoded the
+    // resource: a 404 (silent regression on the public asset
+    // pipeline) would surface as `naturalWidth === 0` while every
+    // DOM-attribute assertion above still passed.
+    const naturalWidth = await img.evaluate((el) => (el as HTMLImageElement).naturalWidth);
+    expect(
+      naturalWidth,
+      'the demo asset must load (non-zero naturalWidth proves the browser fetched and decoded it)',
+    ).toBeGreaterThan(0);
+
+    expect(errors, 'no uncaught exceptions or console errors during boot').toEqual([]);
+  });
+
+  test('present-mode boots the demo composition and starts master playback', async ({ page }) => {
+    // `?composition=demo` (default mode = present per ADR-007) drives
+    // the full slice through the production GSAP master timeline.
+    // `mode=paused` intentionally truncates a composition slice to
+    // the addressed head scene (`src/runtime/scene-navigation.ts`
+    // `truncateToHead`), so the paused-mode test above only proves
+    // demo-title can mount. THIS test covers the seam codex flagged
+    // as missing from the prior pass (cycle 1): under the production
+    // composition path EVERY demo scene mounts before adapter
+    // playback (PUL-F004 mount-then-play, ADR-025), and the head
+    // scene's own timeline activates its root when the master starts
+    // playing.
+    //
+    // The runtime-boundary unit test
+    // (`tests/runtime/demo-composition.test.ts` — "runs the full
+    // slice end-to-end through the production GSAP timeline
+    // adapter") drives `createGsapCompositionTimeline` across the
+    // whole slice and waits for `loadSceneNavigationTarget` to
+    // resolve. That `await` only completes when the master fires
+    // `onComplete` and the resolver finishes the cleanup phase, so
+    // sequential playback + reverse cleanup is already pinned there.
+    // This browser test stays focused on what a polling browser
+    // assertion can prove without racing GSAP's tween-boundary
+    // behavior across engines: every scene root is present (mount-
+    // then-play) and master playback has actually started (head
+    // activation).
+    const errors: string[] = [];
+    page.on('pageerror', (err) => errors.push(`pageerror: ${err.message}`));
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') errors.push(`console.error: ${msg.text()}`);
+    });
+
+    await page.goto('/?composition=demo');
+    await page.addStyleTag({ content: DEMO_TEST_CSS });
+
+    const stage = page.locator('#stage');
+    await expect(stage).toBeAttached();
+    await expect(stage).not.toHaveAttribute('data-pulsar-validation-failed', /.*/);
+    await expect(stage).not.toHaveAttribute('data-pulsar-navigation-error', /.*/);
+    await expect(stage).toHaveAttribute('data-pulsar-composition-target', 'demo');
+
+    // Mount-then-play: the resolver runs `create(ctx)` on every scene
+    // in the slice before the adapter starts playing, so all three
+    // scene roots are observable as descendants of `#stage`. This is
+    // race-free — the assertion is about whether mount fired for
+    // every scene, not about timing within the master timeline.
+    for (const sceneId of ['demo-title', 'demo-feature', 'demo-outro'] as const) {
+      await expect(
+        page.locator(`[data-pulsar-demo-scene="${sceneId}"]`),
+        `${sceneId} scene root must mount as a descendant of #stage under mode=present`,
+      ).toBeAttached({ timeout: 10_000 });
+    }
+
+    // Head-scene activation: under `mode=present` the master begins
+    // playing immediately; the head scene's own `tl.call` at segment
+    // start flips `data-pulsar-demo-active` to `"true"`. Under
+    // `mode=paused` (the truncation path above) it would stay
+    // `"false"`. The contrast distinguishes the production
+    // composition-playback path from paused-truncation.
+    await expect(
+      page.locator('[data-pulsar-demo-scene="demo-title"]'),
+      'the head scene must become active under present-mode playback',
+    ).toHaveAttribute('data-pulsar-demo-active', 'true', { timeout: 10_000 });
+
+    expect(errors, 'no uncaught exceptions or console errors during boot').toEqual([]);
+  });
+});

--- a/tests/runtime/demo-composition.test.ts
+++ b/tests/runtime/demo-composition.test.ts
@@ -1,0 +1,539 @@
+// Issue 98 — vertical-slice demo composition runtime-boundary tests.
+//
+// Coverage sits at the same runtime seams the demo flows through in
+// production (per the codex preflight in
+// `docs/design/issue-098-vertical-slice-demo-preflight.md`): the scene
+// schema validator, the navigation resolver, the composition resolver
+// lifecycle, the prompter aggregation function, and the GSAP timeline
+// engine the runtime injects via `ctx.gsap`. The scene modules and
+// composition manifest under test do not exist when this file is first
+// committed; the failing tests drive each piece into existence (TDD per
+// Step 4.4 of `/implement`).
+//
+// The existing PUL-P002 CI gate at `workbench-graph.test.ts` already
+// runs `validateRuntime` over the registered workbench graph, so this
+// file does not re-implement the duplicate-id / unknown-reference /
+// asset-resolvability phases — it covers the demo-specific behavior
+// the validator pass does not (lifecycle ordering across the slice,
+// prompter caption aggregation, GSAP label presence on each scene's
+// timeline). Browser-level reachability and the live-served asset path
+// live in `tests-e2e/demo-composition.spec.ts`.
+
+import { gsap } from 'gsap';
+import { describe, expect, it, vi } from 'vitest';
+import { DEMO_COMPOSITION_ID, demoComposition } from '../../src/compositions/demo';
+import { createCompositionRegistry } from '../../src/runtime/composition-registry';
+import type { CompositionTimelineAdapter } from '../../src/runtime/composition-resolver';
+import type { NavigationTarget } from '../../src/runtime/navigation';
+import { buildPrompterScript } from '../../src/runtime/prompter';
+import { createSceneRegistry } from '../../src/runtime/registry';
+import { type SceneModule, assertSceneModule } from '../../src/runtime/scene';
+import {
+  loadSceneNavigationTarget,
+  resolveSceneNavigation,
+} from '../../src/runtime/scene-navigation';
+import { createGsapCompositionTimeline, createTimelineEngine } from '../../src/runtime/timeline';
+import { DEMO_FEATURE_ASSET_URL, demoFeatureScene } from '../../src/scenes/demo-feature';
+import { demoOutroScene } from '../../src/scenes/demo-outro';
+import { demoTitleScene } from '../../src/scenes/demo-title';
+import { WORKBENCH_COMPOSITIONS, WORKBENCH_SCENES } from '../../src/workbench-graph';
+
+// The three demo scenes the issue 98 vertical slice composes. Listed
+// in manifest order so any drift between this fixture and
+// `src/compositions/demo.ts` surfaces in the slice-order assertion
+// below rather than as a silent re-ordering.
+const DEMO_SCENES: readonly SceneModule[] = [demoTitleScene, demoFeatureScene, demoOutroScene];
+
+// ----- helpers --------------------------------------------------------------
+
+// A minimal stage element good enough for the demo scenes' defensive
+// ctx narrowing — same shape `browser-support-fixture.ts` and
+// `dom-css-accessibility-fixture.ts` use. The recording array makes
+// it easy to assert what attributes a scene wrote.
+interface StageRecorder {
+  readonly attrs: Map<string, string>;
+  readonly children: unknown[];
+  readonly removed: string[];
+}
+
+const createStage = (): {
+  recorder: StageRecorder;
+  stage: {
+    setAttribute(name: string, value: string): void;
+    removeAttribute(name: string): void;
+    appendChild(node: unknown): unknown;
+    querySelector(selector: string): { remove(): void } | null;
+    readonly ownerDocument: {
+      createElement(tag: string): {
+        setAttribute(name: string, value: string): void;
+        appendChild(node: unknown): unknown;
+        readonly tagName: string;
+        textContent: string;
+      };
+    };
+  };
+} => {
+  const attrs = new Map<string, string>();
+  const children: unknown[] = [];
+  const removed: string[] = [];
+  const createElement = (
+    tag: string,
+  ): {
+    setAttribute(name: string, value: string): void;
+    appendChild(node: unknown): unknown;
+    readonly tagName: string;
+    textContent: string;
+    readonly attrs: Map<string, string>;
+  } => {
+    const elAttrs = new Map<string, string>();
+    const elChildren: unknown[] = [];
+    return {
+      tagName: tag.toUpperCase(),
+      textContent: '',
+      attrs: elAttrs,
+      setAttribute: (n, v) => {
+        elAttrs.set(n, v);
+      },
+      appendChild: (node) => {
+        elChildren.push(node);
+        return node;
+      },
+    };
+  };
+  const stage = {
+    setAttribute: (n: string, v: string) => {
+      attrs.set(n, v);
+    },
+    removeAttribute: (n: string) => {
+      attrs.delete(n);
+    },
+    appendChild: (node: unknown) => {
+      children.push(node);
+      return node;
+    },
+    // Returns whichever child carries the matched attribute prefix so
+    // cleanup can find it. The demo scenes locate their root via a
+    // `data-pulsar-demo-scene` marker; mirroring the fixture pattern
+    // is sufficient for these tests.
+    querySelector: (selector: string) => {
+      const match = selector.match(/\[([^\]]+)\]/);
+      if (match === null) return null;
+      const inside = match[1] ?? '';
+      // Handle both `[attr]` and `[attr="value"]` shapes. We compare
+      // on attribute name AND, when supplied, the value so the demo
+      // scenes' per-scene `[data-pulsar-demo-scene="demo-title"]`
+      // lookups distinguish between sibling scenes mounted on the
+      // same stage. Strip surrounding quotes from the value.
+      const [rawAttr, rawValue] = inside.split('=');
+      const attr = rawAttr?.trim() ?? '';
+      const value = rawValue?.trim().replace(/^["']|["']$/g, '');
+      const found = children.find((c) => {
+        if (typeof c !== 'object' || c === null) return false;
+        const elAttrs = (c as { attrs?: Map<string, string> }).attrs;
+        if (!(elAttrs instanceof Map) || !elAttrs.has(attr)) return false;
+        if (value === undefined) return true;
+        return elAttrs.get(attr) === value;
+      });
+      if (found === undefined) return null;
+      return {
+        remove: () => {
+          removed.push(attr);
+          const idx = children.indexOf(found);
+          if (idx >= 0) children.splice(idx, 1);
+        },
+      };
+    },
+    ownerDocument: { createElement },
+  };
+  return { recorder: { attrs, children, removed }, stage };
+};
+
+// A ctx shape that satisfies every demo scene's ctx predicate (stage +
+// mode + gsap). `mode: 'present'` because the demo runs under
+// `?composition=demo` (default mode = present per ADR-007). A real GSAP
+// instance is wired in so the timeline assertions are against the
+// production engine, not a stub — same approach `timeline.test.ts` uses.
+const createCtx = (stage: ReturnType<typeof createStage>['stage']) => ({
+  stage,
+  mode: 'present' as const,
+  gsap,
+});
+
+// ----- scene contract -------------------------------------------------------
+
+describe('demo scenes — schema (issue 98)', () => {
+  it.each(DEMO_SCENES.map((s) => [s.id, s] as const))(
+    '"%s" satisfies the SceneModule contract',
+    (_id, scene) => {
+      expect(() => assertSceneModule(scene)).not.toThrow();
+    },
+  );
+
+  it('the three demo scene ids are distinct', () => {
+    const ids = new Set(DEMO_SCENES.map((s) => s.id));
+    expect(ids.size).toBe(DEMO_SCENES.length);
+  });
+
+  it('every demo scene id begins with "demo-" so the demo namespace is greppable', () => {
+    for (const scene of DEMO_SCENES) {
+      expect(scene.id.startsWith('demo-')).toBe(true);
+    }
+  });
+});
+
+// ----- demo-title -----------------------------------------------------------
+
+describe('demo-title scene (issue 98)', () => {
+  it('declares the documented named beats as GSAP labels on its timeline', () => {
+    const { stage } = createStage();
+    const ctx = createCtx(stage);
+    demoTitleScene.create(ctx);
+    const tl = demoTitleScene.timeline(ctx) as gsap.core.Timeline | null;
+    expect(tl).not.toBeNull();
+    if (tl === null) return;
+    expect(tl.labels).toHaveProperty('title-in');
+    expect(tl.labels).toHaveProperty('subtitle-in');
+    tl.kill();
+    demoTitleScene.cleanup(ctx);
+  });
+
+  it('caption beat labels resolve against the scene timeline labels', () => {
+    const { stage } = createStage();
+    const ctx = createCtx(stage);
+    demoTitleScene.create(ctx);
+    const tl = demoTitleScene.timeline(ctx) as gsap.core.Timeline | null;
+    if (tl === null) throw new Error('expected non-null timeline');
+    const labels = new Set(Object.keys(tl.labels));
+    for (const caption of demoTitleScene.captions) {
+      if (typeof caption.at === 'string') {
+        expect(labels.has(caption.at)).toBe(true);
+      }
+    }
+    tl.kill();
+    demoTitleScene.cleanup(ctx);
+  });
+
+  it('cleanup removes everything create mounted', () => {
+    const { recorder, stage } = createStage();
+    const ctx = createCtx(stage);
+    demoTitleScene.create(ctx);
+    expect(recorder.children.length).toBeGreaterThan(0);
+    demoTitleScene.cleanup(ctx);
+    expect(recorder.children.length).toBe(0);
+  });
+});
+
+// ----- demo-feature ---------------------------------------------------------
+
+describe('demo-feature scene (issue 98)', () => {
+  it('declares the static asset URL the e2e spec proves is served', () => {
+    expect(demoFeatureScene.assets).toEqual([DEMO_FEATURE_ASSET_URL]);
+    // The asset is same-origin and root-relative; bare root-relative
+    // paths bypass the preloader's scheme validation by design (see
+    // `src/runtime/asset-preloader.ts` `resolveAssetUrl`), so this
+    // assertion fences future drift to a disallowed scheme.
+    expect(DEMO_FEATURE_ASSET_URL.startsWith('/')).toBe(true);
+    expect(DEMO_FEATURE_ASSET_URL.includes('://')).toBe(false);
+  });
+
+  it('declares no audio sources on the first authored pass', () => {
+    // The PUL-F030 / ADR-029 audio⊆assets invariant is already
+    // enforced by `assertSceneModule` (covered above in the schema
+    // describe). This assertion documents the deliberate first-pass
+    // decision the codex preflight names: no audio in the demo
+    // composition until the asset-policy decision is in scope. A
+    // future demo-scene PR that adds an audio source will fail this
+    // test, prompting a review of the policy choice — that is the
+    // change-detection signal the previous vacuous loop did not
+    // provide (test-quality review, cycle 1).
+    expect(demoFeatureScene.audio).toEqual([]);
+  });
+
+  it('declares at least one named GSAP beat the prompter captions reference', () => {
+    const { stage } = createStage();
+    const ctx = createCtx(stage);
+    demoFeatureScene.create(ctx);
+    const tl = demoFeatureScene.timeline(ctx) as gsap.core.Timeline | null;
+    expect(tl).not.toBeNull();
+    if (tl === null) return;
+    const labels = new Set(Object.keys(tl.labels));
+    const beatCaptions = demoFeatureScene.captions.filter((c) => typeof c.at === 'string');
+    expect(beatCaptions.length).toBeGreaterThan(0);
+    for (const c of beatCaptions) {
+      expect(labels.has(c.at as string)).toBe(true);
+    }
+    tl.kill();
+    demoFeatureScene.cleanup(ctx);
+  });
+});
+
+// ----- demo-outro -----------------------------------------------------------
+
+describe('demo-outro scene (issue 98)', () => {
+  it('declares the documented named beat as a GSAP label on its timeline', () => {
+    // Symmetric with the demo-title and demo-feature label-presence
+    // tests: the prior version asserted only `typeof tl.addLabel ===
+    // 'function'`, which is true of every GSAP timeline regardless of
+    // what the scene actually labeled. Removing `tl.addLabel(BEAT_
+    // OUTRO_OUT, 1)` would not be caught; the caption `{ at: 'outro-
+    // out', ... }` would silently reference a non-existent label
+    // (test-quality review, cycle 1).
+    const { stage } = createStage();
+    const ctx = createCtx(stage);
+    demoOutroScene.create(ctx);
+    const tl = demoOutroScene.timeline(ctx) as gsap.core.Timeline | null;
+    expect(tl).not.toBeNull();
+    if (tl === null) return;
+    expect(tl.labels).toHaveProperty('outro-out');
+    tl.kill();
+    demoOutroScene.cleanup(ctx);
+  });
+
+  it('caption beat labels resolve against the scene timeline labels', () => {
+    // Same shape as the demo-title test. Catches a future drift
+    // between `demoOutroScene.captions[*].at` and the GSAP labels
+    // its `timeline(ctx)` actually adds.
+    const { stage } = createStage();
+    const ctx = createCtx(stage);
+    demoOutroScene.create(ctx);
+    const tl = demoOutroScene.timeline(ctx) as gsap.core.Timeline | null;
+    if (tl === null) throw new Error('expected non-null timeline');
+    const labels = new Set(Object.keys(tl.labels));
+    for (const caption of demoOutroScene.captions) {
+      if (typeof caption.at === 'string') {
+        expect(labels.has(caption.at)).toBe(true);
+      }
+    }
+    tl.kill();
+    demoOutroScene.cleanup(ctx);
+  });
+});
+
+// ----- composition manifest -------------------------------------------------
+
+describe('demo composition manifest (issue 98)', () => {
+  it('exports the canonical id and a static manifest in the documented order', () => {
+    expect(DEMO_COMPOSITION_ID).toBe('demo');
+    expect(demoComposition).toEqual(['demo-title', 'demo-feature', 'demo-outro']);
+  });
+
+  it('every manifest entry id matches a demo scene module id', () => {
+    const sceneIds = new Set(DEMO_SCENES.map((s) => s.id));
+    for (const entry of demoComposition) {
+      const id = typeof entry === 'string' ? entry : entry.id;
+      expect(sceneIds.has(id)).toBe(true);
+    }
+  });
+});
+
+// ----- navigation resolver --------------------------------------------------
+
+// Build the registries from the CANONICAL workbench graph so this
+// test always sees what `src/main.ts` and the PUL-P002 CI gate see.
+// A future change to `src/workbench-graph.ts` (a new fixture scene, a
+// reorder, a renamed composition) will flow through here without
+// requiring a parallel test-only registry edit (codex pre-push
+// review, cycle 1 — class finding on test-private registry drift).
+const buildRegistries = (): {
+  scenes: ReturnType<typeof createSceneRegistry>;
+  compositions: ReturnType<typeof createCompositionRegistry>;
+} => {
+  const scenes = createSceneRegistry(WORKBENCH_SCENES);
+  const compositions = createCompositionRegistry(WORKBENCH_COMPOSITIONS);
+  return { scenes, compositions };
+};
+
+describe('demo composition navigation (issue 98)', () => {
+  it('resolveSceneNavigation produces the three-scene slice in manifest order', () => {
+    const { scenes, compositions } = buildRegistries();
+    const navTarget: NavigationTarget = {
+      locator: { kind: 'composition', composition: DEMO_COMPOSITION_ID },
+    };
+    const resolved = resolveSceneNavigation(navTarget, { scenes, compositions });
+    expect(resolved).not.toBeNull();
+    if (resolved === null) return;
+    expect(resolved.composition?.id).toBe(DEMO_COMPOSITION_ID);
+    expect(resolved.composition?.sceneSlice.map((s) => s.id)).toEqual([
+      'demo-title',
+      'demo-feature',
+      'demo-outro',
+    ]);
+    expect(resolved.scene.id).toBe('demo-title');
+  });
+
+  it('buildPrompterScript aggregates the demo slice captions', () => {
+    const { scenes, compositions } = buildRegistries();
+    const navTarget: NavigationTarget = {
+      locator: { kind: 'composition', composition: DEMO_COMPOSITION_ID },
+    };
+    const resolved = resolveSceneNavigation(navTarget, { scenes, compositions });
+    if (resolved === null) throw new Error('expected resolved target');
+    const script = buildPrompterScript(resolved);
+    expect(script.composition?.id).toBe(DEMO_COMPOSITION_ID);
+    expect(script.entries.map((e) => e.sceneId)).toEqual([
+      'demo-title',
+      'demo-feature',
+      'demo-outro',
+    ]);
+    for (const entry of script.entries) {
+      const source = DEMO_SCENES.find((s) => s.id === entry.sceneId);
+      if (source === undefined) throw new Error(`unknown scene ${entry.sceneId}`);
+      expect(entry.captions.length).toBe(source.captions.length);
+    }
+  });
+});
+
+// ----- end-to-end lifecycle through loadSceneNavigationTarget --------------
+
+// Wrap a scene module with a proxy that records create / timeline /
+// cleanup invocations into a shared `log` array. Used by the
+// lifecycle test below so create + cleanup are actually observed,
+// not just inferred from preload + timeline-adapter calls (codex
+// pre-push review, cycle 1 — the previous test had no eyes on the
+// create/cleanup ordering at all).
+const instrumentScene = (scene: SceneModule, log: string[]): SceneModule => ({
+  ...scene,
+  create: (ctx) => {
+    log.push(`create:${scene.id}`);
+    return scene.create(ctx);
+  },
+  timeline: (ctx) => {
+    log.push(`timeline:${scene.id}`);
+    return scene.timeline(ctx);
+  },
+  cleanup: (ctx) => {
+    log.push(`cleanup:${scene.id}`);
+    return scene.cleanup(ctx);
+  },
+});
+
+describe('demo composition lifecycle (issue 98)', () => {
+  it('runs preload, create, timeline, and cleanup across the slice in the documented order', async () => {
+    // Build registries from instrumented copies of the demo scenes so
+    // each lifecycle hook records its invocation; the fixture and
+    // placeholder scenes pass through unchanged because the demo
+    // composition only references the three demo scenes.
+    const log: string[] = [];
+    const instrumented = WORKBENCH_SCENES.map((s) =>
+      s.id.startsWith('demo-') ? instrumentScene(s, log) : s,
+    );
+    const scenes = createSceneRegistry(instrumented);
+    const compositions = createCompositionRegistry(WORKBENCH_COMPOSITIONS);
+
+    const navTarget: NavigationTarget = {
+      locator: { kind: 'composition', composition: DEMO_COMPOSITION_ID },
+    };
+    const resolved = resolveSceneNavigation(navTarget, { scenes, compositions });
+    if (resolved === null) throw new Error('expected resolved target');
+
+    const preloadAssets = vi.fn(async (scene: SceneModule) => {
+      log.push(`preload:${scene.id}`);
+    });
+    // A recording timeline adapter — same shape the
+    // composition-resolver tests use. Resolves immediately so the
+    // resolver advances into the cleanup phase.
+    const adapter: CompositionTimelineAdapter = {
+      run: async (segments) => {
+        for (const segment of segments) {
+          log.push(`adapter:${segment.id}`);
+        }
+      },
+    };
+
+    const { stage } = createStage();
+    const ctx = createCtx(stage);
+
+    await loadSceneNavigationTarget(resolved, {
+      ctx,
+      preloadAssets,
+      timeline: adapter,
+    });
+
+    // PUL-F004 / ADR-025 lifecycle: preload(every scene) →
+    // create(every scene) → timeline(every scene) →
+    // adapter.run(slice) → cleanup(reverse mount order).
+    expect(log.filter((e) => e.startsWith('preload:'))).toEqual([
+      'preload:demo-title',
+      'preload:demo-feature',
+      'preload:demo-outro',
+    ]);
+    expect(log.filter((e) => e.startsWith('create:'))).toEqual([
+      'create:demo-title',
+      'create:demo-feature',
+      'create:demo-outro',
+    ]);
+    expect(log.filter((e) => e.startsWith('timeline:'))).toEqual([
+      'timeline:demo-title',
+      'timeline:demo-feature',
+      'timeline:demo-outro',
+    ]);
+    expect(log.filter((e) => e.startsWith('adapter:'))).toEqual([
+      'adapter:demo-title',
+      'adapter:demo-feature',
+      'adapter:demo-outro',
+    ]);
+    // Cleanup runs in reverse mount order per PUL-P001 — the resolver
+    // unwinds the slice from tail to head so any later-scene resource
+    // that depends on an earlier scene's setup is released first.
+    expect(log.filter((e) => e.startsWith('cleanup:'))).toEqual([
+      'cleanup:demo-outro',
+      'cleanup:demo-feature',
+      'cleanup:demo-title',
+    ]);
+  });
+
+  it('runs the full slice end-to-end through the production GSAP timeline adapter', async () => {
+    // Drive the production `createGsapCompositionTimeline` adapter
+    // over the demo slice so all three scenes' GSAP timelines are
+    // actually nested into a master timeline and played to natural
+    // completion. The recording adapter test above only proves the
+    // resolver hands segments to *some* adapter in order; this test
+    // proves the real GSAP adapter (ADR-003 / ADR-025) composes the
+    // demo scenes' returned timelines without throwing, runs them to
+    // completion, AND the resolver tears every scene down (codex
+    // pre-push review, cycle 1 — "?composition=demo&mode=paused
+    // only proves demo-title can mount").
+    const scenes = createSceneRegistry(WORKBENCH_SCENES);
+    const compositions = createCompositionRegistry(WORKBENCH_COMPOSITIONS);
+    const navTarget: NavigationTarget = {
+      locator: { kind: 'composition', composition: DEMO_COMPOSITION_ID },
+    };
+    const resolved = resolveSceneNavigation(navTarget, { scenes, compositions });
+    if (resolved === null) throw new Error('expected resolved target');
+
+    const { recorder, stage } = createStage();
+    const ctx = createCtx(stage);
+    const engine = createTimelineEngine();
+    const adapter = createGsapCompositionTimeline({ engine });
+
+    await loadSceneNavigationTarget(resolved, {
+      ctx,
+      preloadAssets: async () => {},
+      timeline: adapter,
+    });
+
+    // Cleanup observation (test-quality review, cycle 1): without
+    // these assertions the test could only fail on an uncaught
+    // exception, which would miss a resolver bug that silently
+    // skipped cleanup, a GSAP adapter that swallowed errors, or a
+    // demo scene whose `cleanup` hook never ran. The fixture stage's
+    // `querySelector('[attr=value]').remove()` splices the child
+    // from `recorder.children`; an empty array proves every scene's
+    // cleanup() located its root and removed it.
+    expect(
+      recorder.children.length,
+      'every scene root must be removed from the stage by the resolver cleanup phase',
+    ).toBe(0);
+    // `recorder.removed` records the attribute key passed to
+    // querySelector for each successful `.remove()`. Cleanup runs in
+    // reverse mount order per PUL-P001, so the three demo scene
+    // roots must come out in that order — confirming the resolver
+    // ran cleanup for ALL THREE scenes in the documented sequence,
+    // not just one or two.
+    expect(recorder.removed).toEqual([
+      'data-pulsar-demo-scene',
+      'data-pulsar-demo-scene',
+      'data-pulsar-demo-scene',
+    ]);
+  }, 30_000);
+});


### PR DESCRIPTION
## Summary

Add the first authored vertical-slice demo: three real scenes (demo-title, demo-feature, demo-outro) arranged into a new `demo` composition reachable at `?composition=demo`. Each scene exercises a different runtime seam (named GSAP beats, prompter captions, real same-origin asset declaration + preload) without introducing any new ADR, scene schema, composition schema, URL grammar, mode, validator finding code, runtime abstraction, or workflow. The slice is the first authored content in `src/scenes/` that is not a fixture, so reviewers can see the runtime seams stay ergonomic under real composition pressure.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #98

## ADR Impact

- No ADR required

## Changes

- Add `src/scenes/demo-title.ts`, `src/scenes/demo-feature.ts`, `src/scenes/demo-outro.ts` — three SceneModule-compliant scenes with timeline-owned activation, defensive ctx narrowing, ownerDocument-allocated DOM (no ambient `document`), and `ctx.gsap` (no scene-side gsap import).
- Add `src/compositions/demo.ts` — static three-entry CompositionManifest (`['demo-title', 'demo-feature', 'demo-outro']`), same declarative shape `defaultComposition` uses.
- Register the demo scenes and composition in `src/workbench-graph.ts` — single source of truth for both `src/main.ts` boot and the PUL-P002 CI gate (`tests/runtime/workbench-graph.test.ts`).
- Add `public/assets/demo/pulsar-mark.svg` — small static SVG served at `/assets/demo/pulsar-mark.svg` via Vite's default public-asset surface; consumed by `demo-feature` via its `assets` declaration.
- Add `tests/runtime/demo-composition.test.ts` — 19 boundary tests covering scene contract, navigation resolution, prompter aggregation, lifecycle ordering (preload/create/timeline/cleanup with reverse-cleanup), and a full-slice run through the production `createGsapCompositionTimeline` adapter that drives the master to natural completion and asserts every scene's cleanup ran.
- Add `tests-e2e/demo-composition.spec.ts` — 4 Playwright tests across the chromium/firefox/webkit matrix: paused-mode head-scene mount, present-mode mount-then-play + head activation, asset path served by `pnpm preview`, and feature-scene <img> loaded (naturalWidth > 0).
- Add `changelog.d/98.added.md` towncrier fragment.
- Carry the docs/design preflight note authored during the architecture preflight phase (issue-098-vertical-slice-demo-preflight.md) and index it in docs/design/README.md.

## Test Plan

- [x] Unit tests pass (`pnpm test`)
- [x] Browser tests pass on chromium + firefox (`pnpm exec playwright test`)
- [x] Lint + typecheck pass (`pnpm lint && pnpm typecheck`)
- [x] No coverage regression

Locally: `pnpm lint && pnpm typecheck && pnpm test` (2223 tests pass). `pnpm exec playwright test --project=chromium --project=firefox` (24 tests pass across chromium + firefox; webkit fails on this host because system libs are missing, but the same failure mode affects the existing browser-support / dom-css / runtime-smoke specs and is environmental — CI runs webkit on a properly provisioned runner). Both pre-push review passes (production-readiness and test-quality) ran on the staged diff and surfaced findings that were all fixed in-turn; the durable decision records for each cycle are on the issue thread (#98).

## Traceability

- IMPLEMENTS: issue#98 ← src/scenes/demo-title.ts, issue#98 ← src/scenes/demo-feature.ts, issue#98 ← src/scenes/demo-outro.ts, issue#98 ← src/compositions/demo.ts, issue#98 ← src/workbench-graph.ts, issue#98 ← public/assets/demo/pulsar-mark.svg
- TESTS: issue#98 ← tests/runtime/demo-composition.test.ts, issue#98 ← tests-e2e/demo-composition.spec.ts

## Checklist

- [x] Code follows project coding standards
- [x] Changelog fragment added at `changelog.d/98.added.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed