### PR TITLE
added: support repeated scene entries via per-occurrence activation context

### DIFF
--- a/changelog.d/99.added.md
+++ b/changelog.d/99.added.md
@@ -1,0 +1,20 @@
+Repeated scene entries via per-occurrence activation context — issue
+#99. A composition slice may now reference the same scene id more than
+once; the composition resolver no longer rejects repeated ids. Each
+occurrence is a distinct activation with a stable identity
+(`SceneActivation` — `{ sceneId, entryIndex, occurrence }`, the 0-based
+per-scene-id ordinal in slice order): lifecycle hooks run once per
+occurrence, cleanup runs once per occurrence in reverse mount order,
+and the timeline composer namespaces repeated occurrences by the same
+ordinal. The resolver's per-scene post-cleanup hook (`onSceneCleaned`)
+now carries the cleaned occurrence's `SceneActivation`, and
+`SceneFailureEvent` carries `occurrence`. Audio-group teardown is
+occurrence-safe: a scene's audio group (`group: <sceneId>`) is
+scene-scoped and the runtime stops it only when the last occurrence of
+that scene id has been cleaned up, so an earlier occurrence's cleanup
+never cuts a still-active sibling's audio. The `data-pulsar-scene-failures`
+diagnostic attribute namespaces a repeated occurrence's failure by
+occurrence (`<sceneId>#<n>:<phase>` for occurrence > 0; bare
+`<sceneId>:<phase>` for occurrence 0, so single-occurrence behavior is
+unchanged). `composition+scene` URL locators still reject an ambiguous
+repeated scene id — `composition+index` is the precise locator.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -10,6 +10,7 @@ Design context for Pulsar. Source material for the ADRs in `../adrs/`.
 | [issue-091-towncrier-fragments-preflight.md](issue-091-towncrier-fragments-preflight.md) | Guardrails for adopting Towncrier-managed changelog fragments without duplicating release workflow logic. |
 | [issue-097-browser-runtime-smoke-preflight.md](issue-097-browser-runtime-smoke-preflight.md) | Guardrails for expanding browser runtime smoke coverage through the existing Playwright workbench gate. |
 | [issue-098-vertical-slice-demo-preflight.md](issue-098-vertical-slice-demo-preflight.md) | Guardrails for adding authored demo scenes that exercise composition, timeline, captions, assets, and workbench routing through existing runtime seams. |
+| [issue-099-repeated-scene-activation-context-preflight.md](issue-099-repeated-scene-activation-context-preflight.md) | Guardrails for supporting repeated scene entries through per-occurrence activation ownership without changing scene, composition, URL, registry, timeline, or audio boundaries. |
 | [positioning-and-landscape.md](positioning-and-landscape.md) | Category, adjacent OSS projects, differentiation, strategic risks. |
 | [pul-p002-validation-ci-preflight.md](pul-p002-validation-ci-preflight.md) | Guardrails for gating pull-request CI on the canonical runtime validation pass. |
 | [pul-p003-adr-format-preflight.md](pul-p003-adr-format-preflight.md) | Guardrails for keeping ADR markdown and Ground Control ADR records aligned without duplicate schemas or workflow logic. |

--- a/docs/design/issue-099-repeated-scene-activation-context-preflight.md
+++ b/docs/design/issue-099-repeated-scene-activation-context-preflight.md
@@ -1,0 +1,199 @@
+# Issue 99 Repeated Scene Activation Context Preflight
+
+Date: 2026-05-21
+
+Issue 99 removes the resolver's temporary "no repeated scene ids in an
+active slice" guard. The change is about activation ownership, not a new
+scene schema, composition schema, registry model, URL grammar, audio
+engine, timeline engine, or workflow.
+
+No new ADR is needed before implementation. Existing ADRs already decide
+the model and the relevant seams: scene/composition identity (ADR-002),
+GSAP and master timeline ownership (ADR-003 / ADR-025 / ADR-026),
+audio through `ctx.audio` (ADR-004 / ADR-029), workbench URL dispatch
+(ADR-007 / ADR-013 / ADR-014), cleanup completeness (ADR-008 /
+PUL-Q004), and scene-level failure isolation (ADR-028).
+
+## Boundary
+
+- Composition manifests may already reference the same scene id more
+  than once. Keep `CompositionManifest`, `assertCompositionManifest()`,
+  and `createCompositionRegistry()` unchanged.
+- Scene registry uniqueness remains module identity, not activation
+  identity. `createSceneRegistry()` must still reject duplicate scene
+  modules with the same `scene.id`.
+- A repeated composition entry is a distinct scene occurrence that
+  references the same `SceneModule` metadata. Do not clone, rewrite, or
+  fork the scene module to manufacture uniqueness.
+- Occurrence ownership belongs at the resolver/loader context seam:
+  DOM mount root, listener tracking, lifecycle bookkeeping, timeline
+  segment identity, audio cleanup, and diagnostics must all agree on
+  the same occurrence identity.
+- Timeline label disambiguation already exists in `timeline.ts` through
+  `sceneSegmentLabel()`, `sceneTimelineLabel()`, `parseSceneTimelineLabel()`,
+  `MasterTimeline.labelFor()`, and `MasterTimeline.beats()`. Reuse it.
+- `?composition=<id>&scene=<scene-id>` remains ambiguous when a scene id
+  appears more than once in that composition. Keep the existing
+  `composition+scene` rejection and use `composition+index` for an
+  addressed repeated occurrence. Do not change URL grammar for this
+  issue.
+- Single-occurrence behavior is the compatibility baseline. A slice with
+  one occurrence of each scene id should keep the same lifecycle order,
+  diagnostics, labels, and audio behavior.
+
+## Required Reuse
+
+- Scene shape and validation: `SceneModule`, `assertSceneModule()`,
+  `sceneDeclaresAudio()`, and `createSceneRegistry()`.
+- Composition shape and lookup: `CompositionManifest`,
+  `assertCompositionManifest()`, `entryId()`, `findUnregisteredEntries()`,
+  `createCompositionRegistry()`, and `createIdRegistry()`.
+- Navigation snapshots: `resolveSceneNavigation()`,
+  `loadSceneNavigationTarget()`, `sliceManifestFromIndex()`,
+  `snapshotSceneSlice()`, `truncateToHead()`, and the existing
+  composition `startIndex` diagnostic contract.
+- Lifecycle and failure handling: `resolveComposition()`, the internal
+  plan/mounted cleanup list, `onSceneCleaned`, `onSceneFailed`,
+  `SceneFailureEvent`, `Error.cause`, and `AggregateError`.
+- Loader context and observability: `createSceneLoader()`, `buildCtx()`,
+  per-navigation `AbortController`, `isPureAbort()`, `onError`, and
+  stage attributes.
+- Timeline: `SceneTimelineSegment`, `composeMasterTimeline()`,
+  `createGsapCompositionTimeline()`, `assertSceneTimeline()`, label
+  helpers, and `MasterTimeline.kill()`.
+- Audio: `createAudioService()`, `AudioService.stopGroup()`,
+  `AudioService.stopAll()`, `AudioService.isDisposed()`,
+  `AUDIO_OUTPUT_POLICIES`, `resolveAssetUrl()`,
+  `DEFAULT_ALLOWED_SCHEMES`, and the existing `AudioError` hierarchy.
+- Error rendering: `describeError()`, `describeErrorDetailed()`, and
+  `formatSceneContext()`. Extend structured context there if public
+  diagnostics need occurrence or entry context.
+- Tests and gates: focused Vitest runtime suites under
+  `tests/runtime/*`, policy source scans, `pnpm test`, `pnpm typecheck`,
+  and `pnpm lint`.
+
+## Cross-Cutting Layers
+
+| Layer | Guardrail |
+|-------|-----------|
+| Scene schema gate | Do not add `RepeatedScene`, `SceneOccurrenceModule`, a second lifecycle hook, or an occurrence field to scene metadata. `SceneModule.id` remains the module id. |
+| Composition schema gate | Repeated entries are valid manifest data. Occurrence identity is resolved from manifest position at activation time, not stored as a manifest override or new DTO. |
+| Registry / snapshot gate | Registries stay id-keyed and immutable. A navigation slice may contain repeated entries, but the synthesized scene registry must still contain one module per id. |
+| URL grammar | Keep `parseNavigationSearch()` grammar unchanged. `composition+scene` is still rejected for ambiguous repeated members; `composition+index` is the existing precise locator. |
+| Mode dispatch | `present` may run the full repeated slice. `standalone`, `loop`, `paused`, `scrub`, and `screenshot` keep truncating to the head entry and should remain unaffected by later repeats. |
+| Lifecycle / cancellation | One navigation `AbortSignal` still drives preloader, resolver, timeline adapter, audio service, presenter controller, and prompter cleanup. Occurrence identity must not create a second cancellation workflow. |
+| DOM ownership | Scenes should receive or derive an occurrence-owned mount surface from the runtime context. Cleanup must remove only that occurrence's DOM and listeners, never clear the whole stage or sibling occurrence roots. |
+| Timeline labels | Use the canonical label helpers. Do not parse `:` / `#` names locally, and do not substitute absolute composition indexes into master label names unless a future ADR changes the label contract. |
+| Audio cleanup | Scene-id-only groups are unsafe for repeated active occurrences. Per-occurrence cleanup must either use an occurrence-scoped audio facade/group or explicitly document a scene-scoped group as shared and not cleaned per occurrence. |
+| Asset security | Asset and audio source strings still flow through declared `scene.assets` / `scene.audio`, `createAssetPreloader()`, `resolveAssetUrl()`, and the audio service allowlist. Occurrence identity must not permit arbitrary URLs or duplicate fetch policy. |
+| Error envelope | Public diagnostics may include scene id, phase, composition id, entry index, occurrence identity, mode, and bounded messages. Never serialize raw scene objects, DOM nodes, listeners, GSAP objects, Howler handles, captions, headers, cookies, env, auth values, stacks, or raw `cause`. |
+| Validation pass | `validateRuntime()` should continue to report duplicate scene modules as invalid, while allowing repeated composition references. Do not add a second validator for composition occurrence identity. |
+| Source-policy security | Existing bans still apply: no scene GSAP imports, Howler imports, `Audio()` construction, dynamic remote imports, `eval`, parallel caption stores, or imperative composition flow control. |
+| Config / env / OS | This design needs no auth surface, secrets, `.env`, `import.meta.env`, `process.env`, `process.argv`, shell flags, temp files, cookies, localStorage, sessionStorage, or history-state fallback. Occurrence ownership is in-memory runtime state. |
+| Observability | Use existing `onError`, stage attributes, and tests. Do not add telemetry, persistent logs, resource dumps, or high-cardinality per-frame diagnostics. |
+
+## Extensibility
+
+The required seam is a deterministic scene activation identity. It
+should be derived from the active manifest slice, not from randomness,
+global counters, storage, process state, or scene-authored data.
+
+The identity needs enough structure for future consumers to ask two
+different questions without parsing strings:
+
+- Which scene module is this? `sceneId`.
+- Which activation owns this resource? entry position plus per-scene
+  occurrence ordinal within the active slice.
+
+The stable parameter belongs on the resolver plan and the scene
+activation context/facade the loader builds. The same identity should
+feed lifecycle bookkeeping, DOM ownership, audio group/facade scoping,
+failure diagnostics, and any future resource owner. Timeline labels may
+continue using the existing slice-local occurrence ordinal; diagnostics
+can carry absolute composition `entryIndex` when the loader knows it.
+
+Future changes such as windowed mounting, cross-scene seek, transition
+ownership, occurrence-aware presenter HUDs, or stricter resource
+tracking should extend this activation identity. They should not add
+parallel registries, parallel scene schemas, or URL state.
+
+## Gotchas
+
+- Module-level mutable state in a scene module is shared by repeated
+  occurrences. Scene-local mutable state must live in the activation
+  context or in data structures keyed by activation identity, not by
+  `scene.id` alone.
+- `onSceneCleaned(sceneId)` and `audio.stopGroup(sceneId)` are the
+  current unsafe point for repeated active occurrences. A cleanup hook
+  keyed only by scene id can stop the sibling occurrence's audio.
+- `data-pulsar-scene-failures` currently records `<sceneId>:<phase>`.
+  That collapses two occurrences of the same scene that fail in the
+  same phase. Repeated-occurrence diagnostics need occurrence or entry
+  context at this surface.
+- Eager cleanup after `create` or `timeline` failure must clean exactly
+  the failed occurrence, remove it from the mounted list exactly once,
+  and leave sibling occurrences mounted.
+- Final cleanup still runs in reverse mount order by occurrence, not by
+  unique scene id. A Set keyed by scene id would drop work.
+- Timeline labels are already unambiguous only if segments remain in
+  manifest order and the occurrence counter is computed from the same
+  segment list the master composes.
+- `headBeat` targets the head segment of the active slice. If navigation
+  starts at the second occurrence by `composition+index`, that head is
+  still occurrence 0 within the sliced master.
+- A throwing diagnostic hook remains a workbench hook failure, not a
+  scene failure. Keep ADR-028 aggregation semantics.
+- Per-occurrence DOM cleanup must not delete workbench chrome,
+  transition overlays, prompter UI, or sibling scene DOM.
+
+## Anti-Patterns
+
+- Rewriting scene ids in manifests or registries to make them unique.
+- Cloning `SceneModule` objects or registering synthetic duplicate
+  modules.
+- Using global counters, random ids, timestamps, localStorage,
+  `history.state`, env vars, process argv, or URL tokens as activation
+  identity.
+- Keying cleanup, listeners, DOM roots, audio groups, or diagnostics by
+  scene id alone after repeated active occurrences are allowed.
+- Parsing timeline label strings in loader, resolver, presenter, or
+  tests instead of using `timeline.ts` helpers.
+- Adding a duplicate validation pass, exception hierarchy, audio
+  service, registry, presenter command schema, or workflow state
+  machine for this issue.
+- Treating audio groups as timeline labels, composition flow control,
+  or scene identity. Groups are audio cleanup scopes.
+- Silencing failures to preserve playback. Scene-level failures should
+  isolate through ADR-028 surfaces; composition-wide failures keep their
+  existing envelopes.
+
+## Tests
+
+Coverage should sit at runtime boundaries:
+
+- Resolver tests for repeated manifest entries, stable occurrence data,
+  failure isolation, eager cleanup, final cleanup order, and
+  no-double-cleanup behavior.
+- Timeline tests should continue to pin occurrence label namespacing
+  through the existing helpers.
+- Navigation and loader tests for repeated composition slices, ambiguous
+  `composition+scene` rejection, precise `composition+index` addressing,
+  stage diagnostics, and single-occurrence compatibility.
+- Audio tests for occurrence-safe cleanup, including create/timeline
+  failure paths and reverse-order final cleanup.
+
+Do not add browser storage, new test-only public APIs, or a second test
+runner. Source changes should add a Towncrier fragment; this preflight
+note alone does not require one.
+
+## Non-Goals
+
+Issue 99 does not require a new URL grammar, new workbench mode, scene
+metadata change, composition manifest change, registry change, asset
+policy change, timeline engine replacement, audio engine replacement,
+presenter command change, prompter change, telemetry, persistence, or
+export semantics.
+
+It also does not require windowed/lazy mounting, cross-scene reverse
+seek, transition redesign, automatic repair of scene module global
+state, raw Web Audio support, or requirement/ADR status transitions.

