### PR TITLE
added: paused-mode hold verification fixture and tests (PUL-F016)

### DIFF
--- a/changelog.d/129.added.md
+++ b/changelog.d/129.added.md
@@ -1,0 +1,22 @@
+PUL-F016 paused-mode hold verification. `mode=paused` already held the
+composed master timeline at its first frame — `positionMaster()` runs
+`master.seek(0)` + `master.pause()` for `headHold === 'first-frame'`;
+this adds the durable proof that was missing.
+  - New paused verification fixture scene at
+    `src/scenes/paused-fixture.ts` registered in `WORKBENCH_SCENES`.
+    Addressable via `?scene=paused-fixture&mode=paused`. Its timeline
+    tweens a numeric progress object 0 -> 100 and projects the current
+    value onto the public DOM attribute `data-pulsar-paused-progress` —
+    an observable that stays `"0"` while the master is held and climbs
+    once it runs.
+  - New Playwright spec at `tests-e2e/paused-mode.spec.ts` covering the
+    hold-at-first-frame clause under the existing chromium / firefox /
+    webkit matrix: it boots the fixture under `mode=paused` and asserts
+    `data-pulsar-paused-progress` stays `"0"` past the tween duration,
+    with a `mode=loop` control proving the same tween does climb when
+    the master is allowed to run.
+  - New `createGsapCompositionTimeline` unit test in
+    `tests/runtime/timeline.test.ts` that observes a scene tween's
+    animated value staying at frame 0 under `headHold: 'first-frame'`,
+    plus contract and ctx-defensiveness unit tests for the fixture
+    scene at `tests/scenes/paused-fixture.test.ts`.

--- a/docs/design/pul-f016-paused-mode-preflight.md
+++ b/docs/design/pul-f016-paused-mode-preflight.md
@@ -13,6 +13,72 @@ ADR-018 (`repeat`) is the precedent for adding a new head-only
 optional field; ADR-019 records the analogous `hold` field for
 paused.
 
+## Runner-Phase Addendum (2026-05-21)
+
+ADR-025 has since landed the GSAP-backed composition timeline adapter.
+Current PUL-F016 work must therefore treat
+`createGsapCompositionTimeline()` and the `MasterTimeline` transport
+surface as the canonical runtime seam for the actual first-frame hold.
+Do not add a second paused-mode path in the loader, resolver, scene
+schema, composition schema, or workbench chrome.
+
+The intended runner behavior is narrow: when the adapter receives
+`headHold === 'first-frame'`, it positions the composed master at time
+0, pauses it, does not resolve while a navigation `AbortSignal` is
+live, and kills the master on abort. With no signal, resolving after
+the held frame is positioned is acceptable for direct test/export
+callers because no runtime navigation is waiting to keep the scene
+mounted. `headHold` wins over `headBeat` and `headRepeat`; the runner
+does not attempt beat lookup and does not invoke `onBeatMissing` for
+a beat ignored by the first-frame policy.
+
+The current repo also has the audio service from ADR-004. Paused mode
+audible-output suppression belongs to
+`scene-loader.ts`'s mode-to-`AudioOutputPolicy` mapping and the
+`ctx.audio` service, not to the timeline adapter. The timeline adapter
+freezes timeline transport only.
+
+Cross-cutting layers in scope for runner-phase work:
+
+- URL and mode input still pass only through `parseNavigationSearch()`,
+  `NAVIGATION_MODES`, `effectiveMode()`, and the loader's
+  defense-in-depth mode grammar check. No storage, cookies,
+  `history.state`, environment variables, process argv, or prior
+  in-memory state may select paused behavior.
+- Scene and composition shape still pass through
+  `assertSceneModule()`, `createSceneRegistry()`,
+  `assertCompositionManifest()`, `createCompositionRegistry()`,
+  `resolveSceneNavigation()`, and `loadSceneNavigationTarget()`.
+  Paused mode does not add scene fields, composition fields, DTOs, or
+  validation rules.
+- Asset security still passes through `createAssetPreloader()` with
+  its scheme allowlist, redirect re-check, `baseUrl`, declared
+  `scene.assets`, and `AbortSignal` wiring. Paused mode does not turn
+  query values into paths, dynamic imports, or network URLs.
+- Audio suppression still passes through `audioOutputPolicyFor()`,
+  `createAudioService()`, declared `scene.audio` / composition-bed
+  sources, source allowlists, and service cleanup. Do not import Howler
+  in scenes or mute a global engine for paused mode.
+- Timeline validation and transport still pass through
+  `assertSceneTimeline()`, `composeMasterTimeline()`,
+  `MasterTimeline.seek(0)`, `MasterTimeline.pause()`,
+  `runMasterUntilDone()`, and `MasterTimeline.kill()`. Do not
+  manipulate raw GSAP timelines outside `src/runtime/timeline.ts`.
+- Error surfacing keeps the existing envelopes:
+  `navigation grammar is invalid:`, `scene navigation failed:`,
+  `composition resolution failed:`, `composition timeline failed:`,
+  and non-fatal `beat positioning failed:` where a beat lookup is
+  actually attempted. Do not add paused-specific exception classes,
+  logger paths, telemetry, or public diagnostics that serialize raw
+  GSAP objects, DOM nodes, stacks, scene objects, headers, cookies,
+  env, or argv.
+
+The extension seam is the existing literal runner hint:
+`headHold?: 'first-frame'`. A future hold variant should extend that
+union and the adapter's positioning decision at the timeline boundary.
+It should not become a boolean, a generic `ModePolicy`, a manifest
+behavior key, a scene metadata flag, or a second URL-derived workflow.
+
 ## Boundary
 
 `paused` selection must reuse the existing navigation path:
@@ -55,7 +121,7 @@ Implementation must reuse these cross-cutting concerns:
 - Navigation resolution: `resolveSceneNavigation()` and
   `loadSceneNavigationTarget()`.
 - Lifecycle orchestration: `resolveComposition()` with injected
-  `createPreloader()` and `runTimeline()` adapters.
+  preload and `CompositionTimelineAdapter` adapters.
 - Asset handling: `createAssetPreloader()` with the existing
   scheme, redirect, `baseUrl`, and `AbortSignal` rules. Paused mode
   does not change preload semantics — the addressed scene's assets
@@ -114,18 +180,18 @@ is missing — there is no missing-label event because no seek was
 attempted. The loader still forwards `beat` and `onBeatMissing` to
 the runner unchanged (the loader does not couple `beat` and `mode`
 at its layer); whether a missing-label diagnostic surfaces under
-paused is the runner's policy. The placeholder runner today does
-invoke `onBeatMissing` because it has no real timeline at all,
-which is honest within the placeholder world but not the contract
-the GSAP runner will follow.
+paused is the runner's policy. The older placeholder runner invoked
+`onBeatMissing` because it had no real timeline at all, which was
+honest within the placeholder world but is not the contract the GSAP
+adapter follows.
 
 ## Guardrails
 
 - Keep `paused` mode behavior at the loader / runner seam. The
   resolver must remain mode-opaque and must not learn about
   hold-at-first-frame semantics.
-- Prefer the runner's native pause controls once ADR-003's GSAP
-  runner lands (`timeline.pause()`, `timeline.seek(0)`). Do not
+- Use the runner's native pause controls (`MasterTimeline.seek(0)`,
+  `MasterTimeline.pause()`, backed by GSAP). Do not
   build hold loops with `setTimeout`,
   `requestAnimationFrame` checks that gate themselves on a paused
   flag, CSS / keyframe animation suppression layers, canvas loops
@@ -150,11 +216,11 @@ the GSAP runner will follow.
   keep describing the addressed scene / composition and navigation
   errors.
 - Paused mode should not trigger autoplay audio or scene-local raw
-  `<audio>` behavior. Audio suppression under paused is a future
-  audio-service-surface concern (ADR-004) — when the audio service
-  lands it will read `ctx.mode === 'paused'` at its own seam and
-  suppress the audio bed; today there is no audio service to
-  suppress.
+  `<audio>` behavior. Audio suppression under paused is now an
+  audio-service-surface concern: the loader maps `mode=paused` to the
+  silent `AudioOutputPolicy`, and scenes reach sound through
+  `ctx.audio`. Do not duplicate that policy in the timeline adapter,
+  in scene code, or through global Howler / DOM audio state.
 
 ## Non-Goals
 
@@ -164,17 +230,18 @@ PUL-F016 should not implement `present`, `standalone`, `loop`,
 export behavior; decode-complete asset semantics; new scene
 metadata; new composition metadata; persistence; or a generic
 mode-policy framework. It should not make paused imply chrome
-suppression, audio suppression, deterministic rendering, or
-visible scrub controls. It should not implement transport
+suppression, deterministic rendering, or visible scrub controls, and
+it should not add audio behavior beyond the existing silent
+`AudioOutputPolicy` for paused. It should not implement transport
 controls, scrub UI, screenshot determinism, or presenter resume
 behavior.
 
-PUL-F016 should not transition to ACTIVE until implementation
-includes tests proving first-frame mount without timeline
-advancement against a real timeline runner. The placeholder runner
-in `src/main.ts` has no real timeline, so PUL-F016 stays DRAFT
-after the contract-layer PR; the GSAP runner (ADR-003) is the
-natural trigger to revisit the status.
+Earlier contract-layer work kept PUL-F016 DRAFT until implementation
+included tests proving first-frame mount without timeline advancement
+against a real timeline runner. That historical blocker is no longer
+the architectural dependency in the current repo: ADR-025 supplies the
+GSAP adapter. New work must preserve the ACTIVE semantics and add or
+maintain tests at the runner seam when changing hold behavior.
 
 ## Anti-Patterns
 

