### PR TITLE
test: verify PUL-F015 loop-mode timeline restart with fixture and e2e

### DIFF
--- a/changelog.d/128.added.md
+++ b/changelog.d/128.added.md
@@ -1,0 +1,19 @@
+PUL-F015 loop-mode restart verification. `mode=loop` already set the
+composed master timeline to `repeat(-1)` so it restarts on completion;
+this adds the durable proof that was missing.
+  - New loop verification fixture scene at `src/scenes/loop-fixture.ts`
+    registered in `WORKBENCH_SCENES`. Addressable via
+    `?scene=loop-fixture&mode=loop`. Its timeline ends with a `.call()`
+    that increments a per-navigation counter into the public DOM
+    attribute `data-pulsar-loop-iteration` — a distinct per-iteration
+    observable, unlike a sticky terminal state.
+  - New Playwright spec at `tests-e2e/loop-mode.spec.ts` covering the
+    restart-on-completion clause under the existing chromium / firefox
+    / webkit matrix: it boots the fixture under `mode=loop` and polls
+    `data-pulsar-loop-iteration` until it reaches at least two distinct
+    iterations.
+  - New `createGsapCompositionTimeline` unit test in
+    `tests/runtime/timeline.test.ts` that observes the master timeline
+    completing at least twice under `headRepeat: 'until-aborted'`,
+    plus contract and ctx-defensiveness unit tests for the fixture
+    scene at `tests/scenes/loop-fixture.test.ts`.

--- a/docs/design/pul-f015-loop-mode-preflight.md
+++ b/docs/design/pul-f015-loop-mode-preflight.md
@@ -53,11 +53,42 @@ Implementation must reuse these cross-cutting concerns:
   `createPreloader()` and `runTimeline()` adapters.
 - Asset handling: `createAssetPreloader()` with the existing scheme,
   redirect, `baseUrl`, and `AbortSignal` rules.
-- Error rendering: `describeError()` plus the existing
-  `data-pulsar-navigation-error` stage diagnostic and `onError` sink.
+- Error rendering: `describeError()` / `describeErrorDetailed()` plus
+  the existing `data-pulsar-navigation-error` stage diagnostic and
+  `onError` sink.
 - Cancellation and cleanup: one per-navigation `AbortController`,
   forwarded to preload and timeline adapters; cleanup remains
   resolver-owned.
+
+## Cross-Cutting Layers
+
+The actual runner-repeat pass must satisfy every layer below. Passing
+the local `timeline.ts` style is not enough if one of these outer
+contracts is bypassed.
+
+| Layer | Guardrail |
+|-------|-----------|
+| URL grammar / public input | `mode=loop` is accepted only through `parseNavigationSearch()` and `NAVIGATION_MODES`. Unknown or repeated `mode` values keep failing through `navigation grammar is invalid:`. Unknown query keys must not influence loop behavior. |
+| Programmatic navigation | Hand-built `NavigationTarget` objects still pass the loader's `validateModeGrammar()` defense before `effectiveMode()` reaches `buildCtx()` or runner-hint dispatch. |
+| Source of truth | The URL-derived `effectiveMode(target)` remains the only selector. Do not read localStorage, sessionStorage, cookies, `history.state`, env vars, process argv, files, or prior in-memory navigation state to recover loop. |
+| Workbench graph validation | Browser boot and CI keep using `validateRuntime()` over `WORKBENCH_SCENES` and `WORKBENCH_COMPOSITIONS` before lifecycle effects. Loop fixtures must be registered in `src/workbench-graph.ts`; no test-only registry path. |
+| Scene and composition schemas | No scene field, composition manifest key, `behavior` key, sentinel scene, fake transition, or mutable manifest rewrite may become the loop selector. Existing `assertSceneModule()`, `assertCompositionManifest()`, `createSceneRegistry()`, and `createCompositionRegistry()` stay authoritative. |
+| Navigation and slicing | `resolveSceneNavigation()` must validate composition membership, indexes, empty manifests, and referenced scene ids before any truncation. `applySingleSceneSlice()` and `truncateToHead()` preserve the addressed head entry's `range` / `behavior` overrides. |
+| Resolver lifecycle | `resolveComposition()` remains mode-opaque. It forwards `headRepeat` as an optional head hint and keeps preload, create, timeline, abort, scene-failure isolation, and cleanup ownership unchanged. |
+| Timeline adapter | `createGsapCompositionTimeline()` is the canonical runner boundary. It should interpret `headRepeat === 'until-aborted'` through the existing `MasterTimeline.repeat(-1)` transport, then run until the navigation `AbortSignal` resolves and kills the master. |
+| Asset policy | Loop does not relax asset validation or preload. Declared assets still flow through `createAssetPreloader()`, `resolveAssetUrl()`, scheme allowlists, redirect re-checks, `baseUrl`, and fetch abort wiring. |
+| Audio policy | Loop keeps the normal audible policy unless a separate mode says otherwise. Do not conflate timeline repeat with Howler loop flags, global mute, rehearsal cue logging, paused silence, or screenshot silence. |
+| Error envelopes | Keep existing public envelopes: `navigation grammar is invalid:`, `scene navigation failed:`, `composition resolution failed:`, `beat positioning failed:`, and scene-failure diagnostics through `formatSceneContext()`. Do not introduce `LoopError` or serialize raw causes, stacks, DOM, captions, headers, cookies, env, auth values, or credentialed URLs. |
+| OS / config exposure | No loop token, target, or secret-bearing URL belongs in process argv, environment bindings, local files, cookies, browser storage, or persisted history state. Playwright/Vite config may carry only non-secret host, port, path, and project values. |
+| Browser evidence | Browser e2e proof must use the existing Playwright stack (`tests-e2e/`, `playwright.config.ts`, `pnpm test:browsers`, CI `browser-support` job). A sticky terminal state such as `data-pulsar-fixture-state="ran"` proves one completion only; loop acceptance needs an observable counter, toggle, or callback evidence for at least two iterations. |
+
+## Workflow Note
+
+The issue text may still mention a DRAFT -> ACTIVE transition from the
+first seam-only delivery. Follow the current Ground Control requirement
+state. If PUL-F015 is already ACTIVE, do not attempt another status
+transition; reconcile `IMPLEMENTS` / `TESTS` traceability after the
+source and acceptance tests land.
 
 ## Loop Contract
 
@@ -80,6 +111,14 @@ Scene setup should occur once for the active navigation, the runner
 should repeat the timeline until the navigation is aborted or disposed,
 and resolver-owned cleanup should run once when the scene exits.
 
+For the current GSAP adapter, the intended design is the narrow runner
+interpretation of the already-plumbed hint: `headRepeat ===
+'until-aborted'` sets the composed master to repeat indefinitely, then
+normal playback starts. The loop resolves only on the navigation abort
+path so the resolver can run the usual cleanup. This must not restart
+the loader, rebuild scene ctx, remount DOM, replay preload, or create a
+parallel lifecycle controller.
+
 When the URL used composition context, validation must still happen
 before lifecycle effects. Unknown compositions, unknown member scenes,
 ambiguous `composition+scene` locators, out-of-range indexes, empty
@@ -91,9 +130,9 @@ must not silently degrade to direct scene lookup.
 
 - Keep `loop` mode behavior at the loader / runner seam. The resolver
   must remain mode-opaque and must not learn about repeat semantics.
-- Prefer the runner's native repeat / restart controls once ADR-003's
-  GSAP runner lands. Do not build timing loops with `setInterval`,
-  polling, sleeps, or recursive `handle()` calls.
+- Use the runner's native repeat / restart controls. Do not build
+  timing loops with `setInterval`, polling, sleeps, or recursive
+  `handle()` calls.
 - Preserve runner input semantics: `range`, `behavior`, `beat`,
   `onBeatMissing`, and `signal` keep their existing meanings. If loop
   needs an additional runner hint, extend the runner input deliberately
@@ -111,6 +150,17 @@ must not silently degrade to direct scene lookup.
 - Do not preemptively write `data-pulsar-mode-*` attributes unless a
   concrete workbench surface needs them. Stage diagnostics should keep
   describing the addressed scene / composition and navigation errors.
+- Keep `headHold` and `headScreenshot` precedence intact. First-frame
+  hold and screenshot capture are non-playing modes; they must not also
+  loop if a direct adapter caller supplies conflicting hints.
+- Preserve key-presence semantics for optional runner hints. Non-loop
+  modes omit `headRepeat`; do not pass `undefined` as a semantic value
+  or add a second boolean such as `loop: true`.
+- Verify real iteration, not just durable final state. Unit tests should
+  observe at least two completions/cycles on the master or a scene-owned
+  callback target, then abort and assert settlement. Browser tests
+  should observe the same through public DOM state, not internal GSAP
+  handles.
 
 ## Non-Goals
 
@@ -136,3 +186,6 @@ suppression, deterministic rendering, or visible scrub controls.
 - Encoding loop behavior in scene metadata, composition entries,
   sentinel scenes, fake transitions, or mutable manifest rewrites.
 - Persisting the last loop target, loop state, or mode outside the URL.
+- Treating the browser-support fixture's durable `"ran"` attribute as
+  proof of restart-on-completion. It is a good "timeline ran once"
+  smoke signal, not a loop acceptance signal.

--- a/src/scenes/browser-support-fixture.ts
+++ b/src/scenes/browser-support-fixture.ts
@@ -38,85 +38,24 @@
 // for and would couple the gate to file-serving behavior that is
 // already covered by Vitest unit tests.
 //
+// The ctx validation and DOM mount/find/remove scaffolding is shared
+// with the loop verification fixture via `./fixture-support.ts`.
+//
 // The scene is `standalone: true` — it does not assume surrounding
 // composition context. `trailerSafe: false` — it has nothing
 // trailer-worthy to show.
 
-import { NAVIGATION_MODES } from '../runtime/navigation';
 import type { SceneModule } from '../runtime/scene';
-import type { WorkbenchSceneCtx } from '../runtime/scene-loader';
+import {
+  findFixtureElement,
+  isFixtureCtx,
+  mountFixtureElement,
+  removeFixtureElement,
+} from './fixture-support';
 
 const FIXTURE_TARGET_ATTR = 'data-pulsar-fixture-target';
 const FIXTURE_STATE_ATTR = 'data-pulsar-fixture-state';
 const FIXTURE_DURATION_SECONDS = 0.1;
