### PR TITLE
added: composition audio bed with mode=standalone suppression (PUL-F014)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     name: Pre-commit hooks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
@@ -54,7 +54,7 @@ jobs:
     name: Typecheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: pnpm/action-setup@v4
         with:
           version: 9.15.0
@@ -69,7 +69,7 @@ jobs:
     name: Test + coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # SonarCloud needs full history for blame; the sonar job consumes
           # this artifact, so fetch it here too.
@@ -83,7 +83,7 @@ jobs:
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:coverage
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: coverage
           path: coverage/
@@ -93,7 +93,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: pnpm/action-setup@v4
         with:
           version: 9.15.0
@@ -108,7 +108,7 @@ jobs:
     name: Dependency audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: pnpm/action-setup@v4
         with:
           version: 9.15.0
@@ -130,7 +130,7 @@ jobs:
       OSV_VERSION: v2.3.8
       OSV_SHA256: bc98e15319ed0d515e3f9235287ba53cdc5535d576d24fd573978ecfe9ab92dc
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install OSV-Scanner
         run: |
           set -euo pipefail
@@ -175,7 +175,7 @@ jobs:
           fi
       - name: Upload OSV results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: osv-results
           path: osv-results.json
@@ -190,7 +190,7 @@ jobs:
     name: Browser support (PUL-Q002)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: pnpm/action-setup@v4
         with:
           version: 9.15.0
@@ -205,7 +205,7 @@ jobs:
         run: pnpm test:browsers
       - name: Upload Playwright report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: playwright-report
           path: |
@@ -219,14 +219,14 @@ jobs:
     needs: [test]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: coverage
           path: coverage/
-      - uses: SonarSource/sonarqube-scan-action@v6
+      - uses: SonarSource/sonarqube-scan-action@v7
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,13 +29,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           version: 9.15.0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -55,10 +55,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           version: 9.15.0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -74,10 +74,10 @@ jobs:
           # SonarCloud needs full history for blame; the sonar job consumes
           # this artifact, so fetch it here too.
           fetch-depth: 0
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           version: 9.15.0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -94,10 +94,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           version: 9.15.0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -109,10 +109,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           version: 9.15.0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -191,10 +191,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           version: 9.15.0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'pnpm'

--- a/changelog.d/127.added.md
+++ b/changelog.d/127.added.md
@@ -1,0 +1,13 @@
+Composition-level audio bed with `mode=standalone` suppression —
+PUL-F014. A composition may declare a single `audioBed` (a continuous
+looping source, scene-independent) at the composition-registration
+boundary; the runtime plays it underneath the slice for a composition
+navigation and tears it down with the per-navigation audio service.
+Under `mode=standalone` the bed is suppressed entirely — the scene
+runs as if no surrounding composition existed — through a bed-specific
+`bedSuppressed` scope on the audio service, distinct from the
+`silent` output policy so scene-owned `ctx.audio` is unaffected. The
+runtime validation pass rejects a malformed `audioBed` at boot. With
+chrome suppression (already shipped) and inter-scene-transition
+suppression (structural, single-scene slice), all three PUL-F014
+standalone-mode suppression surfaces are now in place.

--- a/docs/adrs/004-howler-audio-engine.md
+++ b/docs/adrs/004-howler-audio-engine.md
@@ -200,6 +200,46 @@ PUL-F024 lands the runtime side in `src/runtime/audio.ts`:
   their own timeline callbacks. Wiring scrub's monotonic-forward cue
   gate to the audio service is a follow-up that extends `AudioService`.
 
+## Subsequent Updates
+
+### 2026-05-21: Composition audio bed (PUL-F014)
+
+The "background beds" the Context names are now a first-class concept
+on this seam. A composition may declare a single composition-level
+audio bed — a continuous looping source that belongs to the
+composition, not to any one scene — at the composition-registration
+boundary (`CompositionRegistryEntry.audioBed`, an `AudioBedDeclaration`
+of `{ src, volume? }`). The per-navigation `AudioService` gains two
+construction options:
+
+- `bed` — the resolved composition's `AudioBedDeclaration`. When
+  supplied, `createAudioService` starts it looping at construction and
+  tears it down with `stopAll()` / abort, exactly like every other
+  sound. The bed is registered under a non-kebab internal key, so it is
+  unreachable through the scene-facing `load` / `play` / `stop` API —
+  composition-level bed playback stays distinct from scene-owned
+  `ctx.audio` playback.
+- `bedSuppressed` — a bed-specific scope, deliberately separate from
+  `AudioOutputPolicy`. The loader sets it for `mode=standalone`
+  (PUL-F014 / ADR-017): a scene inspected on its own runs as if no
+  surrounding composition existed, so the bed never plays. Scene-owned
+  `ctx.audio` is unaffected — unlike `outputPolicy: 'silent'`, which
+  would also silence the scene's own audio.
+
+Bed sources pass the same `resolveAssetUrl()` scheme allowlist scene
+sounds pass, but their membership allowlist is the bed declaration's
+own `src` — **not** the scene-facing `allowedSources` (the slice's
+`scene.audio`). The bed declaration is authoritative for the bed
+exactly as `scene.audio` is for scenes. Routing the bed source through
+`allowedSources` would expose the bed URL to `ctx.audio.load()`,
+letting a scene register and replay the bed as its own sound even
+under `mode=standalone` where the bed is suppressed; gating the bed
+against its own declaration keeps the scene allowlist limited to
+`scene.audio`. The runtime validation pass (PUL-F028) rejects a
+malformed `audioBed` at boot. A future crossfade / ducking / multi-bed
+need extends `AudioBedDeclaration` at this one seam rather than
+scattering bed flags.
+
 ## Related ADRs
 
 - [ADR-002](002-scene-registry-and-compositions.md) — defines where
@@ -208,3 +248,6 @@ PUL-F024 lands the runtime side in `src/runtime/audio.ts`:
   most audio cues fire.
 - [ADR-008](008-agent-native-authoring.md) — #1 kebab ids, #5 the only
   asset inventory is `scene.assets`.
+- [ADR-017](017-workbench-mode-standalone.md) — `mode=standalone`
+  suppresses the composition audio bed through the `bedSuppressed`
+  scope added here.

--- a/docs/adrs/017-workbench-mode-standalone.md
+++ b/docs/adrs/017-workbench-mode-standalone.md
@@ -213,26 +213,56 @@ to inspect — fully supported.
   `validateModeGrammar` already rejects unknown mode strings at the
   loader boundary. Slice transforms only run when the mode passes
   validation.
-- Inter-scene transition rendering does not exist yet. When ADR-003's
-  GSAP runner lands, the runner will see `ctx.mode === 'standalone'`
-  at the seam and know not to schedule a transition out of the head
-  scene — but until then, "no transition runs" is true because there
-  is no transition code anywhere. A regression that *added* transition
-  scheduling without consulting `ctx.mode` would re-introduce the
-  facet PUL-F014 forbids; the seam test
-  (`ctx.mode === 'standalone'` reaches every lifecycle hook of the
-  head scene) is the structural defense against that.
+- At acceptance time inter-scene transition rendering did not exist.
+  The subsequent update below records the current state: transitions
+  now exist, and standalone suppresses them by running a one-entry
+  slice.
+
+## Subsequent Updates
+
+### 2026-05-21: Suppression Surfaces Now Exist
+
+This ADR's original context predates several runtime surfaces. The
+loader slice decision still stands, but the implementation landscape is
+now different:
+
+- Workbench chrome exists in ADR-031. `chromeVisibilityFor()` maps
+  `standalone` to `hidden`, and the loader dispatches chrome
+  synchronously from the URL-derived effective mode before resolution
+  or scene lifecycle. That is the canonical suppression seam for
+  surrounding chrome.
+- GSAP master-timeline transitions exist in ADR-025. Transitions are
+  inserted only between composition segments present in the active
+  slice. Standalone's one-entry slice is therefore the canonical
+  suppression mechanism for inter-scene transitions; do not add a
+  parallel transition flag or fake no-op transition.
+- The Howler-backed audio service exists in ADR-004, with
+  per-navigation `AudioOutputPolicy`. It still does not model a
+  composition-level audio bed separately from scene-owned audio. A
+  future standalone completion change must add or select a bed-specific
+  scope on the existing audio-service seam, not map all standalone
+  audio to `silent`.
+
+These updates do not introduce a generic mode-policy object. Chrome,
+audio, and timeline remain separate subsystem seams; shared policy is
+only justified if a later requirement has multiple concrete consumers
+with the same stable representation.
+
+The original DRAFT / ACTIVE transition language in this ADR is
+historical context from the slice-truncation PR. Treat Ground Control
+as the source of truth for requirement status; this ADR continues to
+govern architecture boundaries, not workflow transitions.
 
 ## Related ADRs
 
-- [ADR-003](003-gsap-timeline-engine.md) — the timeline runner is the
-  seam through which inter-scene transition rendering will flow when
-  it lands; today the runner is a placeholder, so transition
-  suppression under standalone is structural.
-- [ADR-004](004-howler-audio-engine.md) — `ctx.audio` is the seam
-  through which audio rendering will flow; the surrounding-audio-bed
-  suppression clause maps onto a future audio surface reading
-  `ctx.mode === 'standalone'`.
+- [ADR-003](003-gsap-timeline-engine.md) / [ADR-025](025-timeline-adapter-boundary.md)
+  — the GSAP master and transition registry now insert inter-scene
+  transitions between active composition segments; standalone's
+  one-entry slice is the suppression mechanism.
+- [ADR-004](004-howler-audio-engine.md) — `ctx.audio` is the seam for
+  audio rendering. The current audio service has output policies but no
+  distinct composition-level audio-bed scope; PUL-F014 bed suppression
+  must extend that seam rather than silencing all scene audio.
 - [ADR-007](007-browser-workbench.md) — defines the eight workbench
   modes and the URL-only-source invariant for mode selection.
 - [ADR-008](008-agent-native-authoring.md) — manifests-over-flow-
@@ -248,10 +278,7 @@ to inspect — fully supported.
 - [ADR-015](015-url-beat-positioning.md) — beat semantics under
   standalone are unchanged: head-scope only, runner-side label
   resolution, non-fatal missing-label diagnostic.
-- [ADR-016](016-workbench-mode-present.md) — establishes the
-  precedent this ADR follows: land the contract layer plus seam
-  tests, keep the requirement DRAFT until each named facet has a
-  real rendering / input surface that actively conforms. PUL-F014's
-  ACTIVE transition is gated on chrome, audio-bed, and
-  inter-scene-transition surfaces all reading `ctx.mode ===
-  'standalone'` and suppressing.
+- [ADR-016](016-workbench-mode-present.md) — established the original
+  precedent this ADR followed: land the contract layer plus seam tests
+  before every named facet had a real surface. Current workflow status
+  belongs to Ground Control; this ADR records architecture boundaries.

--- a/docs/design/pul-f014-standalone-mode-preflight.md
+++ b/docs/design/pul-f014-standalone-mode-preflight.md
@@ -1,13 +1,34 @@
 # PUL-F014 Standalone Mode Preflight
 
 PUL-F014 specifies `mode=standalone`: render one scene as an isolated
-authoring / inspection target, with surrounding chrome,
-inter-scene transitions, and the audio bed suppressed. The scene still
-runs through the runtime lifecycle and sees the effective mode through
-`ctx.mode`.
+authoring / inspection target, with surrounding chrome, inter-scene
+transitions, and the audio bed suppressed. The scene still runs through
+the runtime lifecycle and sees the effective mode through `ctx.mode`.
 
 This is a mode-dispatch requirement across existing runtime seams. It
-is not a new scene model, router, composition schema, or lifecycle.
+is not a new scene model, router, composition schema, lifecycle,
+workbench shell, or generic mode-policy framework.
+
+## Current State
+
+The repo now has real seams for all three suppressed facets:
+
+- Single-scene execution is already structural. The loader's
+  `applySingleSceneSlice()` and the bridge-level `truncateToHead()`
+  preserve the addressed head entry's `range` / `behavior` overrides
+  and drop following entries.
+- Chrome exists. `src/runtime/workbench-chrome.ts`
+  `chromeVisibilityFor('standalone') === 'hidden'`, and the loader
+  dispatches chrome synchronously from the URL-derived effective mode.
+- Inter-scene transitions exist as `behavior.transition` declarations
+  consumed by `src/runtime/timeline.ts` through a `TransitionRegistry`.
+  Standalone suppresses them by running a one-entry slice; no
+  transition can be inserted before a non-existent second segment.
+- Audio exists as a per-navigation `AudioService` selected by
+  `audioOutputPolicyFor(mode)`, but there is no distinct
+  composition-level audio-bed contract yet. `standalone` must not be
+  made silent globally to fake audio-bed suppression, because the
+  requirement names only the surrounding bed, not scene-owned sound.
 
 ## Boundary
 
@@ -17,13 +38,21 @@ is not a new scene model, router, composition schema, or lifecycle.
   `NAVIGATION_MODES` allowlist.
 - `effectiveMode()` owns effective mode derivation.
 - `src/runtime/scene-loader.ts` owns per-navigation mode dispatch,
-  `ctx.mode` construction, cancellation, stage diagnostics, and error
-  surfacing.
+  `ctx.mode` construction, chrome dispatch, audio-service construction,
+  cancellation, stage diagnostics, and error surfacing.
 - `src/runtime/scene-navigation.ts` owns target resolution and
   composition slicing.
 - `src/runtime/composition-resolver.ts` owns preload -> create ->
   timeline -> cleanup ordering, abort propagation, and exactly-once
   cleanup.
+- `src/runtime/workbench-chrome.ts` owns chrome visibility.
+- `src/runtime/audio.ts` owns audio output policy, Howler
+  encapsulation, source allowlists, cue logging, and cleanup.
+- `src/runtime/timeline.ts` owns master timeline composition and
+  transition insertion.
+- `src/main.ts` is the browser composition root that wires chrome,
+  transition registry, audio engine, unlock adapter, validation, and
+  HMR disposal.
 
 Do not add a second route, mode enum, `standalone` boolean, scene schema
 field, manifest flag, or local URL parser. URL input remains the only
@@ -37,28 +66,57 @@ Implementation must reuse these cross-cutting concerns:
 
 - Identifier validation: `src/runtime/identifier.ts`.
 - URL and mode validation: `parseNavigationSearch()` and
-  `NAVIGATION_MODES`.
+  `NAVIGATION_MODES`, plus the loader's defensive mode / beat grammar
+  checks for hand-built targets.
 - Effective mode derivation: `effectiveMode()`.
 - Scene and composition validation:
   `assertSceneModule()`, `createSceneRegistry()`,
-  `assertCompositionManifest()`, and `createCompositionRegistry()`.
+  `assertCompositionManifest()`, `createCompositionRegistry()`, and
+  `validateRuntime()` over the canonical `src/workbench-graph.ts`
+  declarations.
 - Navigation resolution: `resolveSceneNavigation()` and
   `loadSceneNavigationTarget()`.
 - Lifecycle orchestration: `resolveComposition()` with injected
-  `createPreloader()` and `runTimeline()` adapters.
+  preloader and `CompositionTimelineAdapter` seams.
 - Asset handling: `createAssetPreloader()` with the existing scheme,
   redirect, `baseUrl`, and `AbortSignal` rules.
+- Chrome: `WorkbenchChromeAdapter`, `createDomWorkbenchChrome()`, and
+  `chromeVisibilityFor()`.
+- Audio: `createHowlerAudioEngine()`, `createAudioService()`,
+  `AudioOutputPolicy`, `scene.audio`, `allowedSources`, `stopGroup()`,
+  `stopAll()`, and the existing `onAudioCue` / `onError` sinks.
+- Timeline / transitions: `createGsapCompositionTimeline()`,
+  `composeMasterTimeline()`, `TransitionRegistry`, and
+  `behavior.transition`.
 - Error rendering: `describeError()` plus the existing
   `data-pulsar-navigation-error` stage diagnostic and `onError` sink.
 - Cancellation and cleanup: one per-navigation `AbortController`,
-  forwarded to preload and timeline adapters; cleanup remains
-  resolver-owned.
+  forwarded to preload, timeline, audio, presenter, and prompter
+  adapters; cleanup remains resolver-owned.
 
 If implementation needs a shared suppression representation, it must
 live at the workbench / adapter boundary that owns chrome, audio, and
 timeline execution. The resolver must remain mode-opaque and must not
 learn about chrome, Howler, GSAP, presenter controls, or DOM
 suppression attributes.
+
+## Cross-Cutting Layers
+
+| Layer | Guardrail |
+|-------|-----------|
+| URL grammar / public input | `mode=standalone` is accepted only through `NAVIGATION_MODES`; unknown or repeated `mode` values keep failing through the navigation grammar envelope. Unknown query keys must not influence suppression. |
+| Programmatic navigation | Loader-side `validateModeGrammar()` must reject forged mode strings before `effectiveMode()` reaches `ctx.mode`, chrome, or audio. |
+| Source of truth | `effectiveMode(target)` is recomputed per navigation from the parsed target. No storage, cookies, `history.state`, env vars, argv, config files, or previous in-memory state. |
+| Graph validation | Browser boot and CI must continue using `validateRuntime()` over `WORKBENCH_SCENES` / `WORKBENCH_COMPOSITIONS` before lifecycle effects. Do not create a standalone-only graph path. |
+| Scene schema | Do not add `standaloneAudio`, `hideChrome`, `audioBed`, or mode-selector fields to scene modules. Scenes may read `ctx.mode` only as a bounded hint for scene-owned behavior. |
+| Composition schema | Do not represent standalone by mutating manifests, inserting sentinel scenes, fake transitions, or mode flags. If a composition-level audio-bed declaration becomes necessary, extend the existing composition-registration boundary once and validate it there; do not hide it in per-entry `behavior` unless it is truly entry-scoped. |
+| Asset and audio-source security | Scene audio sources must remain declared assets and pass `scene.audio` / `allowedSources` plus `resolveAssetUrl()` scheme checks. The composition bed source carries the same scheme discipline but a **separate** allowlist: it is gated against the bed declaration's own `src`, not the scene-facing `scene.audio` allowlist — adding the bed URL to `allowedSources` would let a scene `ctx.audio.load()` it as its own sound and replay the bed even under `mode=standalone`. No `ctx.audio.play(url)` or query-derived fetch path. |
+| Chrome / DOM ownership | Workbench chrome is mounted once outside `#stage` and hidden through `chromeVisibilityFor()` / `hidden`. Scene cleanup must not remove chrome or the transition overlay. |
+| Timeline / transitions | Standalone transition suppression comes from one-entry execution. Do not add a runner flag, URL flag, fake transition name, or CSS-only hide that still composes following segments. |
+| Audio output | Do not map `standalone` to `outputPolicy: 'silent'` unless the requirement changes to suppress all scene-owned audio. The required seam is a bed-specific policy or scope on the existing audio service. |
+| Error envelope | Keep existing public envelopes: `navigation grammar is invalid:`, `scene navigation failed:`, `composition resolution failed:`, `beat positioning failed:`, and scene-failure diagnostics via `formatSceneContext()`. Do not serialize raw scene objects, DOM nodes, full captions, source URLs, headers, cookies, env, auth values, or engine handles. |
+| Source policy / security | Keep scene modules inside the existing A002/A008/Q007 gates: no direct Howler or `<audio>`, no scene-owned mode dispatch branches for central behavior, no dynamic remote code execution. |
+| OS / config exposure | No mode, target, audio source, token, or graph payload belongs in process argv, env bindings, local files, browser storage, cookies, or persisted history state. |
 
 ## Standalone Contract
 
@@ -75,21 +133,26 @@ suppression attributes.
 
 The suppressed surfaces are external to the scene lifecycle:
 
-- Chrome suppression is workbench-shell behavior. Do not make scenes own
-  global chrome state.
+- Chrome suppression is already workbench-shell behavior:
+  `chromeVisibilityFor('standalone')` returns `hidden`, and loader
+  dispatch occurs before target resolution / lifecycle. Do not make
+  scenes own global chrome state to preserve template visuals.
 - Audio-bed suppression is audio-service behavior per ADR-004. It must
   not suppress scene-owned sound effects unless a later requirement says
-  standalone is silent.
-- Inter-scene transition rendering, when ADR-003's runner lands, is
-  workbench/runner adapter behavior — a future runner reading
-  `ctx.mode` from its seam, not loader logic. Do not encode
+  standalone is silent. The current `AudioOutputPolicy` values express
+  whole-service output (`audible`, `silent`, `log-cues`); the bed needs
+  its own scope or policy parameter on the existing audio seam.
+- Inter-scene transition suppression is timeline-slice behavior. The
+  GSAP master only inserts transitions between segments that exist in
+  the slice; under standalone there is one segment. Do not encode
   transition suppression by mutating manifest entry CONTENTS (e.g.,
   swapping a scene id, editing a `range` value, rewriting a
-  `behavior` blob, inserting a sentinel entry). Truncating the
-  resolved slice at the loader to a one-entry slice that preserves
-  the addressed head entry verbatim is the chosen mechanism for
-  single-scene execution under `mode=standalone` and is recorded in
-  ADR-017 — that is selection, not rewriting.
+  `behavior` blob, inserting a sentinel entry, or declaring a fake
+  `none` transition). Truncating the resolved slice at the loader to a
+  one-entry slice that preserves the addressed head entry verbatim is
+  the chosen mechanism for single-scene execution under
+  `mode=standalone` and is recorded in ADR-017 — that is selection, not
+  rewriting.
 
 ## Guardrails
 
@@ -119,14 +182,42 @@ The suppressed surfaces are external to the scene lifecycle:
   `composition+scene` locators, out-of-range indexes, empty
   compositions, or preload failures because standalone is an inspection
   mode.
+- Do not let L2 chrome-slot usage blur ownership. `ctx.chrome` slot refs
+  are a template-system affordance mounted inside the workbench chrome
+  surface; hidden standalone chrome means content written only into
+  those slots is intentionally suppressed. Essential single-scene
+  inspection content belongs in the scene's stage DOM, or the template
+  requirement must explicitly redefine what counts as scene-owned.
+
+## Extensibility
+
+The required seams stay subsystem-specific:
+
+- Chrome variants extend `chromeVisibilityFor()` /
+  `WorkbenchChromeAdapter`.
+- Transition variations extend `TransitionRegistry` and
+  `behavior.transition` validation at the timeline boundary.
+- Audio-bed suppression extends `AudioService` / `AudioServiceOptions`
+  with a bed-specific scope or policy, selected by the loader from
+  `effectiveMode(target)`. The parameter must distinguish
+  composition-level bed playback from ordinary scene `ctx.audio`
+  playback.
+
+Do not extract a generic `ModePolicy` until more than two concrete
+subsystems need the same representation and the representation is
+stable enough to avoid concept loss.
 
 ## Non-Goals
 
 PUL-F014 should not implement `present`, `loop`, `paused`, `scrub`,
 `screenshot`, or `prompter`; presenter controls; export behavior;
-decode-complete asset semantics; authoring UI; new scene metadata;
-persistence; or a generic mode-policy framework unless the concrete
-chrome / audio / timeline adapters need one now.
+decode-complete asset semantics; authoring UI; persistence; remote
+control; authentication; telemetry; a generic mode-policy framework; or
+new scene metadata.
+
+This preflight should not transition requirement status or create
+traceability links. The implementation that follows owns tests and any
+Ground Control workflow step.
 
 ## Anti-Patterns
 
@@ -145,4 +236,11 @@ chrome / audio / timeline adapters need one now.
   not mutation, and is the mechanism ADR-017 chose.)
 - Suppressing all audio when the requirement only names the surrounding
   audio bed.
+- Treating the present-mode audio unlock gate as the audio-bed
+  suppression mechanism. Unlock gating applies only to present-mode
+  audio-declaring composition navigations; standalone must stay out of
+  that gate.
+- Adding a composition-level bed as a fake first scene, fake
+  transition, scene-local ambient loop, global Howler singleton call,
+  or browser `<audio>` element.
 - Persisting the last standalone target or mode outside the URL.

--- a/src/runtime/audio.ts
+++ b/src/runtime/audio.ts
@@ -529,6 +529,40 @@ export type AudioCueLogEntry =
   | AudioCueLogStop
   | AudioCueLogStopGroup;
 