--- a/src/scenes/paused-fixture.ts
+++ b/src/scenes/paused-fixture.ts
@@ -1,0 +1,107 @@
+// PUL-F016 / ADR-019 — paused verification fixture scene.
+//
+// PUL-F016: "In `mode=paused`, the runtime SHALL mount the addressed
+// scene and hold it at its first frame without advancing the
+// timeline." The hold mechanic is shipped — `positionMaster()` in
+// `src/runtime/timeline.ts` handles `headHold === 'first-frame'` by
+// `master.seek(0)` + `master.pause()` and never advances the master.
+// What that implementation lacked was an *observable* paused-acceptance
+// signal.
+//
+// The browser-support fixture (`./browser-support-fixture.ts`) advances
+// a sticky `data-pulsar-fixture-state` from `"mounted"` to `"ran"` at
+// the end of its timeline. Under `mode=paused` it would simply never
+// reach `"ran"` — but a runner that skipped `timeline(ctx)` entirely
+// would be indistinguishable from one that built the timeline and held
+// it at frame 0.
+//
+// This fixture gives paused mode a *progress* observable:
+//
+//   1. `create(ctx)` mounts a `<div data-pulsar-paused-target>` under
+//      the workbench stage, with `data-pulsar-paused-progress` starting
+//      at `"0"` (mounted, first frame).
+//   2. `timeline(ctx)` returns a GSAP timeline whose single tween moves
+//      a numeric `progress` object from `0` to `100`. Its `onUpdate`
+//      callback writes `Math.round(progress.value)` onto the same
+//      element's `data-pulsar-paused-progress`. Under a held master the
+//      tween value stays at `0`, so the attribute stays `"0"`; under a
+//      playing master the attribute climbs toward `"100"`.
+//   3. `cleanup(ctx)` removes the fixture element entirely.
+//
+// The Playwright spec at `tests-e2e/paused-mode.spec.ts` boots this
+// scene under `mode=paused` and asserts `data-pulsar-paused-progress`
+// holds at `"0"` past the tween's natural duration — proving the GSAP
+// master genuinely held the timeline at its first frame in a real
+// browser engine — and, as a control, boots it under `mode=loop` to
+// confirm the same tween does climb when the master is allowed to run.
+//
+// The `progress` object is a closure local to `timeline(ctx)`: the
+// resolver calls `timeline(ctx)` once per navigation, so a fresh
+// navigation starts a fresh tween from `0`.
+//
+// The ctx validation and DOM mount/find/remove scaffolding is shared
+// with the browser-support and loop fixtures via `./fixture-support.ts`.
+// Scope intentionally narrow: no declared assets, no declared audio.
+// The scene is `standalone: true` — it does not assume surrounding
+// composition context. `trailerSafe: false` — it has nothing
+// trailer-worthy to show.
+
+import type { SceneModule } from '../runtime/scene';
+import {
+  findFixtureElement,
+  isFixtureCtx,
+  mountFixtureElement,
+  removeFixtureElement,
+} from './fixture-support';
+
+const FIXTURE_TARGET_ATTR = 'data-pulsar-paused-target';
+const FIXTURE_PROGRESS_ATTR = 'data-pulsar-paused-progress';
+const FIXTURE_DURATION_SECONDS = 0.1;
+
+export const pausedFixtureScene: SceneModule = {
+  id: 'paused-fixture',
+  title: 'Paused verification fixture',
+  duration: null,
+  tags: ['fixture', 'paused'],
+  assets: [],
+  captions: [],
+  audio: [],
+  defaultNext: null,
+  standalone: true,
+  trailerSafe: false,
+  // The element starts at progress 0 — "mounted, held at first frame" —
+  // so a Playwright poll can distinguish a held master from one that
+  // advanced the timeline.
+  create: (ctx: unknown) => {
+    mountFixtureElement(ctx, FIXTURE_TARGET_ATTR, [[FIXTURE_PROGRESS_ATTR, '0']]);
+  },
+  timeline: (ctx: unknown) => {
+    if (!isFixtureCtx(ctx)) return null;
+    const stage = ctx.stage;
+    if (stage === null) return null;
+    const el = findFixtureElement(stage, FIXTURE_TARGET_ATTR);
+    if (el === null) return null;
+    // Build a real GSAP timeline through `ctx.gsap`. The single tween
+    // would move `progress.value` from 0 to 100 over the fixture
+    // duration; `onUpdate` projects the current value onto
+    // `data-pulsar-paused-progress`. Under `mode=paused` the master is
+    // `seek(0)` + `pause()` (PUL-F016 / ADR-019), so the tween never
+    // advances and the attribute stays `"0"` — the observable the
+    // paused-mode e2e spec asserts. A linear ease keeps the projected
+    // value a faithful read of how far the timeline progressed.
+    const progress = { value: 0 };
+    const tl = ctx.gsap.timeline();
+    tl.to(progress, {
+      value: 100,
+      duration: FIXTURE_DURATION_SECONDS,
+      ease: 'none',
+      onUpdate: () => {
+        el.setAttribute(FIXTURE_PROGRESS_ATTR, String(Math.round(progress.value)));
+      },
+    });
+    return tl;
+  },
+  cleanup: (ctx: unknown) => {
+    removeFixtureElement(ctx, FIXTURE_TARGET_ATTR);
+  },
+};