-
-interface FixtureDomFactory {
-  createElement(tag: string): { setAttribute(name: string, value: string): void };
-}
-
-interface FixtureStageElement {
-  setAttribute(name: string, value: string): void;
-  removeAttribute(name: string): void;
-  appendChild?(node: unknown): unknown;
-  querySelector?(selector: string): {
-    setAttribute(name: string, value: string): void;
-    remove?(): void;
-  } | null;
-  // Real DOM elements expose `ownerDocument`; the fixture allocates
-  // DOM through the injected stage's owner document rather than the
-  // ambient global `document` so the scene stays pure against
-  // injected dependencies (ADR-008 #2). Optional so off-DOM test
-  // harnesses can supply a bare stage without a document.
-  readonly ownerDocument?: FixtureDomFactory | null;
-}
-
-// PUL-F012 / PUL-F022 / ADR-003: the runtime fills `ctx.stage`,
-// `ctx.mode`, and `ctx.gsap`. The fixture only reads those three
-// fields; the predicate narrows to that subset so a malformed ctx
-// (no `stage`, no `mode`, unknown `mode`, non-element `stage`) is
-// a no-op rather than a crash. Same defensive pattern the
-// placeholder scene uses, scoped to what this scene actually reads.
-// `stage` narrows to `FixtureStageElement | null` (not the
-// runtime's `StageElement | null`) so the lifecycle hooks can
-// read the optional `appendChild` / `querySelector` /
-// `ownerDocument` members without a per-hook type assertion.
-interface FixtureCtx {
-  readonly stage: FixtureStageElement | null;
-  readonly mode: WorkbenchSceneCtx['mode'];
-  readonly gsap: WorkbenchSceneCtx['gsap'];
-}
-
-const isStageShape = (stage: unknown): stage is FixtureStageElement | null => {
-  if (stage === null) return true;
-  if (typeof stage !== 'object') return false;
-  const candidate = stage as Partial<Record<'setAttribute' | 'removeAttribute', unknown>>;
-  return (
-    typeof candidate.setAttribute === 'function' && typeof candidate.removeAttribute === 'function'
-  );
-};
-
-const isGsapShape = (gsap: unknown): gsap is WorkbenchSceneCtx['gsap'] => {
-  if (gsap === null || typeof gsap !== 'object') return false;
-  return typeof (gsap as { timeline?: unknown }).timeline === 'function';
-};
-
-const isFixtureCtx = (value: unknown): value is FixtureCtx => {
-  if (typeof value !== 'object' || value === null) return false;
-  if (!('stage' in value) || !('mode' in value) || !('gsap' in value)) return false;
-  const { stage, mode, gsap } = value;
-  if (!isStageShape(stage)) return false;
-  if (typeof mode !== 'string' || !(NAVIGATION_MODES as readonly string[]).includes(mode)) {
-    return false;
-  }
-  return isGsapShape(gsap);
-};
-
-const findFixtureElement = (
-  stage: FixtureStageElement,
-): { setAttribute(name: string, value: string): void; remove?: () => void } | null => {
-  if (typeof stage.querySelector !== 'function') return null;
-  return stage.querySelector(`[${FIXTURE_TARGET_ATTR}]`);
-};
 
 export const browserSupportFixtureScene: SceneModule = {
   id: 'browser-support-fixture',
@@ -130,30 +69,13 @@ export const browserSupportFixtureScene: SceneModule = {
   standalone: true,
   trailerSafe: false,
   create: (ctx: unknown) => {
-    if (!isFixtureCtx(ctx)) return;
-    const stage = ctx.stage;
-    if (stage === null) return;
-    if (typeof stage.appendChild !== 'function') return;
-    // Allocate the fixture element through the stage's owner
-    // document — same dependency seam the runtime hands scenes via
-    // `ctx.stage`. Reaching for the ambient global `document` would
-    // bypass the explicit-dependency boundary the rest of the
-    // runtime enforces (ADR-008 #2; codex pre-push review, cycle
-    // 2). Off-DOM test harnesses that supply a stage without
-    // `ownerDocument` are a no-op rather than a crash.
-    const ownerDoc = stage.ownerDocument;
-    if (ownerDoc === undefined || ownerDoc === null) return;
-    if (typeof ownerDoc.createElement !== 'function') return;
-    const el = ownerDoc.createElement('div');
-    el.setAttribute(FIXTURE_TARGET_ATTR, '');
-    el.setAttribute(FIXTURE_STATE_ATTR, 'mounted');
-    stage.appendChild(el);
+    mountFixtureElement(ctx, FIXTURE_TARGET_ATTR, [[FIXTURE_STATE_ATTR, 'mounted']]);
   },
   timeline: (ctx: unknown) => {
     if (!isFixtureCtx(ctx)) return null;
     const stage = ctx.stage;
     if (stage === null) return null;
-    const el = findFixtureElement(stage);
+    const el = findFixtureElement(stage, FIXTURE_TARGET_ATTR);
     if (el === null) return null;
     // Build a real GSAP timeline through `ctx.gsap`. A `.call(...)` at
     // the timeline's end advances the fixture state, which the
@@ -170,12 +92,6 @@ export const browserSupportFixtureScene: SceneModule = {
     return tl;
   },
   cleanup: (ctx: unknown) => {
-    if (!isFixtureCtx(ctx)) return;
-    const stage = ctx.stage;
-    if (stage === null) return;
-    const el = findFixtureElement(stage);
-    if (el !== null && typeof el.remove === 'function') {
-      el.remove();
-    }
+    removeFixtureElement(ctx, FIXTURE_TARGET_ATTR);
   },
 };

--- a/src/scenes/fixture-support.ts
+++ b/src/scenes/fixture-support.ts
@@ -1,0 +1,136 @@
+// Shared scaffolding for the GSAP-timeline workbench fixture scenes
+// (`browser-support-fixture.ts`, `loop-fixture.ts`).
+//
+// Both fixtures validate the same `ctx` subset — `stage`, `mode`,
+// `gsap` (PUL-F012 / PUL-F022 / ADR-003) — and both mount a single
+// marked `<div>` allocated through the stage's owner document
+// (ADR-008 #2: DOM allocation goes through the injected `ctx.stage`,
+// never the ambient global `document`). Extracting that common shape
+// here keeps the fixtures from re-implementing it scene by scene; a
+// new GSAP fixture is then a `mountFixtureElement` / `findFixtureElement`
+// / `removeFixtureElement` call plus its own `timeline(ctx)` body.
+//
+// The DOM/CSS accessibility fixture (`dom-css-accessibility-fixture.ts`)
+// deliberately does NOT consume this module: it validates a different
+// ctx subset (no `gsap`) and builds a multi-element accessibility tree
+// rather than a single timeline target, so sharing here would couple
+// two unrelated fixture shapes.
+
+import { NAVIGATION_MODES } from '../runtime/navigation';
+import type { WorkbenchSceneCtx } from '../runtime/scene-loader';
+
+/** Minimal owner-document seam: the fixtures only call `createElement`. */
+export interface FixtureDomFactory {
+  createElement(tag: string): { setAttribute(name: string, value: string): void };
+}
+
+/** The fixture element once mounted — the subset the lifecycle hooks touch. */
+export interface FixtureElement {
+  setAttribute(name: string, value: string): void;
+  remove?(): void;
+}
+
+/**
+ * The stage subset a GSAP fixture reads. Real DOM elements expose
+ * `ownerDocument`; the fixture allocates DOM through the injected
+ * stage's owner document rather than the ambient global `document`
+ * (ADR-008 #2). The optional members let off-DOM test harnesses
+ * supply a bare stage without a document.
+ */
+export interface FixtureStageElement {
+  setAttribute(name: string, value: string): void;
+  removeAttribute(name: string): void;
+  appendChild?(node: unknown): unknown;
+  querySelector?(selector: string): FixtureElement | null;
+  readonly ownerDocument?: FixtureDomFactory | null;
+}
+
+/**
+ * The ctx subset a GSAP fixture reads. A malformed ctx (no `stage`,
+ * no `mode`, unknown `mode`, non-element `stage`, non-gsap `gsap`)
+ * narrows out via {@link isFixtureCtx} so the lifecycle hooks no-op
+ * rather than crash.
+ */
+export interface FixtureCtx {
+  readonly stage: FixtureStageElement | null;
+  readonly mode: WorkbenchSceneCtx['mode'];
+  readonly gsap: WorkbenchSceneCtx['gsap'];
+}
+
+const isStageShape = (stage: unknown): stage is FixtureStageElement | null => {
+  if (stage === null) return true;
+  if (typeof stage !== 'object') return false;
+  const candidate = stage as Partial<Record<'setAttribute' | 'removeAttribute', unknown>>;
+  return (
+    typeof candidate.setAttribute === 'function' && typeof candidate.removeAttribute === 'function'
+  );
+};
+
+const isGsapShape = (gsap: unknown): gsap is WorkbenchSceneCtx['gsap'] => {
+  if (gsap === null || typeof gsap !== 'object') return false;
+  return typeof (gsap as { timeline?: unknown }).timeline === 'function';
+};
+
+/** Narrow an unknown lifecycle argument to the {@link FixtureCtx} subset. */
+export const isFixtureCtx = (value: unknown): value is FixtureCtx => {
+  if (typeof value !== 'object' || value === null) return false;
+  if (!('stage' in value) || !('mode' in value) || !('gsap' in value)) return false;
+  const { stage, mode, gsap } = value;
+  if (!isStageShape(stage)) return false;
+  if (typeof mode !== 'string' || !(NAVIGATION_MODES as readonly string[]).includes(mode)) {
+    return false;
+  }
+  return isGsapShape(gsap);
+};
+
+/** Locate the mounted fixture element by its target attribute, or `null`. */
+export const findFixtureElement = (
+  stage: FixtureStageElement,
+  targetAttr: string,
+): FixtureElement | null => {
+  if (typeof stage.querySelector !== 'function') return null;
+  return stage.querySelector(`[${targetAttr}]`);
+};
+
+/**
+ * `create(ctx)` body for a GSAP fixture: allocate a `<div>` through
+ * the stage's owner document, mark it with `targetAttr`, apply the
+ * `extraAttrs` initial-state attributes, and append it to the stage.
+ * An invalid ctx, a null stage, a stage without `appendChild`, or a
+ * missing owner document is a silent no-op (matching the defensive
+ * pattern the fixtures use against injected dependencies).
+ */
+export const mountFixtureElement = (
+  ctx: unknown,
+  targetAttr: string,
+  extraAttrs: ReadonlyArray<readonly [string, string]>,
+): void => {
+  if (!isFixtureCtx(ctx)) return;
+  const stage = ctx.stage;
+  if (stage === null) return;
+  if (typeof stage.appendChild !== 'function') return;
+  const ownerDoc = stage.ownerDocument;
+  if (ownerDoc === undefined || ownerDoc === null) return;
+  if (typeof ownerDoc.createElement !== 'function') return;
+  const el = ownerDoc.createElement('div');
+  el.setAttribute(targetAttr, '');
+  for (const [name, value] of extraAttrs) {
+    el.setAttribute(name, value);
+  }
+  stage.appendChild(el);
+};
+
+/**
+ * `cleanup(ctx)` body for a GSAP fixture: remove the mounted fixture
+ * element. An invalid ctx, a null stage, or a missing element is a
+ * silent no-op.
+ */
+export const removeFixtureElement = (ctx: unknown, targetAttr: string): void => {
+  if (!isFixtureCtx(ctx)) return;
+  const stage = ctx.stage;
+  if (stage === null) return;
+  const el = findFixtureElement(stage, targetAttr);
+  if (el !== null && typeof el.remove === 'function') {
+    el.remove();
+  }
+};

--- a/src/scenes/loop-fixture.ts
+++ b/src/scenes/loop-fixture.ts
@@ -38,83 +38,24 @@
 // replays that one timeline, so a per-`timeline`-call counter
 // matches the contract — a fresh navigation starts a fresh count.
 //
-// Scope intentionally narrow, mirroring the browser-support fixture:
-// no declared assets, no declared audio. The scene is
-// `standalone: true` — it does not assume surrounding composition
-// context. `trailerSafe: false` — it has nothing trailer-worthy to
-// show.
+// The ctx validation and DOM mount/find/remove scaffolding is shared
+// with the browser-support fixture via `./fixture-support.ts`. Scope
+// intentionally narrow: no declared assets, no declared audio. The
+// scene is `standalone: true` — it does not assume surrounding
+// composition context. `trailerSafe: false` — it has nothing
+// trailer-worthy to show.
 
-import { NAVIGATION_MODES } from '../runtime/navigation';
 import type { SceneModule } from '../runtime/scene';
-import type { WorkbenchSceneCtx } from '../runtime/scene-loader';
+import {
+  findFixtureElement,
+  isFixtureCtx,
+  mountFixtureElement,
+  removeFixtureElement,
+} from './fixture-support';
 
 const FIXTURE_TARGET_ATTR = 'data-pulsar-loop-target';
 const FIXTURE_ITERATION_ATTR = 'data-pulsar-loop-iteration';
 const FIXTURE_DURATION_SECONDS = 0.1;
-
-interface FixtureDomFactory {
-  createElement(tag: string): { setAttribute(name: string, value: string): void };
-}
-
-interface FixtureStageElement {
-  setAttribute(name: string, value: string): void;
-  removeAttribute(name: string): void;
-  appendChild?(node: unknown): unknown;
-  querySelector?(selector: string): {
-    setAttribute(name: string, value: string): void;
-    remove?(): void;
-  } | null;
-  // Real DOM elements expose `ownerDocument`; the fixture allocates
-  // DOM through the injected stage's owner document rather than the
-  // ambient global `document` so the scene stays pure against
-  // injected dependencies (ADR-008 #2). Optional so off-DOM test
-  // harnesses can supply a bare stage without a document.
-  readonly ownerDocument?: FixtureDomFactory | null;
-}
-
-// PUL-F012 / PUL-F022 / ADR-003: the runtime fills `ctx.stage`,
-// `ctx.mode`, and `ctx.gsap`. The fixture only reads those three
-// fields; the predicate narrows to that subset so a malformed ctx
-// (no `stage`, no `mode`, unknown `mode`, non-element `stage`) is a
-// no-op rather than a crash. Same defensive pattern the
-// browser-support fixture uses, scoped to what this scene reads.
-interface FixtureCtx {
-  readonly stage: FixtureStageElement | null;
-  readonly mode: WorkbenchSceneCtx['mode'];
-  readonly gsap: WorkbenchSceneCtx['gsap'];
-}
-
-const isStageShape = (stage: unknown): stage is FixtureStageElement | null => {
-  if (stage === null) return true;
-  if (typeof stage !== 'object') return false;
-  const candidate = stage as Partial<Record<'setAttribute' | 'removeAttribute', unknown>>;
-  return (
-    typeof candidate.setAttribute === 'function' && typeof candidate.removeAttribute === 'function'
-  );
-};
-
-const isGsapShape = (gsap: unknown): gsap is WorkbenchSceneCtx['gsap'] => {
-  if (gsap === null || typeof gsap !== 'object') return false;
-  return typeof (gsap as { timeline?: unknown }).timeline === 'function';
-};
-
-const isFixtureCtx = (value: unknown): value is FixtureCtx => {
-  if (typeof value !== 'object' || value === null) return false;
-  if (!('stage' in value) || !('mode' in value) || !('gsap' in value)) return false;
-  const { stage, mode, gsap } = value;
-  if (!isStageShape(stage)) return false;
-  if (typeof mode !== 'string' || !(NAVIGATION_MODES as readonly string[]).includes(mode)) {
-    return false;
-  }
-  return isGsapShape(gsap);
-};
-
-const findFixtureElement = (
-  stage: FixtureStageElement,
-): { setAttribute(name: string, value: string): void; remove?: () => void } | null => {
-  if (typeof stage.querySelector !== 'function') return null;
-  return stage.querySelector(`[${FIXTURE_TARGET_ATTR}]`);
-};
 
 export const loopFixtureScene: SceneModule = {
   id: 'loop-fixture',
@@ -127,33 +68,17 @@ export const loopFixtureScene: SceneModule = {
   defaultNext: null,
   standalone: true,
   trailerSafe: false,
+  // The element starts at iteration 0 — "mounted, not yet run" — so a
+  // Playwright poll can distinguish a mounted-but-stalled runner from
+  // a looping one.
   create: (ctx: unknown) => {
-    if (!isFixtureCtx(ctx)) return;
-    const stage = ctx.stage;
-    if (stage === null) return;
-    if (typeof stage.appendChild !== 'function') return;
-    // Allocate the fixture element through the stage's owner
-    // document — the same dependency seam the runtime hands scenes
-    // via `ctx.stage`. Reaching for the ambient global `document`
-    // would bypass the explicit-dependency boundary the rest of the
-    // runtime enforces (ADR-008 #2). Off-DOM test harnesses that
-    // supply a stage without `ownerDocument` are a no-op rather than
-    // a crash.
-    const ownerDoc = stage.ownerDocument;
-    if (ownerDoc === undefined || ownerDoc === null) return;
-    if (typeof ownerDoc.createElement !== 'function') return;
-    const el = ownerDoc.createElement('div');
-    el.setAttribute(FIXTURE_TARGET_ATTR, '');
-    // Start at 0 — "mounted, not yet run" — so a Playwright poll can
-    // distinguish a mounted-but-stalled runner from a looping one.
-    el.setAttribute(FIXTURE_ITERATION_ATTR, '0');
-    stage.appendChild(el);
+    mountFixtureElement(ctx, FIXTURE_TARGET_ATTR, [[FIXTURE_ITERATION_ATTR, '0']]);
   },
   timeline: (ctx: unknown) => {
     if (!isFixtureCtx(ctx)) return null;
     const stage = ctx.stage;
     if (stage === null) return null;
-    const el = findFixtureElement(stage);
+    const el = findFixtureElement(stage, FIXTURE_TARGET_ATTR);
     if (el === null) return null;
     // Build a real GSAP timeline through `ctx.gsap`. The `.call(...)`
     // at the timeline's end increments a per-navigation counter and
@@ -175,12 +100,6 @@ export const loopFixtureScene: SceneModule = {
     return tl;
   },
   cleanup: (ctx: unknown) => {
-    if (!isFixtureCtx(ctx)) return;
-    const stage = ctx.stage;
-    if (stage === null) return;
-    const el = findFixtureElement(stage);
-    if (el !== null && typeof el.remove === 'function') {
-      el.remove();
-    }
+    removeFixtureElement(ctx, FIXTURE_TARGET_ATTR);
   },
 };

--- a/src/scenes/loop-fixture.ts
+++ b/src/scenes/loop-fixture.ts
@@ -1,0 +1,186 @@
+// PUL-F015 / ADR-018 — loop verification fixture scene.
+//
+// PUL-F015: "In `mode=loop`, the runtime SHALL run the addressed
+// scene's timeline and restart it on completion." The restart
+// mechanic is shipped — `positionMaster()` in
+// `src/runtime/timeline.ts` sets `master.repeat(-1)` for
+// `headRepeat === 'until-aborted'`. What that implementation lacked
+// was an *observable* loop-acceptance signal.
+//
+// The browser-support fixture (`./browser-support-fixture.ts`)
+// advances a single sticky `data-pulsar-fixture-state="ran"`
+// attribute. That proves one timeline completion, not
+// restart-on-completion: under `mode=loop` the attribute reaches
+// `"ran"` once and never changes again, so a runner that played the
+// timeline exactly once would be indistinguishable from one that
+// genuinely loops.
+//
+// This fixture gives loop mode a *distinct per-iteration* observable:
+//
+//   1. `create(ctx)` mounts a `<div data-pulsar-loop-target>` under
+//      the workbench stage, with `data-pulsar-loop-iteration`
+//      starting at `"0"` (mounted, not yet run).
+//   2. `timeline(ctx)` returns a GSAP timeline whose end `.call()`
+//      increments a per-navigation counter and writes it to the same
+//      element's `data-pulsar-loop-iteration`. Under a looping
+//      master (`repeat(-1)`) the nested scene timeline replays each
+//      cycle, so the attribute strictly increases: `"1"`, `"2"`, ….
+//   3. `cleanup(ctx)` removes the fixture element entirely.
+//
+// The Playwright spec at `tests-e2e/loop-mode.spec.ts` boots this
+// scene under `mode=loop` and polls `data-pulsar-loop-iteration`
+// until it reaches at least `2` — proving the GSAP master actually
+// restarted the timeline on completion in a real browser engine.
+//
+// The counter is a closure local to `timeline(ctx)`. PUL-F015 loops
+// the *timeline*, not the scene lifecycle: the resolver calls
+// `timeline(ctx)` once per navigation and the master's `repeat(-1)`
+// replays that one timeline, so a per-`timeline`-call counter
+// matches the contract — a fresh navigation starts a fresh count.
+//
+// Scope intentionally narrow, mirroring the browser-support fixture:
+// no declared assets, no declared audio. The scene is
+// `standalone: true` — it does not assume surrounding composition
+// context. `trailerSafe: false` — it has nothing trailer-worthy to
+// show.
+
+import { NAVIGATION_MODES } from '../runtime/navigation';
+import type { SceneModule } from '../runtime/scene';
+import type { WorkbenchSceneCtx } from '../runtime/scene-loader';
+
+const FIXTURE_TARGET_ATTR = 'data-pulsar-loop-target';
+const FIXTURE_ITERATION_ATTR = 'data-pulsar-loop-iteration';
+const FIXTURE_DURATION_SECONDS = 0.1;
+
+interface FixtureDomFactory {
+  createElement(tag: string): { setAttribute(name: string, value: string): void };
+}
+
+interface FixtureStageElement {
+  setAttribute(name: string, value: string): void;
+  removeAttribute(name: string): void;
+  appendChild?(node: unknown): unknown;
+  querySelector?(selector: string): {
+    setAttribute(name: string, value: string): void;
+    remove?(): void;
+  } | null;
+  // Real DOM elements expose `ownerDocument`; the fixture allocates
+  // DOM through the injected stage's owner document rather than the
+  // ambient global `document` so the scene stays pure against
+  // injected dependencies (ADR-008 #2). Optional so off-DOM test
+  // harnesses can supply a bare stage without a document.
+  readonly ownerDocument?: FixtureDomFactory | null;
+}
+
+// PUL-F012 / PUL-F022 / ADR-003: the runtime fills `ctx.stage`,
+// `ctx.mode`, and `ctx.gsap`. The fixture only reads those three
+// fields; the predicate narrows to that subset so a malformed ctx
+// (no `stage`, no `mode`, unknown `mode`, non-element `stage`) is a
+// no-op rather than a crash. Same defensive pattern the
+// browser-support fixture uses, scoped to what this scene reads.
+interface FixtureCtx {
+  readonly stage: FixtureStageElement | null;
+  readonly mode: WorkbenchSceneCtx['mode'];
+  readonly gsap: WorkbenchSceneCtx['gsap'];
+}
+
+const isStageShape = (stage: unknown): stage is FixtureStageElement | null => {
+  if (stage === null) return true;
+  if (typeof stage !== 'object') return false;
+  const candidate = stage as Partial<Record<'setAttribute' | 'removeAttribute', unknown>>;
+  return (
+    typeof candidate.setAttribute === 'function' && typeof candidate.removeAttribute === 'function'
+  );
+};
+
+const isGsapShape = (gsap: unknown): gsap is WorkbenchSceneCtx['gsap'] => {
+  if (gsap === null || typeof gsap !== 'object') return false;
+  return typeof (gsap as { timeline?: unknown }).timeline === 'function';
+};
+
+const isFixtureCtx = (value: unknown): value is FixtureCtx => {
+  if (typeof value !== 'object' || value === null) return false;
+  if (!('stage' in value) || !('mode' in value) || !('gsap' in value)) return false;
+  const { stage, mode, gsap } = value;
+  if (!isStageShape(stage)) return false;
+  if (typeof mode !== 'string' || !(NAVIGATION_MODES as readonly string[]).includes(mode)) {
+    return false;
+  }
+  return isGsapShape(gsap);
+};
+
+const findFixtureElement = (
+  stage: FixtureStageElement,
+): { setAttribute(name: string, value: string): void; remove?: () => void } | null => {
+  if (typeof stage.querySelector !== 'function') return null;
+  return stage.querySelector(`[${FIXTURE_TARGET_ATTR}]`);
+};
+
+export const loopFixtureScene: SceneModule = {
+  id: 'loop-fixture',
+  title: 'Loop verification fixture',
+  duration: null,
+  tags: ['fixture', 'loop'],
+  assets: [],
+  captions: [],
+  audio: [],
+  defaultNext: null,
+  standalone: true,
+  trailerSafe: false,
+  create: (ctx: unknown) => {
+    if (!isFixtureCtx(ctx)) return;
+    const stage = ctx.stage;
+    if (stage === null) return;
+    if (typeof stage.appendChild !== 'function') return;
+    // Allocate the fixture element through the stage's owner
+    // document — the same dependency seam the runtime hands scenes
+    // via `ctx.stage`. Reaching for the ambient global `document`
+    // would bypass the explicit-dependency boundary the rest of the
+    // runtime enforces (ADR-008 #2). Off-DOM test harnesses that
+    // supply a stage without `ownerDocument` are a no-op rather than
+    // a crash.
+    const ownerDoc = stage.ownerDocument;
+    if (ownerDoc === undefined || ownerDoc === null) return;
+    if (typeof ownerDoc.createElement !== 'function') return;
+    const el = ownerDoc.createElement('div');
+    el.setAttribute(FIXTURE_TARGET_ATTR, '');
+    // Start at 0 — "mounted, not yet run" — so a Playwright poll can
+    // distinguish a mounted-but-stalled runner from a looping one.
+    el.setAttribute(FIXTURE_ITERATION_ATTR, '0');
+    stage.appendChild(el);
+  },
+  timeline: (ctx: unknown) => {
+    if (!isFixtureCtx(ctx)) return null;
+    const stage = ctx.stage;
+    if (stage === null) return null;
+    const el = findFixtureElement(stage);
+    if (el === null) return null;
+    // Build a real GSAP timeline through `ctx.gsap`. The `.call(...)`
+    // at the timeline's end increments a per-navigation counter and
+    // writes it to `data-pulsar-loop-iteration`. Under `mode=loop`
+    // the master is set to `repeat(-1)` (PUL-F015 / ADR-018), so the
+    // nested scene timeline replays on every cycle and the `.call()`
+    // re-fires — the attribute strictly increases, which is the
+    // observable the loop-mode e2e spec polls. The tween itself is a
+    // no-op `to` so the test does not depend on visual styles
+    // surviving a CSS reset; the structural datum is the counter.
+    let iterations = 0;
+    const tl = ctx.gsap.timeline();
+    tl.set(el, { opacity: 1 });
+    tl.to(el, { opacity: 1, duration: FIXTURE_DURATION_SECONDS });
+    tl.call(() => {
+      iterations += 1;
+      el.setAttribute(FIXTURE_ITERATION_ATTR, String(iterations));
+    });
+    return tl;
+  },
+  cleanup: (ctx: unknown) => {
+    if (!isFixtureCtx(ctx)) return;
+    const stage = ctx.stage;
+    if (stage === null) return;
+    const el = findFixtureElement(stage);
+    if (el !== null && typeof el.remove === 'function') {
+      el.remove();
+    }
+  },
+};

--- a/src/workbench-graph.ts
+++ b/src/workbench-graph.ts
@@ -18,6 +18,7 @@ import type { CompositionRegistryEntry } from './runtime/composition-registry';
 import type { SceneModule } from './runtime/scene';
 import { browserSupportFixtureScene } from './scenes/browser-support-fixture';
 import { domCssAccessibilityFixtureScene } from './scenes/dom-css-accessibility-fixture';
+import { loopFixtureScene } from './scenes/loop-fixture';
 import { placeholderScene } from './scenes/placeholder';
 
 // Optional local decks live under `src/decks/local-*/index.ts` and
@@ -47,6 +48,12 @@ const LOCAL_COMPOSITIONS: readonly CompositionRegistryEntry[] = Object.values(
 // the same way so the PUL-Q008 Playwright spec can boot it via
 // `?scene=dom-css-accessibility-fixture`.
 //
+// PUL-F015 / ADR-018: the loop verification fixture is registered the
+// same way so the loop-mode Playwright spec can boot it via
+// `?scene=loop-fixture&mode=loop` and observe the master timeline
+// genuinely restarting on completion (a strictly increasing
+// `data-pulsar-loop-iteration` attribute).
+//
 // Pulsar L2: the pulsar-intro reference deck (`?composition=pulsar-intro`)
 // is the self-referential proof of the L2 system layer. Its 15 scenes
 // collectively exercise every shipped template, every transition, every
@@ -57,6 +64,7 @@ export const WORKBENCH_SCENES: readonly SceneModule[] = [
   placeholderScene,
   browserSupportFixtureScene,
   domCssAccessibilityFixtureScene,
+  loopFixtureScene,
   ...PULSAR_INTRO_SCENES,
   ...LOCAL_SCENES,
 ];

--- a/tests-e2e/loop-mode.spec.ts
+++ b/tests-e2e/loop-mode.spec.ts
@@ -1,0 +1,83 @@
+import { expect, test } from '@playwright/test';
+
+// PUL-F015 / ADR-018 — loop-mode restart-on-completion spec.
+//
+// PUL-F015: "In `mode=loop`, the runtime SHALL run the addressed
+// scene's timeline and restart it on completion." The restart
+// mechanic is `positionMaster()` in `src/runtime/timeline.ts` setting
+// `master.repeat(-1)` for `headRepeat === 'until-aborted'`. The
+// PUL-Q002 browser-support spec boots `mode=loop` too, but asserts a
+// sticky `data-pulsar-fixture-state="ran"` attribute — that proves
+// one timeline completion, not restart-on-completion: a runner that
+// played the timeline exactly once would be indistinguishable from a
+// genuinely looping one through that attribute.
+//
+// This spec uses the dedicated loop fixture
+// (`src/scenes/loop-fixture.ts`), whose timeline ends with a
+// `.call()` that increments a per-navigation counter into
+// `data-pulsar-loop-iteration`. Under a looping master the nested
+// scene timeline replays each cycle, so the attribute strictly
+// increases. Observing it reach `2` proves the timeline completed
+// once and then *restarted* and completed again — the actual
+// PUL-F015 contract, in a real browser engine.
+//
+// The spec runs in every Playwright project declared in
+// `playwright.config.ts` (chromium / firefox / webkit). It is
+// deliberately separate from `browser-support.spec.ts`: that spec is
+// the PUL-Q002 engine smoke gate; this one is the PUL-F015 loop
+// acceptance gate. Mixing the two would overload one fixture with two
+// unrelated gate responsibilities.
+
+test.describe('PUL-F015 — mode=loop restarts the timeline on completion', () => {
+  test('the loop fixture timeline restarts and completes at least twice', async ({ page }) => {
+    const errors: string[] = [];
+    page.on('pageerror', (err) => errors.push(`pageerror: ${err.message}`));
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') errors.push(`console.error: ${msg.text()}`);
+    });
+
+    await page.goto('/?scene=loop-fixture&mode=loop');
+
+    const stage = page.locator('#stage');
+    await expect(stage, 'the workbench stage element must mount').toBeAttached();
+
+    await expect(
+      stage,
+      'PUL-F028 boot validation must succeed (no data-pulsar-validation-failed)',
+    ).not.toHaveAttribute('data-pulsar-validation-failed', /.*/);
+
+    await expect(
+      stage,
+      'the URL grammar parser must accept ?scene=loop-fixture&mode=loop (no data-pulsar-navigation-error)',
+    ).not.toHaveAttribute('data-pulsar-navigation-error', /.*/);
+
+    await expect(stage, 'the resolver must have mounted the loop fixture scene').toHaveAttribute(
+      'data-pulsar-scene-target',
+      'loop-fixture',
+    );
+
+    const fixture = page.locator('[data-pulsar-loop-target]');
+    await expect(fixture, 'the loop fixture element must mount').toBeAttached();
+
+    // The fixture's GSAP timeline increments `data-pulsar-loop-iteration`
+    // at the end of each ~100ms cycle. Reaching `>= 2` proves the
+    // master timeline ran the scene timeline to completion, then
+    // restarted it under `repeat(-1)` and ran it to completion again
+    // — the restart-on-completion clause of PUL-F015. A runner that
+    // honored the hint as a no-op (played once, parked) would stall
+    // at `1` and this poll would time out.
+    await expect
+      .poll(
+        async () => {
+          const raw = await fixture.getAttribute('data-pulsar-loop-iteration');
+          return raw === null ? 0 : Number.parseInt(raw, 10);
+        },
+        {
+          message: 'mode=loop must restart the timeline so the iteration counter reaches >= 2',
+        },
+      )
+      .toBeGreaterThanOrEqual(2);
+
+    expect(errors, 'no uncaught exceptions or console errors during the loop').toEqual([]);
+  });
+});

--- a/tests/runtime/timeline.test.ts
+++ b/tests/runtime/timeline.test.ts
@@ -648,13 +648,50 @@ describe('createGsapCompositionTimeline', () => {
     await r2.settled;
   });
 
-  it('repeats the master indefinitely under headRepeat and keeps playing', async () => {
+  it('starts the master playing (unpaused) under headRepeat', async () => {
     const controller = new AbortController();
     const { master, settled } = runWith([segment('a', sceneTl(1))], {
       signal: controller.signal,
       headRepeat: 'until-aborted',
     });
     await flush();
+    expect(master().isPaused()).toBe(false);
+    controller.abort();
+    await settled;
+  });
+
+  it('actually restarts the timeline on completion under headRepeat (>= 2 distinct iterations)', async () => {
+    // PUL-F015 acceptance criterion 2: `mode=loop` must produce a
+    // timeline that genuinely *restarts* on completion, not one that
+    // plays once and parks at its last frame. The test above only
+    // proves the master is unpaused; a runner that played the
+    // composition exactly once and never advanced would still pass
+    // it. This test pins the real contract: a scene timeline with a
+    // terminal `.call()` re-fires that callback on every loop cycle,
+    // so the cycle counter must reach >= 2. The promise resolves the
+    // instant the second iteration completes — a non-restarting
+    // implementation never reaches 2, so the test fails by hitting
+    // the vitest timeout rather than passing silently.
+    const controller = new AbortController();
+    let iterations = 0;
+    let reachedTwo: () => void = () => undefined;
+    const twoIterations = new Promise<void>((resolve) => {
+      reachedTwo = resolve;
+    });
+    const counted = gsap.timeline({ paused: true });
+    counted.to({ v: 0 }, { v: 1, duration: 0.02 });
+    counted.call(() => {
+      iterations += 1;
+      if (iterations >= 2) reachedTwo();
+    });
+
+    const { master, settled } = runWith([segment('a', counted)], {
+      signal: controller.signal,
+      headRepeat: 'until-aborted',
+    });
+    await twoIterations;
+    expect(iterations).toBeGreaterThanOrEqual(2);
+    // Still looping (not parked) when the second iteration landed.
     expect(master().isPaused()).toBe(false);
     controller.abort();
     await settled;

--- a/tests/scenes/loop-fixture.test.ts
+++ b/tests/scenes/loop-fixture.test.ts
@@ -1,0 +1,325 @@
+// PUL-F015 / ADR-018 — loop verification fixture scene unit tests.
+//
+// The fixture scene is exercised end-to-end by Playwright in
+// `tests-e2e/loop-mode.spec.ts`, where `mode=loop` drives the GSAP
+// master through `repeat(-1)` and the per-iteration counter is
+// observed across two cycles. These unit tests cover the PUL-F001
+// contract shape and the ctx defensiveness — the same surface
+// `browser-support-fixture.test.ts` covers for its fixture — plus the
+// one behavior unique to this fixture: the `timeline(ctx)` `.call()`
+// callback increments the iteration counter each time it fires, so a
+// looping master produces a strictly increasing
+// `data-pulsar-loop-iteration` attribute. They do NOT run a real GSAP
+// timeline; that responsibility lives in `tests/runtime/timeline.test.ts`
+// and in the Playwright e2e spec.
+
+import { describe, expect, it } from 'vitest';
+import { loopFixtureScene } from '../../src/scenes/loop-fixture';
+
+interface FakeStage {
+  readonly children: { attrs: Map<string, string> }[];
+  readonly element: {
+    setAttribute(name: string, value: string): void;
+    removeAttribute(name: string): void;
+    appendChild(node: unknown): unknown;
+    querySelector(selector: string): {
+      setAttribute(name: string, value: string): void;
+      remove(): void;
+    } | null;
+    ownerDocument: {
+      createElement(tag: string): { setAttribute(name: string, value: string): void };
+    };
+  };
+}
+
+// Stage stub mirroring `browser-support-fixture.test.ts`: `appendChild`
+// records children, `querySelector` looks them up by the attribute
+// name in the `[<attr>]` selector, and `ownerDocument.createElement`
+// returns a recording stub. The fixture allocates DOM through the
+// stage's owner document rather than an ambient `document` global
+// (ADR-008 #2), so the stub mirrors that seam.
+const buildStage = (): FakeStage => {
+  const children: { attrs: Map<string, string> }[] = [];
+  return {
+    children,
+    element: {
+      setAttribute: () => undefined,
+      removeAttribute: () => undefined,
+      appendChild: (node: unknown) => {
+        children.push(node as { attrs: Map<string, string> });
+        return node;
+      },
+      querySelector: (selector: string) => {
+        const attr = selector.replace(/^\[|\]$/g, '').split('=')[0];
+        if (attr === undefined) return null;
+        for (let i = 0; i < children.length; i += 1) {
+          const child = children[i];
+          if (child === undefined) continue;
+          if (child.attrs.has(attr)) {
+            return {
+              setAttribute: (name: string, value: string) => child.attrs.set(name, value),
+              remove: () => {
+                children.splice(i, 1);
+              },
+            };
+          }
+        }
+        return null;
+      },
+      ownerDocument: {
+        createElement: () => {
+          const attrs = new Map<string, string>();
+          return {
+            attrs,
+            setAttribute: (name: string, value: string) => attrs.set(name, value),
+          };
+        },
+      },
+    },
+  };
+};
+
+describe('loopFixtureScene', () => {
+  it('declares the PUL-F001 contract fields with kebab-case id', () => {
+    expect(loopFixtureScene.id).toBe('loop-fixture');
+    expect(loopFixtureScene.title).toBe('Loop verification fixture');
+    expect(loopFixtureScene.duration).toBeNull();
+    expect(loopFixtureScene.standalone).toBe(true);
+    expect(loopFixtureScene.trailerSafe).toBe(false);
+    expect(loopFixtureScene.assets).toEqual([]);
+    expect(loopFixtureScene.captions).toEqual([]);
+    expect(loopFixtureScene.audio).toEqual([]);
+    expect(loopFixtureScene.tags).toEqual(['fixture', 'loop']);
+    expect(loopFixtureScene.defaultNext).toBeNull();
+  });
+
+  it('appends a fixture element at iteration 0 on `create`', () => {
+    const stage = buildStage();
+    loopFixtureScene.create({
+      stage: stage.element,
+      mode: 'loop',
+      gsap: { timeline: () => ({}) } as never,
+      audio: {} as never,
+    });
+    expect(stage.children).toHaveLength(1);
+    const attrs = stage.children[0]?.attrs;
+    expect(attrs?.get('data-pulsar-loop-target')).toBe('');
+    // The counter starts at 0 so a Playwright poll can distinguish
+    // "fixture mounted, not yet run" from "ran at least once".
+    expect(attrs?.get('data-pulsar-loop-iteration')).toBe('0');
+  });
+
+  it('increments `data-pulsar-loop-iteration` each time the timeline `.call()` fires', () => {
+    // PUL-F015 acceptance criterion 2: loop must be observable as
+    // *distinct iterations*, not a sticky terminal state. Under a
+    // looping master the nested scene timeline replays each cycle and
+    // its end `.call()` re-fires; the fixture's callback must produce
+    // a strictly increasing counter so the e2e spec can poll for two
+    // distinct values. The `.call(fn)` stub captures the callback and
+    // the test invokes it repeatedly to simulate the per-cycle
+    // re-fire a `repeat(-1)` master produces.
+    const stage = buildStage();
+    let captured: (() => void) | null = null;
+    const tlCalls: string[] = [];
+    const tlStub = {
+      set: (_target: unknown, _vars: unknown) => {
+        tlCalls.push('set');
+        return tlStub;
+      },
+      to: (_target: unknown, _vars: unknown) => {
+        tlCalls.push('to');
+        return tlStub;
+      },
+      call: (fn: () => void) => {
+        tlCalls.push('call');
+        captured = fn;
+        return tlStub;
+      },
+    };
+    const gsap = { timeline: () => tlStub } as never;
+    loopFixtureScene.create({ stage: stage.element, mode: 'loop', gsap, audio: {} as never });
+    expect(stage.children[0]?.attrs.get('data-pulsar-loop-iteration')).toBe('0');
+
+    const result = loopFixtureScene.timeline({
+      stage: stage.element,
+      mode: 'loop',
+      gsap,
+      audio: {} as never,
+    });
+    expect(result).toBe(tlStub);
+    expect(tlCalls).toEqual(['set', 'to', 'call']);
+
+    // `timeline(ctx)` only registers the callback; the counter has
+    // not advanced yet.
+    expect(stage.children[0]?.attrs.get('data-pulsar-loop-iteration')).toBe('0');
+    expect(captured).not.toBeNull();
+    const fire = captured as unknown as () => void;
+
+    // Each `.call()` fire — one per loop cycle — advances the counter.
+    fire();
+    expect(stage.children[0]?.attrs.get('data-pulsar-loop-iteration')).toBe('1');
+    fire();
+    expect(stage.children[0]?.attrs.get('data-pulsar-loop-iteration')).toBe('2');
+    fire();
+    expect(stage.children[0]?.attrs.get('data-pulsar-loop-iteration')).toBe('3');
+  });
+
+  it('gives each navigation a fresh counter (the closure does not leak across `timeline` calls)', () => {
+    // Loop must restart the *timeline*, not the scene lifecycle: the
+    // resolver calls `timeline(ctx)` once per navigation, and the
+    // master's `repeat(-1)` replays that one timeline. A second
+    // navigation builds a new timeline whose counter must start from
+    // zero — otherwise a stale module-level counter would make the
+    // e2e poll pass without a genuine restart.
+    const stageA = buildStage();
+    const fires: (() => void)[] = [];
+    const makeStub = () => {
+      const stub: Record<string, unknown> = {};
+      stub.set = () => stub;
+      stub.to = () => stub;
+      stub.call = (fn: () => void) => {
+        fires.push(fn);
+        return stub;
+      };
+      return stub;
+    };
+    const gsapA = { timeline: makeStub } as never;
+    loopFixtureScene.create({
+      stage: stageA.element,
+      mode: 'loop',
+      gsap: gsapA,
+      audio: {} as never,
+    });
+    loopFixtureScene.timeline({
+      stage: stageA.element,
+      mode: 'loop',
+      gsap: gsapA,
+      audio: {} as never,
+    });
+    fires[0]?.();
+    fires[0]?.();
+    expect(stageA.children[0]?.attrs.get('data-pulsar-loop-iteration')).toBe('2');
+
+    const stageB = buildStage();
+    const gsapB = { timeline: makeStub } as never;
+    loopFixtureScene.create({
+      stage: stageB.element,
+      mode: 'loop',
+      gsap: gsapB,
+      audio: {} as never,
+    });
+    loopFixtureScene.timeline({
+      stage: stageB.element,
+      mode: 'loop',
+      gsap: gsapB,
+      audio: {} as never,
+    });
+    fires[1]?.();
+    expect(stageB.children[0]?.attrs.get('data-pulsar-loop-iteration')).toBe('1');
+  });
+
+  it('returns null from `timeline(ctx)` when no fixture element is mounted', () => {
+    const stage = buildStage();
+    const result = loopFixtureScene.timeline({
+      stage: stage.element,
+      mode: 'loop',
+      gsap: { timeline: () => ({}) } as never,
+      audio: {} as never,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('removes the fixture element on `cleanup`', () => {
+    const stage = buildStage();
+    loopFixtureScene.create({
+      stage: stage.element,
+      mode: 'loop',
+      gsap: { timeline: () => ({}) } as never,
+      audio: {} as never,
+    });
+    expect(stage.children).toHaveLength(1);
+    loopFixtureScene.cleanup({
+      stage: stage.element,
+      mode: 'loop',
+      gsap: { timeline: () => ({}) } as never,
+      audio: {} as never,
+    });
+    expect(stage.children).toHaveLength(0);
+  });
+
+  it('is a no-op on `cleanup` when no fixture element was mounted (valid ctx, no prior create)', () => {
+    const stage = buildStage();
+    expect(stage.children).toHaveLength(0);
+    expect(() =>
+      loopFixtureScene.cleanup({
+        stage: stage.element,
+        mode: 'loop',
+        gsap: { timeline: () => ({}) } as never,
+        audio: {} as never,
+      }),
+    ).not.toThrow();
+    expect(stage.children).toHaveLength(0);
+  });
+
+  it('is a no-op when the stage has no ownerDocument (off-DOM harness)', () => {
+    // The scene must NOT reach for the ambient global `document`. A
+    // stage stub without `ownerDocument` must produce no DOM mutation
+    // (ADR-008 #2). Every stage method call is tracked so "no DOM
+    // mutation" is asserted structurally.
+    const calls: { name: string; args: unknown[] }[] = [];
+    const minimalStage = {
+      setAttribute: (...args: unknown[]) => {
+        calls.push({ name: 'setAttribute', args });
+      },
+      removeAttribute: (...args: unknown[]) => {
+        calls.push({ name: 'removeAttribute', args });
+      },
+      appendChild: (...args: unknown[]) => {
+        calls.push({ name: 'appendChild', args });
+        return undefined;
+      },
+    };
+    expect(() =>
+      loopFixtureScene.create({
+        stage: minimalStage,
+        mode: 'loop',
+        gsap: { timeline: () => ({}) } as never,
+        audio: {} as never,
+      }),
+    ).not.toThrow();
+    expect(calls, 'create must not mutate the stage when ownerDocument is absent').toEqual([]);
+  });
+
+  describe.each<[label: string, ctx: unknown]>([
+    ['null', null],
+    ['undefined', undefined],
+    ['object without `stage`/`mode`/`gsap`', {}],
+    ['object with `stage: null`', { stage: null, mode: 'loop', gsap: { timeline: () => ({}) } }],
+    [
+      'object with unknown mode',
+      {
+        stage: { setAttribute: () => undefined, removeAttribute: () => undefined },
+        mode: 'shouty-mode',
+        gsap: { timeline: () => ({}) },
+      },
+    ],
+    [
+      'object with non-gsap shape',
+      {
+        stage: { setAttribute: () => undefined, removeAttribute: () => undefined },
+        mode: 'loop',
+        gsap: {},
+      },
+    ],
+  ])('is a no-op when ctx is %s', (_label, ctx) => {
+    it('does not throw from any lifecycle hook', () => {
+      expect(() => loopFixtureScene.create(ctx)).not.toThrow();
+      expect(() => loopFixtureScene.timeline(ctx)).not.toThrow();
+      expect(() => loopFixtureScene.cleanup(ctx)).not.toThrow();
+    });
+
+    it('timeline() returns null for the invalid ctx', () => {
+      expect(loopFixtureScene.timeline(ctx)).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

PUL-F015 specifies that `mode=loop` runs the addressed scene's timeline and restarts it on completion. The restart mechanic was already shipped — `positionMaster()` in `src/runtime/timeline.ts` sets `master.repeat(-1)` for `headRepeat === 'until-aborted'` — but no test observed an actual restart: the existing coverage only asserted the master was unpaused, and the PUL-Q002 browser spec asserts a sticky `data-pulsar-fixture-state="ran"` attribute that proves one completion, not restart-on-completion. This PR closes that verification gap with a dedicated loop fixture scene and unit + e2e tests that observe at least two distinct timeline iterations under `mode=loop`.

## Requirement UIDs

- `PUL-F015`

## Related Issues

Closes #128

## ADR Impact

- ADR-018
- ADR-021

## Changes

- Add `src/scenes/loop-fixture.ts` — a loop verification fixture scene mirroring the browser-support fixture, whose timeline ends with a `.call()` that increments a per-navigation counter into the public DOM attribute `data-pulsar-loop-iteration`; under a looping master the nested timeline replays each cycle so the attribute strictly increases.
- Register `loopFixtureScene` in `WORKBENCH_SCENES` (`src/workbench-graph.ts`) so `?scene=loop-fixture&mode=loop` resolves through the real `validateRuntime()` boot gate — no test-only registry path.
- Add `tests-e2e/loop-mode.spec.ts` — a Playwright spec that boots the fixture under `mode=loop` and polls `data-pulsar-loop-iteration` until it reaches at least two distinct iterations, across the existing chromium/firefox/webkit matrix.
- Add a `createGsapCompositionTimeline` unit test in `tests/runtime/timeline.test.ts` that observes the master completing at least twice under `headRepeat: 'until-aborted'`; rename the adjacent weaker test to match its actual scope (master starts unpaused).
- Add `tests/scenes/loop-fixture.test.ts` — contract-field, per-iteration increment, fresh-counter-per-navigation, and ctx-defensiveness unit tests for the fixture scene.
- Add changelog fragment `changelog.d/128.added.md`.

## Test Plan

- [x] Unit + fixture tests pass (`pnpm test` — 2477 tests)
- [x] Lint and typecheck pass (`pnpm lint`, `pnpm typecheck`)
- [x] Loop-mode e2e spec runs under `pnpm test:browsers` in the CI browser-support job
- [x] No coverage regression

The loop-mode e2e spec was verified locally on chromium (the `data-pulsar-loop-iteration` counter reached 2 in 360ms); firefox and webkit run in CI.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: PUL-F015 ← src/runtime/timeline.ts (master.repeat(-1) restart mechanic, pre-existing — verified by this PR)
- TESTS: PUL-F015 ← tests/runtime/timeline.test.ts, PUL-F015 ← tests-e2e/loop-mode.spec.ts, PUL-F015 ← tests/scenes/loop-fixture.test.ts

## Checklist

- [x] Code follows project coding standards
- [x] Reuses canonical runtime surfaces (ADR-002 contracts, ADR-018 mode=loop, ADR-003 GSAP runtime)
- [x] Changelog fragment added at `changelog.d/128.added.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
