### PR TITLE
added: scrub-mode timeline controls and monotonic-forward cue gating

### DIFF
--- a/changelog.d/130.added.md
+++ b/changelog.d/130.added.md
@@ -1,0 +1,29 @@
+PUL-F017 scrub-mode timeline controls and monotonic-forward audio cue
+gating. `mode=scrub` previously only forwarded the
+`cueGate: 'monotonic-forward'` hint to the runner; it now delivers the
+behavior the requirement names.
+  - The GSAP composition timeline adapter gained a `scrub` run mode:
+    under `headCueGate: 'monotonic-forward'` the addressed head scene
+    is left mounted with a live master held at its initial cursor,
+    instead of auto-playing to completion. `MasterTimeline` gained a
+    `reverse()` transport method for backward playback.
+  - A dynamic audio cue-eligibility gate (`createCueGate`) wired into
+    the per-navigation `AudioService`: an accepted `play` cue is
+    suppressed (post-validation, pre-output) while the gate is closed.
+    The timeline adapter toggles the gate by playhead direction —
+    `play()` opens it, `pause()` / `reverse()` close it — so audio cues
+    fire only on monotonic forward playback. Reverse playback,
+    jump-to-beat, and direct seek no longer fire cues.
+  - New workbench scrub controls (`createScrubControls`) under the L2
+    chrome surface: a transport bar with play / pause / reverse, a
+    drag scrubber, a `m:ss` readout, and one jump button per named beat
+    from `master.beats()`. Shown only under `mode=scrub`.
+  - New scrub verification fixture scene at `src/scenes/scrub-fixture.ts`
+    registered in `WORKBENCH_SCENES`, addressable via
+    `?scene=scrub-fixture&mode=scrub`. It projects timeline progress
+    onto the public DOM attribute `data-pulsar-scrub-progress` and
+    authors a `midpoint` named beat.
+  - New Playwright spec at `tests-e2e/scrub-mode.spec.ts` and an
+    end-to-end cue-gating unit test at
+    `tests/runtime/scrub-cue-gating.test.ts` proving a cue fires on a
+    forward crossing and is suppressed on a reverse crossing.

--- a/docs/adrs/020-workbench-mode-scrub.md
+++ b/docs/adrs/020-workbench-mode-scrub.md
@@ -468,15 +468,99 @@ cues, AND a workbench scrub-controls surface reading `ctx.mode ===
 end-to-end tests alongside the seam tests in this PR. Treating this
 PR as satisfying PUL-F017 would be a traceability/status mismatch.
 
+## Subsequent update (2026-05-21)
+
+ADR-025 has since landed the GSAP composition timeline adapter, and
+ADR-004 has since landed the Howler-backed per-navigation
+`AudioService`. The historical "future GSAP / future audio engine"
+wording above described the first seam PR; it is no longer the
+implementation blocker for PUL-F017.
+
+The remaining PUL-F017 work is now an integration across existing
+boundaries:
+
+- `src/runtime/timeline.ts` must stop treating
+  `headCueGate: 'monotonic-forward'` as a no-op. Under scrub, the
+  adapter must keep the addressed head scene mounted with a live,
+  workbench-drivable master instead of auto-playing to natural
+  completion before the user can inspect it.
+- `src/runtime/audio.ts` must provide the dynamic cue eligibility
+  behavior the runner toggles by playhead movement direction. This
+  stays distinct from static `AudioOutputPolicy`: scrub is not
+  `silent`, not `log-cues`, and not master mute.
+- The workbench chrome surface must render scrub controls under
+  `mode=scrub` and drive the master through the `MasterTimeline`
+  transport seam exposed by `createGsapCompositionTimeline({ onMaster })`.
+  The UI must consume `master.beats()` for named beat affordances and
+  must not parse master-label strings locally or touch raw GSAP.
+
+PUL-F017 still remains DRAFT until scrub controls and actual
+monotonic-forward cue gating both land with tests. The acceptance
+bar is no longer "GSAP and audio exist"; it is "the existing GSAP
+adapter and audio service actively enforce the scrub cue contract and
+the existing chrome surface exposes the transport controls."
+
+## Implementation (2026-05-21)
+
+Issue #130 delivers the remaining work; PUL-F017 transitions DRAFT →
+ACTIVE. The integration landed across the existing boundaries with no
+new URL grammar, no new schema, and the resolver still mode-opaque:
+
+- **Scrub run mode** — `src/runtime/timeline.ts`. `positionMaster`
+  treats `headCueGate: 'monotonic-forward'` as a real run mode
+  (`'scrub'`): it seeks the master to the addressed beat (the initial
+  cursor — §Beat semantics) or frame 0 and leaves it held and live
+  for the workbench controls, instead of auto-playing to natural
+  completion. `MasterTimeline` gained `reverse()` for backward
+  playback.
+
+- **Dynamic cue gate** — `src/runtime/audio.ts`. A `CueGate` /
+  `CueGateControl` pair (`createCueGate`) is a dynamic cue-eligibility
+  gate, distinct from the static `AudioOutputPolicy`. The audio
+  service consults it inside `play()` *after* every boundary
+  validation and *before* engine output: an accepted cue is suppressed
+  while the gate is closed, but a malformed cue still fails loud.
+  Gating is scoped to cue *firing* (`play`); `fade` / `stop` /
+  `stopGroup` act on already-playing instances and are not gated.
+
+- **Direction-aware gating** — the GSAP `MasterTimeline` toggles the
+  gate synchronously from its transport methods: `play()` opens it
+  (monotonic forward), `pause()` / `reverse()` close it. GSAP ticks
+  asynchronously, so the gate is always set before any `.call()` cue
+  callback fires for that direction. `seek()` keeps GSAP's default
+  `suppressEvents`, so jump-to-beat / drag-preview / direct seek fire
+  no callbacks and replay no cues.
+
+- **Loader wiring** — `src/runtime/scene-loader.ts` builds one
+  `createCueGate(false)` under `mode=scrub` and shares the single
+  instance between the per-navigation `AudioService` (`cueGate`
+  option) and the timeline adapter (`audioCueGate`, forwarded opaquely
+  through `loadSceneNavigationTarget` → `resolveComposition` → `run`
+  the same way the `presenter` controller is).
+
+- **Scrub controls** — `src/system/chrome/scrub.ts`
+  (`createScrubControls`) is the workbench transport surface: play /
+  pause / reverse, a drag scrubber, an `m:ss` readout, and one
+  jump button per `master.beats()` entry. It drives the master only
+  through the `MasterTimeline` port, never raw GSAP, and never parses
+  master-label strings. `src/main.ts` mounts it into the chrome
+  surface and attaches the master via the `onMaster` hook only under
+  `mode=scrub`.
+
+The `cueGate: 'monotonic-forward'` runner-input hint and the
+loader/bridge/resolver slice-truncation seam from the original PR are
+unchanged; this PR makes them behave.
+
 ## Related ADRs
 
 - [ADR-003](003-gsap-timeline-engine.md) — the timeline runner is
-  the seam through which monotonic-forward cue gating will flow
-  when the GSAP runner lands. Today the runner is a placeholder, so
-  scrub behavior is structurally vacuous.
+  the seam through which monotonic-forward cue gating flows. After
+  ADR-025, the live GSAP adapter is the implementation point for
+  direction-aware scrub transport.
 - [ADR-004](004-howler-audio-engine.md) — audio cues are the
-  consumer of the cue gate. Today there is no audio engine, so the
-  gate has no consumer.
+  consumer of the cue gate. After PUL-F024, the per-navigation
+  `AudioService` is the implementation point for dynamic cue
+  suppression.
 - [ADR-007](007-browser-workbench.md) — defines the eight workbench
   modes and the URL-only-source invariant for mode selection.
   Specifically references `mode=scrub` as the timing/beat-alignment

--- a/docs/design/pul-f017-scrub-mode-preflight.md
+++ b/docs/design/pul-f017-scrub-mode-preflight.md
@@ -2,205 +2,225 @@
 
 PUL-F017 specifies `mode=scrub`: display timeline controls allowing
 the user to scrub forward, backward, and to named beats; audio cues
-SHALL fire only on monotonic forward playback. This is a
-timing-and-beat-alignment-inspection mode for runtime review. It is
-not a presenter transport state, a paused layout-review mode, a
-deterministic visual-regression mode, a screenshot mode, or a new
-scene model.
+SHALL fire only on monotonic forward playback.
 
-ADR-007 already defines `scrub` as a workbench mode. ADR-011 already
-defines the resolver as a lifecycle orchestrator with an injected
-timeline runner. The runner-input shape introduced by ADR-018
-(`repeat`) and extended by ADR-019 (`hold`) is the precedent for
-adding a new head-only optional field; ADR-020 records the
-analogous `cueGate` field for scrub.
+The loader, bridge, resolver, GSAP timeline adapter, Howler-backed
+audio service, and workbench chrome surface now exist. The remaining
+implementation is not another seam-only PR: it must connect the
+existing scrub-mode cue hint to real audio-cue gating and mount a
+workbench-owned transport UI for scrub mode.
 
-## Sandbox note
+## Current State
 
-The codex preflight tool's sandbox failed to write design files
-during this preflight run (`bwrap` setup error), so this document is
-a manual transcription of the preflight tool's returned guardrails
-text plus the architecture decisions that follow from it — same
-handling pattern as `pul-f015-loop-mode-preflight.md` and
-`pul-f016-paused-mode-preflight.md`. The structured decisions are
-recorded in ADR-020.
+- `mode=scrub` is already part of `NAVIGATION_MODES`.
+- The loader already derives `effectiveMode(target) === 'scrub'`
+  and forwards `cueGate: 'monotonic-forward'`.
+- The bridge and loader already truncate scrub composition slices to
+  the addressed head entry while preserving object-form `range` /
+  `behavior` overrides.
+- `CompositionTimelineRunOptions.headCueGate` already reaches the
+  GSAP timeline adapter.
+- `MasterTimeline` already exposes `play`, `pause`, `seek`,
+  `setSpeed`, `time`, `duration`, `labels`, and `beats()`.
+- `createGsapCompositionTimeline({ onMaster })` already exposes the
+  live master as the intended workbench transport seam.
+- `AudioService` already owns `load`, `play`, `fade`, `stop`,
+  `stopGroup`, `mute`, output policy, validation, cleanup, and cue
+  logging for rehearsal.
+- `createDomWorkbenchChrome()` and the L2 chrome slots already mount a
+  persistent workbench-owned chrome surface. Chrome is visible under
+  `scrub` by policy.
+
+Open gap:
+
+- The GSAP adapter still treats `headCueGate` as a no-op. It also
+  auto-plays the master under scrub, which is incompatible with an
+  inspection UI that needs a live, user-driven playhead.
+- The audio service has no dynamic cue gate. Timeline callbacks can
+  still call `ctx.audio.play(...)` during reverse playback or direct
+  seeks.
+- The chrome surface has no scrub transport controls and no named
+  beat jump UI.
 
 ## Boundary
 
-`scrub` selection must reuse the existing navigation path:
+Scrub implementation must stay on the existing runtime path:
 
-- `src/runtime/navigation.ts` owns the `mode` URL grammar and the
-  `NAVIGATION_MODES` allowlist.
-- `effectiveMode()` owns effective mode derivation.
-- `src/runtime/scene-loader.ts` owns per-navigation mode dispatch,
-  `ctx.mode` construction, cancellation, stage diagnostics, and
-  error surfacing. It is also the dispatch point that maps
-  `effectiveMode === 'scrub'` to `cueGate: 'monotonic-forward'`.
-- `src/runtime/scene-navigation.ts` owns target resolution and
-  composition slicing. Its `scene` field is the addressed head
-  scene.
-- `src/runtime/composition-resolver.ts` owns preload → create →
-  timeline → cleanup ordering, abort propagation, and exactly-once
-  cleanup. It must remain mode-opaque; `headCueGate` is plumbed
-  the same way `headBeat`, `headRepeat`, and `headHold` are.
-- The timeline runner owns timeline playhead behavior. Under
-  `mode=scrub` the runner reads `input.cueGate === 'monotonic-forward'`
-  and gates audio-cue firing by direction.
-- The future workbench scrub-controls UI surface (separate PR)
-  owns the forward / backward / named-beat controls. It reads
-  `ctx.mode === 'scrub'` (the seam this PR establishes) and drives
-  the runner's transport API.
-
-Do not add a second route, mode enum, `scrub` boolean, scene schema
-field, manifest flag, local URL parser, or scrub-specific resolver.
-URL input remains the only source of mode selection; `scrub` must
-not be recovered from localStorage, sessionStorage, cookies,
-`history.state`, or prior in-memory navigation state.
+- `src/runtime/navigation.ts` owns URL grammar, `NAVIGATION_MODES`,
+  and `effectiveMode()`. Do not add `scrub=true`, `direction=`,
+  `time=`, or a second parser.
+- `src/runtime/scene-loader.ts` remains the mode dispatch boundary:
+  parser-equivalent `mode` / `beat` validation, one navigation
+  `AbortController`, audio-service construction, chrome dispatch,
+  stage diagnostics, and lifecycle handoff.
+- `src/runtime/scene-navigation.ts` remains the target-resolution and
+  slice-snapshot boundary. Composition validation still runs before
+  truncation.
+- `src/runtime/composition-resolver.ts` remains GSAP-free and
+  mode-opaque. It may forward a narrow adapter option, as it already
+  does for `headBeat`, `headRepeat`, `headHold`, `headCueGate`,
+  `headScreenshot`, and presenter, but it must not implement scrub.
+- `src/runtime/timeline.ts` owns GSAP transport, master playhead
+  state, named beat enumeration, direction/time-crossing detection,
+  and the workbench-facing `MasterTimeline` contract.
+- `src/runtime/audio.ts` owns whether an accepted audio cue produces
+  output or is suppressed. Do not implement cue gating in chrome event
+  handlers or scene modules.
+- `src/runtime/workbench-chrome.ts` / `src/system/chrome/*` own the
+  DOM surface for scrub controls. Scenes must not create, query,
+  retain, or mutate scrub controls.
 
 ## Required Reuse
 
-Implementation must reuse these cross-cutting concerns:
+Build on these canonical incumbents:
 
-- Identifier validation: `src/runtime/identifier.ts`.
-- URL and mode validation: `parseNavigationSearch()` and
-  `NAVIGATION_MODES`.
-- Effective mode derivation: `effectiveMode()`.
-- Scene and composition validation:
-  `assertSceneModule()`, `createSceneRegistry()`,
-  `assertCompositionManifest()`, and `createCompositionRegistry()`.
-- Navigation resolution: `resolveSceneNavigation()` and
-  `loadSceneNavigationTarget()`.
-- Lifecycle orchestration: `resolveComposition()` with injected
-  `createPreloader()` and `runTimeline()` adapters.
-- Asset handling: `createAssetPreloader()` with the existing
-  scheme, redirect, `baseUrl`, and `AbortSignal` rules. Scrub mode
-  does not change preload semantics — the addressed scene's assets
-  must still be loaded before `create(ctx)` runs.
-- Error rendering: `describeError()` plus the existing
-  `data-pulsar-navigation-error` stage diagnostic and `onError`
-  sink.
-- Cancellation and cleanup: one per-navigation `AbortController`,
-  forwarded to preload and timeline adapters; cleanup remains
-  resolver-owned.
-- Slice-truncation helper: the `applySingleSceneSlice` loader-side
-  helper and the `truncateToHead` bridge-level helper introduced
-  for `standalone` (ADR-017) and extended for `loop` (ADR-018) and
-  `paused` (ADR-019) are extended again to fire under `scrub`. The
-  shape transform is shared; the predicate widens.
-- Beat lookup / naming contract: `beat=` under `mode=scrub` is the
-  natural scrub-to-named-beat path PUL-F017's "to named beats"
-  clause anticipates. Reuse the existing PUL-F011 / ADR-015
-  forwarding (`headBeat` / `onBeatMissing`).
+- URL and mode: `parseNavigationSearch()`, `NAVIGATION_MODES`,
+  `NavigationMode`, `effectiveMode()`, and loader
+  `validateModeGrammar()`.
+- Beat naming and validation: `isKebabIdentifier()`,
+  `sceneTimelineLabel()`, `parseSceneTimelineLabel()`,
+  `MasterTimeline.beats()`, `MasterTimeline.labelFor()`, and
+  `MasterTimeline.seek()`. Do not parse namespaced beat strings in the
+  UI.
+- Timeline transport: `MasterTimeline` and
+  `createGsapCompositionTimeline({ onMaster })`. Do not expose raw
+  GSAP timelines to chrome.
+- Audio service: `AudioService`, `createAudioService()`,
+  `AudioOutputPolicy`, `AUDIO_OUTPUT_POLICIES`,
+  `assertSoundDefinition()`, `assertPlayOptions()`,
+  `AudioError` subclasses, `stopGroup()`, and `stopAll()`.
+- Asset and audio-source security: `scene.assets`, `scene.audio`,
+  `collectAudioSources()`, `createAssetPreloader()`,
+  `resolveAssetUrl()`, and `DEFAULT_ALLOWED_SCHEMES`.
+- Lifecycle and cleanup: `loadSceneNavigationTarget()`,
+  `resolveComposition()`, per-navigation `AbortSignal`,
+  `onSceneCleaned`, and resolver cleanup aggregation.
+- Workbench chrome: `createDomWorkbenchChrome()`,
+  `chromeVisibilityFor()`, `mountChromeSlots()`, and the existing
+  `main.ts` bootstrap wiring.
+- Error and observability: `describeError()`,
+  `describeErrorDetailed()`, `formatSceneContext()`,
+  `data-pulsar-navigation-error`, `data-pulsar-scene-target`,
+  `data-pulsar-composition-target`, `data-pulsar-scene-failures`, and
+  loader `onError`.
+- Source-policy gates: PUL-A001 (`ctx.gsap`, no scene GSAP imports),
+  PUL-A002 (`ctx.audio`, no scene Howler / `Audio()`), PUL-Q003
+  (URL-only targeting), PUL-Q004 (resource cleanup), PUL-Q007 (no
+  eval / remote dynamic code), and PUL-Q008 (DOM / accessibility).
 
-## Scope: single-scene only
+## Intended Design
 
-Scrub is **single-scene execution at the addressed head**. PUL-F017's
-"timeline controls" are over ONE timeline; "named beats" are
-scene-scoped per ADR-015. There is no composition-wide scrubbing —
-the runtime has no cross-scene timeline abstraction or transport
-API, and PUL-F017 does not call for one. The user addresses a
-specific scene (directly via `?scene=x&mode=scrub`, or within a
-composition via `?composition=c&scene=x&mode=scrub` /
-`?composition=c&index=N&mode=scrub`) and scrubs that scene's
-timeline. To scrub a different scene in the same composition, the
-user navigates to a fresh URL targeting that scene. The four
-single-scene modes (standalone / loop / paused / scrub) share the
-same slice-truncation transform because they share the same
-structural "no following entries run" promise.
+The scrub UI is a workbench transport surface over the active master
+timeline. It should be wired from `src/main.ts` or another
+workbench-owned bootstrap module by using the existing
+`createGsapCompositionTimeline({ onMaster })` seam and the existing
+chrome surface. The UI reads `master.duration()` and `master.beats()`,
+drives transport through `MasterTimeline` methods, and tears down or
+disables itself when navigation aborts or a new master arrives.
 
-## Scrub Contract
+The runner must treat `headCueGate: 'monotonic-forward'` as a real
+scrub-mode run policy, not just an audio flag. A scrub activation must
+leave the addressed head scene mounted with a live master for user
+inspection instead of auto-playing to completion and letting resolver
+cleanup remove the scene before controls can operate. Implement that
+inside the timeline adapter's run-mode decision, not by parking the
+loader or bypassing cleanup.
 
-Scrub mode means: resolve the addressed scene through the existing
-URL/registry/composition path, preload declared assets, run normal
-`create(ctx)` and `timeline(ctx)`, then hand control of the
-timeline's playhead to the workbench scrub-controls UI surface.
-Audio cues fire only when the user's interaction produces monotonic
-forward time progression; backwards scrub, jump-to-beat, hydration,
-and direct seek do not fire cues.
+Cue gating belongs between GSAP transport and `AudioService`. Prefer a
+narrow audio cue-gate port or a small `AudioService` extension that the
+timeline adapter can toggle based on playhead movement direction. The
+adapter should not receive raw Howler handles or full scene objects.
+The audio service should validate cue calls first and then suppress
+output when the current crossing is not monotonic forward. Suppression
+must not mask malformed sound ids, sprite names, group names, source
+URLs, volume/rate ranges, or disposed-service behavior.
 
-- A direct `scene` target presents that scene's timeline for
-  scrubbing.
-- A `composition` target presents the first scene's timeline;
-  following composition entries do not run.
-- A `composition+scene` or `composition+index` target presents the
-  resolved head scene's timeline, preserving the head entry's
-  `range` / `behavior` overrides; following composition entries do
-  not run.
-- `beat=<label>` under `mode=scrub` IS honored as the initial
-  cursor position. Unlike paused mode (where ADR-019 records "first
-  frame wins"), scrub explicitly names beats as a navigation
-  target ("to named beats"). The initial seek to the beat label
-  is a direct seek, not monotonic forward play, so no cues fire
-  for crossings during that initial seek; subsequent forward
-  scrubbing past those crossings DOES fire cues.
+The required extensibility seam is:
 
-The requirement says timeline controls and audio cues. Do not
-implement scrub by skipping `create(ctx)`, by skipping
-`timeline(ctx)`, or by short-circuiting the lifecycle. Scene setup
-runs normally; the timeline-controls UI and the cue gate are
-runner-side concerns delivered by future PRs alongside ADR-003 /
-ADR-004.
+- timeline: a workbench-safe transport API on `MasterTimeline` for
+  scrub operations and direction-aware cue evaluation;
+- audio: a dynamic cue eligibility gate distinct from static
+  `AudioOutputPolicy`;
+- chrome: a dedicated scrub-controls slot/component under workbench
+  chrome, not scene DOM.
 
-## Required Constraints (preflight guardrails)
+This keeps future variations local: step size, playback speed,
+reverse playback, beat filtering, compact controls, or additional cue
+gate modes extend these seams rather than URL grammar, scene schema,
+composition manifests, or resolver workflow.
 
-These are binding unless they are clearly wrong:
+## Cross-Cutting Layers
 
-- Treat `mode=scrub` as a browser workbench/runtime mode under
-  ADR-007, not a new authoring workflow.
-- Scrub controls are UI over the existing timeline/beat/cue model.
-  Do not create duplicate beat, marker, cue, or mode schemas.
-- Audio cue eligibility belongs in the existing playback/cue
-  scheduling layer (when ADR-004 lands), not in timeline control
-  components.
-- Cues fire only for normalized monotonic forward playback
-  intervals. Reverse scrub, direct seek, jump-to-beat, drag
-  preview, hydration, and resync must be silent.
-- Scrub state is transient runtime state. Do not persist cursor,
-  hover, selected beat, or inspection direction into authored
-  performance data.
-
-## Cross-Cutting Concerns To Reuse
-
-- Existing `mode` parsing/routing/validation for `mode=scrub`.
-- Existing timeline duration/time normalization and boundary
-  clamping (when ADR-003's GSAP runner lands).
-- Existing beat lookup/naming contract for named beat navigation.
-- Existing playback clock/state machine and cue scheduler/audio
-  service (when ADR-003 / ADR-004 land).
-- Existing browser-safe error handling for invalid beat targets,
-  invalid time values, and unavailable audio.
-- Existing logging/observability conventions; avoid high-volume
-  pointer-move logs.
-- Existing frontend test harness for controls and playback
-  behavior.
-- Repo workflow: update `CHANGELOG.md` only when source changes,
-  and create IMPLEMENTS/TESTS traceability links only after
-  implementation satisfies PUL-F017.
+| Layer | Guardrail |
+|-------|-----------|
+| URL grammar | `mode=scrub` and optional `beat=` keep flowing through `parseNavigationSearch()`. Unknown modes, repeated keys, malformed beat ids, and invalid locator shapes keep failing through the existing grammar envelope. |
+| Programmatic target defense | Hand-built targets still pass loader `validateModeGrammar()` / `validateBeatGrammar()` before reaching chrome, audio, or timeline code. |
+| Target resolution | `resolveSceneNavigation()` still validates composition existence, member scenes, ambiguity, empty manifests, and indexes before single-scene truncation. No direct-scene fallback. |
+| Scene/composition schemas | No `scrub`, `beats`, `markers`, `cueGate`, `controls`, or transport fields on `SceneModule` or composition manifests. GSAP labels remain the beat source of truth. |
+| Timeline validation | Scene timelines still pass `assertSceneTimeline()`; beat labels are kebab-case and finite. UI times pass through `MasterTimeline.seek()` / speed validation, not direct GSAP mutation. |
+| Audio validation | `AudioService.load()` / `play()` / `fade()` / `stop()` / `stopGroup()` keep existing shape, id, sprite, group, source, and range validation. Cue suppression is post-validation and pre-output. |
+| Asset security | Audio source URLs still come from `scene.audio` and `scene.assets`, pass `resolveAssetUrl()` / `DEFAULT_ALLOWED_SCHEMES`, and are preloaded with the navigation `AbortSignal`. Scrub controls must not turn URL params or beat labels into fetches/imports. |
+| Lifecycle / cleanup | One navigation signal still drives preloader, timeline adapter, audio service, presenter controller, prompter disposal, and cleanup. Scrub pause/play/reverse/seek is transport state, not navigation abort. |
+| Chrome / DOM | Controls live under workbench chrome. Hidden chrome uses the existing chrome policy. Controls must not re-parent `#stage`, remove scene nodes, trap focus when hidden, or let scene cleanup remove chrome. |
+| Error envelope | Use existing `onError` and stage diagnostics. Public messages may include ids, beat names, mode, bounded numeric times, and operation names. Never serialize raw scene objects, DOM nodes, GSAP objects, Howler handles, source URLs with credentials, headers, cookies, env, argv, stacks, or raw `cause`. |
+| Source policy | Existing scans must still pass: scenes do not import GSAP/Howler or construct audio elements; runtime does not use eval/remote dynamic imports or persisted state for target selection. |
+| OS/config exposure | Scrub cursor, direction, selected beat, audio gate state, and target state are transient in-memory runtime state. Do not write them to env, process argv, browser storage, cookies, files, or shell commands. |
+| Observability | Avoid per-frame and pointer-move logs. If diagnostics are needed, log bounded state transitions or rejected inputs through existing sinks only. |
 
 ## Gotchas And Anti-Patterns
 
-- Do not fire cues from React/component event handlers (when a
-  controls UI lands).
-- Do not scatter `if (mode === 'scrub')` cue suppression across
-  unrelated code.
-- Do not treat beat labels as separate UI-only data.
-- Do not replay skipped cues after a seek or beat jump.
-- Do not rebuild the audio graph on every scrub movement (when
-  ADR-004 lands).
-- Use epsilon-aware time comparisons when the GSAP runner lands;
-  floating point jitter must not create duplicate cue fires.
-- Throttle pointer-driven timeline updates through existing UI
-  patterns to avoid render storms (when a controls UI lands).
+- Auto-playing scrub mode to completion before the user can interact.
+- Implementing controls by mutating raw GSAP timelines from DOM event
+  handlers.
+- Exposing full `AudioService` or Howler handles to chrome when a
+  narrow cue-gate port is enough.
+- Implementing monotonic-forward gating as master mute, `outputPolicy:
+  'silent'`, or a per-scene `if (ctx.mode === 'scrub')` branch.
+- Suppressing audio before validation, which would hide malformed
+  scene cue calls.
+- Treating direct seek, hydration, jump-to-beat, drag preview, or
+  reverse playback as forward cue crossings.
+- Replaying skipped cues after a seek or beat jump.
+- Parsing beat label strings in chrome instead of using
+  `master.beats()` / `labelFor()` / `seek()`.
+- Adding duplicate schemas, DTOs, exception families, validators,
+  routers, storage keys, or generic mode-policy abstractions.
+- Reusing lower-third / prompter / practice UI slots in a way that
+  makes scrub controls collide with existing chrome content. Add a
+  named workbench transport slot if the existing slots are not a clean
+  fit.
+- Creating high-frequency `onError` or console output during pointer
+  scrubbing.
 
-## Non-Goals And Boundaries
+## Tests And Workflow
 
-- No new persistence format.
-- No new timeline, beat, cue, exception, validation, or workflow
-  abstraction unless existing contracts are genuinely absent.
-- No authoring/editing of beats or cues.
-- No production analytics expansion unless the project already has
-  safe telemetry for comparable playback events.
-- No timeline-controls UI in this PR — that surface ships with
-  ADR-003's GSAP runner and a transport API on the runner.
-- No real audio cue gating in this PR — that ships with ADR-004's
-  audio engine.
+Source changes should add a Towncrier fragment; docs-only preflight
+changes do not need one. PUL-F017 should move DRAFT -> ACTIVE only
+after all behavior is implemented and IMPLEMENTS / TESTS traceability
+links exist.
+
+Required behavioral coverage for implementation:
+
+- loader/bridge/resolver seam tests remain green for head-only
+  `cueGate`, slice truncation, key-presence semantics, `beat`
+  forwarding, and missing-beat diagnostics;
+- timeline tests prove the scrub run mode keeps the scene mounted for
+  controls and exposes beats through the master;
+- audio/timeline tests prove a cue at master time `T` fires when the
+  playhead crosses `T` monotonically forward and does not fire on
+  reverse crossing, direct seek, hydration, or jump-to-beat;
+- chrome or browser tests prove controls appear only under
+  `mode=scrub`, can scrub forward/backward, and can jump to named
+  beats without overlapping existing chrome.
+
+## Non-Goals
+
+- No new URL grammar, router, storage format, environment binding,
+  CLI flag, auth surface, telemetry stream, or persistence.
+- No scene authoring/editing UI for beats or cues.
+- No duplicate beat metadata or cue schema.
+- No raw GSAP or Howler exposure to scenes or chrome.
+- No resolver-owned scrub logic and no second lifecycle.
+- No composition-wide scrub transport beyond the already-addressed
+  head-scene slice. Cross-scene/windowed scrubbing needs a separate
+  requirement because it changes lifecycle ownership.

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,6 +33,7 @@ import {
   PULSAR_NAVIGATE_ERROR_EVENT_TYPE,
   PULSAR_NAVIGATE_EVENT_TYPE,
   bootstrapNavigation,
+  effectiveMode,
 } from './runtime/navigation';
 import type { PrompterRenderer } from './runtime/prompter';
 import { createSceneRegistry } from './runtime/registry';
@@ -45,7 +46,12 @@ import './system/register/tokens.css';
 import './system/chrome/atmospheric.css';
 import './system/chrome/chrome.css';
 import './system/templates/templates.css';
-import { type ChromeSlots, mountChromeSlots } from './system/chrome';
+import {
+  type ChromeSlots,
+  type ScrubControlsHandle,
+  createScrubControls,
+  mountChromeSlots,
+} from './system/chrome';
 import {
   type PracticeRendererHandle,
   type PresenterBridgeHandle,
@@ -165,10 +171,26 @@ transitionOverlay.style.opacity = '0';
 transitionOverlay.style.display = 'none';
 document.body.appendChild(transitionOverlay);
 
+// PUL-F017 / ADR-020: the workbench scrub controls. Built after the
+// chrome surface is mounted (below); declared here so the timeline
+// adapter's `onMaster` hook can attach the live master to them. The
+// controls are revealed only under `mode=scrub` — `scrubMode` is
+// re-derived from the URL on every navigation (`onNavigate`), so a
+// non-scrub navigation never surfaces the transport bar.
+let scrubControls: ScrubControlsHandle | undefined;
+let scrubMode = false;
+
 const timeline = createGsapCompositionTimeline({
   engine: timelineEngine,
   transitions: defaultTransitions(),
   transitionOverlay,
+  // The composition timeline adapter reports the live master once per
+  // activation. Under `mode=scrub` the master is held live for the
+  // scrub controls to drive (PUL-F017 / ADR-020); every other mode
+  // ignores the hook.
+  onMaster: (master) => {
+    if (scrubMode) scrubControls?.attach(master);
+  },
 });
 
 // Scene context carries the stage handle, the per-navigation effective
@@ -323,7 +345,22 @@ if (chromeSurfaceEl !== null) {
     surface: chromeSurfaceEl,
     ownerDocument: document,
   });
+  // PUL-F017 / ADR-020: mount the scrub transport controls into the
+  // chrome surface AFTER the slot DOM (`mountChromeSlots` clears the
+  // surface, so it must run first). The controls stay hidden until a
+  // `mode=scrub` navigation attaches a master.
+  scrubControls = createScrubControls({
+    ownerDocument: document,
+    parent: chromeSurfaceEl,
+  });
 }
+
+// PUL-F017 / ADR-020: drive the scrub readout off the GSAP ticker so
+// the scrubber thumb and time display track playback. `sync()` is a
+// no-op when the controls are hidden / detached, so this is inert
+// outside `mode=scrub`.
+const syncScrubControls = (): void => scrubControls?.sync();
+timelineEngine.gsap.ticker.add(syncScrubControls);
 
 // Pulsar L2 keyboard presenter source. Arrows / Space / P / M / Escape.
 // `onHome` navigates to the default composition; `bootstrapNavigation`
@@ -398,9 +435,18 @@ const loader = createSceneLoader({
 
 const onNavigate = (event: Event): void => {
   const target = (event as CustomEvent<NavigationTarget>).detail;
+  // PUL-F017 / ADR-020: re-derive scrub mode from the URL (the only
+  // source of mode — ADR-007) and detach the controls from any prior
+  // master. A successful `mode=scrub` activation re-attaches via the
+  // timeline adapter's `onMaster` hook; every other navigation leaves
+  // the controls hidden.
+  scrubMode = effectiveMode(target) === 'scrub';
+  scrubControls?.detach();
   void loader.handle(target);
 };
 const onNavigateError = (event: Event): void => {
+  scrubMode = false;
+  scrubControls?.detach();
   loader.handleError((event as CustomEvent<Error>).detail);
 };
 
@@ -435,4 +481,9 @@ import.meta.hot?.dispose(() => {
   // so HMR re-evaluation does not stack duplicates.
   stageObserver?.disconnect();
   practiceRenderer?.dispose();
+  // PUL-F017 / ADR-020: drop the scrub controls + their ticker sync so
+  // HMR re-evaluation does not accumulate transport bars or ticker
+  // callbacks.
+  timelineEngine.gsap.ticker.remove(syncScrubControls);
+  scrubControls?.dispose();
 });

--- a/src/runtime/audio.ts
+++ b/src/runtime/audio.ts
@@ -563,6 +563,57 @@ export interface AudioBedDeclaration {
   readonly volume?: number;
 }
 
+/* ------------------------------------------------------------------ *
+ *  Dynamic cue eligibility gate (PUL-F017 / ADR-020)
+ * ------------------------------------------------------------------ */
+
+/**
+ * Read-only view of the dynamic audio cue-eligibility gate (PUL-F017 /
+ * ADR-020). The audio service consults {@link isEligible} after a cue
+ * has passed every boundary check and before it reaches the engine: a
+ * closed gate suppresses the cue's audible output without masking a
+ * malformed cue.
+ *
+ * The gate is deliberately distinct from the static
+ * {@link AudioOutputPolicy}: `silent` / `log-cues` are a per-navigation
+ * contract decided at construction, whereas the cue gate is toggled
+ * *during* a navigation by playhead movement direction — a `scrub`-mode
+ * master that plays backwards closes the gate so cues do not re-fire on
+ * reverse playback, and re-opens it on monotonic forward playback.
+ */
+export interface CueGate {
+  /** Whether audio cues are currently eligible to produce output. */
+  isEligible(): boolean;
+}
+
+/**
+ * Controllable {@link CueGate}. The GSAP timeline adapter holds this
+ * side and toggles eligibility from its transport methods so the
+ * decision of *when* to gate stays in one place (the runner that owns
+ * playhead direction) — never in chrome event handlers or scene
+ * modules. Scenes receive the {@link AudioService}, never this control.
+ */
+export interface CueGateControl extends CueGate {
+  /** Open (`true`) or close (`false`) the gate. */
+  setEligible(eligible: boolean): void;
+}
+
+/**
+ * Build a {@link CueGateControl}. Eligible by default; pass
+ * `initialEligible: false` for a `scrub`-mode master, which starts
+ * paused (not playing monotonically forward) so its cues are ineligible
+ * until the user presses play.
+ */
+export function createCueGate(initialEligible = true): CueGateControl {
+  let eligible = initialEligible;
+  return {
+    isEligible: () => eligible,
+    setEligible: (next) => {
+      eligible = next;
+    },
+  };
+}
+
 /** Construction options for {@link createAudioService}. */
 export interface AudioServiceOptions {
   /**
@@ -623,6 +674,17 @@ export interface AudioServiceOptions {
    * {@link AudioOutputPolicy} `'silent'`.
    */
   readonly bedSuppressed?: boolean;
+  /**
+   * Dynamic cue-eligibility gate (PUL-F017 / ADR-020). When supplied,
+   * {@link AudioService.play} suppresses a cue's audible output
+   * (post-validation) whenever {@link CueGate.isEligible} returns
+   * `false`. The scene loader wires this for `mode=scrub` and the GSAP
+   * timeline adapter toggles it by playhead direction, so "audio cues
+   * fire only on monotonic forward playback" holds. Omit it for every
+   * other navigation — an absent gate means cues are always eligible,
+   * so non-scrub playback is unchanged.
+   */
+  readonly cueGate?: CueGate;
 }
 
 /**
@@ -1058,6 +1120,10 @@ export function createAudioService(
   const onError = options.onError ?? ((): void => undefined);
   const onCue = options.onCue;
   const allowed = options.allowedSources === undefined ? null : new Set(options.allowedSources);
+  // PUL-F017 / ADR-020: the dynamic cue-eligibility gate. Absent for
+  // every navigation except `mode=scrub`; an absent gate means cues
+  // are always eligible, so non-scrub playback is unchanged.
+  const cueGate = options.cueGate;
 
   const sounds = new Map<string, RegisteredSound>();
   const groups = new Map<string, GroupedPlay[]>();
@@ -1309,6 +1375,13 @@ export function createAudioService(
       }
       if (opts.group !== undefined) assertGroupName(opts.group);
       if (opts.volume !== undefined) assertGain(opts.volume, 'volume');
+      // PUL-F017 / ADR-020: cue gate. Checked AFTER every boundary
+      // validation above (a malformed cue still fails loud) and BEFORE
+      // any engine output / group bookkeeping / cue-log emit. A closed
+      // gate means the master is not playing monotonically forward
+      // (reverse playback, paused) so this accepted cue produces no
+      // sound — "audio cues fire only on monotonic forward playback".
+      if (cueGate !== undefined && !cueGate.isEligible()) return;
       const playId = sound.handle.play(opts.sprite);
       if (opts.loop === true) sound.handle.loop(true, playId);
       if (opts.volume !== undefined) sound.handle.volume(opts.volume, playId);

--- a/src/runtime/composition-resolver.ts
+++ b/src/runtime/composition-resolver.ts
@@ -64,6 +64,7 @@
 //    adapter, which resolves (does not throw) on abort so the cleanup
 //    phase always runs.
 
+import type { CueGateControl } from './audio';
 import {
   type BehaviorOverride,
   type CompositionManifest,
@@ -157,13 +158,22 @@ export interface CompositionTimelineRunOptions {
    */
   readonly headHold?: 'first-frame';
   /**
-   * URL scrub hint (PUL-F017 / ADR-020): forwarded, but the timeline
-   * adapter does not yet gate audio cues against it — the PUL-F024 audio
-   * service exists, but timeline-callback cue gating is a follow-up;
-   * scenes fire their own `ctx.audio` cues from their timeline callbacks
-   * today.
+   * URL scrub hint (PUL-F017 / ADR-020): the adapter runs the head
+   * scene under the interactive scrub run mode — the master is left
+   * mounted and live (held, not auto-played to completion) so the
+   * workbench scrub controls can drive it, and audio-cue firing is
+   * gated to monotonic forward playback via {@link audioCueGate}.
    */
   readonly headCueGate?: 'monotonic-forward';