+/**
+ * A composition-level audio bed (PUL-F014 / ADR-004): a single
+ * continuous looping source that belongs to the *composition*, not to
+ * any one scene. Unlike a `scene.audio` sound reached through
+ * `ctx.audio`, the bed is started by the runtime when a composition
+ * navigation begins and runs underneath every scene in the slice — an
+ * ambient pad, room tone, or musical bed. It loops for the lifetime of
+ * the navigation and is torn down with the audio service.
+ *
+ * `mode=standalone` suppresses the bed entirely (PUL-F014): a scene
+ * inspected on its own runs "as if no surrounding composition
+ * existed," so the surrounding bed must not play. Suppression is the
+ * {@link AudioServiceOptions.bedSuppressed} scope — deliberately
+ * distinct from {@link AudioOutputPolicy} `'silent'`, which would also
+ * silence the scene's own audio.
+ *
+ * The bed has no sprites and no groups: it is one looping source. A
+ * future crossfade / ducking / multi-bed need extends this
+ * declaration at this one seam rather than scattering bed flags.
+ */
+export interface AudioBedDeclaration {
+  /**
+   * Source URL, or an ordered codec-preference fallback list (same
+   * shape as {@link SoundDefinition.src}). Every URL passes the same
+   * scheme allowlist and {@link AudioServiceOptions.allowedSources}
+   * membership check scene sounds pass.
+   */
+  readonly src: string | readonly string[];
+  /**
+   * Optional playback volume in `[0, 1]`. Omit for the engine default.
+   */
+  readonly volume?: number;
+}
+
 /** Construction options for {@link createAudioService}. */
 export interface AudioServiceOptions {
   /**
@@ -568,6 +602,27 @@ export interface AudioServiceOptions {
   readonly allowedSources?: Iterable<string>;
   /** Sink for non-fatal async audio errors (load / play failure). Defaults to a no-op. */
   readonly onError?: (err: unknown) => void;
+  /**
+   * Composition-level audio bed (PUL-F014 / ADR-004). When supplied —
+   * and not suppressed — the service starts it looping at construction
+   * time and tears it down with `stopAll()`. The loader passes the
+   * resolved composition's {@link AudioBedDeclaration}; a non-
+   * composition navigation omits it. The bed is internal: it is NOT
+   * reachable through any {@link AudioService} method, so scenes (which
+   * receive the service as `ctx.audio`) cannot start, observe, or stop
+   * it — composition-level bed playback stays distinct from scene-owned
+   * `ctx.audio` playback.
+   */
+  readonly bed?: AudioBedDeclaration;
+  /**
+   * Suppress the composition audio {@link bed} entirely (PUL-F014).
+   * When `true`, the bed is never loaded or played — the loader sets
+   * this for `mode=standalone`, where a scene runs as if no surrounding
+   * composition existed. Defaults to `false`. This is a bed-specific
+   * scope: scene-owned `ctx.audio` playback is unaffected, unlike
+   * {@link AudioOutputPolicy} `'silent'`.
+   */
+  readonly bedSuppressed?: boolean;
 }
 
 /**
@@ -619,6 +674,17 @@ export interface AudioService {
 
 const GAIN_MIN = 0;
 const GAIN_MAX = 1;
+
+/**
+ * `sounds`-map key the composition audio bed (PUL-F014) is registered
+ * under. Deliberately NOT a valid kebab identifier: every scene-facing
+ * `load` / `play` / `stop` runs `assertSoundId`, so no scene can ever
+ * name, collide with, or reach the bed entry — bed playback stays
+ * distinct from scene-owned `ctx.audio` playback. Registering it in the
+ * shared `sounds` map still gives the bed `stopAll()` / abort teardown
+ * for free.
+ */
+const BED_SOUND_KEY = 'composition audio bed';
 
 interface RegisteredSound {
   readonly handle: AudioSoundHandle;
@@ -679,6 +745,32 @@ function assertSoundDefinition(
     throw new AudioSourceError(
       `audio sound "${soundId}" "src" must be a string or array of strings`,
     );
+  }
+}
+
+/**
+ * Validate an {@link AudioBedDeclaration} payload shape at the runtime
+ * boundary — composition registrations can be plain JS, so the static
+ * type does not hold. `src` must be a string or array; `volume` (if
+ * present) must be a number. Deep source validation (scheme allowlist,
+ * `allowedSources` membership) and the `[0, 1]` volume range check run
+ * later inside the audio service against the same gates scene sounds
+ * pass — this is only the shallow shape guard, mirroring
+ * {@link assertSoundDefinition}. Exported so the composition-
+ * registration boundary (PUL-F003) and the runtime validation pass
+ * (PUL-F028) reject a malformed bed up front.
+ */
+export function assertAudioBedDeclaration(value: unknown): asserts value is AudioBedDeclaration {
+  if (!isPlainRecord(value)) {
+    throw new AudioError('audio bed declaration must be an object with at least a "src" field');
+  }
+  const src = (value as { src?: unknown }).src;
+  if (typeof src !== 'string' && !Array.isArray(src)) {
+    throw new AudioSourceError('audio bed "src" must be a string or array of strings');
+  }
+  const volume = (value as { volume?: unknown }).volume;
+  if (volume !== undefined && typeof volume !== 'number') {
+    throw new AudioRangeError(`audio bed "volume" must be a number; got ${typeof volume}`);
   }
 }
 
@@ -797,6 +889,56 @@ const assertSpriteMap = (soundId: string, sprite: unknown): void => {
   }
 };
 