--- a/src/workbench-graph.ts
+++ b/src/workbench-graph.ts
@@ -19,6 +19,7 @@ import type { SceneModule } from './runtime/scene';
 import { browserSupportFixtureScene } from './scenes/browser-support-fixture';
 import { domCssAccessibilityFixtureScene } from './scenes/dom-css-accessibility-fixture';
 import { loopFixtureScene } from './scenes/loop-fixture';
+import { pausedFixtureScene } from './scenes/paused-fixture';
 import { placeholderScene } from './scenes/placeholder';
 
 // Optional local decks live under `src/decks/local-*/index.ts` and
@@ -54,6 +55,12 @@ const LOCAL_COMPOSITIONS: readonly CompositionRegistryEntry[] = Object.values(
 // genuinely restarting on completion (a strictly increasing
 // `data-pulsar-loop-iteration` attribute).
 //
+// PUL-F016 / ADR-019: the paused verification fixture is registered the
+// same way so the paused-mode Playwright spec can boot it via
+// `?scene=paused-fixture&mode=paused` and observe the master timeline
+// genuinely holding at its first frame (a `data-pulsar-paused-progress`
+// attribute pinned at `"0"`).
+//
 // Pulsar L2: the pulsar-intro reference deck (`?composition=pulsar-intro`)
 // is the self-referential proof of the L2 system layer. Its 15 scenes
 // collectively exercise every shipped template, every transition, every
@@ -65,6 +72,7 @@ export const WORKBENCH_SCENES: readonly SceneModule[] = [
   browserSupportFixtureScene,
   domCssAccessibilityFixtureScene,
   loopFixtureScene,
+  pausedFixtureScene,
   ...PULSAR_INTRO_SCENES,
   ...LOCAL_SCENES,
 ];

--- a/tests-e2e/paused-mode.spec.ts
+++ b/tests-e2e/paused-mode.spec.ts
@@ -1,0 +1,133 @@
+import { expect, test } from '@playwright/test';
+
+// PUL-F016 / ADR-019 — paused-mode hold-at-first-frame spec.
+//
+// PUL-F016: "In `mode=paused`, the runtime SHALL mount the addressed
+// scene and hold it at its first frame without advancing the
+// timeline." The hold mechanic is `positionMaster()` in
+// `src/runtime/timeline.ts` handling `headHold === 'first-frame'` with
+// `master.seek(0)` + `master.pause()`. The PUL-Q002 browser-support
+// spec boots `mode=paused` too, but against the placeholder scene,
+// whose timeline is empty — that proves the shell boots, not that a
+// real GSAP tween is genuinely held still.
+//
+// This spec uses the dedicated paused fixture
+// (`src/scenes/paused-fixture.ts`), whose timeline tweens a numeric
+// progress object 0 -> 100 and projects the current value onto
+// `data-pulsar-paused-progress`. Under a held master the tween never
+// advances, so the attribute stays `"0"`; under a running master it
+// climbs. The first test asserts the held behavior under `mode=paused`;
+// the second is a control — under `mode=loop` the same fixture's tween
+// must climb, proving the paused test's "stayed 0" is a genuine hold,
+// not a dead fixture.
+//
+// The spec runs in every Playwright project declared in
+// `playwright.config.ts` (chromium / firefox / webkit). It is
+// deliberately separate from `browser-support.spec.ts` (the PUL-Q002
+// engine smoke gate) and `loop-mode.spec.ts` (the PUL-F015 loop gate):
+// this one is the PUL-F016 paused acceptance gate.
+
+test.describe('PUL-F016 — mode=paused holds the timeline at its first frame', () => {
+  test('the paused fixture timeline mounts and does not advance', async ({ page }) => {
+    const errors: string[] = [];
+    page.on('pageerror', (err) => errors.push(`pageerror: ${err.message}`));
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') errors.push(`console.error: ${msg.text()}`);
+    });
+
+    await page.goto('/?scene=paused-fixture&mode=paused');
+
+    const stage = page.locator('#stage');
+    await expect(stage, 'the workbench stage element must mount').toBeAttached();
+
+    await expect(
+      stage,
+      'PUL-F028 boot validation must succeed (no data-pulsar-validation-failed)',
+    ).not.toHaveAttribute('data-pulsar-validation-failed', /.*/);
+
+    await expect(
+      stage,
+      'the URL grammar parser must accept ?scene=paused-fixture&mode=paused (no data-pulsar-navigation-error)',
+    ).not.toHaveAttribute('data-pulsar-navigation-error', /.*/);
+
+    await expect(stage, 'the resolver must have mounted the paused fixture scene').toHaveAttribute(
+      'data-pulsar-scene-target',
+      'paused-fixture',
+    );
+
+    const fixture = page.locator('[data-pulsar-paused-target]');
+    await expect(fixture, 'the paused fixture element must mount').toBeAttached();
+
+    // The fixture's GSAP tween would move `data-pulsar-paused-progress`
+    // from "0" toward "100" over a ~100ms tween. Under `mode=paused`
+    // the master is `seek(0)` + `pause()`, so the playhead never
+    // advances and the attribute stays "0".
+    await expect(
+      fixture,
+      'mode=paused must render the timeline at its first frame (progress 0)',
+    ).toHaveAttribute('data-pulsar-paused-progress', '0');
+
+    // Wait well past the tween's natural duration, then re-assert. A
+    // runner that briefly played, or one whose pause leaked, would have
+    // let the GSAP ticker advance the attribute by now.
+    await page.waitForTimeout(500);
+    await expect(
+      fixture,
+      'mode=paused must keep holding the first frame — progress must not advance over time',
+    ).toHaveAttribute('data-pulsar-paused-progress', '0');
+
+    expect(errors, 'no uncaught exceptions or console errors while holding').toEqual([]);
+  });
+
+  test('control: the same fixture timeline does climb when the master runs (mode=loop)', async ({
+    page,
+  }) => {
+    // This control proves the paused test above is meaningful: the
+    // fixture's tween genuinely animates `data-pulsar-paused-progress`,
+    // so the paused test's pinned "0" is a real hold rather than a
+    // fixture whose tween does nothing. `mode=loop` keeps the element
+    // durably mounted (the master never completes, so cleanup never
+    // runs) — the same race-free observation technique
+    // `browser-support.spec.ts` uses.
+    const errors: string[] = [];
+    page.on('pageerror', (err) => errors.push(`pageerror: ${err.message}`));
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') errors.push(`console.error: ${msg.text()}`);
+    });
+
+    await page.goto('/?scene=paused-fixture&mode=loop');
+
+    const stage = page.locator('#stage');
+    await expect(stage, 'the workbench stage element must mount').toBeAttached();
+
+    await expect(
+      stage,
+      'PUL-F028 boot validation must succeed (no data-pulsar-validation-failed)',
+    ).not.toHaveAttribute('data-pulsar-validation-failed', /.*/);
+
+    await expect(
+      stage,
+      'the URL grammar parser must accept ?scene=paused-fixture&mode=loop (no data-pulsar-navigation-error)',
+    ).not.toHaveAttribute('data-pulsar-navigation-error', /.*/);
+
+    const fixture = page.locator('[data-pulsar-paused-target]');
+    await expect(fixture, 'the paused fixture element must mount').toBeAttached();
+
+    // Under a running (looping) master the tween advances, so the
+    // projected progress climbs above 0. Reaching a positive value
+    // proves the tween is a real, moving animation.
+    await expect
+      .poll(
+        async () => {
+          const raw = await fixture.getAttribute('data-pulsar-paused-progress');
+          return raw === null ? 0 : Number.parseInt(raw, 10);
+        },
+        {
+          message: 'a running master must let the paused fixture tween advance past 0',
+        },
+      )
+      .toBeGreaterThan(0);
+
+    expect(errors, 'no uncaught exceptions or console errors while running').toEqual([]);
+  });
+});

--- a/tests/runtime/timeline.test.ts
+++ b/tests/runtime/timeline.test.ts
@@ -622,6 +622,43 @@ describe('createGsapCompositionTimeline', () => {
     await settled;
   });
 
+  it('does not advance a scene tween under headHold — the animated value stays at frame 0', async () => {
+    // PUL-F016 acceptance criterion 2: `mode=paused` must hold the
+    // composition at its first frame *without advancing the timeline*.
+    // The `isPaused()` / `time()` assertions in the test above prove
+    // the master is parked at 0, but a runner that paused the master
+    // yet still let a nested tween render forward — or one that briefly
+    // played before pausing — would pass them. This test pins the
+    // behavioral contract: a tween that animates an external attribute
+    // from 0 -> 1 must leave that attribute at its initial value, and
+    // must keep it there as real wall-clock time elapses past the
+    // tween's duration. It is the runner-seam unit counterpart of the
+    // headRepeat "actually restarts" test below.
+    const controller = new AbortController();
+    const target = { v: 0 };
+    const child = gsap.timeline({ paused: true });
+    child.to(target, { v: 1, duration: 0.05, ease: 'none' });
+
+    const { master, settled } = runWith([segment('a', child)], {
+      signal: controller.signal,
+      headHold: 'first-frame',
+    });
+    await flush();
+    expect(master().isPaused()).toBe(true);
+    expect(target.v).toBeCloseTo(0);
+
+    // Let real time pass well beyond the tween's 50ms duration. A
+    // master that was not genuinely held would have the GSAP ticker
+    // advance `target.v` toward 1; a held master leaves it untouched.
+    await new Promise((r) => setTimeout(r, 80));
+    expect(master().isPaused()).toBe(true);
+    expect(master().time()).toBeCloseTo(0);
+    expect(target.v).toBeCloseTo(0);
+
+    controller.abort();
+    await settled;
+  });
+
   it('freezes the master at the addressed beat under headScreenshot (frame 0 with no beat)', async () => {
     const c1 = new AbortController();
     const r1 = runWith([segment('intro', sceneTl(6, { mid: 3 }))], {

--- a/tests/scenes/paused-fixture.test.ts
+++ b/tests/scenes/paused-fixture.test.ts
@@ -1,0 +1,278 @@
+// PUL-F016 / ADR-019 — paused verification fixture scene unit tests.
+//
+// The fixture scene is exercised end-to-end by Playwright in
+// `tests-e2e/paused-mode.spec.ts`, where `mode=paused` drives the GSAP
+// master through `seek(0)` + `pause()` and the progress attribute is
+// observed to stay pinned at its first-frame value. These unit tests
+// cover the PUL-F001 contract shape and the ctx defensiveness — the
+// same surface `loop-fixture.test.ts` covers for its fixture — plus the
+// one behavior unique to this fixture: the `timeline(ctx)` tween's
+// `onUpdate` callback maps the tween's current value onto the
+// `data-pulsar-paused-progress` attribute, so a held master (value
+// pinned at 0) leaves the attribute at `"0"`. They do NOT run a real
+// GSAP timeline; that responsibility lives in
+// `tests/runtime/timeline.test.ts` and in the Playwright e2e spec.
+
+import { describe, expect, it } from 'vitest';
+import { pausedFixtureScene } from '../../src/scenes/paused-fixture';
+
+interface FakeStage {
+  readonly children: { attrs: Map<string, string> }[];
+  readonly element: {
+    setAttribute(name: string, value: string): void;
+    removeAttribute(name: string): void;
+    appendChild(node: unknown): unknown;
+    querySelector(selector: string): {
+      setAttribute(name: string, value: string): void;
+      remove(): void;
+    } | null;
+    ownerDocument: {
+      createElement(tag: string): { setAttribute(name: string, value: string): void };
+    };
+  };
+}
+
+// Stage stub mirroring `loop-fixture.test.ts`: `appendChild` records
+// children, `querySelector` looks them up by the attribute name in the
+// `[<attr>]` selector, and `ownerDocument.createElement` returns a
+// recording stub. The fixture allocates DOM through the stage's owner
+// document rather than an ambient `document` global (ADR-008 #2), so
+// the stub mirrors that seam.
+const buildStage = (): FakeStage => {
+  const children: { attrs: Map<string, string> }[] = [];
+  return {
+    children,
+    element: {
+      setAttribute: () => undefined,
+      removeAttribute: () => undefined,
+      appendChild: (node: unknown) => {
+        children.push(node as { attrs: Map<string, string> });
+        return node;
+      },
+      querySelector: (selector: string) => {
+        const attr = selector.replace(/^\[|\]$/g, '').split('=')[0];
+        if (attr === undefined) return null;
+        for (let i = 0; i < children.length; i += 1) {
+          const child = children[i];
+          if (child === undefined) continue;
+          if (child.attrs.has(attr)) {
+            return {
+              setAttribute: (name: string, value: string) => child.attrs.set(name, value),
+              remove: () => {
+                children.splice(i, 1);
+              },
+            };
+          }
+        }
+        return null;
+      },
+      ownerDocument: {
+        createElement: () => {
+          const attrs = new Map<string, string>();
+          return {
+            attrs,
+            setAttribute: (name: string, value: string) => attrs.set(name, value),
+          };
+        },
+      },
+    },
+  };
+};
+
+describe('pausedFixtureScene', () => {
+  it('declares the PUL-F001 contract fields with kebab-case id', () => {
+    expect(pausedFixtureScene.id).toBe('paused-fixture');
+    expect(pausedFixtureScene.title).toBe('Paused verification fixture');
+    expect(pausedFixtureScene.duration).toBeNull();
+    expect(pausedFixtureScene.standalone).toBe(true);
+    expect(pausedFixtureScene.trailerSafe).toBe(false);
+    expect(pausedFixtureScene.assets).toEqual([]);
+    expect(pausedFixtureScene.captions).toEqual([]);
+    expect(pausedFixtureScene.audio).toEqual([]);
+    expect(pausedFixtureScene.tags).toEqual(['fixture', 'paused']);
+    expect(pausedFixtureScene.defaultNext).toBeNull();
+  });
+
+  it('appends a fixture element at progress 0 on `create`', () => {
+    const stage = buildStage();
+    pausedFixtureScene.create({
+      stage: stage.element,
+      mode: 'paused',
+      gsap: { timeline: () => ({}) } as never,
+      audio: {} as never,
+    });
+    expect(stage.children).toHaveLength(1);
+    const attrs = stage.children[0]?.attrs;
+    expect(attrs?.get('data-pulsar-paused-target')).toBe('');
+    // The progress attribute starts at 0 — "mounted, timeline rendered
+    // at its first frame" — so a Playwright poll can distinguish a held
+    // first frame from a timeline that advanced.
+    expect(attrs?.get('data-pulsar-paused-progress')).toBe('0');
+  });
+
+  it('maps the tween value onto `data-pulsar-paused-progress` via `onUpdate`', () => {
+    // PUL-F016 acceptance criterion 2: paused mode must be observable as
+    // an animation that does NOT progress. The fixture's `timeline(ctx)`
+    // tweens a numeric `progress` object 0 -> 100; its `onUpdate`
+    // callback writes the rounded current value onto the DOM attribute.
+    // Under a held master (`seek(0)` + `pause()`) the tween value stays
+    // at 0, so the attribute stays `"0"`; under a playing master it
+    // climbs. The `.to(target, vars)` stub captures both the tween
+    // target object and the `onUpdate` callback, so the test can drive
+    // the target value GSAP would otherwise interpolate and assert the
+    // callback's mapping directly.
+    const stage = buildStage();
+    let capturedTarget: { value: number } | null = null;
+    let capturedOnUpdate: (() => void) | null = null;
+    const tlCalls: string[] = [];
+    const tlStub = {
+      to: (target: unknown, vars: Record<string, unknown>) => {
+        tlCalls.push('to');
+        capturedTarget = target as { value: number };
+        capturedOnUpdate = vars.onUpdate as () => void;
+        return tlStub;
+      },
+    };
+    const gsap = { timeline: () => tlStub } as never;
+    pausedFixtureScene.create({ stage: stage.element, mode: 'paused', gsap, audio: {} as never });
+    expect(stage.children[0]?.attrs.get('data-pulsar-paused-progress')).toBe('0');
+
+    const result = pausedFixtureScene.timeline({
+      stage: stage.element,
+      mode: 'paused',
+      gsap,
+      audio: {} as never,
+    });
+    expect(result).toBe(tlStub);
+    expect(tlCalls).toEqual(['to']);
+    expect(capturedTarget).not.toBeNull();
+    expect(capturedOnUpdate).not.toBeNull();
+
+    const target = capturedTarget as unknown as { value: number };
+    const fireUpdate = capturedOnUpdate as unknown as () => void;
+
+    // The tween declares `value: 100` as its end state, so the target
+    // starts at 0 — the held first frame.
+    expect(target.value).toBe(0);
+
+    // Frame 0: a held master leaves the value at 0; the callback writes
+    // `"0"`.
+    fireUpdate();
+    expect(stage.children[0]?.attrs.get('data-pulsar-paused-progress')).toBe('0');
+
+    // A non-integer interpolated value is rounded.
+    target.value = 41.6;
+    fireUpdate();
+    expect(stage.children[0]?.attrs.get('data-pulsar-paused-progress')).toBe('42');
+
+    // The tween's terminal value.
+    target.value = 100;
+    fireUpdate();
+    expect(stage.children[0]?.attrs.get('data-pulsar-paused-progress')).toBe('100');
+  });
+
+  it('returns null from `timeline(ctx)` when no fixture element is mounted', () => {
+    const stage = buildStage();
+    const result = pausedFixtureScene.timeline({
+      stage: stage.element,
+      mode: 'paused',
+      gsap: { timeline: () => ({}) } as never,
+      audio: {} as never,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('removes the fixture element on `cleanup`', () => {
+    const stage = buildStage();
+    pausedFixtureScene.create({
+      stage: stage.element,
+      mode: 'paused',
+      gsap: { timeline: () => ({}) } as never,
+      audio: {} as never,
+    });
+    expect(stage.children).toHaveLength(1);
+    pausedFixtureScene.cleanup({
+      stage: stage.element,
+      mode: 'paused',
+      gsap: { timeline: () => ({}) } as never,
+      audio: {} as never,
+    });
+    expect(stage.children).toHaveLength(0);
+  });
+
+  it('is a no-op on `cleanup` when no fixture element was mounted (valid ctx, no prior create)', () => {
+    const stage = buildStage();
+    expect(stage.children).toHaveLength(0);
+    expect(() =>
+      pausedFixtureScene.cleanup({
+        stage: stage.element,
+        mode: 'paused',
+        gsap: { timeline: () => ({}) } as never,
+        audio: {} as never,
+      }),
+    ).not.toThrow();
+    expect(stage.children).toHaveLength(0);
+  });
+
+  it('is a no-op when the stage has no ownerDocument (off-DOM harness)', () => {
+    // The scene must NOT reach for the ambient global `document`. A
+    // stage stub without `ownerDocument` must produce no DOM mutation
+    // (ADR-008 #2). Every stage method call is tracked so "no DOM
+    // mutation" is asserted structurally.
+    const calls: { name: string; args: unknown[] }[] = [];
+    const minimalStage = {
+      setAttribute: (...args: unknown[]) => {
+        calls.push({ name: 'setAttribute', args });
+      },
+      removeAttribute: (...args: unknown[]) => {
+        calls.push({ name: 'removeAttribute', args });
+      },
+      appendChild: (...args: unknown[]) => {
+        calls.push({ name: 'appendChild', args });
+        return undefined;
+      },
+    };
+    expect(() =>
+      pausedFixtureScene.create({
+        stage: minimalStage,
+        mode: 'paused',
+        gsap: { timeline: () => ({}) } as never,
+        audio: {} as never,
+      }),
+    ).not.toThrow();
+    expect(calls, 'create must not mutate the stage when ownerDocument is absent').toEqual([]);
+  });
+
+  describe.each<[label: string, ctx: unknown]>([
+    ['null', null],
+    ['undefined', undefined],
+    ['object without `stage`/`mode`/`gsap`', {}],
+    ['object with `stage: null`', { stage: null, mode: 'paused', gsap: { timeline: () => ({}) } }],
+    [
+      'object with unknown mode',
+      {
+        stage: { setAttribute: () => undefined, removeAttribute: () => undefined },
+        mode: 'shouty-mode',
+        gsap: { timeline: () => ({}) },
+      },
+    ],
+    [
+      'object with non-gsap shape',
+      {
+        stage: { setAttribute: () => undefined, removeAttribute: () => undefined },
+        mode: 'paused',
+        gsap: {},
+      },
+    ],
+  ])('is a no-op when ctx is %s', (_label, ctx) => {
+    it('does not throw from any lifecycle hook', () => {
+      expect(() => pausedFixtureScene.create(ctx)).not.toThrow();
+      expect(() => pausedFixtureScene.timeline(ctx)).not.toThrow();
+      expect(() => pausedFixtureScene.cleanup(ctx)).not.toThrow();
+    });
+
+    it('timeline() returns null for the invalid ctx', () => {
+      expect(pausedFixtureScene.timeline(ctx)).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

PUL-F016 ("in mode=paused, the runtime SHALL mount the addressed scene and hold it at its first frame without advancing the timeline") was already satisfied at runtime — positionMaster() in src/runtime/timeline.ts holds the composed master at frame 0 via master.seek(0) + master.pause() for headHold === 'first-frame', and runMasterUntilDone() parks the held master without ever calling play(). What was missing was the durable proof. This PR adds the verification package, mirroring the PUL-F015 loop verification work in #128: a dedicated fixture scene whose tween would visibly advance an attribute, observed to stay pinned at its first frame under mode=paused. No runtime/source behavior of the paused runner changed.

## Requirement UIDs

- `PUL-F016`

## Related Issues

Closes #129

## ADR Impact

- ADR-019
- ADR-025

## Changes

- Add src/scenes/paused-fixture.ts — a verification scene whose timeline tweens a numeric progress object 0 -> 100 and projects the value onto the public DOM attribute data-pulsar-paused-progress; reuses the existing fixture-support.ts ctx-validation and DOM-mount scaffolding
- Register pausedFixtureScene in WORKBENCH_SCENES (src/workbench-graph.ts) so it is addressable via ?scene=paused-fixture&mode=paused and covered by the PUL-F028 boot-validation gate
- Add tests-e2e/paused-mode.spec.ts — a Playwright spec on the chromium/firefox/webkit matrix asserting data-pulsar-paused-progress holds at "0" under mode=paused past the tween duration, with a mode=loop control proving the same tween climbs when the master runs
- Add a createGsapCompositionTimeline unit test in tests/runtime/timeline.test.ts observing a scene tween's animated value held at frame 0 under headHold: 'first-frame', including after wall-clock time elapses past the tween duration
- Add tests/scenes/paused-fixture.test.ts — fixture PUL-F001 contract assertions, the onUpdate value->attribute mapping, and ctx-defensiveness coverage
- Add changelog.d/129.added.md

## Test Plan

- [x] Unit tests pass (`pnpm test`)
- [x] `pnpm lint` and `pnpm typecheck` pass
- [x] No coverage regression

pnpm lint, pnpm typecheck, and pnpm test (2497 tests) all pass. The new Playwright spec passes locally on chromium and firefox; webkit was not run locally (this host is missing WebKit's system libraries) but runs in CI alongside the existing browser-support and loop-mode specs.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: PUL-F016 ← src/scenes/paused-fixture.ts, PUL-F016 ← src/workbench-graph.ts
- TESTS: PUL-F016 ← tests/runtime/timeline.test.ts, PUL-F016 ← tests-e2e/paused-mode.spec.ts, PUL-F016 ← tests/scenes/paused-fixture.test.ts

## Checklist

- [x] Code follows project coding standards
- [x] Changelog fragment added at `changelog.d/129.added.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