+  /**
+   * Dynamic audio cue-eligibility gate (PUL-F017 / ADR-020). Paired
+   * with {@link headCueGate}: the adapter toggles it `false` whenever
+   * the scrub master is paused or playing in reverse and `true` on
+   * monotonic forward playback, so the per-navigation audio service
+   * suppresses cues that are not produced by forward playback.
+   * Forwarded opaquely — the resolver does not interpret it (ADR-011).
+   */
+  readonly audioCueGate?: CueGateControl;
   /**
    * URL screenshot hint (PUL-F018 / ADR-021): the adapter freezes the
    * master at the addressed beat (or frame 0).
@@ -308,6 +318,8 @@ export interface ResolveCompositionOptions {
   readonly headHold?: 'first-frame';
   /** URL scrub hint (PUL-F017 / ADR-020). */
   readonly headCueGate?: 'monotonic-forward';
+  /** Dynamic audio cue-eligibility gate paired with {@link headCueGate} (PUL-F017 / ADR-020). */
+  readonly audioCueGate?: CueGateControl;
   /** URL screenshot hint (PUL-F018 / ADR-021). */
   readonly headScreenshot?: 'capture';
   /** Present-mode presenter command controller (PUL-F020 / ADR-023). */
@@ -807,6 +819,7 @@ function buildRunOptions(options: ResolveCompositionOptions): CompositionTimelin
   if (options.headRepeat !== undefined) opts.headRepeat = options.headRepeat;
   if (options.headHold !== undefined) opts.headHold = options.headHold;
   if (options.headCueGate !== undefined) opts.headCueGate = options.headCueGate;
+  if (options.audioCueGate !== undefined) opts.audioCueGate = options.audioCueGate;
   if (options.headScreenshot !== undefined) opts.headScreenshot = options.headScreenshot;
   if (options.presenter !== undefined) {
     opts.presenter = options.presenter;

--- a/src/runtime/scene-loader.ts
+++ b/src/runtime/scene-loader.ts
@@ -34,7 +34,9 @@ import {
   type AudioEngine,
   type AudioOutputPolicy,
   type AudioService,
+  type CueGateControl,
   createAudioService,
+  createCueGate,
   noopAudioEngine,
 } from './audio';
 import type { CompositionRegistry } from './composition-registry';
@@ -1170,6 +1172,16 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
     // rollback-then-surfaceError pattern so a throwing builder does
     // not leave stale stage attrs or skip the queue's error sink.
     const outputPolicy = audioOutputPolicyFor(mode);
+    // PUL-F017 / ADR-020: under `mode=scrub` build the dynamic audio
+    // cue gate ONCE and share the single instance between the audio
+    // service (which consults `isEligible()` to suppress a cue's
+    // output) and the timeline adapter (which toggles it by playhead
+    // direction). It starts closed — a scrub master is held at its
+    // cursor, not playing monotonically forward — and the GSAP adapter
+    // opens it on `play()`. Absent for every other mode, so non-scrub
+    // navigations build an ungated audio service exactly as before.
+    const audioCueGate: CueGateControl | undefined =
+      mode === 'scrub' ? createCueGate(false) : undefined;
     // issue #99: the loader threads a per-occurrence ctx factory rather
     // than a single ctx. `buildCtx` builds the navigation-scoped base
     // (stage / gsap / audio / mode / presenter / chrome) once; the
@@ -1202,6 +1214,9 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
           ? {}
           : { bed: resolved.composition.audioBed }),
         bedSuppressed: mode === 'standalone',
+        // PUL-F017 / ADR-020: the shared cue gate (scrub only). The
+        // audio service consults it; the timeline adapter toggles it.
+        ...(audioCueGate === undefined ? {} : { cueGate: audioCueGate }),
       });
       const pipe = buildPresenterPipe(mode, controller, audio);
       presenter = pipe.presenter;
@@ -1307,6 +1322,9 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
         ...(repeat === undefined ? {} : { repeat }),
         ...(hold === undefined ? {} : { hold }),
         ...(cueGate === undefined ? {} : { cueGate }),
+        // PUL-F017 / ADR-020: the same gate handed to the audio service
+        // above — the timeline adapter toggles it by playhead direction.
+        ...(audioCueGate === undefined ? {} : { audioCueGate }),
         ...(screenshot === undefined ? {} : { screenshot }),
         // Forward `presenter` AND the `onError` sink so the
         // resolver's per-scene wrapper around `presenter` can

--- a/src/runtime/scene-navigation.ts
+++ b/src/runtime/scene-navigation.ts
@@ -25,7 +25,7 @@
 //  - ADR-011 — composition resolver as pure orchestrator with
 //    injected adapters; reused via `loadSceneNavigationTarget`.
 
-import type { AudioBedDeclaration } from './audio';
+import type { AudioBedDeclaration, CueGateControl } from './audio';
 import {
   type CompositionEntry,
   type CompositionManifest,
@@ -202,6 +202,15 @@ export interface LoadSceneNavigationTargetOptions {
    * parameter.
    */
   readonly cueGate?: 'monotonic-forward';
+  /**
+   * Dynamic audio cue-eligibility gate (PUL-F017 / ADR-020) paired with
+   * {@link cueGate}. Forwarded to {@link resolveComposition} as
+   * `audioCueGate`; the GSAP timeline adapter toggles it by playhead
+   * direction so the per-navigation audio service suppresses cues that
+   * are not produced by monotonic forward playback. Absent when the
+   * navigation target had no `mode=scrub` parameter.
+   */
+  readonly audioCueGate?: CueGateControl;
   /**
    * URL screenshot-mode capture-bundle hint (PUL-F018 / ADR-021) the
    * runner uses to decide whether to render the addressed scene at
@@ -715,6 +724,7 @@ function buildResolverOptions(
     ...(options.repeat === undefined ? {} : { headRepeat: options.repeat }),
     ...(options.hold === undefined ? {} : { headHold: options.hold }),
     ...(options.cueGate === undefined ? {} : { headCueGate: options.cueGate }),
+    ...(options.audioCueGate === undefined ? {} : { audioCueGate: options.audioCueGate }),
     ...(options.screenshot === undefined ? {} : { headScreenshot: options.screenshot }),
     ...presenterPair,
     ...(options.onSceneCleaned === undefined ? {} : { onSceneCleaned: options.onSceneCleaned }),

--- a/src/runtime/timeline.ts
+++ b/src/runtime/timeline.ts
@@ -63,6 +63,7 @@
 //    transport API.
 
 import { gsap } from 'gsap';
+import type { CueGateControl } from './audio';
 import type {
   CompositionTimelineAdapter,
   CompositionTimelineRunOptions,
@@ -272,8 +273,15 @@ export interface MasterBeat {
  * timeline directly.
  */
 export interface MasterTimeline {
-  /** Resume (or start) playback from the current playhead. */
+  /** Resume (or start) monotonic forward playback from the current playhead. */
   play(): void;
+  /**
+   * Play backward from the current playhead (PUL-F017 / ADR-020). The
+   * `scrub`-mode transport surface uses this for the "scrub backward"
+   * affordance; the adapter treats reverse playback as non-monotonic,
+   * so audio cues crossed in reverse do not fire.
+   */
+  reverse(): void;
   /** Pause at the current playhead. */
   pause(): void;
   /** Whether playback is currently paused. */
@@ -343,16 +351,35 @@ const validateRepeat = (count: number): void => {
 
 class GsapMasterTimeline implements MasterTimeline {
   readonly #tl: GsapTimeline;
+  /**
+   * Dynamic audio cue gate (PUL-F017 / ADR-020). Present only for a
+   * `scrub`-mode master; the transport methods toggle eligibility so
+   * cues fire only on monotonic forward playback. Absent for every
+   * other run mode — `#cueGate?.setEligible(...)` is then a no-op.
+   */
+  readonly #cueGate: CueGateControl | undefined;
 
-  constructor(tl: GsapTimeline) {
+  constructor(tl: GsapTimeline, cueGate?: CueGateControl) {
     this.#tl = tl;
+    this.#cueGate = cueGate;
   }
 
   play(): void {
+    // Monotonic forward playback — cues crossed forward are eligible.
+    this.#cueGate?.setEligible(true);
     this.#tl.play();
   }
 
+  reverse(): void {
+    // Reverse playback is not monotonic forward — close the gate so a
+    // cue crossed backward does not fire (PUL-F017 / ADR-020).
+    this.#cueGate?.setEligible(false);
+    this.#tl.reverse();
+  }
+
   pause(): void {
+    // A paused master is not playing forward — close the gate.
+    this.#cueGate?.setEligible(false);
     this.#tl.pause();
   }
 
@@ -555,6 +582,13 @@ export interface ComposeMasterTimelineOptions {
   readonly transitions?: TransitionRegistry;
   /** Optional overlay element the registered transitions may mutate. */
   readonly transitionOverlay?: HTMLElement | null;
+  /**
+   * Dynamic audio cue gate (PUL-F017 / ADR-020). Supplied only for a
+   * `scrub`-mode master; the resulting {@link MasterTimeline}'s
+   * transport methods toggle it so audio cues fire only on monotonic
+   * forward playback. Absent for every other run mode.
+   */
+  readonly audioCueGate?: CueGateControl;
 }
 
 /**
@@ -623,7 +657,7 @@ export function composeMasterTimeline(
       }
       segmentIndex++;
     }
-    return new GsapMasterTimeline(master);
+    return new GsapMasterTimeline(master, options.audioCueGate);
   } catch (err) {
     master?.kill();
     for (const segment of segments) {
@@ -692,8 +726,11 @@ function resolveHeadBeatLabel(
  *    `headScreenshot`).
  *  - `'loop'` — plays, repeating forever; never completes (`headRepeat`).
  *  - `'play'` — plays once and reaches its natural end.
+ *  - `'scrub'` — left mounted and live, paused at the initial cursor;
+ *    never auto-completes (`headCueGate`). The workbench scrub controls
+ *    drive playback; the run resolves only on navigation abort.
  */
-type MasterRunMode = 'hold' | 'loop' | 'play';
+type MasterRunMode = 'hold' | 'loop' | 'play' | 'scrub';
 
 /**
  * Apply the URL/runner-input head hints to the freshly-composed master
@@ -710,10 +747,12 @@ type MasterRunMode = 'hold' | 'loop' | 'play';
  *    frame 0), then play forward. → `'play'`.
  *  - `headRepeat: 'until-aborted'` (PUL-F015 / ADR-018): loop the master
  *    forever. → `'loop'`.
- *  - `headCueGate: 'monotonic-forward'` (PUL-F017 / ADR-020): no effect
- *    here yet — the PUL-F024 audio service exists (`ctx.audio`), but
- *    timeline-callback cue gating is a separate follow-up; scenes fire
- *    their own `ctx.audio` cues from their timeline callbacks today.
+ *  - `headCueGate: 'monotonic-forward'` (PUL-F017 / ADR-020): the scrub
+ *    run mode. Seek to the addressed beat (the initial cursor — ADR-020
+ *    §Beat semantics) or frame 0, then hold the master live so the
+ *    workbench scrub controls can drive it. The initial seek is a
+ *    direct seek, not monotonic forward play, so no cue fires for it.
+ *    → `'scrub'`.
  *  - default: → `'play'`.
  */
 function positionMaster(
@@ -731,6 +770,11 @@ function positionMaster(
     master.seek(beatLabel ?? 0);
     master.pause();
     return 'hold';
+  }
+  if (opts.headCueGate === 'monotonic-forward') {
+    master.seek(beatLabel ?? 0);
+    master.pause();
+    return 'scrub';
   }
   if (beatLabel !== undefined) {
     master.seek(beatLabel);
@@ -867,9 +911,12 @@ function applyPresenterCommandToMaster(
  *  - `'loop'`: start (infinite) playback; only abort resolves it. With
  *    no signal there is nothing to wait for, so resolve immediately —
  *    a loop cannot be observed without cancellation.
- *  - `'hold'`: the master is already paused; only abort resolves it.
- *    With no signal, resolve immediately — the held frame has been
- *    rendered.
+ *  - `'hold'` / `'scrub'`: the master is already paused; only abort
+ *    resolves it. With no signal, resolve immediately — the held frame
+ *    has been rendered. Under `'scrub'` the master is additionally left
+ *    live for the workbench scrub controls to drive between now and
+ *    abort; the run does not arm a completion handler, so playing the
+ *    scrub master to its natural end does not tear the scene down.
  */
 function runMasterUntilDone(
   master: MasterTimeline,
@@ -952,6 +999,13 @@ export function createGsapCompositionTimeline(
         if (transitionOverlay !== undefined) {
           (composeOpts as { transitionOverlay?: HTMLElement | null }).transitionOverlay =
             transitionOverlay;
+        }
+        // PUL-F017 / ADR-020: wire the dynamic audio cue gate into the
+        // master ONLY under the scrub run mode. Outside scrub the gate
+        // is never wired, so a normal play-through master's transport
+        // never toggles cue eligibility.
+        if (opts.headCueGate === 'monotonic-forward' && opts.audioCueGate !== undefined) {
+          (composeOpts as { audioCueGate?: CueGateControl }).audioCueGate = opts.audioCueGate;
         }
         master = composeMasterTimeline(engine, segments, composeOpts);
         mode = positionMaster(master, segments[0]?.id, opts);

--- a/src/scenes/scrub-fixture.ts
+++ b/src/scenes/scrub-fixture.ts
@@ -1,0 +1,111 @@
+// PUL-F017 / ADR-020 — scrub verification fixture scene.
+//
+// PUL-F017: "In `mode=scrub`, the runtime SHALL display timeline
+// controls allowing the user to scrub forward, backward, and to named
+// beats. Audio cues SHALL fire only on monotonic forward playback."
+//
+// The scrub run mode and cue gating are shipped — `positionMaster()` in
+// `src/runtime/timeline.ts` leaves the master held and live under
+// `headCueGate`, and the GSAP adapter toggles the audio cue gate by
+// playhead direction. The workbench scrub controls
+// (`src/system/chrome/scrub.ts`) drive that master. What those
+// implementations lacked was an *observable* scrub-acceptance signal in
+// a real browser engine.
+//
+// This fixture gives scrub mode a *progress* observable plus a *named
+// beat* so the transport controls have something to scrub and a beat
+// affordance to render:
+//
+//   1. `create(ctx)` mounts a `<div data-pulsar-scrub-target>` under
+//      the workbench stage, with `data-pulsar-scrub-progress` starting
+//      at `"0"` (mounted, held at frame 0).
+//   2. `timeline(ctx)` returns a GSAP timeline whose single tween moves
+//      a numeric `progress` object from `0` to `100`; its `onUpdate`
+//      callback writes `Math.round(progress.value)` onto the same
+//      element's `data-pulsar-scrub-progress`. The timeline carries a
+//      kebab-case label `midpoint`, so `MasterTimeline.beats()` exposes
+//      one named beat and the scrub controls render one jump button.
+//      Under `mode=scrub` the master is held (PUL-F017 / ADR-020), so
+//      the attribute stays `"0"` until the user presses play; reverse
+//      playback walks it back down.
+//   3. `cleanup(ctx)` removes the fixture element entirely.
+//
+// The Playwright spec at `tests-e2e/scrub-mode.spec.ts` boots this
+// scene under `mode=scrub`, asserts the scrub controls surface appears,
+// drives play / reverse / beat-jump, and watches
+// `data-pulsar-scrub-progress` respond — proving the controls drive a
+// real GSAP master in a real browser engine.
+//
+// The `progress` object is a closure local to `timeline(ctx)`: the
+// resolver calls `timeline(ctx)` once per navigation, so a fresh
+// navigation starts a fresh tween from `0`.
+//
+// The ctx validation and DOM mount/find/remove scaffolding is shared
+// with the browser-support, loop, and paused fixtures via
+// `./fixture-support.ts`. Scope intentionally narrow: no declared
+// assets, no declared audio. The scene is `standalone: true` — it does
+// not assume surrounding composition context. `trailerSafe: false` —
+// it has nothing trailer-worthy to show.
+
+import type { SceneModule } from '../runtime/scene';
+import {
+  findFixtureElement,
+  isFixtureCtx,
+  mountFixtureElement,
+  removeFixtureElement,
+} from './fixture-support';
+
+const FIXTURE_TARGET_ATTR = 'data-pulsar-scrub-target';
+const FIXTURE_PROGRESS_ATTR = 'data-pulsar-scrub-progress';
+const FIXTURE_DURATION_SECONDS = 0.6;
+
+export const scrubFixtureScene: SceneModule = {
+  id: 'scrub-fixture',
+  title: 'Scrub verification fixture',
+  duration: null,
+  tags: ['fixture', 'scrub'],
+  assets: [],
+  captions: [],
+  audio: [],
+  defaultNext: null,
+  standalone: true,
+  trailerSafe: false,
+  // The element starts at progress 0 — "mounted, held at first frame" —
+  // so a Playwright poll can distinguish a held master from one the
+  // scrub controls have started advancing.
+  create: (ctx: unknown) => {
+    mountFixtureElement(ctx, FIXTURE_TARGET_ATTR, [[FIXTURE_PROGRESS_ATTR, '0']]);
+  },
+  timeline: (ctx: unknown) => {
+    if (!isFixtureCtx(ctx)) return null;
+    const stage = ctx.stage;
+    if (stage === null) return null;
+    const el = findFixtureElement(stage, FIXTURE_TARGET_ATTR);
+    if (el === null) return null;
+    // Build a real GSAP timeline through `ctx.gsap`. The single tween
+    // would move `progress.value` from 0 to 100 over the fixture
+    // duration; `onUpdate` projects the current value onto
+    // `data-pulsar-scrub-progress`. Under `mode=scrub` the master is
+    // held (PUL-F017 / ADR-020), so the attribute stays `"0"` until the
+    // scrub controls play it forward — and walks back down under
+    // reverse playback. A linear ease keeps the projected value a
+    // faithful read of how far the timeline progressed. The `midpoint`
+    // label is a kebab-case beat (ADR-026), so the scrub controls
+    // render exactly one named-beat jump button.
+    const progress = { value: 0 };
+    const tl = ctx.gsap.timeline();
+    tl.to(progress, {
+      value: 100,
+      duration: FIXTURE_DURATION_SECONDS,
+      ease: 'none',
+      onUpdate: () => {
+        el.setAttribute(FIXTURE_PROGRESS_ATTR, String(Math.round(progress.value)));
+      },
+    });
+    tl.addLabel('midpoint', FIXTURE_DURATION_SECONDS / 2);
+    return tl;
+  },
+  cleanup: (ctx: unknown) => {
+    removeFixtureElement(ctx, FIXTURE_TARGET_ATTR);
+  },
+};

--- a/src/system/chrome/chrome.css
+++ b/src/system/chrome/chrome.css
@@ -361,3 +361,91 @@
   max-width: 50vw;
   text-align: right;
 }
+
+/* ----- scrub-mode transport controls (PUL-F017 / ADR-020) ------- */
+/* The workbench scrub controls are the one chrome surface that IS
+ * interactive — they drive the live master timeline — so, unlike the
+ * passive chrome slots above, they opt back into pointer events. */
+.pulsar-scrub {
+  position: fixed;
+  left: 50%;
+  bottom: clamp(20px, 4vh, 56px);
+  transform: translateX(-50%);
+  z-index: var(--pulsar-z-hud);
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  max-width: min(92vw, 980px);
+  padding: 10px 16px;
+  border-radius: 10px;
+  background: rgba(8, 9, 12, 0.82);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.55), 0 0 0 1px var(--pulsar-color-fg-hair) inset;
+  color: var(--pulsar-color-fg-soft);
+  font-family: var(--pulsar-type-mono);
+  pointer-events: auto;
+}
+
+.pulsar-scrub[hidden] {
+  display: none;
+}
+
+.pulsar-scrub__btn,
+.pulsar-scrub__beat {
+  cursor: pointer;
+  color: var(--pulsar-color-fg-soft);
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--pulsar-color-fg-hair);
+  border-radius: 6px;
+  font-family: var(--pulsar-type-mono);
+}
+
+.pulsar-scrub__btn {
+  min-width: 44px;
+  padding: 6px 10px;
+  font-size: var(--pulsar-type-caption-size);
+}
+
+.pulsar-scrub__btn:hover,
+.pulsar-scrub__beat:hover {
+  background: rgba(125, 245, 255, 0.16);
+  border-color: var(--pulsar-color-accent-cyan);
+}
+
+.pulsar-scrub__btn:focus-visible,
+.pulsar-scrub__beat:focus-visible,
+.pulsar-scrub__seek:focus-visible {
+  outline: 2px solid var(--pulsar-color-accent-cyan);
+  outline-offset: 2px;
+}
+
+.pulsar-scrub__seek {
+  flex: 1 1 220px;
+  min-width: 160px;
+  accent-color: var(--pulsar-color-accent-cyan);
+  cursor: pointer;
+}
+
+.pulsar-scrub__time {
+  font-size: var(--pulsar-type-caption-size);
+  color: var(--pulsar-color-fg-dim);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.pulsar-scrub__beats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  flex-basis: 100%;
+}
+
+.pulsar-scrub__beat {
+  padding: 4px 9px;
+  font-size: var(--pulsar-type-caption-size);
+  letter-spacing: 0.04em;
+}
+
+.pulsar-scrub__beats:empty {
+  display: none;
+}

--- a/src/system/chrome/index.ts
+++ b/src/system/chrome/index.ts
@@ -32,3 +32,6 @@ export type { PopoutHost } from './popout';
 
 export { createCounter, formatHms } from './counter';
 export type { CounterHandle, CounterHost } from './counter';
+
+export { createScrubControls, formatScrubTime } from './scrub';
+export type { ScrubControlsHandle, ScrubControlsHost } from './scrub';

--- a/src/system/chrome/scrub.ts
+++ b/src/system/chrome/scrub.ts
@@ -1,0 +1,245 @@
+// Pulsar L2 chrome — scrub-mode timeline transport controls.
+//
+// PUL-F017 / ADR-020: "In `mode=scrub`, the runtime SHALL display
+// timeline controls allowing the user to scrub forward, backward, and
+// to named beats."
+//
+// This is the workbench-owned transport surface for `mode=scrub`. It is
+// a thin view over the live `MasterTimeline` the GSAP composition
+// timeline adapter exposes through `createGsapCompositionTimeline({
+// onMaster })`: every control drives the master through its public
+// transport API (`play` / `pause` / `reverse` / `seek`) and every named
+// beat affordance comes from `master.beats()`. The component never
+// touches raw GSAP, never parses master-label strings, and never
+// reaches into scene DOM (ADR-020 §Boundary).
+//
+// `src/main.ts` builds one instance at bootstrap, mounts it into the
+// workbench chrome surface, and `attach()`es a master whenever a
+// `mode=scrub` navigation activates one. The controls are hidden until
+// attached, so they only ever appear under `mode=scrub`.
+//
+// Mount lifecycle:
+//
+//     const scrub = createScrubControls({ ownerDocument: document, parent: chromeSurface });
+//     scrub.attach(master);  // mode=scrub navigation → controls appear
+//     scrub.sync();          // refresh the playhead readout (per frame)
+//     scrub.detach();        // navigation left scrub → controls hide
+//     scrub.dispose();       // workbench teardown
+
+import type { MasterTimeline } from '../../runtime/timeline';
+
+/** Format `seconds` as `m:ss` for the transport readout. Negative clamps to 0. */
+export const formatScrubTime = (seconds: number): string => {
+  const t = Math.max(0, Math.floor(Number.isFinite(seconds) ? seconds : 0));
+  const m = Math.floor(t / 60);
+  const s = t % 60;
+  return `${m}:${String(s).padStart(2, '0')}`;
+};
+
+/** Inputs to {@link createScrubControls}. */
+export interface ScrubControlsHost {
+  /** Document used to allocate the control DOM (threaded so tests pass a fake). */
+  readonly ownerDocument: Document;
+  /** Element the control bar mounts into — the workbench chrome surface. */
+  readonly parent: HTMLElement;
+}
+
+/** The handle {@link createScrubControls} returns. */
+export interface ScrubControlsHandle {
+  /** The mounted control-bar element. */
+  readonly element: HTMLElement;
+  /**
+   * Bind the controls to a live master timeline and reveal them. Called
+   * once per `mode=scrub` navigation with the master the GSAP adapter
+   * reported through `onMaster`. Re-binding replaces any prior master.
+   */
+  attach(master: MasterTimeline): void;
+  /**
+   * Unbind from the current master and hide the controls. Called when a
+   * navigation leaves `mode=scrub` (or aborts) so the controls never
+   * drive a stale master.
+   */
+  detach(): void;
+  /**
+   * Refresh the playhead readout (scrub position + time + play/pause
+   * state) from the bound master. Cheap and idempotent; `src/main.ts`
+   * calls it once per animation frame so the readout tracks playback.
+   * Inert when no master is attached or while the user is scrubbing.
+   */
+  sync(): void;
+  /** Remove the control bar from the workbench. Idempotent; inert afterwards. */
+  dispose(): void;
+}
+
+const BEAT_ATTR = 'data-pulsar-scrub-beat';
+
+/** Build a transport `<button>` with an accessible label. */
+const transportButton = (
+  doc: Document,
+  className: string,
+  label: string,
+  glyph: string,
+): HTMLButtonElement => {
+  const button = doc.createElement('button');
+  button.type = 'button';
+  button.className = className;
+  button.setAttribute('aria-label', label);
+  button.title = label;
+  button.textContent = glyph;
+  return button;
+};
+
+interface ScrubDom {
+  readonly root: HTMLElement;
+  readonly reverse: HTMLButtonElement;
+  readonly playPause: HTMLButtonElement;
+  readonly seek: HTMLInputElement;
+  readonly time: HTMLElement;
+  readonly beats: HTMLElement;
+}
+
+/** Allocate the scrub control-bar DOM. */
+const buildScrubDom = (doc: Document): ScrubDom => {
+  const root = doc.createElement('div');
+  root.className = 'pulsar-scrub';
+  root.setAttribute('role', 'group');
+  root.setAttribute('aria-label', 'timeline scrub controls');
+  root.dataset.pulsarScrub = 'controls';
+  root.hidden = true;
+
+  const reverse = transportButton(
+    doc,
+    'pulsar-scrub__btn pulsar-scrub__reverse',
+    'scrub backward',
+    '◀◀',
+  );
+  const playPause = transportButton(doc, 'pulsar-scrub__btn pulsar-scrub__play', 'play', '▶');
+
+  const seek = doc.createElement('input');
+  seek.type = 'range';
+  seek.className = 'pulsar-scrub__seek';
+  seek.min = '0';
+  seek.max = '0';
+  seek.step = 'any';
+  seek.value = '0';
+  seek.setAttribute('aria-label', 'timeline position');
+
+  const time = doc.createElement('span');
+  time.className = 'pulsar-scrub__time';
+  time.textContent = `${formatScrubTime(0)} / ${formatScrubTime(0)}`;
+
+  const beats = doc.createElement('div');
+  beats.className = 'pulsar-scrub__beats';
+  beats.setAttribute('role', 'group');
+  beats.setAttribute('aria-label', 'named beats');
+
+  root.append(reverse, playPause, seek, time, beats);
+  return { root, reverse, playPause, seek, time, beats };
+};
+
+/**
+ * Build the workbench scrub-mode transport controls (PUL-F017 /
+ * ADR-020).
+ */
+export const createScrubControls = (host: ScrubControlsHost): ScrubControlsHandle => {
+  const doc = host.ownerDocument;
+  const dom = buildScrubDom(doc);
+  host.parent.appendChild(dom.root);
+
+  let master: MasterTimeline | null = null;
+  let disposed = false;
+  // While the user drags the seek slider, `sync()` must not fight the
+  // drag by writing the playhead position back onto the input.
+  let scrubbing = false;
+
+  /** Refresh the play/pause button + numeric readout from the master. */
+  const renderReadout = (): void => {
+    if (master === null) return;
+    const paused = master.isPaused();
+    dom.playPause.textContent = paused ? '▶' : '❚❚';
+    dom.playPause.setAttribute('aria-label', paused ? 'play' : 'pause');
+    dom.playPause.title = paused ? 'play' : 'pause';
+    if (!scrubbing) dom.seek.value = String(master.time());
+    dom.time.textContent = `${formatScrubTime(master.time())} / ${formatScrubTime(master.duration())}`;
+  };
+
+  /** Rebuild the named-beat jump buttons from `master.beats()`. */
+  const renderBeats = (): void => {
+    dom.beats.replaceChildren();
+    if (master === null) return;
+    for (const beat of master.beats()) {
+      const button = doc.createElement('button');
+      button.type = 'button';
+      button.className = 'pulsar-scrub__beat';
+      button.dataset.pulsarScrubBeat = beat.name;
+      button.setAttribute(BEAT_ATTR, beat.name);
+      button.textContent = beat.label;
+      button.title = `jump to beat "${beat.label}" (${formatScrubTime(beat.time)})`;
+      button.setAttribute('aria-label', `jump to beat ${beat.label}`);
+      button.addEventListener('click', () => {
+        if (disposed || master === null) return;
+        master.seek(beat.name);
+        renderReadout();
+      });
+      dom.beats.appendChild(button);
+    }
+  };
+
+  // --- transport wiring (one-time; reads the live `master`) ----------
+  dom.playPause.addEventListener('click', () => {
+    if (disposed || master === null) return;
+    if (master.isPaused()) master.play();
+    else master.pause();
+    renderReadout();
+  });
+  dom.reverse.addEventListener('click', () => {
+    if (disposed || master === null) return;
+    master.reverse();
+    renderReadout();
+  });
+  dom.seek.addEventListener('pointerdown', () => {
+    scrubbing = true;
+  });
+  const endScrub = (): void => {
+    scrubbing = false;
+  };
+  dom.seek.addEventListener('pointerup', endScrub);
+  dom.seek.addEventListener('blur', endScrub);
+  dom.seek.addEventListener('input', () => {
+    if (disposed || master === null) return;
+    const position = Number(dom.seek.value);
+    if (Number.isFinite(position)) master.seek(position);
+    renderReadout();
+  });
+
+  return {
+    element: dom.root,
+    attach(next: MasterTimeline): void {
+      if (disposed) return;
+      master = next;
+      scrubbing = false;
+      dom.seek.max = String(next.duration());
+      dom.seek.value = String(next.time());
+      renderBeats();
+      renderReadout();
+      dom.root.hidden = false;
+    },
+    detach(): void {
+      if (disposed) return;
+      master = null;
+      scrubbing = false;
+      dom.root.hidden = true;
+      dom.beats.replaceChildren();
+    },
+    sync(): void {
+      if (disposed || master === null || dom.root.hidden) return;
+      renderReadout();
+    },
+    dispose(): void {
+      if (disposed) return;
+      disposed = true;
+      master = null;
+      dom.root.remove();
+    },
+  };
+};

--- a/src/workbench-graph.ts
+++ b/src/workbench-graph.ts
@@ -21,6 +21,7 @@ import { domCssAccessibilityFixtureScene } from './scenes/dom-css-accessibility-
 import { loopFixtureScene } from './scenes/loop-fixture';
 import { pausedFixtureScene } from './scenes/paused-fixture';
 import { placeholderScene } from './scenes/placeholder';
+import { scrubFixtureScene } from './scenes/scrub-fixture';
 
 // Optional local decks live under `src/decks/local-*/index.ts` and
 // are gitignored — never enter the public repo, but auto-register at
@@ -61,6 +62,12 @@ const LOCAL_COMPOSITIONS: readonly CompositionRegistryEntry[] = Object.values(
 // genuinely holding at its first frame (a `data-pulsar-paused-progress`
 // attribute pinned at `"0"`).
 //
+// PUL-F017 / ADR-020: the scrub verification fixture is registered the
+// same way so the scrub-mode Playwright spec can boot it via
+// `?scene=scrub-fixture&mode=scrub` and observe the workbench scrub
+// controls driving a real master timeline (a `data-pulsar-scrub-progress`
+// attribute that responds to play / reverse / beat-jump).
+//
 // Pulsar L2: the pulsar-intro reference deck (`?composition=pulsar-intro`)
 // is the self-referential proof of the L2 system layer. Its 15 scenes
 // collectively exercise every shipped template, every transition, every
@@ -73,6 +80,7 @@ export const WORKBENCH_SCENES: readonly SceneModule[] = [
   domCssAccessibilityFixtureScene,
   loopFixtureScene,
   pausedFixtureScene,
+  scrubFixtureScene,
   ...PULSAR_INTRO_SCENES,
   ...LOCAL_SCENES,
 ];

--- a/tests-e2e/scrub-mode.spec.ts
+++ b/tests-e2e/scrub-mode.spec.ts
@@ -118,7 +118,9 @@ test.describe('PUL-F017 — mode=scrub displays timeline controls that drive the
     // itself, which the scrub readout reflects: the seek slider lands
     // on the midpoint beat's time (0.3s of the fixture's 0.6s timeline).
     const seek = controls.locator('.pulsar-scrub__seek');
-    expect(Number(await seek.inputValue()), 'the playhead must start at frame 0').toBeLessThan(0.05);
+    expect(Number(await seek.inputValue()), 'the playhead must start at frame 0').toBeLessThan(
+      0.05,
+    );
     await beat.click();
     await expect
       .poll(async () => Number(await seek.inputValue()), {

--- a/tests-e2e/scrub-mode.spec.ts
+++ b/tests-e2e/scrub-mode.spec.ts
@@ -1,0 +1,129 @@
+import { expect, test } from '@playwright/test';
+
+// PUL-F017 / ADR-020 — scrub-mode timeline controls spec.
+//
+// PUL-F017: "In `mode=scrub`, the runtime SHALL display timeline
+// controls allowing the user to scrub forward, backward, and to named
+// beats." The scrub run mode is `positionMaster()` in
+// `src/runtime/timeline.ts` leaving the master held and live under
+// `headCueGate`; the controls are `createScrubControls()` in
+// `src/system/chrome/scrub.ts`, wired in `src/main.ts` via the timeline
+// adapter's `onMaster` hook.
+//
+// This spec uses the dedicated scrub fixture
+// (`src/scenes/scrub-fixture.ts`), whose timeline tweens a numeric
+// progress object 0 -> 100 onto `data-pulsar-scrub-progress` and
+// carries one named beat (`midpoint`). It boots the fixture under
+// `mode=scrub`, asserts the transport bar appears, and drives play /
+// reverse / named-beat-jump — proving the controls drive a real GSAP
+// master in a real browser engine.
+//
+// It runs in every Playwright project declared in
+// `playwright.config.ts` (chromium / firefox / webkit) and is the
+// PUL-F017 scrub acceptance gate, separate from the PUL-F015 loop and
+// PUL-F016 paused gates.
+
+const SCRUB = '[data-pulsar-scrub="controls"]';
+const PROGRESS = '[data-pulsar-scrub-target]';
+
+const readProgress = async (page: import('@playwright/test').Page): Promise<number> => {
+  const raw = await page.locator(PROGRESS).getAttribute('data-pulsar-scrub-progress');
+  return raw === null ? Number.NaN : Number.parseInt(raw, 10);
+};
+
+test.describe('PUL-F017 — mode=scrub displays timeline controls that drive the master', () => {
+  test('the scrub controls appear, hold at frame 0, and play / reverse drive the timeline', async ({
+    page,
+  }) => {
+    const errors: string[] = [];
+    page.on('pageerror', (err) => errors.push(`pageerror: ${err.message}`));
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') errors.push(`console.error: ${msg.text()}`);
+    });
+
+    await page.goto('/?scene=scrub-fixture&mode=scrub');
+
+    const stage = page.locator('#stage');
+    await expect(stage, 'the workbench stage element must mount').toBeAttached();
+    await expect(
+      stage,
+      'PUL-F028 boot validation must succeed (no data-pulsar-validation-failed)',
+    ).not.toHaveAttribute('data-pulsar-validation-failed', /.*/);
+    await expect(
+      stage,
+      'the URL grammar parser must accept ?scene=scrub-fixture&mode=scrub',
+    ).not.toHaveAttribute('data-pulsar-navigation-error', /.*/);
+    await expect(stage, 'the resolver must have mounted the scrub fixture scene').toHaveAttribute(
+      'data-pulsar-scene-target',
+      'scrub-fixture',
+    );
+
+    // PUL-F017 clause 1: the timeline controls are displayed under
+    // `mode=scrub`.
+    const controls = page.locator(SCRUB);
+    await expect(controls, 'the scrub controls surface must appear under mode=scrub').toBeVisible();
+
+    // The scrub master is held — the fixture progress stays at 0 until
+    // the user drives the transport.
+    await expect(page.locator(PROGRESS), 'the scrub fixture element must mount').toBeAttached();
+    await page.waitForTimeout(400);
+    expect(await readProgress(page), 'a held scrub master must not advance on its own').toBe(0);
+
+    // PUL-F017 clause 1 (forward): pressing play advances the timeline.
+    await controls.locator('.pulsar-scrub__play').click();
+    await expect
+      .poll(() => readProgress(page), {
+        message: 'pressing play must advance the scrub timeline',
+      })
+      .toBeGreaterThan(10);
+    await controls.locator('.pulsar-scrub__play').click(); // pause
+    const paused = await readProgress(page);
+
+    // PUL-F017 clause 1 (backward): reverse playback walks it back down.
+    await controls.locator('.pulsar-scrub__reverse').click();
+    await expect
+      .poll(() => readProgress(page), {
+        message: 'pressing reverse must walk the scrub timeline backward',
+      })
+      .toBeLessThan(paused);
+
+    expect(errors, 'no uncaught exceptions or console errors while scrubbing').toEqual([]);
+  });
+
+  test('a named-beat jump button seeks the master to the authored beat', async ({ page }) => {
+    const errors: string[] = [];
+    page.on('pageerror', (err) => errors.push(`pageerror: ${err.message}`));
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') errors.push(`console.error: ${msg.text()}`);
+    });
+
+    await page.goto('/?scene=scrub-fixture&mode=scrub');
+    await expect(page.locator('#stage')).toHaveAttribute(
+      'data-pulsar-scene-target',
+      'scrub-fixture',
+    );
+
+    const controls = page.locator(SCRUB);
+    await expect(controls).toBeVisible();
+
+    // The fixture authors one beat (`midpoint`) at the timeline's
+    // half-way point, so the controls render exactly one jump button.
+    const beat = controls.locator('.pulsar-scrub__beat');
+    await expect(beat, 'a named-beat jump button must be rendered').toHaveCount(1);
+    await expect(beat).toHaveText('midpoint');
+
+    // Jumping to the midpoint beat seeks the master there — the fixture
+    // progress lands near 50 (a direct seek, so no audio cue fires).
+    await beat.click();
+    await expect
+      .poll(() => readProgress(page), {
+        message: 'jumping to the midpoint beat must seek the master to ~50% progress',
+      })
+      .toBeGreaterThanOrEqual(40);
+    expect(await readProgress(page), 'the midpoint jump must not overshoot').toBeLessThanOrEqual(
+      60,
+    );
+
+    expect(errors, 'no uncaught exceptions or console errors while jumping to a beat').toEqual([]);
+  });
+});

--- a/tests-e2e/scrub-mode.spec.ts
+++ b/tests-e2e/scrub-mode.spec.ts
@@ -112,17 +112,32 @@ test.describe('PUL-F017 — mode=scrub displays timeline controls that drive the
     await expect(beat, 'a named-beat jump button must be rendered').toHaveCount(1);
     await expect(beat).toHaveText('midpoint');
 
-    // Jumping to the midpoint beat seeks the master there — the fixture
-    // progress lands near 50 (a direct seek, so no audio cue fires).
+    // Jumping to the midpoint beat seeks the master there. A seek is a
+    // direct move (GSAP suppresses events, so no audio cue fires and no
+    // tween `onUpdate` runs) — the observable is the master playhead
+    // itself, which the scrub readout reflects: the seek slider lands
+    // on the midpoint beat's time (0.3s of the fixture's 0.6s timeline).
+    const seek = controls.locator('.pulsar-scrub__seek');
+    expect(Number(await seek.inputValue()), 'the playhead must start at frame 0').toBeLessThan(0.05);
     await beat.click();
     await expect
-      .poll(() => readProgress(page), {
-        message: 'jumping to the midpoint beat must seek the master to ~50% progress',
+      .poll(async () => Number(await seek.inputValue()), {
+        message: 'jumping to the midpoint beat must seek the master to ~0.3s',
       })
-      .toBeGreaterThanOrEqual(40);
-    expect(await readProgress(page), 'the midpoint jump must not overshoot').toBeLessThanOrEqual(
-      60,
-    );
+      .toBeGreaterThanOrEqual(0.25);
+    expect(
+      Number(await seek.inputValue()),
+      'the midpoint jump must not overshoot',
+    ).toBeLessThanOrEqual(0.35);
+
+    // Playing from the midpoint then advances the fixture progress from
+    // ~50% — proving the jump genuinely repositioned the live master.
+    await controls.locator('.pulsar-scrub__play').click();
+    await expect
+      .poll(() => readProgress(page), {
+        message: 'playing forward from the midpoint beat must advance progress past 50%',
+      })
+      .toBeGreaterThan(50);
 
     expect(errors, 'no uncaught exceptions or console errors while jumping to a beat').toEqual([]);
   });

--- a/tests/runtime/audio.test.ts
+++ b/tests/runtime/audio.test.ts
@@ -33,6 +33,7 @@ import {
   type SoundDefinition,
   assertAudioBedDeclaration,
   createAudioService,
+  createCueGate,
   noopAudioEngine,
 } from '../../src/runtime/audio';
 
@@ -1416,6 +1417,78 @@ describe('createAudioService — composition audio bed (PUL-F014)', () => {
     expect(build('yes')).toThrow(AudioError);
     expect(build(1)).toThrow(AudioError);
     expect(build(null)).toThrow(AudioError);
+  });
+});
+
+describe('createCueGate (PUL-F017 / ADR-020 — dynamic cue eligibility)', () => {
+  it('is eligible by default and toggles with setEligible', () => {
+    const gate = createCueGate();
+    expect(gate.isEligible()).toBe(true);
+    gate.setEligible(false);
+    expect(gate.isEligible()).toBe(false);
+    gate.setEligible(true);
+    expect(gate.isEligible()).toBe(true);
+  });
+
+  it('honors an initial-ineligible state', () => {
+    expect(createCueGate(false).isEligible()).toBe(false);
+    expect(createCueGate(true).isEligible()).toBe(true);
+  });
+});
+
+describe('createAudioService — cue gate (PUL-F017 / ADR-020)', () => {
+  const playCalls = (fake: FakeEngine): number =>
+    fake.calls.filter((c) => c.method === 'play').length;
+
+  it('suppresses play output while the gate is closed (reverse / non-forward playback)', () => {
+    const { fake, service } = buildService({ cueGate: createCueGate(false) });
+    service.load('cue', { src: '/cue.webm' });
+    service.play('cue');
+    expect(playCalls(fake)).toBe(0);
+  });
+
+  it('produces play output while the gate is open (monotonic forward playback)', () => {
+    const { fake, service } = buildService({ cueGate: createCueGate(true) });
+    service.load('cue', { src: '/cue.webm' });
+    service.play('cue');
+    expect(playCalls(fake)).toBe(1);
+  });
+
+  it('tracks the gate dynamically — a cue fires, is suppressed, then fires again as the gate flips', () => {
+    const gate = createCueGate(true);
+    const { fake, service } = buildService({ cueGate: gate });
+    service.load('cue', { src: '/cue.webm' });
+    service.play('cue');
+    gate.setEligible(false);
+    service.play('cue');
+    gate.setEligible(true);
+    service.play('cue');
+    expect(playCalls(fake)).toBe(2);
+  });
+
+  it('still validates a closed-gate cue — malformed cue calls fail loud (suppression is post-validation)', () => {
+    const { service } = buildService({ cueGate: createCueGate(false) });
+    service.load('cue', { src: '/cue.webm', sprite: { hit: [0, 100] } });
+    expect(() => service.play('missing')).toThrow(AudioSoundError);
+    expect(() => service.play('cue', { sprite: 'ghost' })).toThrow(AudioSoundError);
+    expect(() => service.play('cue', { group: 'Bad Group' })).toThrow(AudioGroupError);
+    expect(() => service.play('cue', { volume: 9 })).toThrow(AudioRangeError);
+  });
+
+  it('does not gate fade / stop — only cue firing (play) is direction-gated', () => {
+    const { fake, service } = buildService({ cueGate: createCueGate(false) });
+    service.load('cue', { src: '/cue.webm' });
+    service.fade('cue', 0, 1, 100);
+    service.stop('cue');
+    expect(fake.calls.some((c) => c.method === 'fade')).toBe(true);
+    expect(fake.calls.some((c) => c.method === 'stop')).toBe(true);
+  });
+
+  it('leaves a service with no cue gate wired always eligible (non-scrub navigations unchanged)', () => {
+    const { fake, service } = buildService();
+    service.load('cue', { src: '/cue.webm' });
+    service.play('cue');
+    expect(playCalls(fake)).toBe(1);
   });
 });
 

--- a/tests/runtime/scene-loader-paused-scrub.test.ts
+++ b/tests/runtime/scene-loader-paused-scrub.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+  type AudioEngine,
   type AudioService,
   type Caption,
   type CompositionTimelineAdapter,
@@ -1313,6 +1314,205 @@ describe('createSceneLoader — paused & scrub modes (PUL-F008)', () => {
           cueGate: 'monotonic-forward',
         },
       ]);
+    });
+  });
+
+  describe('scrub-mode audio cue gate wiring (PUL-F017 / ADR-020)', () => {
+    // PUL-F017: "Audio cues SHALL fire only on monotonic forward
+    // playback." The loader builds ONE dynamic cue gate under
+    // `mode=scrub` and shares it between the per-navigation audio
+    // service (which consults it to suppress a cue's output) and the
+    // timeline adapter (which toggles it by playhead direction). These
+    // tests pin that wiring at the loader seam; the timeline+audio
+    // behavior itself is covered by tests/runtime/scrub-cue-gating.test.ts.
+
+    const scrubSceneTarget = (id: string): NavigationTarget => ({
+      locator: { kind: 'scene', scene: id },
+      mode: 'scrub',
+    });
+
+    /** A recording audio engine — counts every `play()` that reaches it. */
+    const recordingAudioEngine = (): { engine: AudioEngine; plays: () => number } => {
+      let plays = 0;
+      const handle = {
+        play: () => {
+          plays += 1;
+          return plays;
+        },
+        stop: () => undefined,
+        fade: () => undefined,
+        loop: () => undefined,
+        volume: () => undefined,
+        rate: () => undefined,
+        unload: () => undefined,
+      };
+      return {
+        plays: () => plays,
+        engine: {
+          createSound: () => handle,
+          setMasterMute: () => undefined,
+          isMasterMuted: () => false,
+          unlock: () => Promise.resolve(),
+        },
+      };
+    };
+
+    it('forwards an audio cue gate to the timeline adapter under `mode=scrub`', async () => {
+      const sceneA = buildScene({ id: 'scene-a' });
+      const stage = buildStage();
+      const timeline = recordingTimeline();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        timeline: timeline.adapter,
+      });
+
+      await loader.handle(scrubSceneTarget('scene-a'));
+
+      expect(timeline.calls).toHaveLength(1);
+      const opts = timeline.calls[0]?.opts;
+      expect(opts?.headCueGate).toBe('monotonic-forward');
+      expect(opts?.audioCueGate).toBeDefined();
+      expect(typeof opts?.audioCueGate?.setEligible).toBe('function');
+      expect(typeof opts?.audioCueGate?.isEligible).toBe('function');
+    });
+
+    it('does not forward an audio cue gate for any non-scrub, lifecycle-running mode', async () => {
+      const modes = NAVIGATION_MODES.filter((m) => m !== 'scrub' && m !== 'prompter');
+      for (const mode of modes) {
+        const sceneA = buildScene({ id: 'scene-a' });
+        const stage = buildStage();
+        const timeline = recordingTimeline();
+        const loader = createSceneLoader({
+          scenes: createSceneRegistry([sceneA]),
+          compositions: createCompositionRegistry([]),
+          stage: stage.element,
+          buildCtx: stubCtx,
+          createPreloader: () => () => undefined,
+          timeline: timeline.adapter,
+        });
+        await loader.handle({ locator: { kind: 'scene', scene: 'scene-a' }, mode });
+        expect(timeline.calls[0]?.opts.audioCueGate, `mode=${mode}`).toBeUndefined();
+      }
+    });
+
+    it('builds a cue-gated audio service under `mode=scrub`, initialized closed — a cue fired before forward playback is suppressed', async () => {
+      // The scrub master starts held — not playing monotonically
+      // forward — so the gate starts closed: a cue fired during scene
+      // `create(ctx)` (before any play()) produces no audible output.
+      const audio = recordingAudioEngine();
+      let capturedAudio: AudioService | null = null;
+      const sceneA = buildScene({
+        id: 'scene-a',
+        audio: ['/cue.webm'],
+        assets: ['/cue.webm'],
+        create: (ctx) => {
+          const c = ctx as WorkbenchSceneCtx;
+          capturedAudio = c.audio;
+          c.audio.load('cue', { src: '/cue.webm' });
+          c.audio.play('cue');
+        },
+      });
+      const stage = buildStage();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        timeline: recordingTimeline().adapter,
+        audioEngine: audio.engine,
+      });
+
+      await loader.handle(scrubSceneTarget('scene-a'));
+
+      expect(capturedAudio).not.toBeNull();
+      expect(audio.plays()).toBe(0);
+    });
+
+    it('fires a cue from create() under a non-scrub mode — no gate wired (control)', async () => {
+      const audio = recordingAudioEngine();
+      const sceneA = buildScene({
+        id: 'scene-a',
+        audio: ['/cue.webm'],
+        assets: ['/cue.webm'],
+        create: (ctx) => {
+          const c = ctx as WorkbenchSceneCtx;
+          c.audio.load('cue', { src: '/cue.webm' });
+          c.audio.play('cue');
+        },
+      });
+      const stage = buildStage();
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        timeline: recordingTimeline().adapter,
+        audioEngine: audio.engine,
+      });
+
+      await loader.handle({ locator: { kind: 'scene', scene: 'scene-a' }, mode: 'present' });
+
+      expect(audio.plays()).toBe(1);
+    });
+
+    it('hands the SAME gate instance to the audio service and the timeline adapter', async () => {
+      // Toggling the gate the timeline adapter received must change
+      // what the audio service does — proving one shared instance. The
+      // checks run inside the adapter's `run`, mid-navigation, so the
+      // audio service is still live (it is disposed once the
+      // navigation completes).
+      const audio = recordingAudioEngine();
+      let capturedAudio: AudioService | null = null;
+      const observed: number[] = [];
+      const sceneA = buildScene({
+        id: 'scene-a',
+        audio: ['/cue.webm'],
+        assets: ['/cue.webm'],
+        create: (ctx) => {
+          const c = ctx as WorkbenchSceneCtx;
+          capturedAudio = c.audio;
+          c.audio.load('cue', { src: '/cue.webm' });
+        },
+      });
+      const stage = buildStage();
+      const adapter: CompositionTimelineAdapter = {
+        run: (_segments, opts) => {
+          const svc = capturedAudio as unknown as AudioService;
+          const gate = opts.audioCueGate;
+          // Gate still closed (initial scrub state) → cue suppressed.
+          svc.play('cue');
+          observed.push(audio.plays());
+          // Open the gate via the timeline-facing handle → the audio
+          // service the loader built fires the cue.
+          gate?.setEligible(true);
+          svc.play('cue');
+          observed.push(audio.plays());
+          // Close again → suppressed.
+          gate?.setEligible(false);
+          svc.play('cue');
+          observed.push(audio.plays());
+          return Promise.resolve();
+        },
+      };
+      const loader = createSceneLoader({
+        scenes: createSceneRegistry([sceneA]),
+        compositions: createCompositionRegistry([]),
+        stage: stage.element,
+        buildCtx: stubCtx,
+        createPreloader: () => () => undefined,
+        timeline: adapter,
+        audioEngine: audio.engine,
+      });
+
+      await loader.handle(scrubSceneTarget('scene-a'));
+
+      expect(observed).toEqual([0, 1, 1]);
     });
   });
 });