--- a/src/main.ts
+++ b/src/main.ts
@@ -188,12 +188,14 @@ const timeline = createGsapCompositionTimeline({
 // Filled in after the chrome surface is mounted (below).
 let chromeSlots: ChromeSlots | undefined;
 
+// Builds the navigation-scoped scene ctx; the loader adds each
+// occurrence's `activation` (issue #99), so the return type omits it.
 const buildCtx = (
   mode: NavigationMode,
   audio: AudioService,
   presenter?: import('./runtime/presenter').PresenterController,
-): WorkbenchSceneCtx => {
-  const base: WorkbenchSceneCtx = {
+): Omit<WorkbenchSceneCtx, 'activation'> => {
+  const base: Omit<WorkbenchSceneCtx, 'activation'> = {
     stage,
     mode,
     gsap: timelineEngine.gsap,

--- a/src/runtime/audio.ts
+++ b/src/runtime/audio.ts
@@ -22,18 +22,18 @@
 //    service `stopAll()`s — every sound it created is stopped and
 //    unloaded, so fades, loops, sprites, and muted state never survive
 //    scene cleanup (PUL-P001 / ADR-004). One service is shared across a
-//    composition's slice (the resolver already forbids a slice repeating
-//    a scene id), so the sound-id namespace and the source allowlist are
-//    composition-slice-scoped: multi-scene compositions pick distinct
-//    sound ids — the same stable-identity discipline scene ids obey
-//    (ADR-008 #1) — and registering an id twice with the same definition
-//    is idempotent (a shared transition SFX). A scene scopes a sound to
-//    itself with `play(id, { group: <its-scene-id> })`; the resolver's
-//    per-scene post-`cleanup(ctx)` hook stops that group when the scene
-//    cleans up (runtime-driven, not author discipline). True per-scene
-//    activation contexts (one `ctx.audio` facade per scene entry) are a
-//    documented resolver follow-up (see `composition-resolver.ts`'s
-//    `buildPlan`).
+//    composition's slice, so the sound-id namespace and the source
+//    allowlist are composition-slice-scoped: multi-scene compositions
+//    pick distinct sound ids — the same stable-identity discipline
+//    scene ids obey (ADR-008 #1) — and registering an id twice with the
+//    same definition is idempotent (a shared transition SFX). A scene
+//    scopes a sound to itself with `play(id, { group: <its-scene-id> })`;
+//    that group is scene-scoped — shared by every occurrence of a scene
+//    id a slice repeats (issue #99). The loader wires the resolver's
+//    per-scene post-`cleanup(ctx)` hook so the runtime stops that group
+//    when the LAST occurrence of the scene id is cleaned up
+//    (runtime-driven, not author discipline; occurrence-safe — an
+//    earlier occurrence's cleanup never cuts a sibling's audio).
 //
 // Source URLs reuse PUL-F005's `resolveAssetUrl` scheme resolver — no
 // copied scheme rules — and every registered source must be in the

--- a/src/runtime/composition-resolver.ts
+++ b/src/runtime/composition-resolver.ts
@@ -208,29 +208,57 @@ export interface CompositionTimelineAdapter {
 export type SceneFailurePhase = 'create' | 'timeline' | 'cleanup';
 
 /**
+ * The stable per-occurrence activation identity of one composition
+ * entry (issue #99). ADR-002 lets a composition reference the same
+ * scene module more than once; every occurrence is a distinct
+ * activation — its own DOM, listeners, timeline segment, and cleanup
+ * ownership — even though `sceneId` is shared. The identity is derived
+ * purely from the active manifest slice order (never randomness,
+ * counters, storage, or scene-authored data):
+ *
+ *  - `sceneId` — which scene module this is.
+ *  - `entryIndex` — the position of the entry in the manifest the
+ *    resolver was handed. When the resolver is driven from a
+ *    composition slice that started mid-manifest the index is relative
+ *    to that slice, not the absolute composition index — the loader
+ *    (which knows the slice's `startIndex`) translates it to the
+ *    absolute entry for public diagnostics.
+ *  - `occurrence` — the 0-based ordinal of this entry among the entries
+ *    in the slice that share `sceneId` (first / only occurrence is 0).
+ *    Mirrors the occurrence counter the timeline composer uses for
+ *    label namespacing (`sceneSegmentLabel` / `sceneTimelineLabel`), so
+ *    diagnostics, audio-group teardown, and timeline labels all agree
+ *    on the same identity.
+ *
+ * Threaded through {@link ResolveCompositionOptions.onSceneCleaned} and
+ * carried by {@link SceneFailureEvent} so per-occurrence lifecycle
+ * owners (audio-group teardown, failure diagnostics, and any future
+ * per-occurrence resource owner) can disambiguate repeated scene ids.
+ */
+export interface SceneActivation {
+  readonly sceneId: string;
+  readonly entryIndex: number;
+  readonly occurrence: number;
+}
+
+/**
  * The structured per-scene failure event the resolver hands to
  * {@link ResolveCompositionOptions.onSceneFailed} (PUL-F029 / ADR-028).
+ * Extends {@link SceneActivation} so the failing occurrence carries the
+ * same `{ sceneId, entryIndex, occurrence }` identity every other
+ * lifecycle surface uses.
+ *
  * The `cause` field is the original thrown value — programmatic only;
  * the loader MUST NOT serialize it to a public diagnostic surface (per
  * ADR-028: no raw causes, stacks, scene objects, DOM, captions,
  * headers, cookies, environment, or auth values). The `message` field
  * is the {@link describeError} rendering of the cause and IS safe to
- * surface to operators.
- *
- * `entryIndex` carries the position of the failing scene in the
- * manifest the resolver was handed (ADR-028: composition entry index
- * is part of the failure diagnostic contract). When the resolver is
- * driven from a composition slice that started mid-manifest the index
- * is relative to the slice the resolver saw, not the absolute
- * composition index — the loader (which knows the composition's
- * entry-index translation) augments the public diagnostic with the
- * composition id and effective mode (the other two fields ADR-028
+ * surface to operators. The loader augments the public diagnostic with
+ * the composition id and effective mode (the other two fields ADR-028
  * requires) on top of this resolver-level event.
  */
-export interface SceneFailureEvent {
+export interface SceneFailureEvent extends SceneActivation {
   readonly phase: SceneFailurePhase;
-  readonly sceneId: string;
-  readonly entryIndex: number;
   readonly message: string;
   readonly cause: unknown;
 }
@@ -246,11 +274,24 @@ export interface ResolveCompositionOptions {
   /** The ordered manifest to play (PUL-F003). */
   readonly manifest: CompositionManifest;
   /**
-   * Opaque scene context passed straight through to every lifecycle
-   * hook. Carries `ctx.gsap` (ADR-003) and similar engine handles; the
-   * resolver itself does not inspect or extend it.
+   * Per-occurrence scene-context factory. The resolver calls it once
+   * per composition entry — passing that entry's {@link SceneActivation}
+   * — and forwards the returned value opaquely to that occurrence's
+   * `create(ctx)` / `timeline(ctx)` / `cleanup(ctx)` hooks. A
+   * composition slice that repeats a scene id therefore gives each
+   * occurrence a DISTINCT `ctx` (issue #99), so a scene can own its
+   * occurrence's DOM / listeners / state without colliding with a
+   * sibling occurrence of the same module.
+   *
+   * The resolver does not inspect or extend the returned value
+   * (ADR-011): building the per-occurrence `ctx` from a navigation-
+   * scoped base plus the activation is the caller's job (the scene
+   * loader threads `ctx.gsap` / `ctx.audio` / `ctx.stage` and adds the
+   * activation). The factory is called once per entry at plan time,
+   * before any side effect; a throw aborts the composition with the
+   * `composition resolution failed:` envelope.
    */
-  readonly ctx: unknown;
+  readonly ctx: (activation: SceneActivation) => unknown;
   /** Preload adapter — see {@link AssetPreloader}. */
   readonly preloadAssets: AssetPreloader;
   /** Timeline-composition/playback adapter — see {@link CompositionTimelineAdapter}. */
@@ -276,14 +317,18 @@ export interface ResolveCompositionOptions {
   /**
    * Per-scene post-cleanup hook (PUL-F024 / ADR-004). Invoked after each
    * scene's `cleanup(ctx)` completes during the cleanup phase, in the
-   * same reverse-mount order. The scene loader wires this so the runtime
-   * stops the audio group a scene scoped to itself (`group: <sceneId>`)
-   * when that scene's `cleanup` runs — runtime-guaranteed per-scene
-   * audio teardown rather than author discipline. The resolver itself
-   * does not interpret the id; it just forwards it. A throw from the
-   * hook is treated like a cleanup failure (collected, not swallowed).
+   * same reverse-mount order, with the cleaned occurrence's
+   * {@link SceneActivation} identity. The scene loader wires this so the
+   * runtime stops the audio group a scene scoped to itself
+   * (`group: <sceneId>`) when that scene's `cleanup` runs —
+   * runtime-guaranteed per-scene audio teardown rather than author
+   * discipline. The resolver itself does not interpret the activation;
+   * it just forwards it. Invoked exactly once per occurrence (issue
+   * #99): for a slice that repeats a scene id every occurrence gets its
+   * own call with a distinct `occurrence` ordinal. A throw from the hook
+   * is treated like a cleanup failure (collected, not swallowed).
    */
-  readonly onSceneCleaned?: (sceneId: string) => void;
+  readonly onSceneCleaned?: (activation: SceneActivation) => void;
   /**
    * Per-scene failure sink (PUL-F029 / ADR-028). Invoked once per
    * isolated lifecycle failure with structured `{ phase, sceneId,
@@ -327,10 +372,35 @@ interface PlanStep {
   /**
    * Position of the entry in the manifest the resolver was handed
    * (PUL-F029 / ADR-028 diagnostic contract — see
-   * {@link SceneFailureEvent.entryIndex}).
+   * {@link SceneActivation.entryIndex}).
    */
   readonly entryIndex: number;
+  /**
+   * 0-based ordinal of this entry among the plan entries that share
+   * `scene.id` (issue #99 — see {@link SceneActivation.occurrence}).
+   */
+  readonly occurrence: number;
+  /**
+   * The per-occurrence scene context (issue #99). Built once at plan
+   * time from {@link ResolveCompositionOptions.ctx} and this entry's
+   * activation, then handed unchanged to this occurrence's
+   * `create(ctx)` / `timeline(ctx)` / `cleanup(ctx)` — so two
+   * occurrences of the same scene module each get their own `ctx`.
+   * Opaque to the resolver.
+   */
+  readonly ctx: unknown;
 }
+
+/**
+ * Project a {@link PlanStep} onto its {@link SceneActivation} identity —
+ * the `{ sceneId, entryIndex, occurrence }` tuple every per-occurrence
+ * lifecycle surface (`onSceneCleaned`, `SceneFailureEvent`) carries.
+ */
+const activationOf = (step: PlanStep): SceneActivation => ({
+  sceneId: step.scene.id,
+  entryIndex: step.entryIndex,
+  occurrence: step.occurrence,
+});
 
 /**
  * Build the resolver's wrapping `Error`. Every public failure carries
@@ -365,48 +435,50 @@ function throwIfAborted(signal: AbortSignal | undefined, detail: string): void {
 /**
  * Clause (a) plus snapshot capture: walk every entry exactly once,
  * resolve every scene id against the registry, snapshot per-entry
- * `range` / `behavior` overrides, and aggregate ALL missing ids into
- * one error before any side effect (friendlier than fail-on-first — a
- * manifest author fixes every typo in one pass).
+ * `range` / `behavior` overrides, assign each entry its per-occurrence
+ * activation identity + `ctx` (issue #99), and aggregate ALL missing
+ * ids into one error before any side effect (friendlier than
+ * fail-on-first — a manifest author fixes every typo in one pass).
  */
-function buildPlan(manifest: CompositionManifest, registry: SceneRegistry): readonly PlanStep[] {
+function buildPlan(
+  manifest: CompositionManifest,
+  registry: SceneRegistry,
+  ctxFor: (activation: SceneActivation) => unknown,
+): readonly PlanStep[] {
   const missing = findUnregisteredEntries(manifest, (id) => registry.has(id));
   if (missing.length > 0) {
     const list = missing.map(({ id, index }) => `${quoteId(id)} (entry [${index}])`).join(', ');
     throw fail(`unknown scene id(s): ${list} — not registered`, undefined);
   }
-  // ADR-025: the mount-all lifecycle activates every entry concurrently
-  // (every scene's DOM coexists while the master plays), so two entries
-  // with the same scene id would share one activation context — the
-  // second `create(ctx)` would clobber the first's DOM / listeners and
-  // `cleanup(ctx)` could not tell which occurrence it owns. Per-entry
-  // activation contexts (a container / occurrence handle threaded
-  // through create / timeline / cleanup) are a follow-up; until then a
-  // composition slice may not repeat a scene id. Single-scene workbench
-  // modes truncate the slice to the head before the resolver sees it,
-  // so a `[x, x]` composition is still navigable under those modes.
-  const occurrences = new Map<string, number[]>();
-  for (const [index, entry] of manifest.entries()) {
-    const id = entryId(entry);
-    const at = occurrences.get(id);
-    if (at === undefined) occurrences.set(id, [index]);
-    else at.push(index);
-  }
-  for (const [id, indices] of occurrences) {
-    if (indices.length > 1) {
-      const entryList = indices.map((i) => `[${i}]`).join(', ');
-      throw fail(
-        `composition references scene id ${quoteId(id)} more than once (entries ${entryList}) — repeated scene ids in a composition slice are not yet supported: each occurrence would share one activation context (DOM, listeners, timeline targets, cleanup ownership)`,
-        undefined,
-      );
-    }
-  }
+  // ADR-002 / issue #99: a composition slice MAY reference the same
+  // scene id more than once. Each occurrence is a distinct activation
+  // — the resolver tracks one `PlanStep` per entry, so `create` /
+  // `timeline` / `cleanup` run once per occurrence and the eager- and
+  // final-cleanup paths key off the step object, never the scene id.
+  // The 0-based per-scene-id `occurrence` ordinal computed here is the
+  // stable occurrence identity threaded to `onSceneCleaned` and
+  // `onSceneFailed`; it mirrors the counter the timeline composer uses
+  // for label namespacing so every surface agrees.
+  const occurrenceCounter = new Map<string, number>();
   const plan: PlanStep[] = [];
   for (const [entryIndex, entry] of manifest.entries()) {
-    const scene = registry.get(entryId(entry));
+    const id = entryId(entry);
+    const scene = registry.get(id);
+    const occurrence = occurrenceCounter.get(id) ?? 0;
+    occurrenceCounter.set(id, occurrence + 1);
     const range = typeof entry === 'string' ? undefined : entry.range;
     const behavior = typeof entry === 'string' ? undefined : entry.behavior;
-    plan.push({ scene, range, behavior, entryIndex });
+    const activation: SceneActivation = { sceneId: id, entryIndex, occurrence };
+    let ctx: unknown;
+    try {
+      ctx = ctxFor(activation);
+    } catch (cause) {
+      throw fail(
+        `scene ${quoteId(id)} (entry [${entryIndex}]) ctx factory threw: ${describeError(cause)}`,
+        cause,
+      );
+    }
+    plan.push({ scene, range, behavior, entryIndex, occurrence, ctx });
   }
   return Object.freeze(plan);
 }
@@ -434,9 +506,8 @@ function buildSceneFailure(
   detail: string,
 ): { event: SceneFailureEvent; wrapper: Error } {
   const event: SceneFailureEvent = {
+    ...activationOf(step),
     phase,
-    sceneId: step.scene.id,
-    entryIndex: step.entryIndex,
     message: describeError(cause),
     cause,
   };
@@ -472,9 +543,8 @@ interface FailureBucket {
  * wiring identical across phases.
  */
 interface LifecycleContext {
-  readonly ctx: unknown;
   readonly signal: AbortSignal | undefined;
-  readonly onSceneCleaned: ((sceneId: string) => void) | undefined;
+  readonly onSceneCleaned: ((activation: SceneActivation) => void) | undefined;
   readonly onSceneFailed: ((event: SceneFailureEvent) => void) | undefined;
   readonly bucket: FailureBucket;
 }
@@ -524,7 +594,7 @@ function notifyFailure(
  */
 async function cleanOneScene(step: PlanStep, lc: LifecycleContext): Promise<void> {
   try {
-    await step.scene.cleanup(lc.ctx);
+    await step.scene.cleanup(step.ctx);
   } catch (error_) {
     const { event, wrapper } = buildSceneFailure(
       'cleanup',
@@ -537,7 +607,7 @@ async function cleanOneScene(step: PlanStep, lc: LifecycleContext): Promise<void
     notifyFailure(lc.onSceneFailed, event, lc.bucket);
   }
   try {
-    lc.onSceneCleaned?.(step.scene.id);
+    lc.onSceneCleaned?.(activationOf(step));
   } catch (err) {
     lc.bucket.hookErrors.push(
       fail(`scene ${quoteId(step.scene.id)} onSceneCleaned threw: ${describeError(err)}`, err),
@@ -572,7 +642,7 @@ async function mountPlan(
     // scene only after its cleanup ran (one cleanup per scene).
     mounted.push(step);
     try {
-      await step.scene.create(lc.ctx);
+      await step.scene.create(step.ctx);
     } catch (cause) {
       const { event, wrapper } = buildSceneFailure(
         'create',
@@ -632,7 +702,7 @@ async function composeSegments(
   for (const step of snapshot) {
     let timeline: unknown;
     try {
-      timeline = step.scene.timeline(lc.ctx);
+      timeline = step.scene.timeline(step.ctx);
     } catch (cause) {
       const { event, wrapper } = buildSceneFailure(
         'timeline',
@@ -798,7 +868,7 @@ export async function resolveComposition(options: ResolveCompositionOptions): Pr
   }
 
   assertCompositionManifest(manifest);
-  const plan = buildPlan(manifest, registry);
+  const plan = buildPlan(manifest, registry, options.ctx);
 
   // Pre-start abort: nothing was touched, so this needs no cleanup.
   throwIfAborted(signal, 'aborted before the composition started');
@@ -810,7 +880,6 @@ export async function resolveComposition(options: ResolveCompositionOptions): Pr
   // option's contract a hook throw is "treated like a cleanup failure
   // (collected, not swallowed)."
   const lc: LifecycleContext = {
-    ctx: options.ctx,
     signal,
     onSceneCleaned: options.onSceneCleaned,
     onSceneFailed: options.onSceneFailed,

--- a/src/runtime/error.ts
+++ b/src/runtime/error.ts
@@ -166,6 +166,15 @@ export interface SceneErrorContext {
    * authored label for a {@link import('./timeline').SceneTimelineLabelError}.
    */
   readonly beat?: string;
+  /**
+   * The 0-based per-scene-id occurrence ordinal, when the diagnostic
+   * concerns one occurrence of a composition that repeats a scene id
+   * (issue #99 — see `SceneActivation` in `composition-resolver.ts`).
+   * Occurrence `0` (the first / only use) renders bare, so a
+   * single-occurrence diagnostic is byte-identical to one with no
+   * `occurrence` supplied; only a later occurrence shows the ordinal.
+   */
+  readonly occurrence?: number;
 }
 
 /**
@@ -187,9 +196,17 @@ export interface SceneErrorContext {
  *  - `{ sceneId: 'X', phase: 'create' }`                      → `scene "X" failed during create`
  *  - `{ sceneId: 'X', beat: 'b' }`                            → `scene "X" at beat "b"`
  *  - `{ sceneId: 'X', phase: 'timeline', beat: 'b' }`         → `scene "X" failed during timeline at beat "b"`
+ *  - `{ sceneId: 'X', occurrence: 0 }`                        → `scene "X"`
+ *  - `{ sceneId: 'X', phase: 'create', occurrence: 2 }`       → `scene "X" (occurrence 2) failed during create`
  */
 export function formatSceneContext(context: SceneErrorContext): string {
   let out = `scene "${context.sceneId}"`;
+  // Occurrence 0 (first / only use) renders bare so a single-occurrence
+  // diagnostic is unchanged; a later occurrence of a repeated scene id
+  // carries the ordinal (issue #99).
+  if (context.occurrence !== undefined && context.occurrence > 0) {
+    out += ` (occurrence ${context.occurrence})`;
+  }
   if (context.phase !== undefined) out += ` failed during ${context.phase}`;
   if (context.beat !== undefined) out += ` at beat "${context.beat}"`;
   return out;

--- a/src/runtime/scene-loader.ts
+++ b/src/runtime/scene-loader.ts
@@ -41,6 +41,7 @@ import type { CompositionRegistry } from './composition-registry';
 import type {
   AssetPreloader,
   CompositionTimelineAdapter,
+  SceneActivation,
   SceneFailureEvent,
 } from './composition-resolver';
 import { describeErrorDetailed, formatSceneContext } from './error';
@@ -69,7 +70,7 @@ import {
   loadSceneNavigationTarget,
   resolveSceneNavigation,
 } from './scene-navigation';
-import type { TimelineEngine } from './timeline';
+import { type TimelineEngine, sceneSegmentLabel } from './timeline';
 
 /** The minimal subset of an HTMLElement the loader writes to. */
 export interface StageElement {
@@ -161,20 +162,36 @@ export interface WorkbenchSceneCtx {
    *
    * One service per navigation: under single-scene modes that is the
    * one scene; under `mode=present` it is shared across the whole
-   * composition slice (the resolver mounts the slice with one ctx and
-   * forbids it repeating a scene id). The sound-id namespace and the
-   * source allowlist (the slice's declared `scene.assets`) are therefore
-   * slice-scoped — multi-scene compositions pick distinct sound ids, the
-   * same stable-identity discipline scene ids obey (ADR-008 #1), and
+   * composition slice. The sound-id namespace and the source allowlist
+   * (the slice's declared `scene.assets`) are therefore slice-scoped —
+   * multi-scene compositions pick distinct sound ids, the same
+   * stable-identity discipline scene ids obey (ADR-008 #1), and
    * registering an id twice with the same definition is idempotent. A
    * scene scopes a sound to itself with `play(id, { group: <its-scene-id> })`;
-   * the loader wires the resolver's per-scene post-`cleanup(ctx)` hook
-   * to `stopGroup(sceneId)`, so the runtime (not the author) stops a
-   * scene's group when that scene's `cleanup` runs. True per-scene
-   * activation contexts (one `ctx.audio` facade per scene entry) are a
-   * documented resolver follow-up.
+   * that group is scene-scoped — shared by every occurrence of a scene
+   * id a composition slice repeats (issue #99). The loader wires the
+   * resolver's per-scene post-`cleanup(ctx)` hook so the runtime (not
+   * the author) stops a scene's group when the LAST occurrence of that
+   * scene id has been cleaned up — occurrence-safe teardown that never
+   * cuts a still-active sibling occurrence's audio.
    */
   readonly audio: AudioService;
+  /**
+   * This activation's stable per-occurrence identity (issue #99 — see
+   * {@link import('./composition-resolver').SceneActivation}):
+   * `{ sceneId, entryIndex, occurrence }`. A composition slice may
+   * reference the same scene module more than once; every occurrence
+   * runs against its OWN `ctx` carrying its own `activation`, so a
+   * scene can own its occurrence's DOM / listeners / state (e.g. derive
+   * an occurrence-scoped mount sub-root, or key any scene-local map by
+   * the activation) without colliding with a sibling occurrence of the
+   * same module. `occurrence` is `0` for the first / only use.
+   *
+   * Loader-contributed: {@link SceneLoaderOptions.buildCtx} builds the
+   * navigation-scoped fields above; the loader then adds `activation`
+   * per occurrence, which is why `buildCtx`'s return type omits it.
+   */
+  readonly activation: SceneActivation;
 }
 
 /**
@@ -194,23 +211,28 @@ export interface SceneLoaderOptions {
    * effective workbench mode derived from the URL via
    * {@link effectiveMode} (PUL-F012 / ADR-007) and the per-navigation
    * audio service (PUL-F024 / ADR-004) the loader built from
-   * {@link audioEngine}. The returned value is forwarded opaquely to
-   * every lifecycle hook (`create` / `timeline` / `cleanup`); the
-   * resolver never inspects it.
+   * {@link audioEngine}. The returned navigation-scoped value is the
+   * base the loader threads, per occurrence, into every lifecycle hook
+   * (`create` / `timeline` / `cleanup`); the resolver never inspects it.
    *
-   * Returns {@link WorkbenchSceneCtx} so the production contract
-   * "scenes receive `ctx.mode` / `ctx.audio`" is enforced at this
-   * boundary rather than relying on a single workbench bootstrap
-   * annotation. Mode dispatch lives at this seam per ADR-007 ("Mode is
-   * dispatched in the runtime core, not per scene"): the workbench
-   * supplies the stage and any other long-lived ctx members through a
-   * closure, the loader contributes the per-navigation `mode` and
-   * `audio`, and the combined value is what scenes see as `ctx`.
-   * Constructing a fresh ctx per navigation also blocks any "previous
-   * mode leaks into a `mode`-less URL" regression — every navigation
-   * re-derives mode from its own target — and a fresh audio service
-   * per navigation makes "audio survives the scene that started it"
-   * structurally impossible.
+   * Returns the navigation-scoped fields of {@link WorkbenchSceneCtx} so
+   * the production contract "scenes receive `ctx.mode` / `ctx.audio`"
+   * is enforced at this boundary rather than relying on a single
+   * workbench bootstrap annotation. Mode dispatch lives at this seam
+   * per ADR-007 ("Mode is dispatched in the runtime core, not per
+   * scene"): the workbench supplies the stage and any other long-lived
+   * ctx members through a closure, the loader contributes the
+   * per-navigation `mode` and `audio`. Constructing a fresh ctx per
+   * navigation also blocks any "previous mode leaks into a `mode`-less
+   * URL" regression — every navigation re-derives mode from its own
+   * target — and a fresh audio service per navigation makes "audio
+   * survives the scene that started it" structurally impossible.
+   *
+   * The return type omits `activation` (issue #99): `buildCtx` is
+   * called once per navigation and cannot know a per-occurrence
+   * identity. The loader adds each occurrence's `SceneActivation` on
+   * top of this base, so a composition slice that repeats a scene id
+   * gives every occurrence a distinct `ctx`.
    *
    * Not invoked when the locator is `kind: 'none'` (no scene mounts)
    * or when the navigation event is a parse-error event, because
@@ -220,7 +242,7 @@ export interface SceneLoaderOptions {
     mode: NavigationMode,
     audio: AudioService,
     presenter?: PresenterController,
-  ) => WorkbenchSceneCtx;
+  ) => Omit<WorkbenchSceneCtx, 'activation'>;
   /**
    * The audio engine (PUL-F024 / ADR-004) — a process singleton, like
    * the timeline engine (ADR-003). The loader builds a fresh
@@ -476,7 +498,9 @@ const ATTR_ERROR = 'data-pulsar-navigation-error';
 // PUL-F029 / ADR-028: per-scene lifecycle failures land on a dedicated
 // attribute so the fatal `data-pulsar-navigation-error` surface keeps
 // its "composition aborted" semantics. The value is a comma-separated
-// list of `<sceneId>:<phase>` entries in encounter order.
+// list of `<sceneId>:<phase>` entries in encounter order; a failure of
+// a repeated scene id (issue #99) namespaces the entry by occurrence
+// (`<sceneId>#<n>:<phase>` for occurrence > 0, bare for occurrence 0).
 const ATTR_SCENE_FAILURES = 'data-pulsar-scene-failures';
 
 /**
@@ -537,6 +561,29 @@ function collectAudioSources(target: SceneNavigationTarget): readonly string[] {
   return target.composition === undefined
     ? target.scene.audio
     : target.composition.sceneSlice.flatMap((scene) => scene.audio);
+}
+
+/**
+ * Count, per scene id, how many times it occurs in the resolved
+ * navigation slice (issue #99). The loader's occurrence-safe audio
+ * teardown consults this so the scene-scoped audio group
+ * (`group: <sceneId>`, shared by every occurrence of that scene because
+ * `ctx.audio` is one slice-scoped service) is stopped exactly once —
+ * when the LAST occurrence of that id has been cleaned up — rather than
+ * once per occurrence. Stopping it on the first occurrence's cleanup
+ * would tear down a still-active sibling occurrence's audio. For a
+ * single-occurrence scene the count is `1`, so teardown fires on its
+ * only cleanup, unchanged. Pure function (no closure captures), hoisted
+ * to module scope so the loader factory does not recreate it per
+ * instance.
+ */
+function countSceneOccurrences(target: SceneNavigationTarget): Map<string, number> {
+  const scenes = target.composition === undefined ? [target.scene] : target.composition.sceneSlice;
+  const counts = new Map<string, number>();
+  for (const scene of scenes) {
+    counts.set(scene.id, (counts.get(scene.id) ?? 0) + 1);
+  }
+  return counts;
 }
 
 /**
@@ -665,10 +712,11 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
    * ADR-028: no raw causes, stacks, scene objects, DOM, captions,
    * headers, cookies, env, auth values).
    *
-   * The handler accumulates `<sceneId>:<phase>` entries into a Set so
+   * The handler accumulates occurrence-namespaced entries into a Set so
    * a scene whose `create` AND `cleanup` both throw shows up once per
-   * (id, phase) tuple in encounter order, not twice for the same
-   * tuple.
+   * (id, occurrence, phase) tuple in encounter order, not twice for the
+   * same tuple — and so two occurrences of one repeated scene id stay
+   * distinguishable (issue #99).
    *
    * Two-tier suppression:
    *  - **Stage attribute writes** are suppressed when the
@@ -690,13 +738,18 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
     const entries: string[] = [];
     const seen = new Set<string>();
     const renderMessage = (event: SceneFailureEvent): string => {
-      // PUL-Q006 / ADR-028: scene id + lifecycle phase come from the
-      // canonical `formatSceneContext` helper in `./error.ts` so any
-      // future PUL-Q006 context (composition entry, occurrence index,
-      // mode) gets added there once instead of re-templated at every
-      // public-surface seam (codex preflight: "do not satisfy the
-      // requirement by parsing Error.message").
-      const prefix = formatSceneContext({ sceneId: event.sceneId, phase: event.phase });
+      // PUL-Q006 / ADR-028: scene id, lifecycle phase, and the
+      // per-occurrence ordinal (issue #99) come from the canonical
+      // `formatSceneContext` helper in `./error.ts` so any future
+      // PUL-Q006 context gets added there once instead of re-templated
+      // at every public-surface seam (codex preflight: "do not satisfy
+      // the requirement by parsing Error.message"). Occurrence 0
+      // renders bare, so a single-occurrence diagnostic is unchanged.
+      const prefix = formatSceneContext({
+        sceneId: event.sceneId,
+        phase: event.phase,
+        occurrence: event.occurrence,
+      });
       // Codex review cycle 2: render the ABSOLUTE composition entry
       // index (slice start + resolver-level slice-relative index).
       // The resolver's `event.entryIndex` is relative to the manifest
@@ -713,7 +766,13 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
     return (event: SceneFailureEvent): void => {
       if (disposed) return;
       if (!signal.aborted) {
-        const key = `${event.sceneId}:${event.phase}`;
+        // issue #99: namespace the entry by the failing occurrence so
+        // two failures of the same scene id in the same phase are
+        // distinguishable. `sceneSegmentLabel` is the canonical
+        // scene+occurrence namer the timeline composer also uses —
+        // occurrence 0 renders bare (`<sceneId>:<phase>`), so a
+        // single-occurrence failures attribute is unchanged.
+        const key = `${sceneSegmentLabel(event.sceneId, event.occurrence)}:${event.phase}`;
         if (!seen.has(key)) {
           seen.add(key);
           entries.push(key);
@@ -1099,7 +1158,12 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
     // rollback-then-surfaceError pattern so a throwing builder does
     // not leave stale stage attrs or skip the queue's error sink.
     const outputPolicy = audioOutputPolicyFor(mode);
-    let ctx: unknown;
+    // issue #99: the loader threads a per-occurrence ctx factory rather
+    // than a single ctx. `buildCtx` builds the navigation-scoped base
+    // (stage / gsap / audio / mode / presenter / chrome) once; the
+    // factory adds each occurrence's `SceneActivation` so a slice that
+    // repeats a scene id gives every occurrence a distinct `ctx`.
+    let buildSceneCtx: (activation: SceneActivation) => unknown;
     let audio: AudioService;
     // Per-navigation presenter pipe is built BEFORE buildCtx so the
     // controller can be threaded onto `ctx.presenter` for scenes that
@@ -1120,7 +1184,8 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
       const pipe = buildPresenterPipe(mode, controller, audio);
       presenter = pipe.presenter;
       presenterAbort = pipe.presenterAbort;
-      ctx = options.buildCtx(mode, audio, presenter);
+      const baseCtx = options.buildCtx(mode, audio, presenter);
+      buildSceneCtx = (activation) => ({ ...baseCtx, activation });
     } catch (err) {
       // Abort the freshly-created controller before bailing so any
       // signal-tied resource (the preloader factory's fetch listener,
@@ -1193,10 +1258,25 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
         ? undefined
         : { id: resolved.composition.id, startIndex: resolved.composition.startIndex },
     );
+    // PUL-F024 / ADR-004 + issue #99: occurrence-safe per-scene audio
+    // teardown. A scene scopes a sound to itself with
+    // `play(id, { group: <its-scene-id> })`; that group is shared by
+    // every occurrence of the scene in the slice (`ctx.audio` is one
+    // slice-scoped service). The runtime stops the group only when the
+    // LAST occurrence of that id has been cleaned up — counting down
+    // per scene id — so an earlier occurrence's cleanup never stops a
+    // still-active sibling occurrence's audio. A single-occurrence
+    // scene counts `1` and tears down on its only cleanup, unchanged.
+    const remainingOccurrences = countSceneOccurrences(resolved);
+    const onSceneCleaned = (activation: SceneActivation): void => {
+      const left = (remainingOccurrences.get(activation.sceneId) ?? 1) - 1;
+      remainingOccurrences.set(activation.sceneId, left);
+      if (left <= 0) audio.stopGroup(activation.sceneId);
+    };
     // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: existing pre-rule offender (cognitive complexity 21). runLifecycle wires every per-target option (preload, timeline, abort, presenter, screenshot, error envelope) into the scene-loader lifecycle; refactor tracked in docs/design/complexity-backlog.md.
     const runLifecycle = (): Promise<void> =>
       loadSceneNavigationTarget(resolved, {
-        ctx,
+        ctx: buildSceneCtx,
         preloadAssets,
         timeline: options.timeline,
         signal: controller.signal,
@@ -1212,12 +1292,10 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
         // through the same diagnostic channel as every other
         // navigation-level error (codex review, cycle 2).
         ...(presenter === undefined ? {} : { presenter, onPresenterError: onError }),
-        // PUL-F024 / ADR-004: the runtime stops the audio group a scene
-        // scoped to itself (`group: <its-scene-id>`) when that scene's
-        // `cleanup(ctx)` runs — runtime-guaranteed per-scene teardown,
-        // not author discipline. (`stopGroup` is a no-op when the group
-        // is empty or the service is already disposed.)
-        onSceneCleaned: (sceneId) => audio.stopGroup(sceneId),
+        // PUL-F024 / ADR-004 + issue #99: runtime-guaranteed per-scene
+        // audio teardown — see `onSceneCleaned` above. (`stopGroup` is
+        // a no-op when the group is empty or the service is disposed.)
+        onSceneCleaned,
         // PUL-F029 / ADR-028: scene-level error isolation. Each
         // isolated `create` / `timeline` / `cleanup` failure becomes
         // a stage attribute entry + `onError` call without halting

--- a/src/runtime/scene-navigation.ts
+++ b/src/runtime/scene-navigation.ts
@@ -36,6 +36,7 @@ import {
   type AssetPreloader,
   type CompositionTimelineAdapter,
   type ResolveCompositionOptions,
+  type SceneActivation,
   resolveComposition,
 } from './composition-resolver';
 import type { NavigationTarget } from './navigation';
@@ -120,8 +121,15 @@ export interface ResolveSceneNavigationOptions {
  * dispatcher verified.
  */
 export interface LoadSceneNavigationTargetOptions {
-  /** Opaque scene context forwarded to every lifecycle hook. */
-  readonly ctx: unknown;
+  /**
+   * Per-occurrence scene-context factory, forwarded to
+   * {@link resolveComposition} as `ctx` (issue #99). The resolver calls
+   * it once per composition entry with that entry's
+   * {@link SceneActivation}; a slice that repeats a scene id therefore
+   * gives each occurrence a distinct `ctx`. The resolver does not
+   * inspect the returned value (ADR-011).
+   */
+  readonly ctx: (activation: SceneActivation) => unknown;
   /** Preload adapter — see {@link AssetPreloader}. */
   readonly preloadAssets: AssetPreloader;
   /** Timeline composition/playback adapter — see {@link CompositionTimelineAdapter}. */
@@ -252,9 +260,12 @@ export interface LoadSceneNavigationTargetOptions {
    * Per-scene post-cleanup hook (PUL-F024 / ADR-004). Forwarded to
    * {@link resolveComposition} as `onSceneCleaned`; the loader wires it
    * to stop the audio group a scene scoped to itself when that scene's
-   * `cleanup(ctx)` runs. Absent for callers that do not need it.
+   * `cleanup(ctx)` runs. Receives the cleaned occurrence's
+   * {@link SceneActivation} identity so a slice that repeats a scene id
+   * can be torn down occurrence-safely (issue #99). Absent for callers
+   * that do not need it.
    */
-  readonly onSceneCleaned?: (sceneId: string) => void;
+  readonly onSceneCleaned?: (activation: SceneActivation) => void;
   /**
    * Per-scene failure sink (PUL-F029 / ADR-028). Forwarded to
    * {@link resolveComposition} as `onSceneFailed`; the loader wires it

--- a/tests/runtime/composition-resolver.test.ts
+++ b/tests/runtime/composition-resolver.test.ts
@@ -15,6 +15,7 @@ import type { CompositionManifest } from '../../src/runtime/composition';
 import {
   type CompositionTimelineAdapter,
   type CompositionTimelineRunOptions,
+  type SceneActivation,
   type SceneFailureEvent,
   type SceneTimelineSegment,
   resolveComposition,
@@ -114,7 +115,7 @@ interface ResolveArgs {
   readonly manifest: CompositionManifest;
   readonly timeline?: CompositionTimelineAdapter;
   readonly preloadAssets?: (scene: SceneModule) => void | Promise<void>;
-  readonly ctx?: unknown;
+  readonly ctx?: (activation: SceneActivation) => unknown;
   readonly signal?: AbortSignal;
   readonly headBeat?: string;
   readonly onBeatMissing?: () => void;
@@ -122,7 +123,7 @@ interface ResolveArgs {
   readonly headHold?: 'first-frame';
   readonly headCueGate?: 'monotonic-forward';
   readonly headScreenshot?: 'capture';
-  readonly onSceneCleaned?: (sceneId: string) => void;
+  readonly onSceneCleaned?: (activation: SceneActivation) => void;
   readonly onSceneFailed?: (event: SceneFailureEvent) => void;
 }
 
@@ -130,7 +131,7 @@ const run = (args: ResolveArgs): Promise<void> =>
   resolveComposition({
     registry: createSceneRegistry([...args.scenes]),
     manifest: args.manifest,
-    ctx: args.ctx ?? {},
+    ctx: args.ctx ?? ((): unknown => ({})),
     preloadAssets: args.preloadAssets ?? ((): void => undefined),
     timeline: args.timeline ?? recordingTimeline().adapter,
     ...(args.signal === undefined ? {} : { signal: args.signal }),
@@ -190,25 +191,122 @@ describe('resolveComposition — boundary validation', () => {
     );
   });
 
-  it('rejects a composition slice that repeats a scene id, before any side effect (ADR-025)', async () => {
-    // The mount-all lifecycle activates every entry concurrently, so two
-    // `intro` occurrences would share one activation context. Per-entry
-    // contexts are a follow-up; until then a repeated scene id in a
-    // slice is a navigation error (single-scene modes truncate the slice
-    // to the head, so they stay navigable).
+  it('resolves a composition slice that repeats a scene id, mounting each occurrence once (issue #99)', async () => {
+    // ADR-002 allows a composition to reference the same scene module
+    // more than once. Each occurrence is a distinct activation: it is
+    // mounted, composed, and torn down once, in manifest / reverse
+    // order — never collapsed by scene id.
     const log: string[] = [];
-    const preloadAssets = vi.fn((): void => undefined);
+    const { adapter, calls } = recordingTimeline();
     await expect(
       run({
         scenes: [recordingScene('intro', log), recordingScene('demo', log)],
         manifest: ['intro', 'demo', 'intro'],
-        preloadAssets,
+        timeline: adapter,
       }),
-    ).rejects.toThrow(
-      'composition resolution failed: composition references scene id "intro" more than once (entries [0], [2]) — repeated scene ids in a composition slice are not yet supported: each occurrence would share one activation context (DOM, listeners, timeline targets, cleanup ownership)',
-    );
-    expect(preloadAssets).not.toHaveBeenCalled();
-    expect(log).toEqual([]);
+    ).resolves.toBeUndefined();
+    expect(log).toEqual([
+      'create:intro',
+      'create:demo',
+      'create:intro',
+      'timeline:intro',
+      'timeline:demo',
+      'timeline:intro',
+      'cleanup:intro',
+      'cleanup:demo',
+      'cleanup:intro',
+    ]);
+    // Both `intro` occurrences contribute a distinct timeline segment,
+    // in manifest order, so the composer can namespace them.
+    expect(calls[0]?.segments.map((s) => s.id)).toEqual(['intro', 'demo', 'intro']);
+  });
+
+  it('hands onSceneCleaned a per-occurrence activation for repeated scene ids (issue #99)', async () => {
+    const log: string[] = [];
+    const cleaned: SceneActivation[] = [];
+    await run({
+      scenes: [recordingScene('intro', log), recordingScene('demo', log)],
+      manifest: ['intro', 'demo', 'intro'],
+      onSceneCleaned: (activation) => cleaned.push(activation),
+    });
+    // Reverse mount order: intro#1 (entry 2), demo#0 (entry 1),
+    // intro#0 (entry 0). Each occurrence carries a stable identity.
+    expect(cleaned).toEqual([
+      { sceneId: 'intro', entryIndex: 2, occurrence: 1 },
+      { sceneId: 'demo', entryIndex: 1, occurrence: 0 },
+      { sceneId: 'intro', entryIndex: 0, occurrence: 0 },
+    ]);
+  });
+
+  it('builds a distinct per-occurrence ctx carrying each occurrence activation (issue #99)', async () => {
+    const seen: Array<{ phase: string; activation: SceneActivation }> = [];
+    const record =
+      (phase: string) =>
+      (ctx: unknown): void => {
+        seen.push({ phase, activation: (ctx as { activation: SceneActivation }).activation });
+      };
+    const intro = scene('intro', { create: record('create'), cleanup: record('cleanup') });
+    await run({
+      scenes: [intro, scene('demo')],
+      manifest: ['intro', 'demo', 'intro'],
+      ctx: (activation) => ({ activation }),
+    });
+    // Each `intro` occurrence's hooks receive a ctx scoped to ITS
+    // activation — distinct entry index and occurrence ordinal — so a
+    // scene can own its occurrence's DOM / listeners / state. Cleanup
+    // runs in reverse mount order (intro#1 then intro#0).
+    expect(seen).toEqual([
+      { phase: 'create', activation: { sceneId: 'intro', entryIndex: 0, occurrence: 0 } },
+      { phase: 'create', activation: { sceneId: 'intro', entryIndex: 2, occurrence: 1 } },
+      { phase: 'cleanup', activation: { sceneId: 'intro', entryIndex: 2, occurrence: 1 } },
+      { phase: 'cleanup', activation: { sceneId: 'intro', entryIndex: 0, occurrence: 0 } },
+    ]);
+  });
+
+  it('isolates one occurrence of a repeated scene id and keeps the sibling (issue #99)', async () => {
+    // The first `intro` occurrence's `create` throws; the resolver
+    // isolates that occurrence (eager cleanup) and the second
+    // occurrence still mounts and runs — repeated ids do not couple
+    // failure isolation.
+    const log: string[] = [];
+    const failed: SceneFailureEvent[] = [];
+    let createCalls = 0;
+    const intro = scene('intro', {
+      create: (): void => {
+        const occurrence = createCalls;
+        createCalls += 1;
+        log.push(`create:intro#${occurrence}`);
+        if (occurrence === 0) throw new Error('first intro boom');
+      },
+      timeline: (): null => {
+        log.push('timeline:intro');
+        return null;
+      },
+      cleanup: (): void => {
+        log.push('cleanup:intro');
+      },
+    });
+    await run({
+      scenes: [intro],
+      manifest: ['intro', 'intro'],
+      onSceneFailed: (event) => failed.push(event),
+    });
+    expect(failed).toHaveLength(1);
+    expect(failed[0]).toMatchObject({
+      sceneId: 'intro',
+      entryIndex: 0,
+      occurrence: 0,
+      phase: 'create',
+    });
+    // intro#0: create throws → eager cleanup. intro#1: create →
+    // timeline → final cleanup. The surviving occurrence is unaffected.
+    expect(log).toEqual([
+      'create:intro#0',
+      'cleanup:intro',
+      'create:intro#1',
+      'timeline:intro',
+      'cleanup:intro',
+    ]);
   });
 });
 
@@ -694,8 +792,8 @@ describe('resolveComposition — cleanup phase', () => {
 
   it('invokes onSceneCleaned after each scene cleanup, in reverse mount order (PUL-F024)', async () => {
     const log: string[] = [];
-    const recordCleaned = (id: string): void => {
-      log.push(`cleaned:${id}`);
+    const recordCleaned = (activation: SceneActivation): void => {
+      log.push(`cleaned:${activation.sceneId}`);
     };
     await run({
       scenes: [recordingScene('a', log), recordingScene('b', log), recordingScene('c', log)],
@@ -726,9 +824,9 @@ describe('resolveComposition — cleanup phase', () => {
         }),
       ],
       manifest: ['a', 'b'],
-      onSceneCleaned: (id) => {
-        log.push(`cleaned:${id}`);
-        if (id === 'a') throw new Error('hook-a kaboom');
+      onSceneCleaned: (activation) => {
+        log.push(`cleaned:${activation.sceneId}`);
+        if (activation.sceneId === 'a') throw new Error('hook-a kaboom');
       },
     }).catch((err: unknown) => {
       caught = err;
@@ -886,7 +984,7 @@ describe('resolveComposition — PUL-F029 scene-level error isolation', () => {
         recordingScene('c', log),
       ],
       manifest: ['a', 'b', 'c'],
-      onSceneCleaned: (id) => cleaned.push(id),
+      onSceneCleaned: (activation) => cleaned.push(activation.sceneId),
       onSceneFailed: () => undefined,
     });
     // b was eagerly cleaned (its `cleanup` ran AND `onSceneCleaned`
@@ -910,7 +1008,7 @@ describe('resolveComposition — PUL-F029 scene-level error isolation', () => {
         recordingScene('c', log),
       ],
       manifest: ['a', 'b', 'c'],
-      onSceneCleaned: (id) => cleaned.push(id),
+      onSceneCleaned: (activation) => cleaned.push(activation.sceneId),
       onSceneFailed: () => undefined,
     });
     // All three mounted; b's timeline throws at compose-time → b is

--- a/tests/runtime/pul-q006-error-context.test.ts
+++ b/tests/runtime/pul-q006-error-context.test.ts
@@ -178,7 +178,7 @@ describe('PUL-Q006 — resolver wrap (no onSceneFailed)', () => {
         await resolveComposition({
           registry,
           manifest: ['broken'],
-          ctx: undefined,
+          ctx: () => undefined,
           preloadAssets: () => undefined,
           timeline,
         });
@@ -207,7 +207,7 @@ describe('PUL-Q006 — resolver wrap (preload throw)', () => {
       resolveComposition({
         registry,
         manifest: ['intro'],
-        ctx: undefined,
+        ctx: () => undefined,
         preloadAssets: () => {
           throw new Error('preload kaboom');
         },
@@ -282,6 +282,22 @@ describe('PUL-Q006 — formatSceneContext as the canonical seam', () => {
     const prefix = formatSceneContext({ sceneId: 'intro', beat: 'hook' });
     expect(prefix).toContain('scene "intro"');
     expect(prefix).toContain('"hook"');
+  });
+
+  it('renders the occurrence ordinal for a repeated scene id and stays bare for occurrence 0 (issue #99)', () => {
+    // Occurrence 0 (first / only use) renders identically to a
+    // single-occurrence scene — single-occurrence diagnostics are
+    // unchanged.
+    expect(formatSceneContext({ sceneId: 'intro', occurrence: 0 })).toBe('scene "intro"');
+    expect(formatSceneContext({ sceneId: 'intro', phase: 'create', occurrence: 0 })).toBe(
+      formatSceneContext({ sceneId: 'intro', phase: 'create' }),
+    );
+    // A later occurrence carries the ordinal so repeated scene ids are
+    // distinguishable on the public diagnostic surface.
+    const repeated = formatSceneContext({ sceneId: 'intro', phase: 'create', occurrence: 2 });
+    expect(repeated).toContain('scene "intro"');
+    expect(repeated).toContain('occurrence 2');
+    expect(repeated).toContain('create');
   });
 
   it('produces a prefix that contains scene id when used by the loader (cleanup failures during a composition)', async () => {

--- a/tests/runtime/scene-loader-audio.test.ts
+++ b/tests/runtime/scene-loader-audio.test.ts
@@ -554,6 +554,46 @@ describe('scene loader — mode=rehearsal (PUL-F026 / ADR-004)', () => {
     expect(calls[0]?.segments.map((s) => s.id)).toEqual(['scene-a', 'scene-b', 'scene-c']);
   });
 
+  it('stops a repeated scene id audio group once, after every occurrence is cleaned up (issue #99)', async () => {
+    // A composition that uses the same scene id twice: both
+    // occurrences play into the shared scene-scoped group `a`. The
+    // runtime stops that group exactly ONCE — when the last occurrence
+    // is cleaned up — so the first occurrence's cleanup cannot tear
+    // down the still-active sibling's audio. The old per-`onSceneCleaned`
+    // `stopGroup` fired once per occurrence (two `stop-group` cues).
+    const cues: AudioCueLogEntry[] = [];
+    const audio = recordingAudioEngine();
+    const scene = buildScene({
+      id: 'a',
+      assets: ['/audio/bed.mp3'],
+      audio: ['/audio/bed.mp3'],
+      create: (ctx) => {
+        const x = (ctx as { audio: AudioService }).audio;
+        x.load('bed', { src: '/audio/bed.mp3' });
+        x.play('bed', { group: 'a' });
+      },
+    });
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([scene]),
+      compositions: createCompositionRegistry([{ id: 'twice', manifest: ['a', 'a'] }]),
+      stage: null,
+      buildCtx: stubCtx,
+      createPreloader: () => () => Promise.resolve(),
+      timeline: noopTimeline,
+      audioEngine: audio.engine,
+      onAudioCue: (entry) => cues.push(entry),
+    });
+    await loader.handle({
+      locator: { kind: 'composition', composition: 'twice' },
+      mode: 'rehearsal',
+    });
+    await loader.idle();
+    // play (a#0), play (a#1), then a SINGLE stop-group on the last
+    // occurrence's cleanup — never one stop-group per occurrence.
+    expect(cues.map((c) => c.operation)).toEqual(['play', 'play', 'stop-group']);
+    expect(cues[2]).toMatchObject({ operation: 'stop-group', group: 'a' });
+  });
+
   it('rehearses a composition+scene target from the addressed head onward (slice preserved)', async () => {
     const a = buildScene({ id: 'scene-a' });
     const b = buildScene({ id: 'scene-b' });
@@ -882,8 +922,9 @@ describe('scene loader — PUL-F030 audio unlock gate (ADR-029)', () => {
       if (gate === undefined) throw new Error('gate not called');
       expect(gate.compositionId).toBe('show');
       expect(gate.sceneIds).toEqual(['a', 'b', 'c']);
-      // The signal exists and is NOT aborted (lifecycle completed).
-      expect(typeof gate.signal.aborted).toBe('boolean');
+      // The signal is live — NOT pre-aborted — so the adapter can
+      // listen for supersession.
+      expect(gate.signal.aborted).toBe(false);
       // Adapter received an `unlock` callback that, when called,
       // forwards to engine.unlock() — but we don't call it here in
       // the success path; that's covered by the "adapter calls

--- a/tests/runtime/scene-loader-beat-mode.test.ts
+++ b/tests/runtime/scene-loader-beat-mode.test.ts
@@ -474,17 +474,22 @@ describe('createSceneLoader — beat positioning & mode dispatch (PUL-F008)', ()
 
     interface ModeProbe {
       readonly modes: NavigationMode[];
-      readonly buildCtx: (mode: NavigationMode, audio: AudioService) => WorkbenchSceneCtx;
+      readonly buildCtx: (
+        mode: NavigationMode,
+        audio: AudioService,
+      ) => Omit<WorkbenchSceneCtx, 'activation'>;
     }
 
     const buildModeProbe = (): ModeProbe => {
       const modes: NavigationMode[] = [];
       return {
         modes,
-        buildCtx: vi.fn((mode: NavigationMode, audio: AudioService): WorkbenchSceneCtx => {
-          modes.push(mode);
-          return { stage: null, mode, gsap, audio };
-        }),
+        buildCtx: vi.fn(
+          (mode: NavigationMode, audio: AudioService): Omit<WorkbenchSceneCtx, 'activation'> => {
+            modes.push(mode);
+            return { stage: null, mode, gsap, audio };
+          },
+        ),
       };
     };
 
@@ -753,7 +758,10 @@ describe('createSceneLoader — beat positioning & mode dispatch (PUL-F008)', ()
       const outro = buildScene({ id: 'outro' });
       const stage = buildStage();
       let ctxCalls = 0;
-      const buildCtx = (mode: NavigationMode, audio: AudioService): WorkbenchSceneCtx => {
+      const buildCtx = (
+        mode: NavigationMode,
+        audio: AudioService,
+      ): Omit<WorkbenchSceneCtx, 'activation'> => {
         ctxCalls += 1;
         if (ctxCalls === 1) {
           throw new Error('builder bug');

--- a/tests/runtime/scene-loader-screenshot-prompter.test.ts
+++ b/tests/runtime/scene-loader-screenshot-prompter.test.ts
@@ -738,7 +738,10 @@ describe('createSceneLoader — screenshot & prompter modes (PUL-F008)', () => {
       readonly probe: LifecycleProbe;
       readonly preloader: () => Promise<void>;
       readonly runner: (input: LegacyRunInput) => void;
-      readonly buildCtxFn: (mode: NavigationMode, audio: AudioService) => WorkbenchSceneCtx;
+      readonly buildCtxFn: (
+        mode: NavigationMode,
+        audio: AudioService,
+      ) => Omit<WorkbenchSceneCtx, 'activation'>;
       readonly scenes: readonly SceneModule[];
     };
 
@@ -772,7 +775,10 @@ describe('createSceneLoader — screenshot & prompter modes (PUL-F008)', () => {
         probe.preloaderInvocations += 1;
         return Promise.resolve();
       };
-      const buildCtxFn = (mode: NavigationMode, audio: AudioService): WorkbenchSceneCtx => {
+      const buildCtxFn = (
+        mode: NavigationMode,
+        audio: AudioService,
+      ): Omit<WorkbenchSceneCtx, 'activation'> => {
         probe.buildCtxInvocations += 1;
         return { stage: null, mode, gsap, audio };
       };

--- a/tests/runtime/scene-loader.helpers.ts
+++ b/tests/runtime/scene-loader.helpers.ts
@@ -68,7 +68,13 @@ export type {
 // by forwarding it.
 import { createTimelineEngine } from '../../src/runtime/timeline';
 export const { gsap } = createTimelineEngine();
-export const stubCtx = (mode: NavigationMode, audio: AudioService): WorkbenchSceneCtx => ({
+// `buildCtx` builds the navigation-scoped ctx; the loader adds each
+// occurrence's `activation` (issue #99), so the stub's return type
+// omits it — same as the production `SceneLoaderOptions.buildCtx`.
+export const stubCtx = (
+  mode: NavigationMode,
+  audio: AudioService,
+): Omit<WorkbenchSceneCtx, 'activation'> => ({
   stage: null,
   mode,
   gsap,

--- a/tests/runtime/scene-loader.test.ts
+++ b/tests/runtime/scene-loader.test.ts
@@ -1007,6 +1007,79 @@ describe('createSceneLoader — PUL-F029 scene-level error isolation', () => {
     expect(onError).toHaveBeenCalledTimes(2);
   });
 
+  it('disambiguates repeated occurrences of a failing scene on the scene-failures attribute (issue #99)', async () => {
+    const onError = vi.fn();
+    const broken = buildScene({
+      id: 'broken',
+      create: () => {
+        throw new Error('create kaboom');
+      },
+    });
+    const stage = buildStage();
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([broken]),
+      compositions: createCompositionRegistry([{ id: 'twice', manifest: ['broken', 'broken'] }]),
+      stage: stage.element,
+      buildCtx: stubCtx,
+      createPreloader: () => () => undefined,
+      timeline: noopTimeline,
+      onError,
+    });
+
+    await loader.handle(compositionTarget('twice'));
+
+    // Each occurrence is isolated separately; the failures attribute
+    // carries the occurrence ordinal so two failures of the same scene
+    // id in the same phase are distinguishable. Occurrence 0 stays bare
+    // (`broken:create`) so single-occurrence diagnostics are unchanged.
+    expect(stage.attrs.get('data-pulsar-scene-failures')).toBe('broken:create,broken#1:create');
+    expect(onError).toHaveBeenCalledTimes(2);
+    const messages = onError.mock.calls.map((c) => (c[0] as Error).message);
+    expect(messages.some((m) => m.includes('occurrence 1'))).toBe(true);
+  });
+
+  it('threads a distinct per-occurrence ctx.activation into a repeated scene id (issue #99)', async () => {
+    // Capture ctx fields into `seen` and assert after the navigation —
+    // an `expect()` thrown inside a lifecycle hook is absorbed by the
+    // resolver's PUL-F029 isolation and would never reach the test.
+    const seen: Array<{
+      sceneId: string;
+      entryIndex: number;
+      occurrence: number;
+      mode: NavigationMode;
+    }> = [];
+    const a = buildScene({
+      id: 'a',
+      create: (ctx) => {
+        const c = ctx as {
+          activation: { sceneId: string; entryIndex: number; occurrence: number };
+          mode: NavigationMode;
+        };
+        seen.push({ ...c.activation, mode: c.mode });
+      },
+    });
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([a]),
+      compositions: createCompositionRegistry([{ id: 'twice', manifest: ['a', 'a'] }]),
+      stage: null,
+      buildCtx: stubCtx,
+      createPreloader: () => () => undefined,
+      timeline: noopTimeline,
+    });
+
+    await loader.handle(compositionTarget('twice'));
+    await loader.idle();
+
+    // Each occurrence's `create` saw a ctx scoped to its own
+    // activation; the navigation-scoped base fields (here `mode`) are
+    // still present on every occurrence's ctx — only `activation`
+    // differs between occurrences.
+    expect(seen).toEqual([
+      { sceneId: 'a', entryIndex: 0, occurrence: 0, mode: 'present' },
+      { sceneId: 'a', entryIndex: 1, occurrence: 1, mode: 'present' },
+    ]);
+  });
+
   it('enriches the onError message with composition id, entry index, and mode (ADR-028 diagnostic contract)', async () => {
     const onError = vi.fn();
     const intro = buildScene({ id: 'intro' });

--- a/tests/runtime/scene-navigation.test.ts
+++ b/tests/runtime/scene-navigation.test.ts
@@ -515,7 +515,7 @@ describe('loadSceneNavigationTarget (PUL-F008 lifecycle bridge — ADR-025)', ()
     const tl = recordingTimeline();
 
     await loadSceneNavigationTarget(target, {
-      ctx: {},
+      ctx: () => ({}),
       preloadAssets: (scene) => {
         log.push(`preload:${scene.id}`);
       },
@@ -552,7 +552,7 @@ describe('loadSceneNavigationTarget (PUL-F008 lifecycle bridge — ADR-025)', ()
     const tl = recordingTimeline();
 
     await loadSceneNavigationTarget(target, {
-      ctx: {},
+      ctx: () => ({}),
       preloadAssets: () => undefined,
       timeline: tl.adapter,
     });
@@ -569,32 +569,38 @@ describe('loadSceneNavigationTarget (PUL-F008 lifecycle bridge — ADR-025)', ()
     expect(segmentIds(tl.calls[0]?.segments ?? [])).toEqual(['middle', 'outro']);
   });
 
-  it('rejects a composition slice that repeats a scene id (ADR-025: each occurrence would share one activation context)', async () => {
+  it('runs a composition slice that repeats a scene id, mounting each occurrence (issue #99)', async () => {
     const log: string[] = [];
     const intro = buildScene({
       id: 'intro',
       create: () => log.push('create'),
+      timeline: () => {
+        log.push('timeline');
+        return undefined;
+      },
       cleanup: () => log.push('cleanup'),
     });
-    // The dispatcher resolves `?composition=loop-once` fine; the
-    // lifecycle bridge rejects because mount-all cannot give two `intro`
-    // occurrences distinct DOM / cleanup ownership yet (single-scene
-    // modes truncate the slice to the head, so they stay navigable).
+    // The dispatcher resolves `?composition=loop-once`; the bridge
+    // de-duplicates the synthesized scene registry by id and the
+    // resolver mounts each `intro` occurrence as a distinct activation
+    // (issue #99 — repeated scene ids are supported).
     const target = resolveSceneNavigation(compositionTarget('loop-once'), {
       scenes: createSceneRegistry([intro]),
       compositions: createCompositionRegistry([{ id: 'loop-once', manifest: ['intro', 'intro'] }]),
     }) as SceneNavigationTarget;
+    const tl = recordingTimeline();
 
     await expect(
       loadSceneNavigationTarget(target, {
-        ctx: {},
+        ctx: () => ({}),
         preloadAssets: () => undefined,
-        timeline: recordingTimeline().adapter,
+        timeline: tl.adapter,
       }),
-    ).rejects.toThrow(
-      /composition resolution failed: composition references scene id "intro" more than once/,
-    );
-    expect(log).toEqual([]);
+    ).resolves.toBeUndefined();
+
+    // Each occurrence is mounted, composed, and torn down once.
+    expect(log).toEqual(['create', 'create', 'timeline', 'timeline', 'cleanup', 'cleanup']);
+    expect(segmentIds(tl.calls[0]?.segments ?? [])).toEqual(['intro', 'intro']);
   });
 
   it('still calls cleanup when create throws (mandatory-cleanup invariant)', async () => {
@@ -624,7 +630,7 @@ describe('loadSceneNavigationTarget (PUL-F008 lifecycle bridge — ADR-025)', ()
 
     let caught: unknown;
     await loadSceneNavigationTarget(target, {
-      ctx: {},
+      ctx: () => ({}),
       preloadAssets: () => undefined,
       timeline: recordingTimeline().adapter,
     }).catch((err: unknown) => {
@@ -652,7 +658,7 @@ describe('loadSceneNavigationTarget (PUL-F008 lifecycle bridge — ADR-025)', ()
 
     await expect(
       loadSceneNavigationTarget(target, {
-        ctx: {},
+        ctx: () => ({}),
         preloadAssets: () => {
           log.push('preload');
           throw new Error('preload failed');
@@ -674,7 +680,7 @@ describe('loadSceneNavigationTarget (PUL-F008 lifecycle bridge — ADR-025)', ()
     void createSceneRegistry([decoyIntro]);
 
     await loadSceneNavigationTarget(target, {
-      ctx: {},
+      ctx: () => ({}),
       preloadAssets: () => undefined,
       timeline: recordingTimeline().adapter,
     });
@@ -699,7 +705,7 @@ describe('loadSceneNavigationTarget (PUL-F008 lifecycle bridge — ADR-025)', ()
     const tl = recordingTimeline();
 
     await loadSceneNavigationTarget(target, {
-      ctx: {},
+      ctx: () => ({}),
       preloadAssets: () => undefined,
       timeline: tl.adapter,
     });
@@ -709,8 +715,8 @@ describe('loadSceneNavigationTarget (PUL-F008 lifecycle bridge — ADR-025)', ()
     ]);
   });
 
-  it('forwards ctx unchanged to every lifecycle hook (the adapter receives no ctx)', async () => {
-    const ctx = { tag: 'workbench-ctx' };
+  it('builds ctx per occurrence and forwards it unchanged to that occurrence lifecycle hooks', async () => {
+    const activations: Array<{ sceneId: string; entryIndex: number; occurrence: number }> = [];
     const seen: unknown[] = [];
     const intro = buildScene({
       id: 'intro',
@@ -727,11 +733,21 @@ describe('loadSceneNavigationTarget (PUL-F008 lifecycle bridge — ADR-025)', ()
     }) as SceneNavigationTarget;
 
     await loadSceneNavigationTarget(target, {
-      ctx,
+      ctx: (activation) => {
+        activations.push(activation);
+        return { tag: 'workbench-ctx', activation };
+      },
       preloadAssets: () => undefined,
       timeline: recordingTimeline().adapter,
     });
-    expect(seen).toEqual([ctx, ctx, ctx]);
+    // One occurrence → the factory is called once, with that
+    // occurrence's activation; its single ctx reaches all three hooks.
+    expect(activations).toEqual([{ sceneId: 'intro', entryIndex: 0, occurrence: 0 }]);
+    const expectedCtx = {
+      tag: 'workbench-ctx',
+      activation: { sceneId: 'intro', entryIndex: 0, occurrence: 0 },
+    };
+    expect(seen).toEqual([expectedCtx, expectedCtx, expectedCtx]);
   });
 
   // ----- head-hint forwarding -------------------------------------------
@@ -763,7 +779,7 @@ describe('loadSceneNavigationTarget (PUL-F008 lifecycle bridge — ADR-025)', ()
     }) as SceneNavigationTarget;
     const tl = recordingTimeline();
     await loadSceneNavigationTarget(resolved, {
-      ctx: {},
+      ctx: () => ({}),
       preloadAssets: () => undefined,
       timeline: tl.adapter,
       ...options,
@@ -807,7 +823,7 @@ describe('loadSceneNavigationTarget (PUL-F008 lifecycle bridge — ADR-025)', ()
       }) as SceneNavigationTarget;
       await expect(
         loadSceneNavigationTarget(resolved, {
-          ctx: {},
+          ctx: () => ({}),
           preloadAssets: () => undefined,
           timeline: recordingTimeline().adapter,
           beat: 'hook',

--- a/tests/runtime/timeline.test.ts
+++ b/tests/runtime/timeline.test.ts
@@ -710,7 +710,7 @@ describe('createGsapCompositionTimeline', () => {
         }),
       ]),
       manifest: ['intro'],
-      ctx: {},
+      ctx: () => ({}),
       preloadAssets: () => undefined,
       timeline: adapter,
       headBeat: 'the-end',
@@ -777,7 +777,7 @@ describe('createGsapCompositionTimeline', () => {
     await resolveComposition({
       registry: createSceneRegistry([trace('intro'), trace('demo'), trace('outro')]),
       manifest: ['intro', 'demo', 'outro'],
-      ctx: {},
+      ctx: () => ({}),
       preloadAssets: () => undefined,
       timeline: adapter,
     });
@@ -808,7 +808,7 @@ describe('createGsapCompositionTimeline', () => {
           trace('outro', () => sceneTl(0.005)),
         ]),
         manifest: ['intro', 'demo', 'outro'],
-        ctx: {},
+        ctx: () => ({}),
         preloadAssets: () => undefined,
         timeline: adapter,
       });


### PR DESCRIPTION
## Summary

Composition slices may now reference the same scene id more than once. The PUL-F004 composition resolver no longer rejects repeated scene ids; each occurrence is a distinct activation with a stable identity (SceneActivation — { sceneId, entryIndex, occurrence }) threaded through the lifecycle so a scene can own its occurrence's DOM / listeners / state without colliding with a sibling occurrence of the same module. This is a requirement-free enhancement issue — it carries no in-scope Ground Control requirements; it extends the existing PUL-F004 resolver lifecycle and the PUL-F029 scene-level error-isolation diagnostics.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #99

## ADR Impact

- No ADR required

## Changes

- composition-resolver: buildPlan drops the repeated-id rejection guard and assigns each entry its 0-based per-scene-id occurrence ordinal; new exported SceneActivation interface; SceneFailureEvent extends it; cleanup still runs once per occurrence in reverse mount order
- ResolveCompositionOptions.ctx becomes a per-occurrence factory (activation) => unknown — each occurrence's create/timeline/cleanup runs against its own ctx; WorkbenchSceneCtx gains an activation field; the loader builds the navigation-scoped base once and adds each occurrence's activation
- onSceneCleaned receives the cleaned occurrence's SceneActivation; the loader's audio-group teardown is occurrence-safe — the scene-scoped group is stopped only when the last occurrence of that scene id is cleaned up, so an earlier occurrence's cleanup never cuts a sibling's audio
- PUL-F029 diagnostics: data-pulsar-scene-failures namespaces a repeated occurrence's failure (<sceneId>#<n>:<phase>); formatSceneContext renders the occurrence ordinal; occurrence 0 stays bare so single-occurrence behavior is unchanged
- timeline label namespacing for repeated occurrences already existed in timeline.ts and is reused unchanged

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

TDD throughout. New regression coverage: resolver mounts/composes/cleans each occurrence of a repeated scene id once in reverse order; per-occurrence ctx carries each occurrence's activation; failure isolation of one occurrence keeps the sibling; occurrence-safe audio-group teardown (single stop-group after the last occurrence); occurrence-namespaced data-pulsar-scene-failures; formatSceneContext occurrence rendering. Full gate green: pnpm lint && pnpm typecheck && pnpm test (2414 tests), pre-commit.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: #99 ← src/runtime/composition-resolver.ts, #99 ← src/runtime/scene-loader.ts, #99 ← src/runtime/scene-navigation.ts, #99 ← src/runtime/error.ts
- TESTS: #99 ← tests/runtime/composition-resolver.test.ts, #99 ← tests/runtime/scene-loader.test.ts, #99 ← tests/runtime/scene-loader-audio.test.ts, #99 ← tests/runtime/scene-navigation.test.ts, #99 ← tests/runtime/pul-q006-error-context.test.ts

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/99.added.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed