### PR TITLE
docs: reconcile PUL-F013 present-mode docs with shipped runtime

### DIFF
--- a/docs/adrs/016-workbench-mode-present.md
+++ b/docs/adrs/016-workbench-mode-present.md
@@ -25,19 +25,22 @@ chrome, inter-scene transitions, and the audio bed (PUL-F014);
 suppresses audible playback (silenced or logged as cues —
 PUL-F026 / ADR-004).
 
-Each of the four facets PUL-F013 names depends on a surface that has
-not yet landed in this repo:
+At the time this ADR was accepted, each of the four facets PUL-F013
+names depended on a surface that had not yet landed in this repo. The
+update sections below record the later deliveries.
 
 | Facet | Surface that delivers it | Status |
 |-------|--------------------------|--------|
-| Render full chrome | PUL-F031 / ADR-031 workbench chrome surface | **delivered (structure)** — workbench-owned DOM root mounted by `src/runtime/workbench-chrome.ts`, mode-governed via `chromeVisibilityFor`. The chrome surface ships empty today; actual presenter UI content lands with the presenter-input facet (PUL-F020 / F021 / F025). |
-| Render audio | Audio service per ADR-004 (Howler.js); a future PUL-F* requirement will deliver the service | absent |
-| Render inter-scene transitions | GSAP timeline runner per ADR-003; the runner's adapter slot exists in `composition-resolver.ts` but the GSAP implementation has not landed | absent (placeholder runner in `src/main.ts`) |
-| Respond to presenter input | Presenter controls per PUL-F020 (advance / hold / skip), PUL-F021 (pause / resume), PUL-F025 (master mute) | absent |
+| Render full chrome | PUL-F031 / ADR-031 workbench chrome surface plus L2 chrome slots | delivered — `src/runtime/workbench-chrome.ts`, `src/system/chrome/*`, and `src/main.ts` mount a workbench-owned surface and slot DOM before navigation. |
+| Render audio | Audio service per ADR-004 (Howler.js) plus the PUL-F030 / ADR-029 unlock gate | delivered — `src/runtime/audio.ts`, `src/runtime/audio-unlock-dom.ts`, and `src/runtime/scene-loader.ts` build per-navigation audio with mode policy, source allowlists, unlock, cleanup, and master mute. |
+| Render inter-scene transitions | GSAP composition master per ADR-003 / ADR-025 plus transition registry | delivered — `src/runtime/timeline.ts` invokes registered `Transition`s between composition segments, and `src/system/transitions/*` ships the default implementations. |
+| Respond to presenter input | Presenter controls per PUL-F020 / F021 / F025 / ADR-023 / ADR-024 | delivered at runtime seam — `src/runtime/presenter.ts`, `src/runtime/scene-loader.ts`, `src/runtime/timeline.ts`, and `src/system/presenter/*` validate commands, bind keyboard / bridge sources, drive master transport, and toggle master mute. |
 
-PUL-F013's natural ACTIVE state — "all four facets are rendered /
-accepting input under `mode=present` end to end" — is therefore not
-currently testable. Three options exist:
+PUL-F013's natural ACTIVE state is "all four facets are rendered /
+accepting input under `mode=present` end to end." It was not testable
+when this ADR first landed, so the original decision was to pin the
+contract seams and defer ACTIVE. That historical decision remains
+below because it explains why the seams exist before their surfaces.
 
 1. **Pre-land an abstraction** (e.g., a `ModePolicy` record on `ctx`)
    so PUL-F013 has something to point at. Risk: the abstraction has
@@ -56,7 +59,7 @@ currently testable. Three options exist:
    and the diagnostic path landed; PUL-F011 stays DRAFT pending the
    GSAP runner that will exercise label seeking end to end.
 
-## Decision
+## Initial Decision (2026-05-06)
 
 Take option 3. PUL-F013 today delivers:
 
@@ -195,6 +198,69 @@ inter-scene transitions, presenter input). The ACTIVE bar is
 unchanged — every facet must land as a real rendering / input
 surface with end-to-end tests.
 
+## Update — 2026-05-21 (PUL-F013 current state)
+
+PUL-F013 is now an integration requirement over shipped runtime and L2
+surfaces, not a placeholder for absent seams. The provided Ground
+Control payload reports PUL-F013 as ACTIVE; this update supersedes the
+historical DRAFT-state notes above.
+
+Current canonical implementation boundaries:
+
+- **Chrome:** `src/runtime/workbench-chrome.ts` owns the workbench
+  surface and `chromeVisibilityFor()`. `src/main.ts` mounts it before
+  navigation and `src/system/chrome/slots.ts` populates the L2 slots.
+  The loader dispatches chrome synchronously at enqueue and applies
+  the optional head-entry chrome override through
+  `WorkbenchChromeAdapter.setForcedVisibility()`.
+- **Audio:** `src/runtime/audio.ts` owns the Howler-backed engine,
+  per-navigation `AudioService`, source allowlist, output policy, cue
+  logging, master mute, and validation. `src/runtime/scene-loader.ts`
+  builds the service once per navigation, enforces the present-mode
+  audio unlock gate, forwards `ctx.audio`, and tears down groups /
+  services through resolver cleanup hooks.
+- **Transitions:** `src/runtime/timeline.ts` owns the
+  `Transition` / `TransitionRegistry` contract and invokes registered
+  transitions while composing the GSAP master timeline. Default L2
+  transitions live in `src/system/transitions/*`; `src/main.ts` wires
+  `defaultTransitions()` and a workbench-owned
+  `[data-pulsar-transition="overlay"]` element.
+- **Presenter input:** `src/runtime/presenter.ts` owns the command
+  schema and boundary validator. The loader creates a per-navigation
+  `PresenterController` only under `mode=present`, threads it into
+  `ctx.presenter` and the timeline adapter, handles master mute at the
+  audio seam, and aborts presenter subscriptions on navigation abort
+  and normal completion. `src/system/presenter/keyboard-source.ts`
+  and `src/system/presenter/bridge.ts` provide the local keyboard and
+  same-origin cross-window sources that `src/main.ts` combines.
+
+Current guardrails for follow-up work:
+
+- Do not create a second present-mode controller, transition adapter,
+  presenter schema, audio policy, chrome ownership model, validation
+  pass, or error hierarchy.
+- Keep the resolver mode-opaque. Mode-specific behavior remains in the
+  loader, timeline adapter, audio service, chrome adapter, or L2
+  workbench modules.
+- Keep transition declarations adapter-owned under
+  `behavior.transition`. Strengthen `durationMs` or future
+  transition-parameter validation centrally before invoking
+  transition implementations; do not add deck-local validators.
+- Keep presenter input on the existing command stream. New commands
+  extend `PRESENTER_COMMAND_KINDS`, `isPresenterCommand()`, and the
+  timeline/audio dispatch sites. A future remote source must
+  authenticate before emitting into `PresenterCommandSource`.
+- Keep public diagnostics on `describeErrorDetailed()`, loader
+  `onError`, and stage attributes. Never serialize raw causes, stacks,
+  DOM nodes, scene objects, full captions, headers, cookies, env,
+  auth values, source URLs beyond existing asset diagnostics, or
+  engine handles.
+
+The companion preflight note
+`docs/design/pul-f013-present-mode-preflight.md` is the current
+repo-wide guardrail summary for implementation work that touches
+present mode.
+
 ## Related ADRs
 
 - [ADR-003](003-gsap-timeline-engine.md) — the timeline runner is
@@ -218,3 +284,11 @@ surface with end-to-end tests.
 - [ADR-015](015-url-beat-positioning.md) — precedent for "deliver
   the contract layer; keep the requirement DRAFT until the
   dependent subsystem lands."
+- [ADR-023](023-presenter-controls.md) — presenter command source and
+  per-navigation controller seam.
+- [ADR-024](024-presenter-pause-resume.md) — pause/resume as
+  runner-owned transport state on the presenter command seam.
+- [ADR-029](029-present-mode-audio-unlock-gate.md) — present-mode
+  audio unlock before lifecycle work.
+- [ADR-031](031-workbench-chrome-surface.md) — workbench-owned,
+  mode-governed chrome surface.

--- a/docs/design/pul-f013-present-mode-preflight.md
+++ b/docs/design/pul-f013-present-mode-preflight.md
@@ -1,101 +1,169 @@
 # PUL-F013 Present Mode Preflight
 
-PUL-F013 specifies the default workbench behavior for `mode=present`:
-full chrome, audio, inter-scene transitions, and presenter input. It is
-an integration requirement across existing runtime seams, not a new
-runtime model. None of the four facets has a rendering / input surface
-in this repo yet (see ADR-016): chrome and audio surfaces have not
-landed, inter-scene transition rendering is reserved by ADR-003's GSAP
-runner, and presenter input is PUL-F020 / PUL-F021 / PUL-F025.
-PUL-F013 ACTIVE requires every facet to land. This preflight defines
-the boundary and required reuse for that future work.
+PUL-F013 is the default live workbench integration contract for
+`mode=present`: full chrome, audible playback, inter-scene
+transitions, and presenter input. The repo now has canonical seams for
+all four facets. Future work must preserve and extend those seams
+rather than adding a second present-mode runtime.
 
-## Boundary
+This note is design guidance only. It is not an implementation plan.
 
-`present` mode must be selected only through the existing navigation
+## Current Boundary
+
+`present` mode is selected only through the existing navigation
 boundary:
 
-- `src/runtime/navigation.ts` owns the `mode` URL grammar and the
-  `NAVIGATION_MODES` allowlist.
-- `effectiveMode()` owns the absent-mode default to `present`.
-- `src/runtime/scene-loader.ts` owns per-navigation mode dispatch and
-  `ctx.mode` construction.
+- `src/runtime/navigation.ts` owns the `mode` URL grammar,
+  `NAVIGATION_MODES`, and `effectiveMode()` defaulting absent `mode`
+  to `present`.
+- `src/runtime/scene-loader.ts` owns mode dispatch, stage diagnostics,
+  per-navigation `AbortController`, audio-service construction,
+  presenter-controller construction, chrome dispatch, audio unlock, and
+  single-scene slice truncation for non-present modes.
 - `src/runtime/scene-navigation.ts` owns scene/composition target
-  resolution.
+  resolution and slice snapshots.
 - `src/runtime/composition-resolver.ts` owns lifecycle ordering,
-  abort propagation, and cleanup.
+  abort propagation, scene-failure isolation, and exactly-once cleanup.
+- `src/runtime/timeline.ts` owns GSAP timeline validation,
+  composition-master construction, presenter command to transport
+  handling, and inter-scene transition invocation.
+- `src/main.ts` is the browser composition root. It wires the runtime
+  seams to the L2 chrome slots, transition registry, keyboard source,
+  cross-window presenter bridge, audio unlock adapter, and graph
+  validation gate.
 
-Do not add a parallel `present` flag, route, controller, enum, or
-manifest field. `mode=present` and omitted `mode` converge only at the
-runtime dispatch seam; parsing must continue to preserve whether the
-URL explicitly supplied `mode`.
+Do not add a parallel `present` flag, route, controller, enum, storage
+state, or manifest selector. `mode=present` and omitted `mode` converge
+only at `effectiveMode()`.
 
 ## Required Reuse
 
 Implementation must reuse these cross-cutting concerns:
 
 - Identifier validation: `src/runtime/identifier.ts`.
-- URL validation and mode parsing: `parseNavigationSearch()` and
-  `NAVIGATION_MODES`.
-- Effective mode derivation: `effectiveMode()`.
-- Scene/composition schemas and validators:
-  `assertSceneModule()`, `createSceneRegistry()`,
-  `assertCompositionManifest()`, and `createCompositionRegistry()`.
+- URL and mode validation: `parseNavigationSearch()`,
+  `NAVIGATION_MODES`, `effectiveMode()`, and the loader's defensive
+  mode/beat grammar checks for hand-built `NavigationTarget` values.
+- Scene and composition schemas: `assertSceneModule()`,
+  `createSceneRegistry()`, `assertCompositionManifest()`,
+  `createCompositionRegistry()`, and the `WORKBENCH_SCENES` /
+  `WORKBENCH_COMPOSITIONS` graph in `src/workbench-graph.ts`.
+- Structural validation: `validateRuntime()` plus the existing
+  browser boot marker `data-pulsar-validation-failed`.
 - Lifecycle orchestration: `loadSceneNavigationTarget()` and
-  `resolveComposition()`.
-- Asset handling: `createAssetPreloader()` with the existing scheme and
-  redirect validation rules.
-- Error rendering: `describeError()` plus existing stage diagnostics
-  (`data-pulsar-navigation-error`).
-- Abort and cleanup: one per-navigation `AbortController`, forwarded to
-  preload and timeline adapters; cleanup remains resolver-owned and
-  exactly-once per activated scene.
+  `resolveComposition()`; the resolver remains DOM-, mode-, GSAP-,
+  Howler-, and chrome-opaque except for injected adapters.
+- Timeline and transitions: `createTimelineEngine()`,
+  `createGsapCompositionTimeline()`, `composeMasterTimeline()`,
+  `Transition`, `TransitionRegistry`, and
+  `src/system/transitions/defaultTransitions()`.
+- Chrome: `createDomWorkbenchChrome()`, `chromeVisibilityFor()`,
+  `WorkbenchChromeAdapter`, and L2 `mountChromeSlots()`.
+- Audio: `createHowlerAudioEngine()`, `createAudioService()`,
+  `AudioOutputPolicy`, scene `audio` declarations, source allowlists,
+  and the loader-owned audio unlock gate.
+- Presenter input: `PresenterCommand`, `PRESENTER_COMMAND_KINDS`,
+  `isPresenterCommand()`, `PresenterCommandSource`,
+  `createPresenterController()`, `createKeyboardPresenterSource()`,
+  `createPresenterBridge()`, and `combinePresenterSources()`.
+- Error surfacing: `describeErrorDetailed()`, `formatSceneContext()`,
+  loader `onError`, `data-pulsar-navigation-error`, and
+  `data-pulsar-scene-failures`.
+- Cleanup: one navigation abort signal, presenter auto-detach via a
+  separate presenter abort signal, resolver cleanup, audio
+  `stopGroup()` / `stopAll()`, chrome disposal, transition overlay
+  removal, keyboard disposal, bridge disposal, and MutationObserver
+  disconnect in HMR teardown.
 
-Chrome, audio, transition, and presenter-control adapters should be
-injected through the workbench context or the timeline runner seam
-already reserved by ADR-003, ADR-004, and ADR-011. The resolver must
-remain opaque to DOM, GSAP, Howler, and presenter UI details.
+## Cross-Cutting Gates
+
+Security and validation layers the design passes through:
+
+| Layer | Canonical gate | Required behavior |
+|-------|----------------|-------------------|
+| URL grammar | `parseNavigationSearch()` and loader defensive checks | Unknown `mode`, invalid `beat`, invalid composition addressing, or forged programmatic targets fail through the navigation error envelope. No alternate query key such as `present=true`. |
+| Mode dispatch | `effectiveMode()` and `SceneLoaderOptions` | Mode is recomputed per navigation from the parsed target. No localStorage, sessionStorage, cookies, `history.state`, process env, argv, or cached prior mode. |
+| Graph validation | `validateRuntime()` over `WORKBENCH_SCENES` / `WORKBENCH_COMPOSITIONS` | Browser boot and CI must validate the same graph before lifecycle effects. Do not create a test-only or deck-only registry path. |
+| Manifest shape | `assertCompositionManifest()` | Keep `behavior` as the existing adapter-owned override bag. Do not add fake transition scenes, mode selector fields, or duplicate manifest schemas. |
+| Timeline shape | `assertSceneTimeline()` and `MasterTimeline` | Scene timelines are GSAP timelines or null; beats are kebab-case finite labels. Presenter, beat, loop, paused, scrub, screenshot, and transition behavior extend the master transport seam. |
+| Transition declaration | `TransitionRegistry` plus `behavior.transition` | Use registered transition names. If `durationMs` or future transition parameters are strengthened, validate once at the transition boundary before invoking implementations; do not duplicate checks in every deck. |
+| Asset/audio sources | `scene.assets`, `scene.audio`, `createAssetPreloader()`, `resolveAssetUrl()`, `createAudioService()` | Audio sources must be declared before use and pass existing scheme/redirect/source allowlist checks. Scenes must not import Howler or create raw `<audio>` as the default path. |
+| Audio unlock | `AudioUnlockAdapter` | The workbench adapter receives only composition id, scene ids, signal, and `unlock()`. It must not receive scene objects, source URLs, cookies, headers, Howler handles, or DOM events as public diagnostics. |
+| Presenter command shape | `isPresenterCommand()` | Keyboard, bridge, tests, and future remotes emit into one `PresenterCommandSource`. Unknown commands are dropped with diagnostics; a future remote source authenticates before this seam. |
+| DOM/chrome | `createDomWorkbenchChrome()` and `mountChromeSlots()` | Chrome is workbench-owned, mounted once, hidden with the `hidden` property where required, and disposed on HMR. Scene cleanup must never remove chrome or the transition overlay. |
+| Error envelopes | `describeErrorDetailed()`, loader attributes, `onError` | Public diagnostics stay bounded. Do not serialize raw causes, stacks, DOM nodes, scene objects, full captions, cookies, headers, env, auth values, or engine handles. |
+| OS/process exposure | package scripts and in-process tests | No secrets or serialized scene graphs in argv. Present-mode runtime behavior is browser/in-process state, not shell state. |
+
+No authentication surface exists for local keyboard or same-origin
+`BroadcastChannel`. If a future remote presenter protocol appears,
+authentication and authorization must sit before it emits into
+`PresenterCommandSource`; the controller remains the local shape gate.
+
+## Extensibility Seams
+
+- New transition implementations register in
+  `src/system/transitions/defaultTransitions()`. New transition
+  parameters belong under `behavior.transition` and must be parsed at
+  the timeline/transition boundary, not by scenes or the resolver.
+- New presenter commands extend `PRESENTER_COMMAND_KINDS`,
+  `PresenterCommand`, `isPresenterCommand()`, and the single runner
+  transport dispatch in `src/runtime/timeline.ts`.
+- Chrome variants extend `chromeVisibilityFor()` /
+  `WorkbenchChromeAdapter` and L2 `ChromeSlots`. Do not introduce a
+  generic `ModePolicy` until more than one concrete surface needs the
+  same representation.
+- Audio variations extend `AudioOutputPolicy` or `AudioService`.
+  Do not add per-scene mute booleans, duplicate audio buses, or direct
+  Howler imports.
+- Browser smoke/e2e checks should assert the observable incumbents:
+  `data-pulsar-chrome-visibility`, `data-pulsar-transition`, absence
+  of navigation/validation errors, audible/silent policy effects,
+  presenter keyboard effects, and cleanup/disposal behavior.
 
 ## Guardrails
 
-- Chrome is workbench-owned persistent UI, not scene metadata and not a
-  lifecycle hook. Scenes may render their content into `ctx.stage`;
-  they must not own global chrome state.
-- Audio is exposed through `ctx.audio` per ADR-004. Scenes must not
-  create raw `<audio>` elements or import Howler directly unless a
-  documented scene-specific exception also registers cleanup with the
-  runtime.
-- Inter-scene transitions belong in the timeline-runner / workbench
-  integration layer. Do not encode transitions as fake scenes or mutate
-  composition manifests to insert transition entries.
-- Presenter input owns cancellation and timeline operations. It should
-  drive the existing `AbortSignal` and runner controls rather than
-  adding a second skip/cleanup path.
-- Missing beats and navigation errors use the existing non-fatal or
-  fatal surfaces. Do not throw from a missing-beat callback or unmount
-  the scene to report a positioning diagnostic.
-- `present` must not read mode, target, mute, or navigation state from
-  localStorage, sessionStorage, cookies, `history.state`, or prior
-  in-memory navigation state.
+- `mode=present` runs the full composition slice. Only `standalone`,
+  `loop`, `paused`, `scrub`, and `screenshot` use the shared
+  single-scene truncation defense.
+- Inter-scene transitions are master-timeline insertions. Do not
+  encode transitions as scenes, lifecycle hooks, URL state, stage
+  attributes, or manifest rewrites.
+- Presenter input is a command stream, not a mode. It must not mutate
+  URL/history, call scene `cleanup()` directly, remount scenes, or
+  persist playhead state.
+- Chrome and transition overlay are workbench-owned siblings of
+  `#stage`. Scenes may receive L2 slot refs through `ctx.chrome`, but
+  they do not create, remount, or dispose the surface.
+- Audio is per navigation. Scene-owned sound uses `ctx.audio` and
+  declared sources; the loader/resolver own stop/unload sequencing.
+- Missing beats and scene failures use existing non-fatal/fatal
+  diagnostic paths. Do not throw from diagnostic sinks to force
+  lifecycle behavior.
+- HMR disposal must clean every long-lived surface that `main.ts`
+  constructs: navigation listener, loader, chrome, transition overlay,
+  keyboard source, presenter bridge, stage observer, and practice
+  renderer.
 
 ## Non-Goals
 
-PUL-F013 should not implement alternate workbench modes (`standalone`,
-`loop`, `paused`, `scrub`, `screenshot`, `prompter`), export behavior,
-decode-complete asset semantics, new scene schema fields, persistence,
-or authoring UI. It may add the minimum shared adapter surface needed
-for full present-mode playback, but only where the existing ADRs have
-already reserved that boundary.
+This preflight should not add runtime code, new workbench modes, export
+behavior, authoring UI, persistence, telemetry, authentication,
+workflow automation, requirement status transitions, traceability
+links, or a generic mode-policy framework. It should not redesign the
+scene schema, composition manifest, timeline engine, audio API,
+presenter command bus, validation pass, or error hierarchy.
 
 ## Anti-Patterns
 
-- Duplicating `NAVIGATION_MODES` or re-validating mode strings with a
-  local enum.
-- Adding per-scene mode detection from `window.location`.
-- Building presenter controls that call scene `cleanup()` directly.
-- Creating a second exception hierarchy for presentation errors.
-- Swallowing `AggregateError.errors` from resolver or preloader
-  failures.
-- Treating `present` as a special-case route that bypasses
-  `SceneLoader`.
-- Persisting the last selected mode or composition target.
+- Re-implementing `mode=present` as a standalone app route or scene.
+- Creating a second transition adapter when `TransitionRegistry` and
+  `composeMasterTimeline()` already provide the seam.
+- Duplicating `PRESENTER_COMMAND_KINDS`, `NAVIGATION_MODES`, audio
+  source validation, or manifest validation in L2 modules.
+- Binding keyboard listeners inside scene modules or individual decks.
+- Letting `BroadcastChannel` become a remote-control auth boundary.
+- Treating unknown transition names or malformed transition parameters
+  as deck-local behavior without a central policy decision.
+- Swallowing `AggregateError.errors`, raw asset-preloader failures, or
+  scene-failure context.
+- Persisting mode, target, mute, or presenter state in browser storage.

--- a/src/main.ts
+++ b/src/main.ts
@@ -224,25 +224,24 @@ const renderPrompter: PrompterRenderer = createChromePrompterRenderer(
   () => chromeSlots?.lowerThird ?? document.body,
 );
 