--- a/tests/runtime/scene-loader.helpers.ts
+++ b/tests/runtime/scene-loader.helpers.ts
@@ -9,7 +9,9 @@
 import {
   type AudioEngine,
   type AudioService,
+  type CueGateControl,
   createAudioService,
+  createCueGate,
   noopAudioEngine,
 } from '../../src/runtime/audio';
 import { createCompositionRegistry } from '../../src/runtime/composition-registry';
@@ -40,12 +42,14 @@ export {
   createPresenterController,
   createSceneLoader,
   createAudioService,
+  createCueGate,
   noopAudioEngine,
   NAVIGATION_MODES,
 };
 export type {
   AudioEngine,
   AudioService,
+  CueGateControl,
   Caption,
   CompositionTimelineAdapter,
   CompositionTimelineRunOptions,
@@ -166,6 +170,7 @@ export interface LegacyRunInput {
   readonly repeat?: 'until-aborted';
   readonly hold?: 'first-frame';
   readonly cueGate?: 'monotonic-forward';
+  readonly audioCueGate?: CueGateControl;
   readonly screenshot?: 'capture';
   readonly presenter?: ReturnType<typeof createPresenterController>;
 }
@@ -188,6 +193,7 @@ export const asTimeline = (
       ...(opts.headRepeat === undefined ? {} : { repeat: opts.headRepeat }),
       ...(opts.headHold === undefined ? {} : { hold: opts.headHold }),
       ...(opts.headCueGate === undefined ? {} : { cueGate: opts.headCueGate }),
+      ...(opts.audioCueGate === undefined ? {} : { audioCueGate: opts.audioCueGate }),
       ...(opts.headScreenshot === undefined ? {} : { screenshot: opts.headScreenshot }),
       ...(opts.presenter === undefined ? {} : { presenter: opts.presenter }),
     };

--- a/tests/runtime/scrub-cue-gating.test.ts
+++ b/tests/runtime/scrub-cue-gating.test.ts
@@ -1,0 +1,139 @@
+// PUL-F017 / ADR-020 — monotonic-forward audio cue gating.
+//
+// The requirement clause "audio cues SHALL fire only on monotonic
+// forward playback" is delivered by three collaborating pieces:
+//
+//   - the dynamic cue gate (`createCueGate`, `src/runtime/audio.ts`):
+//     the audio service suppresses an accepted cue's output while the
+//     gate is closed;
+//   - the GSAP timeline adapter (`src/runtime/timeline.ts`): under the
+//     scrub run mode it toggles that gate by playhead direction —
+//     `play()` opens it, `pause()` / `reverse()` close it;
+//   - the loader, which wires the same gate into both.
+//
+// This file is the end-to-end proof: a real audio service over a
+// recording engine, a real GSAP scene timeline whose `.call()` cue at
+// master time T invokes `ctx.audio.play(...)`, composed under the scrub
+// run mode. It asserts the cue fires when the playhead crosses T
+// monotonically forward and does NOT fire when the playhead crosses T
+// backward under reverse playback.
+
+import { describe, expect, it } from 'vitest';
+import {
+  type AudioEngine,
+  type AudioSoundHandle,
+  createAudioService,
+  createCueGate,
+} from '../../src/runtime/audio';
+import type { SceneTimelineSegment } from '../../src/runtime/composition-resolver';
+import {
+  type MasterTimeline,
+  createGsapCompositionTimeline,
+  createTimelineEngine,
+} from '../../src/runtime/timeline';
+
+const engine = createTimelineEngine();
+const { gsap } = engine;
+
+const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
+
+/** Pump the event loop until `pred` holds or the iteration budget runs out. */
+const pumpUntil = async (pred: () => boolean, limit = 400): Promise<void> => {
+  for (let i = 0; i < limit && !pred(); i += 1) await flush();
+};
+
+/** A recording audio engine — counts every `play()` that reaches it. */
+const recordingEngine = (): { engine: AudioEngine; plays: () => number } => {
+  let plays = 0;
+  const handle: AudioSoundHandle = {
+    play: () => {
+      plays += 1;
+      return plays;
+    },
+    stop: () => undefined,
+    fade: () => undefined,
+    loop: () => undefined,
+    volume: () => undefined,
+    rate: () => undefined,
+    unload: () => undefined,
+  };
+  return {
+    plays: () => plays,
+    engine: {
+      createSound: () => handle,
+      setMasterMute: () => undefined,
+      isMasterMuted: () => false,
+      unlock: () => Promise.resolve(),
+    },
+  };
+};
+
+describe('PUL-F017 — monotonic-forward audio cue gating', () => {
+  it('fires a cue on a forward crossing of its master time and suppresses it on a reverse crossing', async () => {
+    const nav = new AbortController();
+    const audioEngine = recordingEngine();
+    // One gate shared by the audio service (which reads it) and the
+    // timeline adapter (which toggles it) — exactly the wiring the
+    // scene loader builds for `mode=scrub`.
+    const gate = createCueGate(false);
+    const audio = createAudioService(audioEngine.engine, {
+      signal: nav.signal,
+      cueGate: gate,
+    });
+    audio.load('cue', { src: '/cue.webm' });
+
+    // A 0.4s scene timeline with an audio cue authored at t=0.2 via a
+    // GSAP `.call()` — the canonical way a scene fires `ctx.audio`.
+    const sceneTimeline = gsap.timeline({ paused: true });
+    sceneTimeline.to({ v: 0 }, { v: 1, duration: 0.4, ease: 'none' });
+    sceneTimeline.call(
+      () => {
+        audio.play('cue');
+      },
+      [],
+      0.2,
+    );
+    const segments: SceneTimelineSegment[] = [{ id: 'scene-a', timeline: sceneTimeline }];
+
+    let master: MasterTimeline | null = null;
+    const adapter = createGsapCompositionTimeline({
+      engine,
+      onMaster: (m) => {
+        master = m;
+      },
+    });
+    const settled = adapter.run(segments, {
+      signal: nav.signal,
+      headCueGate: 'monotonic-forward',
+      audioCueGate: gate,
+    });
+    await flush();
+    const tl = master as unknown as MasterTimeline;
+    expect(tl).not.toBeNull();
+    // Scrub run mode: held at frame 0, gate closed.
+    expect(tl.isPaused()).toBe(true);
+    expect(audioEngine.plays()).toBe(0);
+
+    // Monotonic forward playback across t=0.2 — the cue fires.
+    tl.play();
+    await pumpUntil(() => tl.time() >= 0.35);
+    expect(audioEngine.plays()).toBe(1);
+
+    // Reverse playback from the end back across t=0.2 — the cue is
+    // suppressed: `reverse()` closed the gate, so the audio service
+    // accepts the cue call but produces no output.
+    tl.seek(0.4);
+    tl.reverse();
+    await pumpUntil(() => tl.time() <= 0.05);
+    expect(audioEngine.plays()).toBe(1);
+
+    // Forward again — the gate re-opens, the cue fires once more.
+    tl.seek(0);
+    tl.play();
+    await pumpUntil(() => tl.time() >= 0.35);
+    expect(audioEngine.plays()).toBe(2);
+
+    nav.abort();
+    await settled;
+  });
+});

--- a/tests/runtime/timeline.test.ts
+++ b/tests/runtime/timeline.test.ts
@@ -734,14 +734,109 @@ describe('createGsapCompositionTimeline', () => {
     await settled;
   });
 
-  it('ignores headCueGate (no audio engine yet) and plays normally', async () => {
+  it('holds the master mounted and live (paused at frame 0) under headCueGate — scrub run mode', async () => {
+    // PUL-F017 / ADR-020: under scrub the adapter must keep the head
+    // scene mounted with a live master the workbench controls can
+    // drive, instead of auto-playing it to natural completion before
+    // the user can inspect it.
     const controller = new AbortController();
-    const { master, settled } = runWith([segment('a', sceneTl(1))], {
+    const done = vi.fn();
+    const { master, settled } = runWith([segment('a', sceneTl(30))], {
+      signal: controller.signal,
+      headCueGate: 'monotonic-forward',
+    });
+    void settled.then(done);
+    await flush();
+    expect(master().isPaused()).toBe(true);
+    expect(master().time()).toBeCloseTo(0);
+    expect(done).not.toHaveBeenCalled();
+    controller.abort();
+    await settled;
+    expect(done).toHaveBeenCalledOnce();
+  });
+
+  it('honors headBeat as the initial scrub cursor under headCueGate', async () => {
+    const controller = new AbortController();
+    const { master, settled } = runWith([segment('intro', sceneTl(4, { hook: 2 }))], {
+      signal: controller.signal,
+      headCueGate: 'monotonic-forward',
+      headBeat: 'hook',
+      onBeatMissing: vi.fn(),
+    });
+    await flush();
+    expect(master().time()).toBeCloseTo(2, 1);
+    expect(master().isPaused()).toBe(true);
+    controller.abort();
+    await settled;
+  });
+
+  it('resolves immediately with no abort signal under headCueGate (held frame rendered)', async () => {
+    const adapter = createGsapCompositionTimeline({ engine });
+    await expect(
+      adapter.run([segment('a', sceneTl(30))], { headCueGate: 'monotonic-forward' }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('exposes a reverse() transport method on the scrub master', async () => {
+    const controller = new AbortController();
+    const { master, settled } = runWith([segment('a', sceneTl(2))], {
       signal: controller.signal,
       headCueGate: 'monotonic-forward',
     });
     await flush();
+    expect(master().reverse).toBeTypeOf('function');
+    master().seek(1);
+    master().reverse();
     expect(master().isPaused()).toBe(false);
+    controller.abort();
+    await settled;
+  });
+
+  it('toggles the audio cue gate by transport direction — pause/reverse close it, play opens it', async () => {
+    // PUL-F017 / ADR-020: cue eligibility tracks "the master is playing
+    // monotonically forward." The adapter sets it synchronously inside
+    // each transport method, before GSAP's async tick fires any cue.
+    const controller = new AbortController();
+    const calls: boolean[] = [];
+    const gate = {
+      isEligible: () => calls.at(-1) ?? true,
+      setEligible: (e: boolean) => calls.push(e),
+    };
+    const { master, settled } = runWith([segment('a', sceneTl(2))], {
+      signal: controller.signal,
+      headCueGate: 'monotonic-forward',
+      audioCueGate: gate,
+    });
+    await flush();
+    // The initial held frame is not forward playback → gate closed.
+    expect(calls.at(-1)).toBe(false);
+    master().play();
+    expect(calls.at(-1)).toBe(true);
+    master().pause();
+    expect(calls.at(-1)).toBe(false);
+    master().play();
+    expect(calls.at(-1)).toBe(true);
+    master().reverse();
+    expect(calls.at(-1)).toBe(false);
+    controller.abort();
+    await settled;
+  });
+
+  it('does not touch a cue gate for a non-scrub navigation (no headCueGate)', async () => {
+    // The cue gate exists only for scrub. A plain play-through master
+    // must never call into a wired gate.
+    const controller = new AbortController();
+    const calls: boolean[] = [];
+    const gate = {
+      isEligible: () => true,
+      setEligible: (e: boolean) => calls.push(e),
+    };
+    const { settled } = runWith([segment('a', sceneTl(0.02))], {
+      signal: controller.signal,
+      audioCueGate: gate,
+    });
+    await flush();
+    expect(calls).toEqual([]);
     controller.abort();
     await settled;
   });

--- a/tests/scenes/scrub-fixture.test.ts
+++ b/tests/scenes/scrub-fixture.test.ts
@@ -1,0 +1,257 @@
+// PUL-F017 / ADR-020 — scrub verification fixture scene unit tests.
+//
+// The fixture scene is exercised end-to-end by Playwright in
+// `tests-e2e/scrub-mode.spec.ts`, where `mode=scrub` holds the GSAP
+// master live for the workbench scrub controls to drive. These unit
+// tests cover the PUL-F001 contract shape and the ctx defensiveness —
+// the same surface `paused-fixture.test.ts` covers — plus the behaviors
+// unique to this fixture: the `timeline(ctx)` tween's `onUpdate`
+// callback maps the tween's current value onto the
+// `data-pulsar-scrub-progress` attribute, and the timeline carries a
+// kebab-case `midpoint` beat label so the scrub controls render one
+// named-beat jump button. They do NOT run a real GSAP timeline; that
+// responsibility lives in `tests/runtime/timeline.test.ts` and the
+// Playwright e2e spec.
+
+import { describe, expect, it } from 'vitest';
+import { scrubFixtureScene } from '../../src/scenes/scrub-fixture';
+
+interface FakeStage {
+  readonly children: { attrs: Map<string, string> }[];
+  readonly element: {
+    setAttribute(name: string, value: string): void;
+    removeAttribute(name: string): void;
+    appendChild(node: unknown): unknown;
+    querySelector(selector: string): {
+      setAttribute(name: string, value: string): void;
+      remove(): void;
+    } | null;
+    ownerDocument: {
+      createElement(tag: string): { setAttribute(name: string, value: string): void };
+    };
+  };
+}
+
+// Stage stub mirroring `paused-fixture.test.ts`: `appendChild` records
+// children, `querySelector` looks them up by the attribute name in the
+// `[<attr>]` selector, and `ownerDocument.createElement` returns a
+// recording stub. The fixture allocates DOM through the stage's owner
+// document rather than an ambient `document` global (ADR-008 #2).
+const buildStage = (): FakeStage => {
+  const children: { attrs: Map<string, string> }[] = [];
+  return {
+    children,
+    element: {
+      setAttribute: () => undefined,
+      removeAttribute: () => undefined,
+      appendChild: (node: unknown) => {
+        children.push(node as { attrs: Map<string, string> });
+        return node;
+      },
+      querySelector: (selector: string) => {
+        const attr = selector.replace(/^\[|\]$/g, '').split('=')[0];
+        if (attr === undefined) return null;
+        for (let i = 0; i < children.length; i += 1) {
+          const child = children[i];
+          if (child === undefined) continue;
+          if (child.attrs.has(attr)) {
+            return {
+              setAttribute: (name: string, value: string) => child.attrs.set(name, value),
+              remove: () => {
+                children.splice(i, 1);
+              },
+            };
+          }
+        }
+        return null;
+      },
+      ownerDocument: {
+        createElement: () => {
+          const attrs = new Map<string, string>();
+          return {
+            attrs,
+            setAttribute: (name: string, value: string) => attrs.set(name, value),
+          };
+        },
+      },
+    },
+  };
+};
+
+describe('scrubFixtureScene', () => {
+  it('declares the PUL-F001 contract fields with kebab-case id', () => {
+    expect(scrubFixtureScene.id).toBe('scrub-fixture');
+    expect(scrubFixtureScene.title).toBe('Scrub verification fixture');
+    expect(scrubFixtureScene.duration).toBeNull();
+    expect(scrubFixtureScene.standalone).toBe(true);
+    expect(scrubFixtureScene.trailerSafe).toBe(false);
+    expect(scrubFixtureScene.assets).toEqual([]);
+    expect(scrubFixtureScene.captions).toEqual([]);
+    expect(scrubFixtureScene.audio).toEqual([]);
+    expect(scrubFixtureScene.tags).toEqual(['fixture', 'scrub']);
+    expect(scrubFixtureScene.defaultNext).toBeNull();
+  });
+
+  it('appends a fixture element at progress 0 on `create`', () => {
+    const stage = buildStage();
+    scrubFixtureScene.create({
+      stage: stage.element,
+      mode: 'scrub',
+      gsap: { timeline: () => ({}) } as never,
+      audio: {} as never,
+    });
+    expect(stage.children).toHaveLength(1);
+    const attrs = stage.children[0]?.attrs;
+    expect(attrs?.get('data-pulsar-scrub-target')).toBe('');
+    expect(attrs?.get('data-pulsar-scrub-progress')).toBe('0');
+  });
+
+  it('maps the tween value onto `data-pulsar-scrub-progress` and authors a `midpoint` beat', () => {
+    // The fixture's `timeline(ctx)` tweens a numeric `progress` object
+    // 0 -> 100; its `onUpdate` callback writes the rounded current
+    // value onto the DOM attribute. It also adds a kebab-case
+    // `midpoint` label so the scrub controls render one beat button.
+    // The `.to(...)` / `.addLabel(...)` stub captures the tween target,
+    // the `onUpdate` callback, and the label so the test can drive the
+    // value GSAP would otherwise interpolate.
+    const stage = buildStage();
+    let capturedTarget: { value: number } | null = null;
+    let capturedOnUpdate: (() => void) | null = null;
+    const labels: { name: string; at: number }[] = [];
+    const tlStub = {
+      to: (target: unknown, vars: Record<string, unknown>) => {
+        capturedTarget = target as { value: number };
+        capturedOnUpdate = vars.onUpdate as () => void;
+        return tlStub;
+      },
+      addLabel: (name: string, at: number) => {
+        labels.push({ name, at });
+        return tlStub;
+      },
+    };
+    const gsap = { timeline: () => tlStub } as never;
+    scrubFixtureScene.create({ stage: stage.element, mode: 'scrub', gsap, audio: {} as never });
+
+    const result = scrubFixtureScene.timeline({
+      stage: stage.element,
+      mode: 'scrub',
+      gsap,
+      audio: {} as never,
+    });
+    expect(result).toBe(tlStub);
+    expect(capturedTarget).not.toBeNull();
+    expect(capturedOnUpdate).not.toBeNull();
+    // One named beat, kebab-case, at a finite non-negative time.
+    expect(labels).toHaveLength(1);
+    expect(labels[0]?.name).toBe('midpoint');
+    expect(labels[0]?.at).toBeGreaterThan(0);
+
+    const target = capturedTarget as unknown as { value: number };
+    const fireUpdate = capturedOnUpdate as unknown as () => void;
+
+    // The tween declares `value: 100` as its end state, so the target
+    // starts at 0 — the held first frame.
+    expect(target.value).toBe(0);
+    fireUpdate();
+    expect(stage.children[0]?.attrs.get('data-pulsar-scrub-progress')).toBe('0');
+
+    // A non-integer interpolated value is rounded.
+    target.value = 41.6;
+    fireUpdate();
+    expect(stage.children[0]?.attrs.get('data-pulsar-scrub-progress')).toBe('42');
+
+    target.value = 100;
+    fireUpdate();
+    expect(stage.children[0]?.attrs.get('data-pulsar-scrub-progress')).toBe('100');
+  });
+
+  it('returns null from `timeline(ctx)` when no fixture element is mounted', () => {
+    const stage = buildStage();
+    const result = scrubFixtureScene.timeline({
+      stage: stage.element,
+      mode: 'scrub',
+      gsap: { timeline: () => ({ to: () => undefined, addLabel: () => undefined }) } as never,
+      audio: {} as never,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('removes the fixture element on `cleanup`', () => {
+    const stage = buildStage();
+    scrubFixtureScene.create({
+      stage: stage.element,
+      mode: 'scrub',
+      gsap: { timeline: () => ({}) } as never,
+      audio: {} as never,
+    });
+    expect(stage.children).toHaveLength(1);
+    scrubFixtureScene.cleanup({
+      stage: stage.element,
+      mode: 'scrub',
+      gsap: { timeline: () => ({}) } as never,
+      audio: {} as never,
+    });
+    expect(stage.children).toHaveLength(0);
+  });
+
+  it('is a no-op when the stage has no ownerDocument (off-DOM harness)', () => {
+    // The scene must NOT reach for the ambient global `document`
+    // (ADR-008 #2). Every stage method call is tracked so "no DOM
+    // mutation" is asserted structurally.
+    const calls: { name: string; args: unknown[] }[] = [];
+    const minimalStage = {
+      setAttribute: (...args: unknown[]) => {
+        calls.push({ name: 'setAttribute', args });
+      },
+      removeAttribute: (...args: unknown[]) => {
+        calls.push({ name: 'removeAttribute', args });
+      },
+      appendChild: (...args: unknown[]) => {
+        calls.push({ name: 'appendChild', args });
+        return undefined;
+      },
+    };
+    expect(() =>
+      scrubFixtureScene.create({
+        stage: minimalStage,
+        mode: 'scrub',
+        gsap: { timeline: () => ({}) } as never,
+        audio: {} as never,
+      }),
+    ).not.toThrow();
+    expect(calls, 'create must not mutate the stage when ownerDocument is absent').toEqual([]);
+  });
+
+  describe.each<[label: string, ctx: unknown]>([
+    ['null', null],
+    ['undefined', undefined],
+    ['object without `stage`/`mode`/`gsap`', {}],
+    ['object with `stage: null`', { stage: null, mode: 'scrub', gsap: { timeline: () => ({}) } }],
+    [
+      'object with unknown mode',
+      {
+        stage: { setAttribute: () => undefined, removeAttribute: () => undefined },
+        mode: 'shouty-mode',
+        gsap: { timeline: () => ({}) },
+      },
+    ],
+    [
+      'object with non-gsap shape',
+      {
+        stage: { setAttribute: () => undefined, removeAttribute: () => undefined },
+        mode: 'scrub',
+        gsap: {},
+      },
+    ],
+  ])('is a no-op when ctx is %s', (_label, ctx) => {
+    it('does not throw from any lifecycle hook', () => {
+      expect(() => scrubFixtureScene.create(ctx)).not.toThrow();
+      expect(() => scrubFixtureScene.timeline(ctx)).not.toThrow();
+      expect(() => scrubFixtureScene.cleanup(ctx)).not.toThrow();
+    });
+
+    it('timeline() returns null for the invalid ctx', () => {
+      expect(scrubFixtureScene.timeline(ctx)).toBeNull();
+    });
+  });
+});

--- a/tests/system/scrub-controls.test.ts
+++ b/tests/system/scrub-controls.test.ts
@@ -1,0 +1,296 @@
+// Pulsar L2 chrome — scrub-mode transport control coverage.
+//
+// PUL-F017 / ADR-020: the workbench scrub controls let the user scrub
+// forward, backward, and to named beats. These tests pin the control
+// bar against a fake `MasterTimeline` (jsdom-free, like the rest of the
+// chrome suite): the buttons drive the master's transport API, the beat
+// row is built from `master.beats()`, the seek slider seeks, and the
+// readout tracks the playhead. The cue-gating behavior the controls
+// ultimately exercise is covered by tests/runtime/scrub-cue-gating.test.ts.
+
+import { describe, expect, it } from 'vitest';
+import type { MasterBeat, MasterTimeline } from '../../src/runtime/timeline';
+import { createScrubControls, formatScrubTime } from '../../src/system/chrome/scrub';
+
+// ---------- jsdom-free DOM fake (with event dispatch) ----------
+
+type Listener = () => void;
+
+class FakeElement {
+  tagName: string;
+  className = '';
+  textContent: string | null = '';
+  title = '';
+  type = '';
+  hidden = false;
+  min = '';
+  max = '';
+  step = '';
+  value = '';
+  readonly dataset: Record<string, string> = {};
+  readonly children: FakeElement[] = [];
+  readonly #attrs = new Map<string, string>();
+  readonly #listeners = new Map<string, Listener[]>();
+  parentNode: FakeElement | null = null;
+
+  constructor(tagName: string) {
+    this.tagName = tagName;
+  }
+
+  setAttribute(name: string, value: string): void {
+    this.#attrs.set(name, value);
+  }
+  getAttribute(name: string): string | null {
+    return this.#attrs.get(name) ?? null;
+  }
+  appendChild(child: FakeElement): FakeElement {
+    child.parentNode = this;
+    this.children.push(child);
+    return child;
+  }
+  append(...kids: FakeElement[]): void {
+    for (const k of kids) this.appendChild(k);
+  }
+  replaceChildren(...kids: FakeElement[]): void {
+    for (const c of this.children) c.parentNode = null;
+    this.children.length = 0;
+    for (const k of kids) this.appendChild(k);
+  }
+  remove(): void {
+    if (this.parentNode === null) return;
+    const i = this.parentNode.children.indexOf(this);
+    if (i >= 0) this.parentNode.children.splice(i, 1);
+    this.parentNode = null;
+  }
+  addEventListener(type: string, handler: Listener): void {
+    const list = this.#listeners.get(type) ?? [];
+    list.push(handler);
+    this.#listeners.set(type, list);
+  }
+  fire(type: string): void {
+    for (const h of [...(this.#listeners.get(type) ?? [])]) h();
+  }
+}
+
+const fakeDocument = (): Document =>
+  ({ createElement: (tag: string) => new FakeElement(tag) }) as unknown as Document;
+
+/** Recursively find the first descendant whose class list contains `cls`. */
+const find = (root: FakeElement, cls: string): FakeElement | null => {
+  for (const child of root.children) {
+    if (child.className.split(' ').includes(cls)) return child;
+    const nested = find(child, cls);
+    if (nested !== null) return nested;
+  }
+  return null;
+};
+const must = (root: FakeElement, cls: string): FakeElement => {
+  const el = find(root, cls);
+  if (el === null) throw new Error(`fake element ".${cls}" not found`);
+  return el;
+};
+
+// ---------- fake MasterTimeline (records transport calls) ----------
+
+interface FakeMaster {
+  readonly master: MasterTimeline;
+  readonly calls: string[];
+  paused: boolean;
+  now: number;
+}
+
+const fakeMaster = (opts: { duration?: number; beats?: MasterBeat[] } = {}): FakeMaster => {
+  const calls: string[] = [];
+  const state = { paused: true, now: 0 };
+  const beats = opts.beats ?? [];
+  const master = {
+    play: () => {
+      calls.push('play');
+      state.paused = false;
+    },
+    pause: () => {
+      calls.push('pause');
+      state.paused = true;
+    },
+    reverse: () => {
+      calls.push('reverse');
+      state.paused = false;
+    },
+    isPaused: () => state.paused,
+    seek: (position: number | string) => {
+      calls.push(`seek:${position}`);
+      if (typeof position === 'number') state.now = position;
+    },
+    time: () => state.now,
+    duration: () => opts.duration ?? 0,
+    beats: () => beats,
+  } as unknown as MasterTimeline;
+  return {
+    master,
+    calls,
+    get paused() {
+      return state.paused;
+    },
+    set paused(v: boolean) {
+      state.paused = v;
+    },
+    get now() {
+      return state.now;
+    },
+    set now(v: number) {
+      state.now = v;
+    },
+  };
+};
+
+const beat = (label: string, time: number): MasterBeat => ({
+  scene: 'scene-a',
+  occurrence: 0,
+  label,
+  name: `scene-a:${label}`,
+  time,
+});
+
+describe('formatScrubTime', () => {
+  it('formats seconds as m:ss and clamps negatives / non-finite to 0:00', () => {
+    expect(formatScrubTime(0)).toBe('0:00');
+    expect(formatScrubTime(7)).toBe('0:07');
+    expect(formatScrubTime(75)).toBe('1:15');
+    expect(formatScrubTime(-4)).toBe('0:00');
+    expect(formatScrubTime(Number.NaN)).toBe('0:00');
+  });
+});
+
+describe('createScrubControls (PUL-F017 / ADR-020)', () => {
+  const setup = () => {
+    const doc = fakeDocument();
+    const parent = new FakeElement('div');
+    const controls = createScrubControls({
+      ownerDocument: doc,
+      parent: parent as unknown as HTMLElement,
+    });
+    return { parent, controls, root: controls.element as unknown as FakeElement };
+  };
+
+  it('mounts into the parent and starts hidden until a master is attached', () => {
+    const { parent, root } = setup();
+    expect(parent.children).toHaveLength(1);
+    expect(root.hidden).toBe(true);
+    expect(root.getAttribute('role')).toBe('group');
+    expect(root.getAttribute('aria-label')).toBe('timeline scrub controls');
+  });
+
+  it('reveals the controls on attach and hides them again on detach', () => {
+    const { controls, root } = setup();
+    const fm = fakeMaster({ duration: 12 });
+    controls.attach(fm.master);
+    expect(root.hidden).toBe(false);
+    controls.detach();
+    expect(root.hidden).toBe(true);
+  });
+
+  it('sets the seek slider range from the master duration on attach', () => {
+    const { controls, root } = setup();
+    controls.attach(fakeMaster({ duration: 8.5 }).master);
+    expect(must(root, 'pulsar-scrub__seek').max).toBe('8.5');
+  });
+
+  it('toggles play / pause through the master transport', () => {
+    const { controls, root } = setup();
+    const fm = fakeMaster({ duration: 10 });
+    controls.attach(fm.master);
+    const playPause = must(root, 'pulsar-scrub__play');
+    playPause.fire('click'); // paused → play
+    expect(fm.calls).toEqual(['play']);
+    expect(playPause.textContent).toBe('❚❚');
+    playPause.fire('click'); // playing → pause
+    expect(fm.calls).toEqual(['play', 'pause']);
+    expect(playPause.textContent).toBe('▶');
+  });
+
+  it('plays backward through the master when the reverse control is used', () => {
+    const { controls, root } = setup();
+    const fm = fakeMaster({ duration: 10 });
+    controls.attach(fm.master);
+    must(root, 'pulsar-scrub__reverse').fire('click');
+    expect(fm.calls).toEqual(['reverse']);
+  });
+
+  it('seeks the master when the slider is dragged (scrub forward / backward)', () => {
+    const { controls, root } = setup();
+    const fm = fakeMaster({ duration: 10 });
+    controls.attach(fm.master);
+    const seek = must(root, 'pulsar-scrub__seek');
+    seek.value = '6.25';
+    seek.fire('input');
+    expect(fm.calls).toEqual(['seek:6.25']);
+  });
+
+  it('renders one jump button per named beat and seeks to the beat label on click', () => {
+    const { controls, root } = setup();
+    const fm = fakeMaster({
+      duration: 10,
+      beats: [beat('hook', 2), beat('reveal', 6)],
+    });
+    controls.attach(fm.master);
+    const beatRow = must(root, 'pulsar-scrub__beats');
+    expect(beatRow.children).toHaveLength(2);
+    expect(beatRow.children.map((b) => b.textContent)).toEqual(['hook', 'reveal']);
+    beatRow.children[1]?.fire('click');
+    expect(fm.calls).toEqual(['seek:scene-a:reveal']);
+  });
+
+  it('clears the beat buttons on detach', () => {
+    const { controls, root } = setup();
+    controls.attach(fakeMaster({ duration: 10, beats: [beat('hook', 2)] }).master);
+    expect(must(root, 'pulsar-scrub__beats').children).toHaveLength(1);
+    controls.detach();
+    expect(must(root, 'pulsar-scrub__beats').children).toHaveLength(0);
+  });
+
+  it('sync() refreshes the playhead readout from the master', () => {
+    const { controls, root } = setup();
+    const fm = fakeMaster({ duration: 30 });
+    controls.attach(fm.master);
+    fm.now = 12;
+    fm.paused = false;
+    controls.sync();
+    expect(must(root, 'pulsar-scrub__seek').value).toBe('12');
+    expect(must(root, 'pulsar-scrub__time').textContent).toBe('0:12 / 0:30');
+    expect(must(root, 'pulsar-scrub__play').textContent).toBe('❚❚');
+  });
+
+  it('sync() does not fight an in-progress drag (no playhead write-back while scrubbing)', () => {
+    const { controls, root } = setup();
+    const fm = fakeMaster({ duration: 30 });
+    controls.attach(fm.master);
+    const seek = must(root, 'pulsar-scrub__seek');
+    seek.fire('pointerdown'); // user grabs the slider
+    fm.now = 20;
+    controls.sync();
+    expect(seek.value).not.toBe('20'); // drag not overwritten
+    seek.fire('pointerup'); // user releases
+    controls.sync();
+    expect(seek.value).toBe('20');
+  });
+
+  it('sync() is inert when no master is attached', () => {
+    const { controls } = setup();
+    expect(() => controls.sync()).not.toThrow();
+  });
+
+  it('dispose() removes the control bar and renders subsequent calls inert', () => {
+    const { parent, controls } = setup();
+    const fm = fakeMaster({ duration: 10 });
+    controls.dispose();
+    expect(parent.children).toHaveLength(0);
+    // Inert afterwards — no throw, no mounting.
+    expect(() => {
+      controls.attach(fm.master);
+      controls.sync();
+      controls.detach();
+      controls.dispose();
+    }).not.toThrow();
+    expect(parent.children).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Delivers the remaining PUL-F017 (`mode=scrub`) work: a workbench transport-controls UI and real monotonic-forward audio cue gating. `mode=scrub` previously only forwarded the `cueGate: 'monotonic-forward'` runner-input hint; this change makes the runtime behave. The GSAP composition timeline adapter gained a `scrub` run mode that holds the addressed head scene mounted with a live master (instead of auto-playing to completion), a dynamic audio cue-eligibility gate in the audio service suppresses cues that are not produced by monotonic forward playback, and a new L2 chrome component renders the transport bar that drives the master. The composition resolver stays mode-opaque — the cue gate is forwarded as an opaque control object, the same way the presenter controller is.

## Requirement UIDs

- `PUL-F017`

## Related Issues

Closes #130

## ADR Impact

- ADR-020

## Changes

- timeline.ts: a `scrub` run mode under `headCueGate` holds the master mounted and live; `MasterTimeline` gained `reverse()`; the GSAP master toggles the audio cue gate by transport direction (play opens, pause/reverse close)
- audio.ts: `createCueGate` / `CueGate` / `CueGateControl` — a dynamic cue-eligibility gate; `AudioService.play()` suppresses a cue post-validation while the gate is closed (malformed cues still fail loud); fade/stop are not gated
- scene-loader.ts: builds one shared cue gate under `mode=scrub` and wires the single instance into both the audio service and the timeline adapter
- composition-resolver.ts / scene-navigation.ts: forward the `audioCueGate` control opaquely (resolver stays mode-opaque per ADR-011)
- src/system/chrome/scrub.ts: new `createScrubControls` L2 chrome component — play/pause, reverse, drag scrubber, m:ss readout, and named-beat jump buttons from `master.beats()`; shown only under `mode=scrub`
- main.ts: mounts the scrub controls, attaches the master via the `onMaster` hook under `mode=scrub`, and syncs the readout off the GSAP ticker
- src/scenes/scrub-fixture.ts: new scrub verification fixture scene registered in the workbench graph
- docs/adrs/020-workbench-mode-scrub.md: records the implementation and the DRAFT -> ACTIVE transition

## Test Plan

- [x] `pnpm lint` passes (Biome)
- [x] `pnpm typecheck` passes (tsc --noEmit)
- [x] `pnpm test` passes — full suite 2547 tests green
- [x] No coverage regression

Unit/integration: `tests/runtime/scrub-cue-gating.test.ts` proves a cue at master time T fires on a forward crossing and is suppressed on a reverse crossing (real GSAP playback + recording audio engine). `tests/system/scrub-controls.test.ts` covers the transport component. `tests-e2e/scrub-mode.spec.ts` is the Playwright acceptance gate (chromium/firefox/webkit).

## Ground Control Checks

- [x] Codex pre-push review clean (0 findings)
- [x] Test-quality pre-push review clean (0 findings)
- [x] Traceability reconciled post-merge (Steps 15-17)

## Traceability

- IMPLEMENTS: PUL-F017 ← src/runtime/timeline.ts, PUL-F017 ← src/runtime/audio.ts, PUL-F017 ← src/runtime/scene-loader.ts, PUL-F017 ← src/system/chrome/scrub.ts, PUL-F017 ← src/main.ts
- TESTS: PUL-F017 ← tests/runtime/scrub-cue-gating.test.ts, PUL-F017 ← tests/runtime/timeline.test.ts, PUL-F017 ← tests/runtime/audio.test.ts, PUL-F017 ← tests/system/scrub-controls.test.ts, PUL-F017 ← tests/runtime/scene-loader-paused-scrub.test.ts

## Checklist

- [x] Code follows project coding standards
- [x] Changelog fragment added at `changelog.d/130.added.md`
- [x] Architectural docs updated (ADR-020)