+/**
+ * Validate one audio source URL for a registration (a scene sound or
+ * the composition bed). Three checks, in order:
+ *
+ *  1. The URL is a non-empty string — scene modules can be plain JS,
+ *     so the static type does not hold.
+ *  2. The URL resolves under {@link DEFAULT_ALLOWED_SCHEMES}.
+ *     Defense-in-depth: even when an allowlist is supplied, the audio
+ *     service runs the same default scheme allowlist the preloader
+ *     uses by default — so a no-op or weak preloader cannot let
+ *     `file:` / `//host` URLs through. Threading the preloader's exact
+ *     `baseUrl` / `allowedSchemes` policy into the audio service is a
+ *     documented follow-up; for now the service is at least as
+ *     restrictive as `DEFAULT_ALLOWED_SCHEMES`.
+ *  3. When `allowedForSource` is non-null, the URL is a member of it.
+ *     PUL-F030 / ADR-029: `scene.audio` is the audio-source allowlist
+ *     for scene sounds; for the composition bed it is the bed's own
+ *     declared `src`. A URL outside the registration's allowlist is
+ *     rejected — even if it happens to be in `scene.assets`. This is
+ *     what makes the present-mode unlock gate predicate and the
+ *     runtime audio-source allowlist agree, and what keeps the bed
+ *     source out of the scene-facing `ctx.audio.load()` allowlist.
+ *
+ * Hoisted to module scope (pure — no closure captures) so
+ * `normalizeSources` stays within Sonar's / Biome's cognitive-
+ * complexity budget (the per-URL branching is the bulk of it).
+ */
+function assertValidAudioUrl(
+  soundId: string,
+  url: unknown,
+  allowedForSource: ReadonlySet<string> | null,
+): asserts url is string {
+  if (typeof url !== 'string' || url === '') {
+    throw new AudioSourceError(`audio sound "${soundId}" source must be a non-empty URL string`);
+  }
+  try {
+    resolveAssetUrl(url, undefined, DEFAULT_ALLOWED_SCHEMES);
+  } catch (cause) {
+    throw new AudioSourceError(
+      `audio sound "${soundId}" source "${url}" is invalid: ${describeError(cause)}`,
+      { cause },
+    );
+  }
+  if (allowedForSource !== null && !allowedForSource.has(url)) {
+    throw new AudioSourceError(
+      `audio sound "${soundId}" source "${url}" is not a declared audio source — list it in scene.audio (and ensure it is also in scene.assets so the preloader warms it) per PUL-F030 / ADR-029`,
+    );
+  }
+}
+
 /** Build the per-navigation {@link AudioService} over `engine`. */
 /**
  * Render an unknown value for the boundary-validation error message.
@@ -891,6 +1033,22 @@ export function createAudioService(
   if (options.onCue !== undefined && typeof options.onCue !== 'function') {
     throw new AudioError(
       `audio onCue must be a function or omitted; got ${describeRawOption(options.onCue)}`,
+    );
+  }
+  // Same boundary discipline for the PUL-F014 composition audio bed:
+  // the loader passes a registry-validated declaration, but a plain-JS
+  // / direct caller could pass a malformed `bed` or a non-boolean
+  // `bedSuppressed`. Validate the shape up front; deep source / volume
+  // validation runs inside `startBed` against the same gates scene
+  // sounds pass.
+  if (options.bed !== undefined) {
+    assertAudioBedDeclaration(options.bed);
+  }
+  if (options.bedSuppressed !== undefined && typeof options.bedSuppressed !== 'boolean') {
+    throw new AudioError(
+      `audio bedSuppressed must be a boolean or omitted; got ${describeRawOption(
+        options.bedSuppressed,
+      )}`,
     );
   }
   // Engine sounds are constructed muted under both 'silent' and
@@ -1002,8 +1160,23 @@ export function createAudioService(
     }
   };
 
-  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: existing pre-rule offender (cognitive complexity 17). Source list normalizer enforces non-empty + per-item scheme/type validation with detailed error envelopes; refactor tracked in docs/design/complexity-backlog.md.
-  const normalizeSources = (soundId: string, src: string | readonly string[]): string[] => {
+  // `normalizeSources` validates a registration's source list:
+  // non-empty, then each item through `assertValidAudioUrl`. The
+  // `allowedForSource` argument is the membership allowlist for THIS
+  // registration: scene sounds pass `allowed` (the slice's declared
+  // `scene.audio`); the composition bed (PUL-F014) passes its own
+  // declared `src` list via `startBed` — the bed declaration is
+  // authoritative for the bed exactly as `scene.audio` is for scenes.
+  // Keeping the gate per-registration is what stops the bed source
+  // from leaking into the scene-facing `ctx.audio.load()` allowlist
+  // (codex review, cycle 1 — "composition bed source leaks into scene
+  // audio allowlist"). `null` skips the membership check
+  // (non-composition / test callers); scheme validation still applies.
+  const normalizeSources = (
+    soundId: string,
+    src: string | readonly string[],
+    allowedForSource: ReadonlySet<string> | null,
+  ): string[] => {
     const list = typeof src === 'string' ? [src] : [...src];
     if (list.length === 0) {
       throw new AudioSourceError(
@@ -1011,39 +1184,7 @@ export function createAudioService(
       );
     }
     for (const url of list) {
-      if (typeof url !== 'string' || url === '') {
-        throw new AudioSourceError(
-          `audio sound "${soundId}" source must be a non-empty URL string`,
-        );
-      }
-      // Defense-in-depth: even when `allowedSources` is provided (the
-      // slice's declared `scene.audio`, every entry of which is also
-      // in `scene.assets` so the preloader warmed it), the audio
-      // service also runs the same default scheme allowlist the
-      // preloader uses by default — so a no-op or weak preloader
-      // cannot let `file:` / `//host` URLs through. Threading the
-      // preloader's exact `baseUrl` / `allowedSchemes` policy into
-      // the audio service is a documented follow-up; for now the
-      // service is at least as restrictive as `DEFAULT_ALLOWED_SCHEMES`.
-      try {
-        resolveAssetUrl(url, undefined, DEFAULT_ALLOWED_SCHEMES);
-      } catch (cause) {
-        throw new AudioSourceError(
-          `audio sound "${soundId}" source "${url}" is invalid: ${describeError(cause)}`,
-          { cause },
-        );
-      }
-      if (allowed !== null && !allowed.has(url)) {
-        // PUL-F030 / ADR-029: `scene.audio` is the audio-source
-        // allowlist. A URL outside the slice's declared `scene.audio`
-        // is rejected — even if it happens to be in `scene.assets`.
-        // This is what makes the present-mode unlock gate predicate
-        // and the runtime audio-source allowlist agree: a scene
-        // cannot quietly register audio it did not also declare.
-        throw new AudioSourceError(
-          `audio sound "${soundId}" source "${url}" is not a declared audio source — list it in scene.audio (and ensure it is also in scene.assets so the preloader warms it) per PUL-F030 / ADR-029`,
-        );
-      }
+      assertValidAudioUrl(soundId, url, allowedForSource);
     }
     return list;
   };
@@ -1057,12 +1198,63 @@ export function createAudioService(
     return `audio sound "${soundId}" has no sprite "${sprite}"${known}`;
   };
 
+  /**
+   * Start the composition audio bed (PUL-F014 / ADR-004). Runs once at
+   * construction when a bed is supplied and not suppressed. The bed
+   * source passes the SAME `normalizeSources` scheme gate scene sounds
+   * pass, but its membership allowlist is the bed's OWN declared `src`
+   * — NOT the scene-facing `allowedSources`. The bed declaration is
+   * authoritative for the bed exactly as `scene.audio` is for scenes;
+   * routing it through the scene allowlist would leak the bed URL into
+   * `ctx.audio.load()`, letting a scene register and play the bed
+   * source as its own sound even under `mode=standalone` where the bed
+   * is suppressed (codex review, cycle 1). The bed is registered into
+   * the shared `sounds` map under {@link BED_SOUND_KEY} so `stopAll()`
+   * / abort teardown unloads it. The bed loops for the lifetime of the
+   * navigation; it is constructed `muted` under the `silent` /
+   * `log-cues` policies like every other sound. No cue is emitted — the
+   * rehearsal cue log records scene-requested operations, and the bed
+   * is runtime infrastructure, not a scene operation.
+   */
+  const startBed = (bed: AudioBedDeclaration): void => {
+    // The bed's membership allowlist is its own declared source list:
+    // the bed is gated against what the composition declared for the
+    // bed, not against the scene `scene.audio` allowlist. Building the
+    // allowed set from the raw declaration keeps the bed source out of
+    // the scene-facing `allowedSources` entirely.
+    const bedAllowed: ReadonlySet<string> = new Set(
+      typeof bed.src === 'string' ? [bed.src] : bed.src,
+    );
+    const src = normalizeSources(BED_SOUND_KEY, bed.src, bedAllowed);
+    if (bed.volume !== undefined) assertGain(bed.volume, 'bed volume');
+    const handle = engine.createSound({
+      src,
+      muted,
+      onError: (err) => {
+        if (disposed) return;
+        try {
+          onError(new AudioError(`audio bed: ${describeError(err)}`, { cause: err }));
+        } catch {
+          // Intentionally empty: the diagnostic sink is non-fatal.
+        }
+      },
+    });
+    sounds.set(BED_SOUND_KEY, { handle, spriteNames: new Set(), src, sprite: undefined });
+    const playId = handle.play();
+    handle.loop(true, playId);
+    if (bed.volume !== undefined) handle.volume(bed.volume, playId);
+  };
+
   const service: AudioService = {
     load(soundId, definition) {
       if (disposed) return;
       assertSoundId(soundId);
       assertSoundDefinition(soundId, definition);
-      const src = normalizeSources(soundId, definition.src);
+      // Scene-facing `load`: the membership allowlist is the slice's
+      // declared `scene.audio` (`allowed`). The composition bed source
+      // is NOT in this set — it is gated separately inside `startBed`
+      // — so a scene cannot register the bed URL as its own sound.
+      const src = normalizeSources(soundId, definition.src, allowed);
       if (definition.sprite !== undefined) assertSpriteMap(soundId, definition.sprite);
       const existing = sounds.get(soundId);
       if (existing !== undefined) {
@@ -1230,6 +1422,17 @@ export function createAudioService(
       return disposed;
     },
   };
+
+  // Composition audio bed (PUL-F014): start it BEFORE the abort wiring
+  // so a pre-aborted signal's `stopAll()` below also tears the bed
+  // down. Skipped entirely when `bedSuppressed` is set (`mode=
+  // standalone`) — the scene runs as if no surrounding composition
+  // existed — or when no composition supplied a bed, or when the
+  // navigation was already aborted (no point starting a loop the next
+  // line stops).
+  if (options.bed !== undefined && options.bedSuppressed !== true && !options.signal.aborted) {
+    startBed(options.bed);
+  }
 
   if (options.signal.aborted) {
     service.stopAll();

--- a/src/runtime/composition-registry.ts
+++ b/src/runtime/composition-registry.ts
@@ -22,86 +22,107 @@
 //    consults this registry to resolve composition existence and
 //    membership before any scene lifecycle hook runs.
 
-import {
-  type CompositionEntry,
-  type CompositionManifest,
-  assertCompositionManifest,
-} from './composition';
+import { type AudioBedDeclaration, assertAudioBedDeclaration } from './audio';
+import { type CompositionManifest, assertCompositionManifest } from './composition';
 import { type IdRegistry, createIdRegistry } from './id-registry';
 import { KEBAB_IDENTIFIER_FORM, isKebabIdentifier } from './identifier';
 import { deepFreeze } from './object';
 
-/** A composition registration: (kebab-case id, validated manifest). */
+/**
+ * A composition registration: a kebab-case id, a validated manifest,
+ * and an optional composition-level audio bed (PUL-F014 / ADR-004).
+ * The `audioBed`, when present, is the surrounding ambient / musical
+ * loop the runtime plays underneath the slice — and suppresses under
+ * `mode=standalone`.
+ */
 export interface CompositionRegistryEntry {
   readonly id: string;
   readonly manifest: CompositionManifest;
+  readonly audioBed?: AudioBedDeclaration;
 }
 
 /**
- * Id-keyed registry of composition manifests. Mirrors {@link
- * SceneRegistry}'s shape so URL navigation, presenter controls, and
- * any future composition-aware feature dispatch through the same
- * lookup surface. Built once via {@link createCompositionRegistry};
- * the surface is intentionally small — lookup by id only — and the
- * returned registry is frozen.
+ * The value the {@link CompositionRegistry} stores per id: the
+ * validated, deep-frozen manifest plus the optional composition audio
+ * bed declaration (PUL-F014). Extending the registration boundary
+ * here — rather than hiding the bed in a per-entry `behavior` blob —
+ * keeps the bed a composition-level fact, validated once at
+ * registration.
  */
-export type CompositionRegistry = IdRegistry<CompositionManifest>;
+export interface RegisteredComposition {
+  readonly manifest: CompositionManifest;
+  readonly audioBed?: AudioBedDeclaration;
+}
 
 /**
- * Deep-snapshot then deep-freeze the manifest so the stored value
- * cannot be mutated by callers after registration. `structuredClone`
- * gives us a fresh graph (no shared subtrees with the caller's
- * references — defeats the "callers can mutate `behavior.fade.ease`
- * after registration" leak); `deepFreeze` walks the clone and freezes
- * every plain object/array reachable from the manifest (the array,
- * each object-form entry, nested `range` tuples, and the entire
- * `behavior` value graph at every depth). Bare-string entries are
- * immutable already.
+ * Id-keyed registry of compositions. Mirrors {@link SceneRegistry}'s
+ * shape so URL navigation, presenter controls, and any future
+ * composition-aware feature dispatch through the same lookup surface.
+ * Built once via {@link createCompositionRegistry}; the surface is
+ * intentionally small — lookup by id only — and the returned registry
+ * is frozen. Each stored value is a {@link RegisteredComposition}
+ * (manifest + optional audio bed).
+ */
+export type CompositionRegistry = IdRegistry<RegisteredComposition>;
+
+/**
+ * Deep-snapshot then deep-freeze the registered composition so the
+ * stored value cannot be mutated by callers after registration.
+ * `structuredClone` gives us a fresh graph (no shared subtrees with
+ * the caller's references — defeats the "callers can mutate
+ * `behavior.fade.ease` (or `audioBed.src`) after registration" leak);
+ * `deepFreeze` walks the clone and freezes every plain object/array
+ * reachable from it (the manifest array, each object-form entry,
+ * nested `range` tuples, the entire `behavior` value graph, and the
+ * `audioBed` declaration). Bare-string entries are immutable already.
  *
  * `structuredClone` is platform-standard since Node 17 / all current
- * browsers; per ADR-008 #1's declarative-data invariant, manifest
- * payloads (including `behavior` records) are structured data only —
- * no functions, classes, or other non-cloneable values.
- *
- * The `unknown` cast is necessary because the source `manifest` is
- * typed `readonly CompositionEntry[]`; the cloned array has the same
- * shape but TypeScript widens the cloned-readonly to `unknown` for
- * `structuredClone`'s untyped output.
+ * browsers; per ADR-008 #1's declarative-data invariant, manifest and
+ * bed payloads are structured data only — no functions, classes, or
+ * other non-cloneable values.
  */
-function freezeManifest(manifest: CompositionManifest): CompositionManifest {
-  return deepFreeze(structuredClone(manifest as CompositionEntry[])) as CompositionManifest;
+function freezeComposition(composition: RegisteredComposition): RegisteredComposition {
+  return deepFreeze(structuredClone(composition)) as RegisteredComposition;
 }
 
 /**
  * Build a {@link CompositionRegistry} from a collection of (id,
- * manifest) entries.
+ * manifest, audioBed?) entries.
  *
  * Validation rules, applied in iteration order:
  *  1. `id` must satisfy {@link isKebabIdentifier} (ADR-008 #1).
  *  2. `manifest` must satisfy {@link assertCompositionManifest}
  *     (PUL-F003).
- *  3. Ids must be unique within the registry — registration is by id.
+ *  3. `audioBed` (when present) must satisfy
+ *     {@link assertAudioBedDeclaration} (PUL-F014).
+ *  4. Ids must be unique within the registry — registration is by id.
  *
- * Stored manifests are deep-frozen so caller-side mutation of the
- * original array (or of nested override objects) cannot leak into the
- * registry. The returned registry is frozen and exposes only id-based
- * lookup.
+ * Stored compositions are deep-frozen so caller-side mutation of the
+ * original array (or of nested override / bed objects) cannot leak
+ * into the registry. The returned registry is frozen and exposes only
+ * id-based lookup.
  */
 export function createCompositionRegistry(
   entries: Iterable<CompositionRegistryEntry>,
 ): CompositionRegistry {
-  // `assertCompositionManifest` runs before the generic sees the
-  // entry so a malformed manifest raises with the PUL-F003 grammar
-  // (`composition manifest is invalid: ...`) rather than a generic
-  // registry error. The generic itself handles id-shape rejection
-  // (`composition registry: id "<id>" must be ...`) and duplicate-id
-  // rejection. Storage uses `freezeManifest` as the transform so the
-  // generic is still single-purpose.
+  // `assertCompositionManifest` / `assertAudioBedDeclaration` run
+  // before the generic sees the entry so a malformed manifest raises
+  // with the PUL-F003 grammar (`composition manifest is invalid: ...`)
+  // and a malformed bed with the PUL-F014 grammar (`audio bed ...`),
+  // rather than a generic registry error. The generic itself handles
+  // id-shape rejection (`composition registry: id "<id>" must be ...`)
+  // and duplicate-id rejection. Storage uses `freezeComposition` as
+  // the transform so the generic is still single-purpose.
   return createIdRegistry(
     (function* mapToEntries() {
       for (const entry of entries) {
         assertCompositionManifest(entry.manifest);
-        yield { id: entry.id, value: entry.manifest };
+        if (entry.audioBed !== undefined) assertAudioBedDeclaration(entry.audioBed);
+        const value: RegisteredComposition = {
+          manifest: entry.manifest,
+          ...(entry.audioBed === undefined ? {} : { audioBed: entry.audioBed }),
+        };
+        yield { id: entry.id, value };
       }
     })(),
     {
@@ -114,7 +135,7 @@ export function createCompositionRegistry(
           );
         }
       },
-      transform: freezeManifest,
+      transform: freezeComposition,
     },
   );
 }

--- a/src/runtime/scene-loader.ts
+++ b/src/runtime/scene-loader.ts
@@ -543,19 +543,31 @@ function isPureAbort(err: unknown, signal: AbortSignal): boolean {
  * declared as audio — every scene's static {@link import('./scene').SceneModule.audio}
  * list in the slice (just the head scene's for a bare `kind: 'scene'`
  * target, the full composition slice's for composition targets). The
- * per-navigation audio service uses this so `ctx.audio.load()` can
- * only register URLs the scene EXPLICITLY declared as audio — not any
- * URL that happens to be in `scene.assets`. This makes the PUL-F030 /
- * ADR-029 unlock-gate predicate ({@link import('./scene').sceneDeclaresAudio})
- * AND the audio-service allowlist consistent: a scene that registers
- * audio MUST declare it in `scene.audio`, so the present-mode unlock
- * gate cannot be bypassed by a scene that hides its audio in `assets`
+ * per-navigation audio service uses this as the SCENE-FACING source
+ * allowlist so `ctx.audio.load()` can only register URLs the scene
+ * EXPLICITLY declared as audio — not any URL that happens to be in
+ * `scene.assets`. This makes the PUL-F030 / ADR-029 unlock-gate
+ * predicate ({@link import('./scene').sceneDeclaresAudio}) AND the
+ * audio-service allowlist consistent: a scene that registers audio
+ * MUST declare it in `scene.audio`, so the present-mode unlock gate
+ * cannot be bypassed by a scene that hides its audio in `assets`
  * (codex review, cycle 1 — class finding "audio gate can be bypassed
  * by undeclared ctx.audio loads"). `scene.audio` is validated at the
  * schema boundary to be a subset of `scene.assets`, so the preloader
- * still warms every declared audio URL. Pure function (no closure
- * captures), hoisted to module scope so the loader factory does not
- * recreate it per instance.
+ * still warms every declared audio URL.
+ *
+ * The PUL-F014 composition audio bed is deliberately NOT added here.
+ * The bed is composition-owned runtime infrastructure, not a
+ * `scene.audio` entry, and exposing its source through the scene
+ * allowlist would let a scene `ctx.audio.load()` the bed URL as its
+ * own sound — playing the bed even under `mode=standalone` where it
+ * is suppressed. The audio service gates the bed against the bed's
+ * OWN declared `src` inside `startBed`, so the scene allowlist stays
+ * limited to `scene.audio` (codex review, cycle 1 — "composition bed
+ * source leaks into scene audio allowlist").
+ *
+ * Pure function (no closure captures), hoisted to module scope so the
+ * loader factory does not recreate it per instance.
  */
 function collectAudioSources(target: SceneNavigationTarget): readonly string[] {
   return target.composition === undefined
@@ -1180,6 +1192,16 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
         allowedSources: collectAudioSources(resolved),
         onError,
         ...(options.onAudioCue === undefined ? {} : { onCue: options.onAudioCue }),
+        // PUL-F014 / ADR-004: the composition audio bed, played
+        // underneath the slice — suppressed under `mode=standalone`,
+        // where the scene runs as if no surrounding composition
+        // existed. The resolver snapshots the declaration onto the
+        // composition context; the loader is the mode-dispatch point
+        // that decides bed vs no-bed, keeping the resolver mode-opaque.
+        ...(resolved.composition?.audioBed === undefined
+          ? {}
+          : { bed: resolved.composition.audioBed }),
+        bedSuppressed: mode === 'standalone',
       });
       const pipe = buildPresenterPipe(mode, controller, audio);
       presenter = pipe.presenter;

--- a/src/runtime/scene-navigation.ts
+++ b/src/runtime/scene-navigation.ts
@@ -25,13 +25,14 @@
 //  - ADR-011 — composition resolver as pure orchestrator with
 //    injected adapters; reused via `loadSceneNavigationTarget`.
 
+import type { AudioBedDeclaration } from './audio';
 import {
   type CompositionEntry,
   type CompositionManifest,
   entryId,
   findUnregisteredEntries,
 } from './composition';
-import type { CompositionRegistry } from './composition-registry';
+import type { CompositionRegistry, RegisteredComposition } from './composition-registry';
 import {
   type AssetPreloader,
   type CompositionTimelineAdapter,
@@ -87,6 +88,15 @@ export interface SceneNavigationCompositionContext {
    * the head entry.
    */
   readonly startIndex: number;
+  /**
+   * The composition-level audio bed (PUL-F014 / ADR-004), copied
+   * verbatim from the {@link RegisteredComposition}, when the
+   * composition declared one. The resolver snapshots it but makes no
+   * suppression decision — the loader selects bed playback vs
+   * suppression from the effective mode (`mode=standalone` suppresses
+   * it). `undefined` when the composition declared no bed.
+   */
+  readonly audioBed?: AudioBedDeclaration;
 }
 
 /**
@@ -330,14 +340,37 @@ const sliceManifestFromIndex = (
   startIndex: number,
 ): CompositionManifest => deepFreeze(manifest.slice(startIndex)) as readonly CompositionEntry[];
 
-function resolveCompositionManifest(
+function resolveRegisteredComposition(
   compositionId: string,
   compositions: CompositionRegistry,
-): CompositionManifest {
+): RegisteredComposition {
   if (!compositions.has(compositionId)) {
     fail(`composition "${compositionId}" is not registered`);
   }
   return compositions.get(compositionId);
+}
+
+/**
+ * Build the {@link SceneNavigationCompositionContext}, attaching the
+ * resolved composition's `audioBed` (PUL-F014) only when one was
+ * declared. Centralized so all three locator kinds carry the bed
+ * declaration identically; the conditional spread keeps `audioBed`
+ * absent rather than `undefined` under `exactOptionalPropertyTypes`.
+ */
+function buildCompositionContext(
+  compositionId: string,
+  manifestSlice: CompositionManifest,
+  sceneSlice: readonly SceneModule[],
+  startIndex: number,
+  audioBed: AudioBedDeclaration | undefined,
+): SceneNavigationCompositionContext {
+  return {
+    id: compositionId,
+    manifestSlice,
+    sceneSlice,
+    startIndex,
+    ...(audioBed === undefined ? {} : { audioBed }),
+  };
 }
 
 function resolveCompositionFromStart(
@@ -345,13 +378,13 @@ function resolveCompositionFromStart(
   scenes: SceneRegistry,
   compositions: CompositionRegistry,
 ): SceneNavigationCompositionContext {
-  const manifest = resolveCompositionManifest(compositionId, compositions);
+  const { manifest, audioBed } = resolveRegisteredComposition(compositionId, compositions);
   if (manifest.length === 0) {
     fail(`composition "${compositionId}" is empty — no scene to navigate to`);
   }
   const manifestSlice = sliceManifestFromIndex(manifest, 0);
   const sceneSlice = snapshotSceneSlice(manifestSlice, 0, scenes, compositionId);
-  return { id: compositionId, manifestSlice, sceneSlice, startIndex: 0 };
+  return buildCompositionContext(compositionId, manifestSlice, sceneSlice, 0, audioBed);
 }
 
 function resolveCompositionAndScene(
@@ -360,7 +393,7 @@ function resolveCompositionAndScene(
   scenes: SceneRegistry,
   compositions: CompositionRegistry,
 ): SceneNavigationCompositionContext {
-  const manifest = resolveCompositionManifest(compositionId, compositions);
+  const { manifest, audioBed } = resolveRegisteredComposition(compositionId, compositions);
   // Walk the whole manifest once: a single occurrence is the
   // unambiguous slice start; zero occurrences is a non-member error;
   // two or more occurrences make `composition+scene` ambiguous and
@@ -386,7 +419,7 @@ function resolveCompositionAndScene(
   }
   const manifestSlice = sliceManifestFromIndex(manifest, startIndex);
   const sceneSlice = snapshotSceneSlice(manifestSlice, startIndex, scenes, compositionId);
-  return { id: compositionId, manifestSlice, sceneSlice, startIndex };
+  return buildCompositionContext(compositionId, manifestSlice, sceneSlice, startIndex, audioBed);
 }
 
 function resolveCompositionAndIndex(
@@ -395,7 +428,7 @@ function resolveCompositionAndIndex(
   scenes: SceneRegistry,
   compositions: CompositionRegistry,
 ): SceneNavigationCompositionContext {
-  const manifest = resolveCompositionManifest(compositionId, compositions);
+  const { manifest, audioBed } = resolveRegisteredComposition(compositionId, compositions);
   // Re-validate the index invariants PUL-F007's parser already
   // enforces. `NavigationTarget` is an exported type and a non-parser
   // caller (event-detail unmarshaling, future test harness, etc.)
@@ -409,7 +442,7 @@ function resolveCompositionAndIndex(
   }
   const manifestSlice = sliceManifestFromIndex(manifest, index);
   const sceneSlice = snapshotSceneSlice(manifestSlice, index, scenes, compositionId);
-  return { id: compositionId, manifestSlice, sceneSlice, startIndex: index };
+  return buildCompositionContext(compositionId, manifestSlice, sceneSlice, index, audioBed);
 }
 
 /**

--- a/src/runtime/validation.ts
+++ b/src/runtime/validation.ts
@@ -53,6 +53,7 @@
 // a CI summary, or a JSON report.
 
 import { DEFAULT_ALLOWED_SCHEMES, resolveAssetUrl } from './asset-preloader';
+import { assertAudioBedDeclaration } from './audio';
 import {
   CompositionManifestError,
   assertCompositionManifest,
@@ -136,7 +137,12 @@ export type FindingCode =
   // resolvable. Resolvability uses the same `resolveAssetUrl` rule
   // the preloader and audio service consume, so tightening the
   // allowlist tightens validation automatically.
-  | 'asset-unresolvable';
+  | 'asset-unresolvable'
+  // PUL-F014 — a composition declared a malformed `audioBed`. The
+  // shape check reuses `assertAudioBedDeclaration` (the same gate the
+  // composition registry and audio service use), so a bad bed fails
+  // the validation pass at boot rather than at navigation time.
+  | 'composition-audio-bed-invalid';
 
 /**
  * One composition registration as the validator sees it. Matches the
@@ -153,6 +159,13 @@ export type FindingCode =
 export interface ValidationCompositionInput {
   readonly id: string;
   readonly manifest: unknown;
+  /**
+   * Optional composition audio bed (PUL-F014). Typed `unknown` at the
+   * boundary — like `manifest` — so callers feed the validator the raw
+   * registration declarations before `assertAudioBedDeclaration` has
+   * run. `undefined` when the composition declared no bed.
+   */
+  readonly audioBed?: unknown;
 }
 
 /**
@@ -341,12 +354,38 @@ function runCompositionPhase(
 ): void {
   if (compositions === undefined) return;
   for (const composition of compositions) {
+    // The audio-bed shape check (PUL-F014) is independent of the
+    // manifest shape — a bad bed must not suppress the reference
+    // check, and a bad manifest must not suppress the bed check.
+    const bedFinding = checkCompositionAudioBed(composition);
+    if (bedFinding !== null) findings.push(bedFinding);
     const manifestFinding = checkCompositionShape(composition);
     if (manifestFinding !== null) {
       findings.push(manifestFinding);
       continue;
     }
     appendCompositionReferenceFindings(composition, validIds, findings);
+  }
+}
+
+/**
+ * PUL-F014 — when a composition declares an `audioBed`, validate its
+ * shape through `assertAudioBedDeclaration` (the same gate the
+ * composition registry and audio service use). Returns a
+ * `composition-audio-bed-invalid` finding on a malformed bed, or
+ * `null` when there is no bed or the bed is well-formed.
+ */
+function checkCompositionAudioBed(composition: ValidationCompositionInput): Finding | null {
+  if (composition.audioBed === undefined) return null;
+  try {
+    assertAudioBedDeclaration(composition.audioBed);
+    return null;
+  } catch (cause) {
+    return {
+      code: 'composition-audio-bed-invalid',
+      message: `composition "${composition.id}": ${describeError(cause)}`,
+      compositionId: composition.id,
+    };
   }
 }
 

--- a/tests/runtime/audio.test.ts
+++ b/tests/runtime/audio.test.ts
@@ -19,6 +19,7 @@
 
 import { afterEach, describe, expect, it } from 'vitest';
 import {
+  type AudioBedDeclaration,
   type AudioCueLogEntry,
   type AudioCueLogStopGroup,
   type AudioEngine,
@@ -30,6 +31,7 @@ import {
   type AudioSoundHandle,
   AudioSourceError,
   type SoundDefinition,
+  assertAudioBedDeclaration,
   createAudioService,
   noopAudioEngine,
 } from '../../src/runtime/audio';
@@ -1226,5 +1228,221 @@ describe('createAudioService — onCue runtime validation (codex review, cycle 2
         outputPolicy: 'log-cues',
       }),
     ).not.toThrow();
+  });
+});
+
+/* -------------------------------------------------------------------- *
+ *  Composition audio bed — PUL-F014 / ADR-004
+ * -------------------------------------------------------------------- */
+
+describe('createAudioService — composition audio bed (PUL-F014)', () => {
+  // PUL-F014: in `mode=standalone` the audio bed is suppressed; under
+  // every other mode a composition bed plays underneath the slice.
+  const BED_SRC = '/audio/bed.webm';
+  const bed = (overrides: Partial<AudioBedDeclaration> = {}): AudioBedDeclaration => ({
+    src: BED_SRC,
+    ...overrides,
+  });
+
+  it('starts the bed looping at construction for a composition navigation', () => {
+    // The bed is gated against its OWN declared `src`, not the
+    // scene-facing `allowedSources` — so it starts even when the
+    // scene allowlist does not list the bed URL.
+    const { fake } = buildService({ bed: bed(), allowedSources: ['/audio/sting.webm'] });
+    // The bed is the only sound the service created.
+    expect(fake.created).toHaveLength(1);
+    expect(fake.created[0]?.src).toEqual([BED_SRC]);
+    // It was played, then marked looping.
+    const methods = fake.calls.map((c) => c.method);
+    expect(methods).toContain('play');
+    const loopCall = fake.calls.find((c) => c.method === 'loop');
+    expect(loopCall?.args[0]).toBe(true);
+  });
+
+  it('does NOT play the bed when bedSuppressed is set (mode=standalone)', () => {
+    const { fake } = buildService({
+      bed: bed(),
+      bedSuppressed: true,
+    });
+    // Suppressed: no bed sound is created at all.
+    expect(fake.created).toHaveLength(0);
+    expect(fake.calls).toHaveLength(0);
+  });
+
+  it('leaves scene-owned ctx.audio playable while the bed is suppressed', () => {
+    // bedSuppressed is a bed-specific scope, NOT outputPolicy:'silent':
+    // scenes can still register and play their own audio.
+    const { fake, service } = buildService({
+      bed: bed(),
+      bedSuppressed: true,
+      allowedSources: ['/audio/sting.webm'],
+    });
+    service.load('sting', { src: '/audio/sting.webm' });
+    service.play('sting');
+    expect(fake.created).toHaveLength(1);
+    expect(fake.created[0]?.muted).toBe(false);
+    expect(fake.calls.some((c) => c.method === 'play')).toBe(true);
+  });
+
+  it('does NOT expose the bed source through the scene-facing load allowlist', () => {
+    // PUL-F014 / codex review cycle 1: the bed source is gated against
+    // the bed's own declaration, NOT the scene `allowedSources`. A
+    // scene that does not declare the bed URL in `scene.audio` cannot
+    // register it as its own sound — so the bed cannot be replayed
+    // through `ctx.audio.load()` even under `mode=standalone` where
+    // the bed itself is suppressed.
+    const { service } = buildService({
+      bed: bed(),
+      allowedSources: ['/audio/sting.webm'],
+    });
+    expect(() => service.load('leak', { src: BED_SRC })).toThrow(AudioSourceError);
+  });
+
+  it('keeps the bed suppressed AND unreachable via load under mode=standalone', () => {
+    // The two halves of PUL-F014 standalone suppression together: the
+    // bed never plays, and a scene cannot smuggle the bed URL back in
+    // through `ctx.audio.load()` because it is not in the scene
+    // allowlist.
+    const { fake, service } = buildService({
+      bed: bed(),
+      bedSuppressed: true,
+      allowedSources: ['/audio/sting.webm'],
+    });
+    expect(fake.created).toHaveLength(0);
+    expect(() => service.load('smuggled-bed', { src: BED_SRC })).toThrow(AudioSourceError);
+  });
+
+  it('constructs the bed muted under the silent output policy', () => {
+    const { fake } = buildService({
+      bed: bed(),
+      outputPolicy: 'silent',
+    });
+    expect(fake.created[0]?.muted).toBe(true);
+  });
+
+  it('constructs the bed muted under the log-cues output policy without emitting a cue', () => {
+    const cues: AudioCueLogEntry[] = [];
+    const { fake } = buildService({
+      bed: bed(),
+      outputPolicy: 'log-cues',
+      onCue: (entry) => cues.push(entry),
+    });
+    expect(fake.created[0]?.muted).toBe(true);
+    // The bed is runtime infrastructure, not a scene-requested
+    // operation — it never appears in the rehearsal cue log.
+    expect(cues).toHaveLength(0);
+  });
+
+  it('applies the bed volume to the looping play', () => {
+    const { fake } = buildService({ bed: bed({ volume: 0.4 }) });
+    const volumeCall = fake.calls.find((c) => c.method === 'volume');
+    expect(volumeCall?.args[0]).toBe(0.4);
+  });
+
+  it('starts the bed regardless of the scene-facing allowedSources set', () => {
+    // The bed declaration is authoritative for the bed; the scene
+    // `allowedSources` set (the slice's `scene.audio`) does not gate
+    // it. A composition whose scenes declare no audio still gets its
+    // bed.
+    const fake = fakeEngine();
+    expect(() =>
+      createAudioService(fake.engine, {
+        signal: liveSignal(),
+        bed: bed(),
+        allowedSources: [],
+      }),
+    ).not.toThrow();
+    expect(fake.created).toHaveLength(1);
+    expect(fake.created[0]?.src).toEqual([BED_SRC]);
+  });
+
+  it('rejects a bed source with a disallowed scheme', () => {
+    const fake = fakeEngine();
+    expect(() =>
+      createAudioService(fake.engine, {
+        signal: liveSignal(),
+        bed: { src: 'file:///etc/passwd' },
+      }),
+    ).toThrow(AudioSourceError);
+  });
+
+  it('rejects an out-of-range bed volume', () => {
+    const fake = fakeEngine();
+    expect(() =>
+      createAudioService(fake.engine, {
+        signal: liveSignal(),
+        bed: bed({ volume: 1.5 }),
+      }),
+    ).toThrow(AudioRangeError);
+  });
+
+  it('tears the bed down when the navigation signal aborts', () => {
+    const { fake, controller } = buildService({ bed: bed() });
+    expect(fake.calls.some((c) => c.method === 'unload')).toBe(false);
+    controller.abort();
+    expect(fake.calls.some((c) => c.method === 'unload')).toBe(true);
+  });
+
+  it('does not start the bed when the navigation signal is already aborted', () => {
+    const fake = fakeEngine();
+    const controller = new AbortController();
+    controller.abort();
+    createAudioService(fake.engine, {
+      signal: controller.signal,
+      bed: bed(),
+    });
+    expect(fake.created).toHaveLength(0);
+  });
+
+  it('keeps the bed unreachable through the scene-facing audio API', () => {
+    // The bed key is not a kebab identifier, so a scene cannot name,
+    // collide with, stop, or re-register it through load/play/stop.
+    const { service } = buildService({ bed: bed() });
+    expect(() => service.load('composition audio bed', { src: BED_SRC })).toThrow(AudioSoundError);
+    expect(() => service.play('composition audio bed')).toThrow(AudioSoundError);
+    expect(() => service.stop('composition audio bed')).toThrow(AudioSoundError);
+  });
+
+  it('rejects a non-boolean bedSuppressed at construction', () => {
+    const fake = fakeEngine();
+    const build = (value: unknown): (() => void) => {
+      return () =>
+        createAudioService(fake.engine, {
+          signal: liveSignal(),
+          bed: bed(),
+          bedSuppressed: value as boolean,
+        });
+    };
+    expect(build('yes')).toThrow(AudioError);
+    expect(build(1)).toThrow(AudioError);
+    expect(build(null)).toThrow(AudioError);
+  });
+});
+
+describe('assertAudioBedDeclaration (PUL-F014)', () => {
+  it('accepts a string source', () => {
+    expect(() => assertAudioBedDeclaration({ src: '/audio/bed.webm' })).not.toThrow();
+  });
+
+  it('accepts an array source and an optional volume', () => {
+    expect(() =>
+      assertAudioBedDeclaration({ src: ['/audio/bed.webm', '/audio/bed.mp3'], volume: 0.5 }),
+    ).not.toThrow();
+  });
+
+  it('rejects a non-object declaration', () => {
+    expect(() => assertAudioBedDeclaration('oops')).toThrow(AudioError);
+    expect(() => assertAudioBedDeclaration(null)).toThrow(AudioError);
+  });
+
+  it('rejects a declaration with a missing or mistyped src', () => {
+    expect(() => assertAudioBedDeclaration({})).toThrow(AudioSourceError);
+    expect(() => assertAudioBedDeclaration({ src: 42 })).toThrow(AudioSourceError);
+  });
+
+  it('rejects a non-numeric volume', () => {
+    expect(() => assertAudioBedDeclaration({ src: '/audio/bed.webm', volume: 'loud' })).toThrow(
+      AudioRangeError,
+    );
   });
 });

--- a/tests/runtime/composition-registry.test.ts
+++ b/tests/runtime/composition-registry.test.ts
@@ -29,7 +29,7 @@ describe('createCompositionRegistry', () => {
       expect(registry.has('full-talk')).toBe(true);
       // The registry stores a deep-frozen copy (immutable-registry
       // contract), so identity differs but contents match.
-      expect(registry.get('full-talk')).toEqual(fullTalk);
+      expect(registry.get('full-talk').manifest).toEqual(fullTalk);
     });
 
     it('registers multiple compositions and exposes each by id', () => {
@@ -38,8 +38,8 @@ describe('createCompositionRegistry', () => {
         { id: 'trailer', manifest: trailer },
       ]);
       expect(registry.size).toBe(2);
-      expect(registry.get('full-talk')).toEqual(fullTalk);
-      expect(registry.get('trailer')).toEqual(trailer);
+      expect(registry.get('full-talk').manifest).toEqual(fullTalk);
+      expect(registry.get('trailer').manifest).toEqual(trailer);
       expect(registry.ids()).toEqual(['full-talk', 'trailer']);
     });
 
@@ -128,10 +128,10 @@ describe('createCompositionRegistry', () => {
       // contradicting the immutable-registry contract).
       const manifest = ['scene-a', 'scene-b'] as unknown as CompositionManifest;
       const registry = createCompositionRegistry([{ id: 'talk', manifest }]);
-      const stored = registry.get('talk');
+      const stored = registry.get('talk').manifest;
       expect(Object.isFrozen(stored)).toBe(true);
-      expect(() => (stored as string[]).push('scene-c')).toThrow();
-      const writable = stored as string[];
+      expect(() => (stored as unknown as string[]).push('scene-c')).toThrow();
+      const writable = stored as unknown as string[];
       expect(() => {
         writable[0] = 'mutated';
       }).toThrow();
@@ -143,7 +143,7 @@ describe('createCompositionRegistry', () => {
         { id: 'scene-b', behavior: { fade: true } },
       ] as unknown as CompositionManifest;
       const registry = createCompositionRegistry([{ id: 'talk', manifest }]);
-      const stored = registry.get('talk');
+      const stored = registry.get('talk').manifest;
       expect(Object.isFrozen(stored[0])).toBe(true);
       expect(Object.isFrozen(stored[1])).toBe(true);
       const entry = stored[1] as unknown as { id: string; behavior: { fade: boolean } };
@@ -161,7 +161,7 @@ describe('createCompositionRegistry', () => {
         { id: 'scene-a', range: ['intro', 'hook'] as const },
       ] as unknown as CompositionManifest;
       const registry = createCompositionRegistry([{ id: 'talk', manifest }]);
-      const stored = registry.get('talk');
+      const stored = registry.get('talk').manifest;
       const entry = stored[0] as unknown as { range: string[] };
       expect(Object.isFrozen(entry.range)).toBe(true);
       expect(() => {
@@ -183,7 +183,7 @@ describe('createCompositionRegistry', () => {
         },
       ] as unknown as CompositionManifest;
       const registry = createCompositionRegistry([{ id: 'talk', manifest }]);
-      const stored = registry.get('talk');
+      const stored = registry.get('talk').manifest;
       const entry = stored[0] as unknown as {
         behavior: { fade: { duration: number; ease: string[] }; flags: string[] };
       };
@@ -215,13 +215,13 @@ describe('createCompositionRegistry', () => {
         { id: 'scene-a', behavior: callerBehavior },
       ] as unknown as CompositionManifest;
       const registry = createCompositionRegistry([{ id: 'talk', manifest }]);
-      const before = registry.get('talk');
+      const before = registry.get('talk').manifest;
 
       // Caller mutates THEIR view (which still has live references).
       callerBehavior.fade.duration = 9999;
       callerBehavior.flags.push('c');
 
-      const after = registry.get('talk');
+      const after = registry.get('talk').manifest;
       const stored = after[0] as unknown as {
         behavior: { fade: { duration: number; ease: string[] }; flags: string[] };
       };
@@ -241,7 +241,53 @@ describe('createCompositionRegistry', () => {
       // Caller mutates their copy after registration.
       manifest.push('scene-c');
       manifest[0] = 'mutated';
-      expect(registry.get('talk')).toEqual(['scene-a', 'scene-b']);
+      expect(registry.get('talk').manifest).toEqual(['scene-a', 'scene-b']);
+    });
+  });
+
+  describe('composition audio bed (PUL-F014)', () => {
+    it('stores a declared audio bed alongside the manifest', () => {
+      const registry = createCompositionRegistry([
+        { id: 'talk', manifest: fullTalk, audioBed: { src: '/audio/bed.webm', volume: 0.6 } },
+      ]);
+      expect(registry.get('talk').audioBed).toEqual({ src: '/audio/bed.webm', volume: 0.6 });
+    });
+
+    it('leaves audioBed undefined for a composition that declared none', () => {
+      const registry = createCompositionRegistry([{ id: 'talk', manifest: fullTalk }]);
+      expect(registry.get('talk').audioBed).toBeUndefined();
+    });
+
+    it('deep-freezes the stored audio bed so caller-side mutation cannot leak in', () => {
+      const bed = { src: ['/audio/bed.webm'] };
+      const registry = createCompositionRegistry([
+        { id: 'talk', manifest: fullTalk, audioBed: bed },
+      ]);
+      const stored = registry.get('talk').audioBed;
+      expect(stored).not.toBeUndefined();
+      expect(Object.isFrozen(stored)).toBe(true);
+      // Caller mutates their own reference after registration.
+      bed.src.push('/audio/other.webm');
+      expect(registry.get('talk').audioBed?.src).toEqual(['/audio/bed.webm']);
+    });
+
+    it('freezes the RegisteredComposition wrapper itself', () => {
+      const registry = createCompositionRegistry([
+        { id: 'talk', manifest: fullTalk, audioBed: { src: '/audio/bed.webm' } },
+      ]);
+      expect(Object.isFrozen(registry.get('talk'))).toBe(true);
+    });
+
+    it('rejects a malformed audio bed declaration with the audio-bed grammar', () => {
+      expect(() =>
+        createCompositionRegistry([
+          {
+            id: 'talk',
+            manifest: fullTalk,
+            audioBed: { volume: 0.5 },
+          } as unknown as CompositionRegistryEntry,
+        ]),
+      ).toThrow(/audio bed/);
     });
   });
 });

--- a/tests/runtime/scene-loader-audio.test.ts
+++ b/tests/runtime/scene-loader-audio.test.ts
@@ -29,6 +29,7 @@ import {
   type NavigationTarget,
   buildScene,
   buildStage,
+  compositionSceneTarget,
   compositionTarget,
   createCompositionRegistry,
   createSceneLoader,
@@ -1191,5 +1192,134 @@ describe('scene loader — PUL-F030 audio unlock gate (ADR-029)', () => {
       await loader.idle();
       expect(calls).toHaveLength(1);
     });
+  });
+});
+
+/* -------------------------------------------------------------------- *
+ *  Composition audio bed — PUL-F014 / ADR-004
+ * -------------------------------------------------------------------- */
+
+describe('scene loader — composition audio bed (PUL-F014 / ADR-004)', () => {
+  // PUL-F014: in `mode=standalone` the runtime renders a single scene
+  // "as if no surrounding composition existed" — the composition audio
+  // bed is suppressed. Under every other mode it plays underneath the
+  // slice.
+  const BED_SRC = '/audio/bed.webm';
+  const bedComposition = () =>
+    createCompositionRegistry([
+      { id: 'deck', manifest: ['head'], audioBed: { src: BED_SRC, volume: 0.5 } },
+    ]);
+
+  it('plays the composition audio bed looping for a composition navigation', async () => {
+    const audio = recordingAudioEngine();
+    const { adapter } = buildRecordingUnlockAdapter('resolve');
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([buildScene({ id: 'head' })]),
+      compositions: bedComposition(),
+      stage: null,
+      buildCtx: stubCtx,
+      createPreloader: () => () => Promise.resolve(),
+      timeline: noopTimeline,
+      audioEngine: audio.engine,
+      audioUnlockAdapter: adapter,
+    });
+    await loader.handle(compositionTarget('deck'));
+    await loader.idle();
+    // The bed is the one sound the navigation created — the scene
+    // itself registers no audio.
+    expect(audio.created).toHaveLength(1);
+    expect(audio.created[0]?.src).toEqual([BED_SRC]);
+    // It was marked looping (composition-level continuous bed).
+    expect(audio.calls.some((c) => c.method === 'loop')).toBe(true);
+  });
+
+  it('suppresses the composition audio bed under mode=standalone', async () => {
+    const audio = recordingAudioEngine();
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([buildScene({ id: 'head' })]),
+      compositions: bedComposition(),
+      stage: null,
+      buildCtx: stubCtx,
+      createPreloader: () => () => Promise.resolve(),
+      timeline: noopTimeline,
+      audioEngine: audio.engine,
+    });
+    await loader.handle({
+      locator: { kind: 'composition', composition: 'deck' },
+      mode: 'standalone',
+    });
+    await loader.idle();
+    // PUL-F014: standalone runs the scene as if no surrounding
+    // composition existed — the bed sound is never created.
+    expect(audio.created).toHaveLength(0);
+  });
+
+  it('plays the bed for a composition+scene standalone sibling mode but not standalone itself', async () => {
+    // Same composition, two navigations: present plays the bed,
+    // standalone suppresses it — the only difference is the mode.
+    const present = recordingAudioEngine();
+    const standalone = recordingAudioEngine();
+    const { adapter } = buildRecordingUnlockAdapter('resolve');
+    const make = (engine: AudioEngine) =>
+      createSceneLoader({
+        scenes: createSceneRegistry([buildScene({ id: 'head' })]),
+        compositions: bedComposition(),
+        stage: null,
+        buildCtx: stubCtx,
+        createPreloader: () => () => Promise.resolve(),
+        timeline: noopTimeline,
+        audioEngine: engine,
+        audioUnlockAdapter: adapter,
+      });
+    const presentLoader = make(present.engine);
+    await presentLoader.handle(compositionSceneTarget('deck', 'head'));
+    await presentLoader.idle();
+    const standaloneLoader = make(standalone.engine);
+    await standaloneLoader.handle({
+      locator: { kind: 'composition-scene', composition: 'deck', scene: 'head' },
+      mode: 'standalone',
+    });
+    await standaloneLoader.idle();
+    expect(present.created).toHaveLength(1);
+    expect(standalone.created).toHaveLength(0);
+  });
+
+  it('plays no bed for a composition that declared none', async () => {
+    const audio = recordingAudioEngine();
+    const { adapter } = buildRecordingUnlockAdapter('resolve');
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([buildScene({ id: 'head' })]),
+      compositions: createCompositionRegistry([{ id: 'deck', manifest: ['head'] }]),
+      stage: null,
+      buildCtx: stubCtx,
+      createPreloader: () => () => Promise.resolve(),
+      timeline: noopTimeline,
+      audioEngine: audio.engine,
+      audioUnlockAdapter: adapter,
+    });
+    await loader.handle(compositionTarget('deck'));
+    await loader.idle();
+    expect(audio.created).toHaveLength(0);
+  });
+
+  it('tears the composition audio bed down when the navigation completes', async () => {
+    const audio = recordingAudioEngine();
+    const { adapter } = buildRecordingUnlockAdapter('resolve');
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([buildScene({ id: 'head' })]),
+      compositions: bedComposition(),
+      stage: null,
+      buildCtx: stubCtx,
+      createPreloader: () => () => Promise.resolve(),
+      timeline: noopTimeline,
+      audioEngine: audio.engine,
+      audioUnlockAdapter: adapter,
+    });
+    await loader.handle(compositionTarget('deck'));
+    await loader.idle();
+    loader.dispose();
+    // The per-navigation audio service stopAll()s on dispose — the bed
+    // is unloaded with it, so the loop never survives the navigation.
+    expect(audio.calls.some((c) => c.method === 'unload')).toBe(true);
   });
 });

--- a/tests/runtime/scene-loader-standalone-loop.test.ts
+++ b/tests/runtime/scene-loader-standalone-loop.test.ts
@@ -42,8 +42,7 @@ describe('createSceneLoader — standalone & loop modes (PUL-F008)', () => {
     // and audio bed suppressed; the scene SHALL run as if no surrounding
     // composition existed.
     //
-    // Materially-implementable parts of the statement that this block
-    // pins:
+    // Parts of the statement that this block pins:
     //   - "Render a single scene" / "run as if no surrounding
     //     composition existed" — composition / composition+scene /
     //     composition+index targets resolve normally (composition
@@ -54,25 +53,25 @@ describe('createSceneLoader — standalone & loop modes (PUL-F008)', () => {
     //     to; no later `runTimeline` call is made for the dropped
     //     slice. The suppression is structural.
     //   - `ctx.mode === 'standalone'` is exposed to every lifecycle
-    //     hook of the head scene — the seam future chrome / audio
-    //     surfaces (ADR-004 / future workbench-shell requirement) will
-    //     read to decide their own suppression behavior. Today there is
-    //     no chrome or audio bed in the repo to suppress, so no
-    //     end-to-end suppression test is possible until those surfaces
-    //     land.
+    //     hook of the head scene.
     //   - No `data-pulsar-mode-*` suppression attribute is preemptively
     //     written under `standalone` (parity with ADR-016's invariant
     //     for `mode=present`; future modes are free to use that
     //     namespace if they actually need it).
     //
-    // PUL-F014 stays DRAFT after this PR (ADR-017 records the
-    // boundary; following the ADR-016 / PUL-F013 precedent). The
-    // single-scene execution mechanism and the `ctx.mode` seam ARE
-    // materially shipped; the three named suppression surfaces
-    // (chrome, audio bed, inter-scene transitions) gate the
-    // DRAFT → ACTIVE transition — each must land as a real surface
-    // that actively reads `ctx.mode === 'standalone'` and suppresses,
-    // with end-to-end tests alongside these seam tests.
+    // The other two named suppression surfaces are now real and pinned
+    // in their own subsystem suites:
+    //   - Chrome suppression — `chromeVisibilityFor('standalone')`
+    //     returns `'hidden'` (`workbench-chrome.test.ts`); the loader
+    //     dispatches it pre-lifecycle (`scene-loader-chrome.test.ts`).
+    //   - Audio-bed suppression — the loader builds the per-navigation
+    //     audio service with `bedSuppressed` set, so a composition's
+    //     audio bed never plays under standalone
+    //     (`scene-loader-audio.test.ts` PUL-F014 block, `audio.test.ts`
+    //     composition-audio-bed block).
+    //
+    // With all three suppression surfaces shipped, PUL-F014 is ACTIVE;
+    // ADR-017 records the architecture boundary.
 
     const standaloneCompositionTarget = (composition: string): NavigationTarget => ({
       locator: { kind: 'composition', composition },

--- a/tests/runtime/scene-navigation.test.ts
+++ b/tests/runtime/scene-navigation.test.ts
@@ -379,7 +379,7 @@ describe('resolveSceneNavigation (PUL-F008)', () => {
       // Hand-rolled CompositionRegistry that returns the mutable
       // manifest as-is — no deep-freeze on its side.
       const mutableCompositions: CompositionRegistry = {
-        get: () => mutableManifest,
+        get: () => ({ manifest: mutableManifest }),
         has: () => true,
         ids: () => ['mixed'],
         get size() {
@@ -943,5 +943,61 @@ describe('loadSceneNavigationTarget (PUL-F008 lifecycle bridge — ADR-025)', ()
       const { calls } = await loadWith(sceneTarget('intro'), [buildScene({ id: 'intro' })], [], {});
       expect('presenter' in (calls[0]?.opts ?? {})).toBe(false);
     });
+  });
+});
+
+describe('resolveSceneNavigation — composition audio bed (PUL-F014)', () => {
+  // The resolver snapshots the registered composition's audio bed onto
+  // the navigation context but makes NO suppression decision — that is
+  // the loader's mode-dispatch job. These tests pin the snapshot for
+  // every composition locator kind.
+  const bed = { src: '/audio/bed.webm', volume: 0.7 };
+
+  it('threads a declared audio bed into the composition context (kind: composition)', () => {
+    const scenes = createSceneRegistry([buildScene({ id: 'intro' })]);
+    const compositions = createCompositionRegistry([
+      { id: 'talk', manifest: ['intro'], audioBed: bed },
+    ]);
+    const target = resolveSceneNavigation(compositionTarget('talk'), { scenes, compositions });
+    expect(target?.composition?.audioBed).toEqual(bed);
+  });
+
+  it('threads the bed for a composition-scene locator', () => {
+    const scenes = createSceneRegistry([buildScene({ id: 'intro' }), buildScene({ id: 'middle' })]);
+    const compositions = createCompositionRegistry([
+      { id: 'talk', manifest: ['intro', 'middle'], audioBed: bed },
+    ]);
+    const target = resolveSceneNavigation(compositionSceneTarget('talk', 'middle'), {
+      scenes,
+      compositions,
+    });
+    expect(target?.composition?.audioBed).toEqual(bed);
+  });
+
+  it('threads the bed for a composition-index locator', () => {
+    const scenes = createSceneRegistry([buildScene({ id: 'intro' }), buildScene({ id: 'middle' })]);
+    const compositions = createCompositionRegistry([
+      { id: 'talk', manifest: ['intro', 'middle'], audioBed: bed },
+    ]);
+    const target = resolveSceneNavigation(compositionIndexTarget('talk', 1), {
+      scenes,
+      compositions,
+    });
+    expect(target?.composition?.audioBed).toEqual(bed);
+  });
+
+  it('leaves audioBed undefined when the composition declared no bed', () => {
+    const scenes = createSceneRegistry([buildScene({ id: 'intro' })]);
+    const compositions = createCompositionRegistry([{ id: 'talk', manifest: ['intro'] }]);
+    const target = resolveSceneNavigation(compositionTarget('talk'), { scenes, compositions });
+    expect(target?.composition).not.toBeUndefined();
+    expect(target?.composition?.audioBed).toBeUndefined();
+  });
+
+  it('carries no composition context — and so no bed — for a bare scene target', () => {
+    const scenes = createSceneRegistry([buildScene({ id: 'intro' })]);
+    const compositions = createCompositionRegistry([]);
+    const target = resolveSceneNavigation(sceneTarget('intro'), { scenes, compositions });
+    expect(target?.composition).toBeUndefined();
   });
 });

--- a/tests/runtime/validation.test.ts
+++ b/tests/runtime/validation.test.ts
@@ -807,4 +807,49 @@ describe('validateRuntime (PUL-Q005 — actionability)', () => {
       }
     });
   });
+
+  describe('PUL-F014 — composition audio bed shape', () => {
+    it('reports composition-audio-bed-invalid for a bed missing its src', () => {
+      const findings = validateRuntime({
+        scenes: [buildScene({ id: 'real' })],
+        compositions: [{ id: 'deck', manifest: ['real'], audioBed: { volume: 0.5 } }],
+      });
+      expect(findingCodes(findings)).toEqual(['composition-audio-bed-invalid']);
+      expect(findings[0]?.compositionId).toBe('deck');
+      // Self-contained location: composition id is prepended to the
+      // message, parallel to the manifest-shape finding.
+      expect(findings[0]?.message).toMatch(/^composition "deck":/);
+      expect(findings[0]?.message).toMatch(/audio bed/);
+    });
+
+    it('reports composition-audio-bed-invalid for a non-object bed', () => {
+      const findings = validateRuntime({
+        scenes: [buildScene({ id: 'real' })],
+        compositions: [{ id: 'deck', manifest: ['real'], audioBed: 'oops' }],
+      });
+      expect(findingCodes(findings)).toEqual(['composition-audio-bed-invalid']);
+    });
+
+    it('reports the bed finding independently of a malformed manifest', () => {
+      // A bad bed must not suppress the manifest diagnostic, and a bad
+      // manifest must not suppress the bed diagnostic.
+      const findings = validateRuntime({
+        scenes: [buildScene({ id: 'real' })],
+        compositions: [{ id: 'deck', manifest: 'not an array', audioBed: { volume: 1 } }],
+      });
+      const codes = findingCodes(findings);
+      expect(codes).toContain('composition-audio-bed-invalid');
+      expect(codes).toContain('composition-manifest-invalid');
+    });
+
+    it('produces no finding for a well-formed audio bed', () => {
+      const findings = validateRuntime({
+        scenes: [buildScene({ id: 'real' })],
+        compositions: [
+          { id: 'deck', manifest: ['real'], audioBed: { src: '/audio/bed.webm', volume: 0.5 } },
+        ],
+      });
+      expect(findings).toEqual([]);
+    });
+  });
 });

--- a/tests/system/standalone-audio-bed.test.ts
+++ b/tests/system/standalone-audio-bed.test.ts
@@ -1,0 +1,121 @@
+// PUL-F014 — composition audio bed, end to end.
+//
+// Composes the real boot + navigation subsystems for a bed-carrying
+// composition: the runtime validation pass (`validateRuntime`) accepts
+// the bed at boot, the composition registry stores and freezes it, and
+// the scene loader plays it looping underneath a composition navigation
+// — but suppresses it under `mode=standalone`, where the scene runs as
+// if no surrounding composition existed. This is the PUL-F014 audio-bed
+// contract exercised through the full navigation path, not a single
+// subsystem in isolation.
+
+import { describe, expect, it } from 'vitest';
+import type { AudioEngine, AudioSoundConfig, AudioSoundHandle } from '../../src/runtime/audio';
+import { validateRuntime } from '../../src/runtime/validation';
+import {
+  type NavigationTarget,
+  buildScene,
+  createCompositionRegistry,
+  createSceneLoader,
+  createSceneRegistry,
+  noopTimeline,
+  stubCtx,
+} from '../runtime/scene-loader.helpers';
+
+const BED_SRC = '/audio/room-tone.webm';
+
+interface RecordingEngine {
+  readonly engine: AudioEngine;
+  readonly created: AudioSoundConfig[];
+  readonly looped: boolean[];
+}
+
+/** Engine fake that records every sound built and every loop toggle. */
+const recordingEngine = (): RecordingEngine => {
+  const created: AudioSoundConfig[] = [];
+  const looped: boolean[] = [];
+  let muted = false;
+  return {
+    created,
+    looped,
+    engine: {
+      createSound(config) {
+        created.push(config);
+        const handle: AudioSoundHandle = {
+          play: () => 1,
+          stop: () => undefined,
+          fade: () => undefined,
+          loop: (enabled) => {
+            looped.push(enabled);
+          },
+          volume: () => undefined,
+          rate: () => undefined,
+          unload: () => undefined,
+        };
+        return handle;
+      },
+      setMasterMute: (value) => {
+        muted = value;
+      },
+      isMasterMuted: () => muted,
+      unlock: () => Promise.resolve(),
+    },
+  };
+};
+
+const bedComposition = () =>
+  createCompositionRegistry([
+    { id: 'keynote', manifest: ['opener'], audioBed: { src: BED_SRC, volume: 0.4 } },
+  ]);
+
+describe('PUL-F014 — composition audio bed (end-to-end)', () => {
+  it('the runtime validation pass accepts a composition that declares an audio bed', () => {
+    const findings = validateRuntime({
+      scenes: [buildScene({ id: 'opener' })],
+      compositions: [
+        { id: 'keynote', manifest: ['opener'], audioBed: { src: BED_SRC, volume: 0.4 } },
+      ],
+    });
+    expect(findings).toEqual([]);
+  });
+
+  it('plays the composition audio bed looping for a composition navigation', async () => {
+    const audio = recordingEngine();
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([buildScene({ id: 'opener' })]),
+      compositions: bedComposition(),
+      stage: null,
+      buildCtx: stubCtx,
+      createPreloader: () => () => Promise.resolve(),
+      timeline: noopTimeline,
+      audioEngine: audio.engine,
+    });
+    await loader.handle({ locator: { kind: 'composition', composition: 'keynote' } });
+    await loader.idle();
+    // The bed is the one sound the navigation built, and it loops.
+    expect(audio.created.map((config) => config.src)).toEqual([[BED_SRC]]);
+    expect(audio.looped).toContain(true);
+  });
+
+  it('suppresses the composition audio bed under mode=standalone', async () => {
+    const audio = recordingEngine();
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry([buildScene({ id: 'opener' })]),
+      compositions: bedComposition(),
+      stage: null,
+      buildCtx: stubCtx,
+      createPreloader: () => () => Promise.resolve(),
+      timeline: noopTimeline,
+      audioEngine: audio.engine,
+    });
+    const target: NavigationTarget = {
+      locator: { kind: 'composition', composition: 'keynote' },
+      mode: 'standalone',
+    };
+    await loader.handle(target);
+    await loader.idle();
+    // PUL-F014: standalone runs the scene as if no surrounding
+    // composition existed — the audio bed never plays.
+    expect(audio.created).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the audio-bed suppression surface for PUL-F014. In `mode=standalone` the runtime renders a single scene as if no surrounding composition existed; this PR adds a composition-level audio bed concept so the suppression contract has a real implementation surface, and suppresses the bed under standalone. Chrome suppression (`chromeVisibilityFor('standalone')` → `hidden`) and inter-scene-transition suppression (structural, via the single-scene slice) were already in place, so all three PUL-F014 standalone suppression surfaces now ship.

## Requirement UIDs

- `PUL-F014`

## Related Issues

Closes #127

## ADR Impact

- ADR-004
- ADR-017
- ADR-021

## Changes

- audio.ts: define AudioBedDeclaration + assertAudioBedDeclaration; add AudioServiceOptions.bed (a composition-level looping source started at construction) and bedSuppressed (a bed-specific scope, distinct from outputPolicy 'silent', so scene-owned ctx.audio is unaffected). The bed is registered under a non-kebab internal key — unreachable through the scene-facing load/play/stop API — and torn down with stopAll().
- composition-registry.ts: extend the composition-registration boundary — CompositionRegistryEntry carries an optional audioBed; the registry stores and deep-freezes a RegisteredComposition {manifest, audioBed}.
- scene-navigation.ts: thread audioBed from the registered composition onto SceneNavigationCompositionContext for every composition locator kind; the resolver stays mode-opaque.
- scene-loader.ts: wire the loader to play the bed for a composition navigation and set bedSuppressed for mode=standalone; the bed validates against its own declared src, not the scene-facing allowlist.
- validation.ts: validateRuntime shape-checks audioBed (new composition-audio-bed-invalid finding) so a malformed bed fails the boot gate.
- Updates ADR-004 with the composition audio bed seam; adds changelog.d/127.added.md.