-// Presenter command source (PUL-F020 / PUL-F021 / ADR-023 /
-// ADR-024): intentionally OMITTED here. The runtime-side contract
-// layer ships the `PresenterCommandSource` / per-navigation
-// `PresenterController` seam and the `advance` / `hold` /
-// `skip-forward` / `skip-backward` (PUL-F020) plus `pause` /
-// `resume` (PUL-F021, ADR-024) command kinds — the loader builds a
-// per-navigation `PresenterController` when `mode=present` AND
-// `presenterCommands` is supplied. By omitting the field, the
-// loader gracefully degrades (runners see `input.presenter ===
-// undefined`) and the seam stays structurally inert until a real
-// presenter UI surface lands. The future workbench surface owns
-// the keyboard listener / on-screen controls and emits
-// `PresenterCommand`s through a `PresenterCommandSource`; ADR-023
-// (advance/hold/skip) and ADR-024 (pause/resume — including the
-// cross-command precedence the runner must honor: `pause` / `resume`
-// are a transport-freeze gate orthogonal to the beat-pacing kinds)
-// record the DRAFT → ACTIVE bar (presenter UI module + GSAP runner
-// that translates commands to transport calls — including playhead-
-// preserving pause/resume — + end-to-end tests).
+// Presenter command source (PUL-F013 / PUL-F020 / PUL-F021 /
+// ADR-023 / ADR-024): present-mode presenter input is wired in this
+// composition root. `createKeyboardPresenterSource()` (arrows /
+// Space / P / M / Escape) and `createPresenterBridge()` (same-origin
+// cross-window `BroadcastChannel`) are constructed below and merged
+// by `combinePresenterSources()` into the single
+// `PresenterCommandSource` handed to `createSceneLoader` as
+// `presenterCommands`. The loader builds a per-navigation
+// `PresenterController` when `mode=present`, threads it into
+// `ctx.presenter` and the timeline adapter, and aborts the
+// subscription on navigation abort / completion. The command kinds
+// are `advance` / `hold` / `skip-forward` / `skip-backward`
+// (PUL-F020) plus the `pause` / `resume` transport-freeze gate
+// (PUL-F021, ADR-024) — the runner honors the latter with
+// playhead-preserving precedence over the beat-pacing kinds. A
+// future remote presenter source must authenticate before emitting
+// into `PresenterCommandSource`; the controller stays the local
+// command-shape gate.
 // PUL-F030 / ADR-029: present-mode audio unlock adapter. The loader
 // invokes this BEFORE preload + scene `create(ctx)` + scene
 // `timeline(ctx)` + master timeline playback when a present-mode


### PR DESCRIPTION
## Summary

PUL-F013's four present-mode facets — full chrome, audio, inter-scene transitions, and presenter input — are already implemented, wired in the `src/main.ts` composition root, and covered by the unit suites and the Playwright e2e matrix (chromium/firefox/webkit); PUL-F013 is ACTIVE in Ground Control. The issue body described a stale repo state. This PR carries no runtime behavior change: it reconciles the documentation with the shipped runtime and corrects one misleading in-code comment.

## Requirement UIDs

- `PUL-F013`

## Related Issues

Closes #126

## ADR Impact

- ADR-016

## Changes

- ADR-016: add the 2026-05-21 current-state section recording present mode as an integration requirement over shipped surfaces, superseding the historical DRAFT-state framing, and naming the canonical implementation boundaries (chrome / audio / transitions / presenter input).
- docs/design/pul-f013-present-mode-preflight.md: rewrite as the repo-wide guardrail summary for present-mode work — required reuse seams, cross-cutting validation gates, extensibility seams, and anti-patterns.
- src/main.ts: replace a stale comment block claiming the presenter command source is "intentionally OMITTED" with an accurate description of the keyboard + same-origin cross-window bridge presenter sources the file actually combines and threads into the loader. Comment-only; no behavior change.

## Test Plan

- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] `make policy` passes (documentation/workflow guardrails)
- Unit tests / integration tests: N/A — docs-only change

No new tests: this PR introduces no behavior to cover. The completion gate (pnpm lint && pnpm typecheck && pnpm test — 2414 tests) and the pre-commit hook suite pass; present-mode behavior remains exercised by the existing unit + e2e suites listed under Traceability.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: PUL-F013 ← src/runtime/timeline.ts (Transition/TransitionRegistry + applySegmentTransition), PUL-F013 ← src/runtime/workbench-chrome.ts (mode-governed chrome surface), PUL-F013 ← src/runtime/audio.ts (per-navigation AudioService), PUL-F013 ← src/main.ts (keyboard + bridge presenter sources into the loader)
- TESTS: PUL-F013 ← tests/system/transitions.test.ts, PUL-F013 ← tests/runtime/scene-loader-present.test.ts, PUL-F013 ← tests/system/presenter-keyboard.test.ts, PUL-F013 ← tests-e2e/pulsar-intro.spec.ts (chromium/firefox/webkit)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- Changelog fragment: N/A — docs-only change
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