## Test Plan

- [x] Unit tests pass (`pnpm test`)
- [x] `pnpm lint && pnpm typecheck` pass
- [x] No coverage regression

All three suppression surfaces are pinned at the runtime boundary and the integration tier: audio-bed seam (audio.test.ts), loader wiring + standalone suppression (scene-loader-audio.test.ts), registry storage/freeze/validation (composition-registry.test.ts), resolver threading (scene-navigation.test.ts), boot-gate validation (validation.test.ts), and an end-to-end system test (tests/system/standalone-audio-bed.test.ts). Chrome suppression remains pinned by workbench-chrome.test.ts and scene-loader-chrome.test.ts. Full suite: 2456 tests green.

## Traceability

- IMPLEMENTS: PUL-F014 ← src/runtime/audio.ts, PUL-F014 ← src/runtime/composition-registry.ts, PUL-F014 ← src/runtime/scene-navigation.ts, PUL-F014 ← src/runtime/scene-loader.ts, PUL-F014 ← src/runtime/validation.ts
- TESTS: PUL-F014 ← tests/runtime/audio.test.ts, PUL-F014 ← tests/runtime/composition-registry.test.ts, PUL-F014 ← tests/runtime/scene-navigation.test.ts, PUL-F014 ← tests/runtime/scene-loader-audio.test.ts, PUL-F014 ← tests/runtime/validation.test.ts, PUL-F014 ← tests/system/standalone-audio-bed.test.ts

## Changelog

Fragment added at `changelog.d/127.added.md`.