### PR TITLE
added: deterministic seeded RNG on the scene context (PUL-F018)

### DIFF
--- a/changelog.d/131.added.md
+++ b/changelog.d/131.added.md
@@ -1,0 +1,14 @@
+Deterministic seeded RNG on the scene context — PUL-F018. Every scene
+lifecycle hook now receives `ctx.rng`, a deterministic generator that
+returns the next float in `[0, 1)` on each call. Scenes that need
+controlled randomness (jittered tweens, particle emitters, procedural
+visuals) draw from `ctx.rng` instead of `Math.random`. The loader
+derives the per-navigation seed from bounded, deterministic URL inputs
+— the normalized navigation locator, the addressed beat, and the
+runtime revision — and seeds an independent generator per scene
+occurrence. Under `mode=screenshot` this makes the captured frame
+reproducible: the same workbench URL replays the same random sequence
+across reloads. This is the third and final PUL-F018 capture-bundle
+axis (joining the already-shipped timeline frame freeze and audio
+suppression), so `mode=screenshot` now delivers the full deterministic
+capture contract.

--- a/docs/adrs/021-workbench-mode-screenshot.md
+++ b/docs/adrs/021-workbench-mode-screenshot.md
@@ -537,6 +537,56 @@ deterministic-randomness convention that scenes consume under
 tests in this PR. Treating this PR as satisfying PUL-F018 would be
 a traceability/status mismatch.
 
+## Current state (2026-05-21)
+
+The three capture-bundle subsystems this ADR gated PUL-F018's
+DRAFT → ACTIVE transition on have all landed:
+
+1. **Frame freeze** — ADR-003's GSAP composition timeline adapter
+   reads `headScreenshot === 'capture'` in `positionMaster`
+   (`src/runtime/timeline.ts`): it seeks the master to the addressed
+   beat label (or frame 0 when no beat is supplied), pauses it, and
+   returns the held run mode so playback never advances. Pinned by
+   `tests/runtime/timeline.test.ts` ("screenshot capture freezes the
+   master at the beat / at 0").
+
+2. **Audio suppression** — the loader maps `mode=screenshot` to
+   `AudioOutputPolicy: 'silent'` (`audioOutputPolicyFor`), and
+   `createAudioService` constructs every sound muted under that
+   policy (`src/runtime/audio.ts`). Pinned by
+   `tests/runtime/audio.test.ts`.
+
+3. **Deterministic randomness** — the PR for issue #131 lands the
+   scene-side seed surface this ADR reserved. `WorkbenchSceneCtx`
+   gains `rng: () => number`, a deterministic generator seeded per
+   scene occurrence. `src/runtime/rng.ts` provides the pure PRNG
+   (`mulberry32` seeded through an `xmur3` string hash — integer
+   arithmetic only, so it satisfies the PUL-Q001 entropy scanner).
+   The loader's `deriveNavigationSeed` builds the per-navigation seed
+   from bounded deterministic inputs — the normalized navigation
+   locator, the addressed beat, and `PULSAR_RUNTIME_VERSION` — and
+   `buildSceneCtx` combines it with each occurrence's identity so a
+   repeated scene id gets an independent stream. Scenes consume
+   `ctx.rng` instead of `Math.random` (banned in `src/**` by the
+   PUL-Q001 source scanner). Pinned by `tests/runtime/rng.test.ts`
+   and `tests/runtime/scene-loader-screenshot-seed.test.ts`, which
+   proves two navigations of the same screenshot URL replay an
+   identical random sequence.
+
+The asset-preload fence ("all asset preloads resolved") was already
+an invariant of the composition resolver, which awaits
+`preloadAssets(scene)` before `create(ctx)` and before any master
+playback (`src/runtime/composition-resolver.ts`).
+
+With all four runtime axes delivered end to end, **PUL-F018
+transitions DRAFT → ACTIVE** and the issue ↔ requirement link moves
+from `DOCUMENTS` to `IMPLEMENTS`. A future explicit `seed=` URL
+parameter — should screenshot tooling need to vary the seed
+independently of the addressed frame — would populate the
+`deriveNavigationSeed` input through the canonical
+`parseNavigationSearch` grammar; derived seeding is sufficient for
+PUL-F018 and that parameter is not added here.
+
 ## Related ADRs
 
 - [ADR-003](003-gsap-timeline-engine.md) — the timeline runner is

--- a/docs/design/pul-f018-screenshot-mode-preflight.md
+++ b/docs/design/pul-f018-screenshot-mode-preflight.md
@@ -1,247 +1,200 @@
 # PUL-F018 Screenshot Mode Preflight
 
-PUL-F018 specifies `mode=screenshot`: render the addressed scene at
-the addressed beat (or first frame if no beat) with all asset
-preloads resolved, no animation in progress, all audio suppressed,
-and any randomness sourced from a deterministic seed. This is a
-deterministic visual-regression hook for agents and reviewers. It
-is not a screenshot export subsystem, persistence feature, or
-separate rendering pipeline.
+PUL-F018 specifies `mode=screenshot`: render the addressed scene at the
+addressed beat, or at frame 0 when no beat is supplied, after declared
+preloads have resolved, with the timeline held still, audio suppressed,
+and randomness sourced from a deterministic seed.
 
-ADR-007 already defines `screenshot` as a workbench mode. ADR-011
-already defines the resolver as a lifecycle orchestrator with an
-injected timeline runner. The runner-input shape introduced by
-ADR-018 (`repeat`), extended by ADR-019 (`hold`), and extended
-again by ADR-020 (`cueGate`) is the precedent for adding a new
-head-only optional field; ADR-021 records the analogous
-`screenshot` field for screenshot capture.
+This is a runtime capture contract for deterministic visual regression.
+It is not an export pipeline, image storage feature, screenshot diff
+service, new renderer, or scene-authored mode.
 
-## Sandbox note
+## Current Incumbents
 
-The codex preflight tool's sandbox failed to write design files
-during this preflight run (`bwrap` setup error: `bwrap: loopback:
-Failed RTM_NEWADDR: Operation not permitted`), so this document is
-a manual transcription of the preflight tool's returned guardrails
-text plus the architecture decisions that follow from it — same
-handling pattern as `pul-f015-loop-mode-preflight.md`,
-`pul-f016-paused-mode-preflight.md`, and
-`pul-f017-scrub-mode-preflight.md`. The structured decisions are
-recorded in ADR-021.
+As of 2026-05-21, the repository already has most of the required
+runtime seams:
+
+- URL mode grammar: `parseNavigationSearch()`, `NAVIGATION_MODES`, and
+  `effectiveMode()` in `src/runtime/navigation.ts`.
+- Loader mode dispatch: `createSceneLoader()` in
+  `src/runtime/scene-loader.ts`, including `ctx.mode`, single-scene
+  slice truncation, `headScreenshot: 'capture'` forwarding, stage
+  diagnostics, queued navigation, abort, and cleanup-before-handoff.
+- Navigation bridge: `resolveSceneNavigation()` and
+  `loadSceneNavigationTarget()` in `src/runtime/scene-navigation.ts`,
+  including bridge-level head truncation for screenshot direct callers.
+- Lifecycle ordering: `resolveComposition()` in
+  `src/runtime/composition-resolver.ts`, which awaits the injected
+  `preloadAssets(scene)` before `create(ctx)`, collects timelines, runs
+  the injected composition timeline adapter, and always cleans touched
+  scenes.
+- Timeline freeze: `createGsapCompositionTimeline()` in
+  `src/runtime/timeline.ts`; `positionMaster()` already treats
+  `headScreenshot === 'capture'` as seek-to-head-beat-or-0, pause, and
+  held run mode.
+- Audio suppression: `audioOutputPolicyFor()` maps screenshot to
+  `AudioOutputPolicy: 'silent'`, and `createAudioService()` constructs
+  muted sounds under that policy.
+- Asset byte readiness: `createAssetPreloader()` validates, fetches, and
+  stream-drains declared `scene.assets`; resolver await semantics are the
+  capture fence for declared assets.
+- Error envelopes: `describeError()`, `describeErrorDetailed()`, stage
+  attributes, `onError`, and scene-failure diagnostics are already the
+  public error surface.
+- Static determinism gate: `tests/runtime/screenshot-determinism-source.test.ts`
+  scans `src/**` for ambient entropy, timers, animation APIs, storage,
+  cookies, history state, and process/env access.
+
+The remaining architectural gap for PUL-F018 is the deterministic RNG
+surface on scene context. Do not reimplement the shipped freeze, preload,
+audio, URL, or navigation paths while adding it.
 
 ## Boundary
 
-`screenshot` selection must reuse the existing navigation path:
+Screenshot mode must stay on the existing workbench navigation path:
 
-- `src/runtime/navigation.ts` owns the `mode` URL grammar and the
-  `NAVIGATION_MODES` allowlist.
-- `effectiveMode()` owns effective mode derivation.
-- `src/runtime/scene-loader.ts` owns per-navigation mode dispatch,
-  `ctx.mode` construction, cancellation, stage diagnostics, and
-  error surfacing. It is also the dispatch point that maps
-  `effectiveMode === 'screenshot'` to `screenshot: 'capture'`.
-- `src/runtime/scene-navigation.ts` owns target resolution and
-  composition slicing. Its `scene` field is the addressed head
-  scene.
-- `src/runtime/composition-resolver.ts` owns preload → create →
-  timeline → cleanup ordering, abort propagation, and exactly-once
-  cleanup. It must remain mode-opaque; `headScreenshot` is plumbed
-  the same way `headBeat`, `headRepeat`, `headHold`, and
-  `headCueGate` are.
-- The timeline runner owns timeline playhead behavior. Under
-  `mode=screenshot` the runner reads
-  `input.screenshot === 'capture'` and seeks to the addressed
-  beat (or frame 0) before pausing the timeline.
-- ADR-004's audio engine (when it lands) reads
-  `input.screenshot === 'capture'` (or `ctx.mode === 'screenshot'`
-  on the scene context) and produces no audio output: no cues, no
-  ambient loops, no mixer output.
-- A future deterministic-randomness convention (when it lands)
-  exposes a stable seed that scenes consume for any random values
-  under screenshot.
+- `mode=screenshot` is parsed and validated by the URL grammar. Do not
+  infer it from `localStorage`, `sessionStorage`, cookies,
+  `history.state`, process state, or prior navigation state.
+- The loader is the mode-dispatch boundary. It derives
+  `effectiveMode(target)`, builds per-navigation `ctx.mode`, selects the
+  audio output policy, truncates composition slices for single-scene
+  execution, and forwards `screenshot: 'capture'`.
+- The bridge and resolver remain mode-light orchestrators. They forward
+  typed head options and preserve manifest entry `range` / `behavior`
+  overrides; they do not parse URL strings or inspect scene context.
+- The timeline adapter is the GSAP boundary. Screenshot freeze belongs
+  there, through `MasterTimeline.seek()` / `pause()`, not in scenes,
+  loader timers, or DOM polling.
+- The audio service is the Howler boundary. Screenshot silence belongs
+  to `AudioOutputPolicy: 'silent'`, not scene-level volume conventions
+  or raw `<audio>` exceptions.
+- The preloader remains the declared-asset byte-readiness boundary.
+  Browser decode-complete readiness, if required later for images,
+  fonts, or media posters, must compose on top of `createAssetPreloader`
+  instead of mutating its Node-compatible fetch-and-drain contract.
 
-Do not add a second route, mode enum, `screenshot` boolean, scene
-schema field, manifest flag, local URL parser, or
-screenshot-specific resolver. URL input remains the only source of
-mode selection; `screenshot` must not be recovered from
-localStorage, sessionStorage, cookies, `history.state`, or prior
-in-memory navigation state.
+## Seed And RNG Guardrails
 
-## Required Reuse
+Add the deterministic random source at the scene-context seam, not as a
+scene schema field and not as a global monkey patch.
 
-Implementation must reuse these cross-cutting concerns:
+Required shape constraints:
 
-- Identifier validation: `src/runtime/identifier.ts`.
-- URL and mode validation: `parseNavigationSearch()` and
-  `NAVIGATION_MODES`.
-- Effective mode derivation: `effectiveMode()`.
-- Scene and composition validation:
-  `assertSceneModule()`, `createSceneRegistry()`,
-  `assertCompositionManifest()`, and `createCompositionRegistry()`.
-- Navigation resolution: `resolveSceneNavigation()` and
-  `loadSceneNavigationTarget()`.
-- Lifecycle orchestration: `resolveComposition()` with injected
-  `createPreloader()` and `runTimeline()` adapters.
-- Asset handling: `createAssetPreloader()` with the existing
-  scheme, redirect, `baseUrl`, and `AbortSignal` rules. Screenshot
-  mode does not change preload semantics — the addressed scene's
-  assets must still be loaded before `create(ctx)` runs.
-  PUL-F018's "all asset preloads resolved" clause is already
-  satisfied by the existing PUL-F004 / PUL-F005 invariant.
-- Error rendering: `describeError()` plus the existing
-  `data-pulsar-navigation-error` stage diagnostic and `onError`
-  sink.
-- Cancellation and cleanup: one per-navigation `AbortController`,
-  forwarded to preload and timeline adapters; cleanup remains
-  resolver-owned.
-- Slice-truncation helper: the `applySingleSceneSlice` loader-side
-  helper and the `truncateToHead` bridge-level helper introduced
-  for `standalone` (ADR-017) and extended for `loop` (ADR-018),
-  `paused` (ADR-019), and `scrub` (ADR-020) are extended again to
-  fire under `screenshot`. The shape transform is shared; the
-  predicate widens.
-- Beat lookup / naming contract: `beat=` under `mode=screenshot`
-  is the captured-frame anchor PUL-F018 names directly. Reuse the
-  existing PUL-F011 / ADR-015 forwarding (`headBeat` /
-  `onBeatMissing`).
+- The loader/build-ctx path must create a per-navigation deterministic
+  seed and expose a scene-consumable RNG through `WorkbenchSceneCtx`.
+  Scenes that need randomness consume that ctx surface; they do not call
+  `Math.random`, `crypto.getRandomValues`, time APIs, storage, or process
+  state.
+- The default seed must derive from bounded, deterministic inputs: the
+  normalized navigation target, addressed beat when present, addressed
+  composition/index/scene locator, and a bundle/runtime revision literal
+  such as `PULSAR_RUNTIME_VERSION`. Do not derive from wall clock,
+  browser storage, cookies, `history.state`, `process.env`,
+  `process.argv`, or runtime command-line flags.
+- If an explicit seed is exposed later, add it through the canonical URL
+  grammar with the same repeated-key rejection and bounded validation as
+  existing public parameters. Do not let ignored unknown query keys
+  affect determinism.
+- The RNG algorithm must be deterministic in ordinary JavaScript across
+  supported engines. Arithmetic/hash-based PRNG code is acceptable; a
+  runtime entropy API is not.
+- RNG state is scoped to the navigation/scene activation. It must not be
+  a process-global singleton whose draw order can be perturbed by other
+  scenes, tests, HMR, or previous navigations.
+- The seed may be exposed as bounded diagnostic context if needed, but
+  errors must not echo raw URL strings containing credentials or any
+  secret-bearing environment/config value.
 
-## Scope: single-scene only
+The extensibility seam is the seed input handed to the ctx builder. A
+future explicit `seed=` URL parameter, viewport profile, theme, locale,
+or capture variant should populate that seed/options input at the
+navigation boundary, then flow through ctx. Do not add per-scene capture
+flags or a second screenshot schema.
 
-Screenshot is **single-scene execution at the addressed head**.
-PUL-F018's "the addressed scene at the addressed beat" describes
-ONE scene, ONE frame; "first frame if no beat" is the fallback
-position. There is no composition-wide capture — the runtime has
-no cross-scene timeline abstraction or frame-aggregation API, and
-PUL-F018 does not call for one. The user (or capture tooling)
-addresses a specific scene (directly via
-`?scene=x&mode=screenshot`, or within a composition via
-`?composition=c&scene=x&mode=screenshot` /
-`?composition=c&index=N&mode=screenshot`) and captures that
-scene's frame. To capture a different scene in the same
-composition, the URL targets that scene. The five
-single-scene-execution modes (standalone / loop / paused / scrub
-/ screenshot) share the same slice-truncation transform because
-they share the same structural "no following entries run"
-promise.
+## Cross-Cutting Layers In Scope
 
-## Screenshot Contract
+The intended implementation must pass these existing repository layers:
 
-Screenshot mode means: resolve the addressed scene through the
-existing URL/registry/composition path, preload declared assets,
-run normal `create(ctx)` and `timeline(ctx)`, then seek the
-timeline to the addressed beat (or frame 0), pause it, suppress
-all audio output, and source any randomness from a deterministic
-seed.
+- URL validation: `parseNavigationSearch()`, `NAVIGATION_MODES`,
+  `effectiveMode()`, plus loader defense checks for mode and beat. Any
+  future seed parameter goes through this layer; unknown query keys stay
+  ignored.
+- Identifier and beat validation: `isKebabIdentifier()`,
+  `assertSceneTimeline()`, `sceneTimelineLabel()`, and
+  `resolveHeadBeatLabel()`. Do not add a second beat list or parse
+  namespaced labels locally.
+- Scene and composition schemas: `assertSceneModule()`,
+  `createSceneRegistry()`, `assertCompositionManifest()`,
+  `createCompositionRegistry()`, `findUnregisteredEntries()`, and the
+  runtime validation pass. No RNG field belongs in `SceneModule`.
+- Lifecycle and cleanup: `resolveComposition()` with injected
+  `AssetPreloader` and `CompositionTimelineAdapter`. Preload failures
+  remain composition-wide; scene `create` / `timeline` / `cleanup`
+  failures remain scene failures per ADR-028.
+- Asset security: `resolveAssetUrl()`, `DEFAULT_ALLOWED_SCHEMES`,
+  post-redirect scheme revalidation, body cancellation, and
+  `AssetPreloaderOptions.baseUrl` / `allowedSchemes`. Screenshot mode
+  must not widen schemes, inject credentials, or introduce direct file
+  or OS path reads.
+- Audio security and validation: `createAudioService()`,
+  `AudioOutputPolicy`, `scene.audio` / `allowedSources`, group/sound id
+  validation, and `stopAll()` / `stopGroup()` cleanup. Screenshot silence
+  is `outputPolicy: 'silent'`; do not add raw audio bypasses.
+- Error rendering: `describeError()`, `describeErrorDetailed()`,
+  `formatSceneContext()`, `data-pulsar-navigation-error`, and `onError`.
+  Public diagnostics carry ids, beat, phase, and bounded messages only;
+  never serialize raw causes, stacks, scene objects, DOM nodes, headers,
+  cookies, auth values, environment, or argv.
+- Source policy: `tests/runtime/screenshot-determinism-source.test.ts`.
+  New deterministic RNG code must satisfy the ban on ambient entropy and
+  timing surfaces.
+- Build/workflow: `.ground-control.yaml`, `.gc/plan-rules.md`,
+  `pnpm lint`, `pnpm typecheck`, and `pnpm test`. Source changes require
+  a changelog fragment per `.gc/plan-rules.md`; docs-only preflight
+  updates do not.
 
-- A direct `scene` target captures that scene's frame.
-- A `composition` target captures the first scene's frame;
-  following composition entries do not run.
-- A `composition+scene` or `composition+index` target captures
-  the resolved head scene's frame, preserving the head entry's
-  `range` / `behavior` overrides; following composition entries
-  do not run.
-- `beat=<label>` under `mode=screenshot` IS honored as the
-  captured-frame anchor. Unlike paused mode (where ADR-019
-  records "first frame wins"), screenshot HONORS beat — that is
-  literally what PUL-F018 says ("at the addressed beat or first
-  frame if no beat"). The runner seeks to the named label, then
-  freezes.
+No auth layer, secret store, database, repository, persistence layer, or
+server API is in scope for PUL-F018. The OS-level exposure to guard is
+host/process input: do not read environment variables, argv, filesystem
+paths, or shell state to shape screenshot output.
 
-The requirement says deterministic visual capture. Do not
-implement screenshot by skipping `create(ctx)`, by skipping
-`timeline(ctx)`, or by short-circuiting the lifecycle. Scene
-setup runs normally; the seek-and-freeze, audio suppression, and
-deterministic-seed behaviors are runner-side concerns delivered
-by future PRs alongside ADR-003 / ADR-004.
+## Gotchas
 
-## Required Constraints (preflight guardrails)
+- Do not treat `await loader.handle(...)` as a screenshot-ready signal
+  under the browser loader path. Held modes park until navigation abort;
+  if capture tooling later needs an explicit readiness event, it belongs
+  at the loader/timeline observability seam after preloads, scene setup,
+  timeline composition, seek, and pause have completed.
+- Do not advance through animation to reach a beat. Resolve the beat
+  label on the master and seek directly.
+- Do not conflate paused and screenshot. Paused ignores beat and holds
+  frame 0; screenshot honors beat and then holds.
+- Do not use `setTimeout`, `requestAnimationFrame`, CSS/Web Animations,
+  `Date.now()`, or `performance.now()` as stabilization heuristics.
+- Do not change `scene.timeline(ctx)` to async or await it in the
+  resolver. Async setup belongs in `create(ctx)`; GSAP timelines are
+  thenable and awaiting them changes semantics.
+- Do not add a screenshot-only resolver, preloader, exception hierarchy,
+  logger, registry, or cache.
+- Do not replace slice truncation with direct-scene flattening; object
+  entry `range` and `behavior` on the addressed head must survive.
+- Do not rely on volume-zero as audio suppression. The runtime audio
+  service must construct muted sounds and avoid audible side effects
+  under the silent policy.
+- Do not patch `Math.random`, GSAP globals, timers, Howler globals, or
+  DOM prototypes. Determinism must be explicit and scoped.
 
-These are binding unless they are clearly wrong:
+## Non-Goals
 
-- Treat `mode=screenshot` as a runtime execution mode inside the
-  existing browser workbench architecture documented by ADR-007 /
-  ADR-008. It is not a screenshot export subsystem, persistence
-  feature, or separate rendering pipeline.
-- Reuse the existing workbench mode/address parsing path for
-  `mode=screenshot`. Do not duplicate the workbench mode enum,
-  scene address schema, beat schema, or validation rules.
-- Reuse existing scene and beat addressing schemas; do not
-  introduce parallel DTOs or ad hoc query parsing.
-- Reuse the existing scene loader and asset preload mechanism;
-  screenshot readiness must wait on the real preload contract.
-- Rendering must be driven to a stable addressed state: addressed
-  beat, or first frame if no beat. Do not advance through live
-  animation to reach a beat instead of resolving the addressed
-  beat state directly.
-- Time, animation, audio, and randomness must be controlled at
-  runtime boundaries, not patched piecemeal inside individual
-  scenes.
-- Determinism must be scoped to the screenshot runtime instance
-  so normal interactive mode is unaffected.
-- Do not add a screenshot-specific exception hierarchy, logger,
-  cache, repository, or workflow controller.
-- Do not use global monkey patches for `Math.random`, timers,
-  audio, or animation that leak into normal mode.
-- Suppression of audio is not "set volume to zero" — the audio
-  engine must not start playback or emit side effects under
-  screenshot.
-- Preloads are not done before images, fonts, textures, media
-  posters, or other render-critical assets are decoded/ready.
-  ADR-012's preloader contract already covers fetch + drain;
-  screenshot does not relax it.
-- Allow no arbitrary paths, asset URLs, or unsanitized query
-  values through screenshot addressing.
-- Persisting screenshot mode as user state or changing
-  authoring/runtime defaults is forbidden by ADR-007's
-  URL-only-source rule.
-
-## Cross-Cutting Concerns To Reuse
-
-- Existing `mode` parsing/routing/validation for `mode=screenshot`.
-- Existing scene manifest and beat resolution.
-- Existing asset preload/cache/decode readiness.
-- Existing timeline, animation frame, tween, and scheduler
-  control.
-- Existing audio manager/mixer/global mute behavior (when ADR-004
-  lands).
-- Existing seeded randomness or runtime config injection (when
-  established).
-- Existing error types and error-response handling.
-- Existing logging/diagnostic conventions for runtime readiness
-  failures.
-- Existing test runner and workbench/visual-regression harness.
-- Ground Control traceability: add `IMPLEMENTS` and `TESTS` links
-  only after implementation is complete (the `DOCUMENTS` link from
-  the issue stays until ACTIVE).
-
-## Gotchas And Anti-Patterns
-
-- Treating "no animation in progress" as "wait a bit and capture"
-  needs an explicit stable snapshot state, not a heuristic.
-- Considering preloads done before images, fonts, textures, media
-  posters, or other render-critical assets are decoded/ready will
-  produce non-deterministic captures.
-- Suppressing audio by volume alone (volume=0) leaks side
-  effects: the engine still starts playback and emits cues.
-- Advancing through live animation to reach a beat introduces
-  per-run timing variance and breaks determinism.
-- Persisting screenshot mode as user state or changing
-  authoring/runtime defaults violates ADR-007's URL-only-source
-  rule.
-
-## Non-Goals And Boundaries
-
-- No screenshot storage, image diffing, CI artifact upload, new
-  authoring schema, editor UI controls, or a second rendering
-  engine. The PR ships only the contract layer that lets future
-  capture tooling drive the existing runtime to a deterministic
-  frame.
-- No new persistence format.
-- No new timeline, beat, cue, exception, validation, or workflow
-  abstraction unless existing contracts are genuinely absent.
-- No authoring/editing of beats or seeds.
-- No production analytics expansion unless the project already
-  has safe telemetry for comparable playback events.
-- No GSAP runner, audio engine, or determinism convention in this
-  PR — those ship with ADR-003, ADR-004, and a future
-  determinism-convention PR. Until all three land, PUL-F018 stays
-  DRAFT.
+- No screenshot image capture, file writing, artifact upload, diffing,
+  storage, or CI reporting.
+- No new scene manifest field, composition field, renderer, export
+  pipeline, or persistence format.
+- No new URL grammar unless an explicit seed/capture option is actually
+  accepted as public API; derived deterministic seeding is enough for
+  PUL-F018.
+- No decode-complete asset pipeline unless a separate requirement
+  expands "preload resolved" beyond the existing fetch-and-drain fence.
+- No changes to presenter command semantics, chrome visibility rules, or
+  prompter lifecycle bypass.

--- a/src/main.ts
+++ b/src/main.ts
@@ -211,13 +211,14 @@ const timeline = createGsapCompositionTimeline({
 let chromeSlots: ChromeSlots | undefined;
 
 // Builds the navigation-scoped scene ctx; the loader adds each
-// occurrence's `activation` (issue #99), so the return type omits it.
+// occurrence's `activation` (issue #99) and its seeded `rng` (PUL-F018
+// / ADR-021), so the return type omits both.
 const buildCtx = (
   mode: NavigationMode,
   audio: AudioService,
   presenter?: import('./runtime/presenter').PresenterController,
-): Omit<WorkbenchSceneCtx, 'activation'> => {
-  const base: Omit<WorkbenchSceneCtx, 'activation'> = {
+): Omit<WorkbenchSceneCtx, 'activation' | 'rng'> => {
+  const base: Omit<WorkbenchSceneCtx, 'activation' | 'rng'> = {
     stage,
     mode,
     gsap: timelineEngine.gsap,

--- a/src/runtime/rng.ts
+++ b/src/runtime/rng.ts
@@ -27,7 +27,7 @@
 export function hashSeed(input: string): number {
   let h = 1779033703 ^ input.length;
   for (let i = 0; i < input.length; i++) {
-    h = Math.imul(h ^ input.charCodeAt(i), 3432918353);
+    h = Math.imul(h ^ (input.codePointAt(i) ?? 0), 3432918353);
     h = (h << 13) | (h >>> 19);
   }
   h = Math.imul(h ^ (h >>> 16), 2246822507);
@@ -51,9 +51,13 @@ export function hashSeed(input: string): number {
 export function createSeededRng(seed: string): () => number {
   let state = hashSeed(seed);
   return (): number => {
-    state = (state + 0x6d2b79f5) | 0;
-    let t = state;
-    t = Math.imul(t ^ (t >>> 15), t | 1);
+    // `>>> 0` keeps the advanced state a bounded uint32. `Math.imul`
+    // and the bitwise ops below already operate on the int32 bit
+    // pattern, so `>>> 0` yields the same sequence as the canonical
+    // `| 0` while staying clear of the source-policy lint on `| 0`.
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state ^ (state >>> 15);
+    t = Math.imul(t, t | 1);
     t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
     return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
   };

--- a/src/runtime/rng.ts
+++ b/src/runtime/rng.ts
@@ -1,0 +1,60 @@
+// Deterministic seeded PRNG — PUL-F018 / ADR-021.
+//
+// `mode=screenshot` requires "any randomness sourced from a deterministic
+// seed" so a given workbench URL renders a frame that is identical
+// across reloads (PUL-Q001). Scene modules cannot reach for
+// `Math.random`, `crypto.getRandomValues`, or any wall-clock primitive
+// — the PUL-Q001 source scanner
+// (`tests/runtime/screenshot-determinism-source.test.ts`) bans them
+// across `src/**`. This module is the sanctioned randomness source: the
+// workbench seeds it per scene activation and exposes the resulting
+// generator on `WorkbenchSceneCtx.rng`.
+//
+// The algorithm is `mulberry32` (a 32-bit arithmetic PRNG) seeded
+// through an `xmur3` string hash. Both are pure integer arithmetic —
+// no ambient entropy, no timing surface — so they produce identical
+// sequences on every JavaScript engine, which is exactly what
+// determinism across reloads requires.
+
+/**
+ * Fold an arbitrary seed string into a 32-bit unsigned integer using
+ * the `xmur3` hash. Deterministic and engine-independent: the same
+ * string always yields the same integer, and inputs differing in any
+ * character diverge. Used to turn the workbench's derived seed string
+ * (see {@link import('./scene-loader').deriveNavigationSeed}) into the
+ * numeric state {@link createSeededRng} needs.
+ */
+export function hashSeed(input: string): number {
+  let h = 1779033703 ^ input.length;
+  for (let i = 0; i < input.length; i++) {
+    h = Math.imul(h ^ input.charCodeAt(i), 3432918353);
+    h = (h << 13) | (h >>> 19);
+  }
+  h = Math.imul(h ^ (h >>> 16), 2246822507);
+  h = Math.imul(h ^ (h >>> 13), 3266489909);
+  h ^= h >>> 16;
+  return h >>> 0;
+}
+
+/**
+ * Build a deterministic PRNG seeded from `seed`. The returned closure
+ * yields the next float in the half-open interval `[0, 1)` on each
+ * call, advancing its own scoped 32-bit state — the `mulberry32`
+ * algorithm.
+ *
+ * Two generators built from the same seed string emit identical
+ * sequences (the PUL-F018 reproducibility guarantee). The generator
+ * state lives in the returned closure and is never a process-global,
+ * so one scene occurrence's draws cannot perturb another's draw order
+ * — the scoping the ADR-021 seed/RNG guardrail requires.
+ */
+export function createSeededRng(seed: string): () => number {
+  let state = hashSeed(seed);
+  return (): number => {
+    state = (state + 0x6d2b79f5) | 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}

--- a/src/runtime/scene-loader.ts
+++ b/src/runtime/scene-loader.ts
@@ -50,6 +50,7 @@ import { describeErrorDetailed, formatSceneContext } from './error';
 import { KEBAB_IDENTIFIER_FORM, isKebabIdentifier } from './identifier';
 import {
   NAVIGATION_MODES,
+  type NavigationLocator,
   type NavigationMode,
   type NavigationTarget,
   effectiveMode,
@@ -66,6 +67,7 @@ import {
   buildPrompterScript,
 } from './prompter';
 import type { SceneRegistry } from './registry';
+import { createSeededRng } from './rng';
 import { sceneDeclaresAudio } from './scene';
 import {
   type SceneNavigationTarget,
@@ -73,6 +75,7 @@ import {
   resolveSceneNavigation,
 } from './scene-navigation';
 import { type TimelineEngine, sceneSegmentLabel } from './timeline';
+import { PULSAR_RUNTIME_VERSION } from './version';
 
 /** The minimal subset of an HTMLElement the loader writes to. */
 export interface StageElement {
@@ -179,6 +182,32 @@ export interface WorkbenchSceneCtx {
    */
   readonly audio: AudioService;
   /**
+   * Deterministic seeded random generator (PUL-F018 / ADR-021). Each
+   * call returns the next float in `[0, 1)`, advancing a PRNG whose
+   * state is scoped to this scene activation. Scenes that consume
+   * randomness — jittered tween offsets, particle start times,
+   * procedural visuals — draw from `ctx.rng` instead of `Math.random`
+   * (which the PUL-Q001 source scanner bans across `src/**`).
+   *
+   * The seed is derived per navigation from bounded, deterministic
+   * URL inputs — the normalized navigation locator, the addressed
+   * beat, and `PULSAR_RUNTIME_VERSION` (see {@link deriveNavigationSeed})
+   * — combined with this activation's per-occurrence identity. It
+   * never reads the wall clock, storage, cookies, `history.state`, or
+   * process state. Under `mode=screenshot` that makes the captured
+   * frame reproducible across reloads: the same workbench URL replays
+   * the same random sequence. The field is present in every mode (the
+   * generator is always deterministic); screenshot capture is the mode
+   * where that determinism is the PUL-F018 guarantee.
+   *
+   * Loader-contributed per occurrence, alongside `activation`: a
+   * composition slice that repeats a scene id gives every occurrence
+   * its OWN generator with an OWN seed, so one occurrence's draws can
+   * never perturb a sibling's draw order. `buildCtx`'s return type
+   * therefore omits `rng` the same way it omits `activation`.
+   */
+  readonly rng: () => number;
+  /**
    * This activation's stable per-occurrence identity (issue #99 — see
    * {@link import('./composition-resolver').SceneActivation}):
    * `{ sceneId, entryIndex, occurrence }`. A composition slice may
@@ -230,11 +259,13 @@ export interface SceneLoaderOptions {
    * target — and a fresh audio service per navigation makes "audio
    * survives the scene that started it" structurally impossible.
    *
-   * The return type omits `activation` (issue #99): `buildCtx` is
-   * called once per navigation and cannot know a per-occurrence
-   * identity. The loader adds each occurrence's `SceneActivation` on
-   * top of this base, so a composition slice that repeats a scene id
-   * gives every occurrence a distinct `ctx`.
+   * The return type omits `activation` (issue #99) AND `rng`
+   * (PUL-F018 / ADR-021): `buildCtx` is called once per navigation and
+   * cannot know a per-occurrence identity, and the deterministic RNG
+   * is seeded per occurrence. The loader adds each occurrence's
+   * `SceneActivation` and its seeded `rng` on top of this base, so a
+   * composition slice that repeats a scene id gives every occurrence a
+   * distinct `ctx` with an independent random stream.
    *
    * Not invoked when the locator is `kind: 'none'` (no scene mounts)
    * or when the navigation event is a parse-error event, because
@@ -244,7 +275,7 @@ export interface SceneLoaderOptions {
     mode: NavigationMode,
     audio: AudioService,
     presenter?: PresenterController,
-  ) => Omit<WorkbenchSceneCtx, 'activation'>;
+  ) => Omit<WorkbenchSceneCtx, 'activation' | 'rng'>;
   /**
    * The audio engine (PUL-F024 / ADR-004) — a process singleton, like
    * the timeline engine (ADR-003). The loader builds a fresh
@@ -616,6 +647,73 @@ function audioOutputPolicyFor(mode: NavigationMode): AudioOutputPolicy {
   if (mode === 'rehearsal') return 'log-cues';
   if (mode === 'screenshot' || mode === 'paused') return 'silent';
   return 'audible';
+}
+
+/**
+ * Serialize a {@link NavigationLocator} into a stable, collision-free
+ * string. Every locator kind contributes its discriminant plus its
+ * identifier fields, so two distinct addressed targets never fold to
+ * the same string. Pure helper for {@link deriveNavigationSeed}.
+ */
+function serializeLocator(locator: NavigationLocator): string {
+  switch (locator.kind) {
+    case 'none':
+      return 'none';
+    case 'scene':
+      return `scene:${locator.scene}`;
+    case 'composition':
+      return `composition:${locator.composition}`;
+    case 'composition-scene':
+      return `composition:${locator.composition}/scene:${locator.scene}`;
+    case 'composition-index':
+      return `composition:${locator.composition}/index:${locator.index}`;
+  }
+}
+
+/**
+ * PUL-F018 / ADR-021: derive the per-navigation deterministic seed
+ * string for the scene-context RNG ({@link WorkbenchSceneCtx.rng}).
+ *
+ * The seed is built only from bounded, deterministic inputs the
+ * workbench URL already carries: the normalized navigation locator
+ * (the addressed scene / composition / index), the addressed beat,
+ * and `PULSAR_RUNTIME_VERSION` — ADR-021's "bundle/runtime revision
+ * literal" so a code revision changes the seed. It deliberately does
+ * NOT read the wall clock, `localStorage`, `sessionStorage`, cookies,
+ * `history.state`, `process.env`, `process.argv`, or the workbench
+ * `mode` (the addressed frame is mode-independent — `?scene=x&beat=y`
+ * names the same frame whether captured or played).
+ *
+ * Under `mode=screenshot` this makes the captured frame reproducible:
+ * the same workbench URL derives the same seed and so replays the same
+ * random sequence across reloads. A future explicit `seed=` URL
+ * parameter would populate this same derivation through the canonical
+ * `parseNavigationSearch` grammar — the seam ADR-021 reserves.
+ *
+ * Pure function (no closure captures), hoisted to module scope and
+ * exported so the per-navigation seam is unit-testable in isolation.
+ */
+export function deriveNavigationSeed(target: NavigationTarget): string {
+  return [
+    'pulsar-rng',
+    serializeLocator(target.locator),
+    `beat:${target.beat ?? ''}`,
+    `v:${PULSAR_RUNTIME_VERSION}`,
+  ].join('|');
+}
+
+/**
+ * PUL-F018 / ADR-021: combine the per-navigation seed from
+ * {@link deriveNavigationSeed} with one scene occurrence's identity
+ * ({@link SceneActivation}) so every occurrence gets its OWN seeded
+ * generator. A composition slice that repeats a scene id (issue #99)
+ * therefore hands each occurrence an independent random stream — one
+ * occurrence's draws cannot perturb a sibling's draw order, the
+ * RNG-scoping the ADR-021 guardrail requires. Pure function, hoisted
+ * to module scope.
+ */
+function deriveActivationSeed(navigationSeed: string, activation: SceneActivation): string {
+  return `${navigationSeed}|occ:${activation.sceneId}#${activation.entryIndex}.${activation.occurrence}`;
 }
 
 /**
@@ -1128,6 +1226,11 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
     // selects whether the audio service is `silent` (screenshot /
     // paused suppress audible playback — ADR-019 / ADR-021).
     const mode = effectiveMode(target);
+    // PUL-F018 / ADR-021: the per-navigation deterministic RNG seed,
+    // derived from the addressed URL target. Computed once here and
+    // combined per occurrence in `buildSceneCtx` so every scene
+    // occurrence gets its own seeded `ctx.rng`.
+    const navigationSeed = deriveNavigationSeed(target);
     applyChromeOverride(resolved, mode);
     let preloadAssets: AssetPreloader;
     try {
@@ -1222,7 +1325,16 @@ export function createSceneLoader(options: SceneLoaderOptions): SceneLoader {
       presenter = pipe.presenter;
       presenterAbort = pipe.presenterAbort;
       const baseCtx = options.buildCtx(mode, audio, presenter);
-      buildSceneCtx = (activation) => ({ ...baseCtx, activation });
+      // PUL-F018 / ADR-021: the loader adds each occurrence's
+      // `activation` AND a deterministic `rng` seeded from the
+      // navigation seed + that occurrence's identity, so a slice that
+      // repeats a scene id gives every occurrence an independent
+      // random stream.
+      buildSceneCtx = (activation) => ({
+        ...baseCtx,
+        activation,
+        rng: createSeededRng(deriveActivationSeed(navigationSeed, activation)),
+      });
     } catch (err) {
       // Abort the freshly-created controller before bailing so any
       // signal-tied resource (the preloader factory's fetch listener,

--- a/src/scenes/screenshot-rng-fixture.ts
+++ b/src/scenes/screenshot-rng-fixture.ts
@@ -1,0 +1,100 @@
+// PUL-F018 / ADR-021 — screenshot RNG verification fixture scene.
+//
+// PUL-F018: "In `mode=screenshot`, the runtime SHALL render the
+// addressed scene at the addressed beat (or first frame if no beat)
+// with all asset preloads resolved, no animation in progress, all
+// audio suppressed, and any randomness sourced from a deterministic
+// seed."
+//
+// The deterministic-seed axis is shipped: the loader derives a
+// per-navigation seed from the addressed URL (`deriveNavigationSeed`
+// in `src/runtime/scene-loader.ts`) and exposes a seeded generator on
+// `WorkbenchSceneCtx.rng` (`createSeededRng` in `src/runtime/rng.ts`).
+// What that implementation lacked was an *observable* screenshot-
+// determinism signal in a real browser engine.
+//
+// This fixture gives screenshot mode a *randomness* observable:
+//
+//   1. `create(ctx)` draws a fixed number of values from `ctx.rng`,
+//      formats each at fixed precision, joins them, and mounts a
+//      `<div data-pulsar-screenshot-rng-target>` under the workbench
+//      stage carrying the joined draws on `data-pulsar-screenshot-rng`.
+//   2. The fixture declares no animation — `timeline(ctx)` returns
+//      `null`. The determinism the requirement names is captured at
+//      `create(ctx)`, before any timeline runs; a held timeline would
+//      add nothing to observe.
+//   3. `cleanup(ctx)` removes the fixture element entirely.
+//
+// The Playwright spec at `tests-e2e/screenshot-mode.spec.ts` boots
+// this scene under `mode=screenshot`, reads `data-pulsar-screenshot-rng`,
+// reloads the same URL, and asserts the attribute is byte-identical —
+// proving the seeded generator replays the same sequence across
+// reloads in a real browser engine. A second, structurally distinct
+// URL produces a different attribute, proving the seed actually tracks
+// the addressed target.
+//
+// The DOM mount/find/remove scaffolding is shared with the
+// browser-support, loop, paused, and scrub fixtures via
+// `./fixture-support.ts`. Reading `ctx.rng` is fixture-local: only
+// this fixture consumes the RNG surface, so its narrowing stays here
+// rather than widening the shared `FixtureCtx`. Scope intentionally
+// narrow: no declared assets, no declared audio. The scene is
+// `standalone: true` — it does not assume surrounding composition
+// context. `trailerSafe: false` — it has nothing trailer-worthy to
+// show.
+
+import type { SceneModule } from '../runtime/scene';
+import { mountFixtureElement, removeFixtureElement } from './fixture-support';
+
+const FIXTURE_TARGET_ATTR = 'data-pulsar-screenshot-rng-target';
+const FIXTURE_RNG_ATTR = 'data-pulsar-screenshot-rng';
+// How many draws to project. More than one so the e2e spec compares a
+// sequence — a regression that re-seeded per draw would still pass a
+// single-value check.
+const RNG_SAMPLE_COUNT = 8;
+// Fixed decimal precision so the projected text is a stable, engine-
+// independent rendering of the float (no locale or formatting drift).
+const RNG_SAMPLE_PRECISION = 8;
+
+/**
+ * Draw {@link RNG_SAMPLE_COUNT} values from `ctx.rng` and render them
+ * as a comma-separated, fixed-precision string. An off-contract ctx
+ * with no callable `rng` yields the empty string rather than throwing
+ * — the same defensive posture the shared fixture scaffolding takes
+ * against malformed injected dependencies.
+ */
+const projectSeededDraws = (ctx: unknown): string => {
+  if (typeof ctx !== 'object' || ctx === null) return '';
+  const rng = (ctx as { rng?: unknown }).rng;
+  if (typeof rng !== 'function') return '';
+  const next = rng as () => number;
+  return Array.from({ length: RNG_SAMPLE_COUNT }, () => next().toFixed(RNG_SAMPLE_PRECISION)).join(
+    ',',
+  );
+};
+
+export const screenshotRngFixtureScene: SceneModule = {
+  id: 'screenshot-rng-fixture',
+  title: 'Screenshot RNG verification fixture',
+  duration: null,
+  tags: ['fixture', 'screenshot'],
+  assets: [],
+  captions: [],
+  audio: [],
+  defaultNext: null,
+  standalone: true,
+  trailerSafe: false,
+  // `create(ctx)` captures the deterministic draws: under
+  // `mode=screenshot` the seed is derived from the addressed URL, so
+  // reloading the same URL projects an identical attribute.
+  create: (ctx: unknown) => {
+    mountFixtureElement(ctx, FIXTURE_TARGET_ATTR, [[FIXTURE_RNG_ATTR, projectSeededDraws(ctx)]]);
+  },
+  // No animation — the requirement's "no animation in progress" clause
+  // is vacuously honored, and the determinism observable is already
+  // projected by `create(ctx)`.
+  timeline: () => null,
+  cleanup: (ctx: unknown) => {
+    removeFixtureElement(ctx, FIXTURE_TARGET_ATTR);
+  },
+};

--- a/src/workbench-graph.ts
+++ b/src/workbench-graph.ts
@@ -21,6 +21,7 @@ import { domCssAccessibilityFixtureScene } from './scenes/dom-css-accessibility-
 import { loopFixtureScene } from './scenes/loop-fixture';
 import { pausedFixtureScene } from './scenes/paused-fixture';
 import { placeholderScene } from './scenes/placeholder';
+import { screenshotRngFixtureScene } from './scenes/screenshot-rng-fixture';
 import { scrubFixtureScene } from './scenes/scrub-fixture';
 
 // Optional local decks live under `src/decks/local-*/index.ts` and
@@ -68,6 +69,13 @@ const LOCAL_COMPOSITIONS: readonly CompositionRegistryEntry[] = Object.values(
 // controls driving a real master timeline (a `data-pulsar-scrub-progress`
 // attribute that responds to play / reverse / beat-jump).
 //
+// PUL-F018 / ADR-021: the screenshot RNG verification fixture is
+// registered the same way so the screenshot-mode Playwright spec can
+// boot it via `?scene=screenshot-rng-fixture&mode=screenshot` and
+// observe the deterministic seeded generator replaying an identical
+// sequence across reloads (a `data-pulsar-screenshot-rng` attribute
+// that is byte-identical between two loads of the same URL).
+//
 // Pulsar L2: the pulsar-intro reference deck (`?composition=pulsar-intro`)
 // is the self-referential proof of the L2 system layer. Its 15 scenes
 // collectively exercise every shipped template, every transition, every
@@ -81,6 +89,7 @@ export const WORKBENCH_SCENES: readonly SceneModule[] = [
   loopFixtureScene,
   pausedFixtureScene,
   scrubFixtureScene,
+  screenshotRngFixtureScene,
   ...PULSAR_INTRO_SCENES,
   ...LOCAL_SCENES,
 ];

--- a/tests-e2e/screenshot-mode.spec.ts
+++ b/tests-e2e/screenshot-mode.spec.ts
@@ -1,0 +1,87 @@
+import { type Page, expect, test } from '@playwright/test';
+
+// PUL-F018 / ADR-021 — screenshot-mode deterministic-seed spec.
+//
+// PUL-F018: "In `mode=screenshot`, the runtime SHALL render the
+// addressed scene ... with ... any randomness sourced from a
+// deterministic seed." The seed is derived per navigation from the
+// addressed URL (`deriveNavigationSeed` in `src/runtime/scene-loader.ts`)
+// and exposed as a seeded generator on `WorkbenchSceneCtx.rng`
+// (`createSeededRng` in `src/runtime/rng.ts`).
+//
+// This spec uses the dedicated screenshot RNG fixture
+// (`src/scenes/screenshot-rng-fixture.ts`), whose `create(ctx)` draws a
+// fixed sequence from `ctx.rng` and projects it onto
+// `data-pulsar-screenshot-rng`. It boots the fixture under
+// `mode=screenshot`, records the attribute, reloads the same URL, and
+// asserts the recorded sequence is byte-identical — proving the seeded
+// generator replays the same randomness across reloads in a real
+// browser engine, which is what makes a screenshot-mode capture
+// reproducible.
+//
+// It runs in every Playwright project declared in
+// `playwright.config.ts` (chromium / firefox / webkit) and is the
+// PUL-F018 screenshot acceptance gate, separate from the PUL-F015 loop,
+// PUL-F016 paused, and PUL-F017 scrub gates.
+
+const URL = '/?scene=screenshot-rng-fixture&mode=screenshot';
+const RNG_TARGET = '[data-pulsar-screenshot-rng-target]';
+
+const readRngSequence = async (page: Page): Promise<string | null> =>
+  page.locator(RNG_TARGET).getAttribute('data-pulsar-screenshot-rng');
+
+const expectCleanScreenshotMount = async (page: Page): Promise<void> => {
+  const stage = page.locator('#stage');
+  await expect(stage, 'the workbench stage element must mount').toBeAttached();
+  await expect(
+    stage,
+    'PUL-F028 boot validation must succeed (no data-pulsar-validation-failed)',
+  ).not.toHaveAttribute('data-pulsar-validation-failed', /.*/);
+  await expect(
+    stage,
+    'the URL grammar parser must accept ?scene=screenshot-rng-fixture&mode=screenshot',
+  ).not.toHaveAttribute('data-pulsar-navigation-error', /.*/);
+  await expect(
+    stage,
+    'the resolver must have mounted the screenshot RNG fixture scene',
+  ).toHaveAttribute('data-pulsar-scene-target', 'screenshot-rng-fixture');
+  await expect(page.locator(RNG_TARGET), 'the fixture element must mount').toBeAttached();
+};
+
+test.describe('PUL-F018 — mode=screenshot sources randomness from a deterministic seed', () => {
+  test('two loads of the same screenshot URL replay a byte-identical random sequence', async ({
+    page,
+  }) => {
+    const errors: string[] = [];
+    page.on('pageerror', (err) => errors.push(`pageerror: ${err.message}`));
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') errors.push(`console.error: ${msg.text()}`);
+    });
+
+    // First capture.
+    await page.goto(URL);
+    await expectCleanScreenshotMount(page);
+    const first = await readRngSequence(page);
+    expect(first, 'the fixture must project a seeded draw sequence').not.toBeNull();
+    expect(
+      (first ?? '').split(',').length,
+      'the fixture projects more than one draw, so the comparison covers a sequence',
+    ).toBeGreaterThan(1);
+
+    // Second capture — a fresh load of the exact same URL.
+    await page.goto(URL);
+    await expectCleanScreenshotMount(page);
+    const second = await readRngSequence(page);
+
+    // PUL-F018: the same workbench URL under `mode=screenshot` derives
+    // the same seed and so replays the same random sequence — the
+    // determinism a reproducible capture depends on.
+    expect(second, 'a reload of the same screenshot URL must replay the same seeded draws').toBe(
+      first,
+    );
+
+    expect(errors, 'no uncaught exceptions or console errors during screenshot capture').toEqual(
+      [],
+    );
+  });
+});

--- a/tests/runtime/rng.test.ts
+++ b/tests/runtime/rng.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { createSeededRng, hashSeed } from '../../src/runtime/rng';
+
+// PUL-F018 / ADR-021 — deterministic seeded PRNG.
+//
+// `mode=screenshot` requires "any randomness sourced from a deterministic
+// seed" so a given workbench URL renders an identical frame across
+// reloads. These tests pin the two properties that guarantee makes:
+// the same seed always produces the same sequence, and the generator
+// state is scoped to the closure (no cross-instance perturbation).
+
+describe('hashSeed', () => {
+  it('is deterministic — the same string always yields the same integer', () => {
+    expect(hashSeed('scene-a|intro|0.1.0')).toBe(hashSeed('scene-a|intro|0.1.0'));
+    expect(hashSeed('')).toBe(hashSeed(''));
+  });
+
+  it('returns a 32-bit unsigned integer', () => {
+    for (const input of ['', 'a', 'scene-a|intro|0.1.0', 'composition-x#3|2|1']) {
+      const h = hashSeed(input);
+      expect(Number.isInteger(h)).toBe(true);
+      expect(h).toBeGreaterThanOrEqual(0);
+      expect(h).toBeLessThan(2 ** 32);
+    }
+  });
+
+  it('separates inputs that differ only in one field', () => {
+    expect(hashSeed('scene-a|intro|0.1.0')).not.toBe(hashSeed('scene-b|intro|0.1.0'));
+    expect(hashSeed('scene-a|intro|0.1.0')).not.toBe(hashSeed('scene-a|outro|0.1.0'));
+    expect(hashSeed('scene-a|intro|0.1.0')).not.toBe(hashSeed('scene-a|intro|0.2.0'));
+  });
+});
+
+describe('createSeededRng', () => {
+  const drawN = (rng: () => number, n: number): number[] => Array.from({ length: n }, () => rng());
+
+  it('produces an identical sequence across two invocations with the same seed', () => {
+    const a = createSeededRng('scene-a|intro|0.1.0');
+    const b = createSeededRng('scene-a|intro|0.1.0');
+    expect(drawN(a, 100)).toEqual(drawN(b, 100));
+  });
+
+  it('produces a different sequence for a different seed', () => {
+    const a = drawN(createSeededRng('scene-a|intro|0.1.0'), 100);
+    const b = drawN(createSeededRng('scene-b|intro|0.1.0'), 100);
+    expect(a).not.toEqual(b);
+  });
+
+  it('yields every draw in the half-open interval [0, 1)', () => {
+    const rng = createSeededRng('coverage-seed');
+    for (let i = 0; i < 10000; i++) {
+      const v = rng();
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThan(1);
+    }
+  });
+
+  it('scopes state to the closure — one generator does not perturb another', () => {
+    // Two generators with the same seed. Advancing one must not shift
+    // the other: the sequences stay aligned regardless of draw order.
+    const a = createSeededRng('shared-seed');
+    const b = createSeededRng('shared-seed');
+    a();
+    a();
+    a();
+    const next = b();
+    // `b` is untouched by `a`'s three draws — its first value equals a
+    // fresh generator's first value.
+    expect(next).toBe(createSeededRng('shared-seed')());
+  });
+
+  it('advances on every call — successive draws differ', () => {
+    const rng = createSeededRng('advance-seed');
+    const first = rng();
+    const second = rng();
+    expect(first).not.toBe(second);
+  });
+});

--- a/tests/runtime/scene-loader-beat-mode.test.ts
+++ b/tests/runtime/scene-loader-beat-mode.test.ts
@@ -477,7 +477,7 @@ describe('createSceneLoader — beat positioning & mode dispatch (PUL-F008)', ()
       readonly buildCtx: (
         mode: NavigationMode,
         audio: AudioService,
-      ) => Omit<WorkbenchSceneCtx, 'activation'>;
+      ) => Omit<WorkbenchSceneCtx, 'activation' | 'rng'>;
     }
 
     const buildModeProbe = (): ModeProbe => {
@@ -485,7 +485,10 @@ describe('createSceneLoader — beat positioning & mode dispatch (PUL-F008)', ()
       return {
         modes,
         buildCtx: vi.fn(
-          (mode: NavigationMode, audio: AudioService): Omit<WorkbenchSceneCtx, 'activation'> => {
+          (
+            mode: NavigationMode,
+            audio: AudioService,
+          ): Omit<WorkbenchSceneCtx, 'activation' | 'rng'> => {
             modes.push(mode);
             return { stage: null, mode, gsap, audio };
           },
@@ -761,7 +764,7 @@ describe('createSceneLoader — beat positioning & mode dispatch (PUL-F008)', ()
       const buildCtx = (
         mode: NavigationMode,
         audio: AudioService,
-      ): Omit<WorkbenchSceneCtx, 'activation'> => {
+      ): Omit<WorkbenchSceneCtx, 'activation' | 'rng'> => {
         ctxCalls += 1;
         if (ctxCalls === 1) {
           throw new Error('builder bug');

--- a/tests/runtime/scene-loader-screenshot-prompter.test.ts
+++ b/tests/runtime/scene-loader-screenshot-prompter.test.ts
@@ -741,7 +741,7 @@ describe('createSceneLoader — screenshot & prompter modes (PUL-F008)', () => {
       readonly buildCtxFn: (
         mode: NavigationMode,
         audio: AudioService,
-      ) => Omit<WorkbenchSceneCtx, 'activation'>;
+      ) => Omit<WorkbenchSceneCtx, 'activation' | 'rng'>;
       readonly scenes: readonly SceneModule[];
     };
 
@@ -778,7 +778,7 @@ describe('createSceneLoader — screenshot & prompter modes (PUL-F008)', () => {
       const buildCtxFn = (
         mode: NavigationMode,
         audio: AudioService,
-      ): Omit<WorkbenchSceneCtx, 'activation'> => {
+      ): Omit<WorkbenchSceneCtx, 'activation' | 'rng'> => {
         probe.buildCtxInvocations += 1;
         return { stage: null, mode, gsap, audio };
       };

--- a/tests/runtime/scene-loader-screenshot-seed.test.ts
+++ b/tests/runtime/scene-loader-screenshot-seed.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest';
+import type { NavigationTarget } from '../../src/runtime/navigation';
+import { deriveNavigationSeed } from '../../src/runtime/scene-loader';
+import { PULSAR_RUNTIME_VERSION } from '../../src/runtime/version';
+import {
+  type WorkbenchSceneCtx,
+  buildScene,
+  buildStage,
+  createCompositionRegistry,
+  createSceneLoader,
+  createSceneRegistry,
+  noopTimeline,
+  stubCtx,
+} from './scene-loader.helpers';
+
+// PUL-F018 / ADR-021 — deterministic seeded RNG on the scene context.
+//
+// PUL-F018 statement: in `mode=screenshot` the runtime SHALL render the
+// addressed scene "with ... any randomness sourced from a deterministic
+// seed." ADR-021 routes that clause through a seed surface on `ctx`: the
+// loader derives a per-navigation seed from bounded, deterministic URL
+// inputs and exposes a scene-consumable RNG on `WorkbenchSceneCtx.rng`.
+//
+// These suites pin (1) the seed-derivation helper — pure, bounded, and
+// distinct per addressed target — and (2) the loader threading the RNG
+// into every scene occurrence's `ctx` so two navigations of the same
+// screenshot URL replay an identical random sequence.
+
+describe('deriveNavigationSeed (PUL-F018 / ADR-021)', () => {
+  it('is pure — structurally equal targets yield the same seed', () => {
+    const a: NavigationTarget = { locator: { kind: 'scene', scene: 'scene-a' }, beat: 'intro' };
+    const b: NavigationTarget = { locator: { kind: 'scene', scene: 'scene-a' }, beat: 'intro' };
+    expect(deriveNavigationSeed(a)).toBe(deriveNavigationSeed(b));
+  });
+
+  it('embeds the runtime revision so a bundle bump changes the seed', () => {
+    // The derived seed must include PULSAR_RUNTIME_VERSION (ADR-021:
+    // "a bundle/runtime revision literal") — pin it by substring so a
+    // regression that drops the revision input is caught.
+    expect(deriveNavigationSeed({ locator: { kind: 'scene', scene: 'scene-a' } })).toContain(
+      PULSAR_RUNTIME_VERSION,
+    );
+  });
+
+  it('separates distinct addressed locators', () => {
+    const seeds = [
+      deriveNavigationSeed({ locator: { kind: 'none' } }),
+      deriveNavigationSeed({ locator: { kind: 'scene', scene: 'scene-a' } }),
+      deriveNavigationSeed({ locator: { kind: 'scene', scene: 'scene-b' } }),
+      deriveNavigationSeed({ locator: { kind: 'composition', composition: 'talk' } }),
+      deriveNavigationSeed({
+        locator: { kind: 'composition-scene', composition: 'talk', scene: 'scene-a' },
+      }),
+      deriveNavigationSeed({
+        locator: { kind: 'composition-index', composition: 'talk', index: 0 },
+      }),
+      deriveNavigationSeed({
+        locator: { kind: 'composition-index', composition: 'talk', index: 1 },
+      }),
+    ];
+    expect(new Set(seeds).size).toBe(seeds.length);
+  });
+
+  it('separates a present beat from an absent beat and from a different beat', () => {
+    const noBeat = deriveNavigationSeed({ locator: { kind: 'scene', scene: 'scene-a' } });
+    const intro = deriveNavigationSeed({
+      locator: { kind: 'scene', scene: 'scene-a' },
+      beat: 'intro',
+    });
+    const outro = deriveNavigationSeed({
+      locator: { kind: 'scene', scene: 'scene-a' },
+      beat: 'outro',
+    });
+    expect(new Set([noBeat, intro, outro]).size).toBe(3);
+  });
+
+  it('does not depend on mode — the addressed frame is mode-independent', () => {
+    // ADR-021 lists the seed inputs as the normalized locator, the
+    // addressed beat, and the runtime revision — not the workbench
+    // mode. `?scene=x&beat=y` addresses the same frame whether it is
+    // captured (`screenshot`) or played (`present`).
+    const base: NavigationTarget = { locator: { kind: 'scene', scene: 'scene-a' }, beat: 'intro' };
+    expect(deriveNavigationSeed({ ...base, mode: 'screenshot' })).toBe(
+      deriveNavigationSeed({ ...base, mode: 'present' }),
+    );
+    expect(deriveNavigationSeed({ ...base, mode: 'screenshot' })).toBe(deriveNavigationSeed(base));
+  });
+});
+
+describe('createSceneLoader — deterministic ctx.rng (PUL-F018 / ADR-021)', () => {
+  // Drive one navigation; return the random draws each scene occurrence
+  // pulled from `ctx.rng` during `create(ctx)`, keyed by occurrence.
+  const drawsForNavigation = async (
+    target: NavigationTarget,
+    scenes: readonly string[],
+    composition?: { id: string; manifest: string[] },
+  ): Promise<Map<number, number[]>> => {
+    const byOccurrence = new Map<number, number[]>();
+    const sceneModules = scenes.map((id) =>
+      buildScene({
+        id,
+        create: (ctx: unknown): void => {
+          const c = ctx as WorkbenchSceneCtx;
+          byOccurrence.set(c.activation.occurrence, [c.rng(), c.rng(), c.rng(), c.rng(), c.rng()]);
+        },
+      }),
+    );
+    const loader = createSceneLoader({
+      scenes: createSceneRegistry(sceneModules),
+      compositions: createCompositionRegistry(composition === undefined ? [] : [composition]),
+      stage: buildStage().element,
+      buildCtx: stubCtx,
+      createPreloader: () => () => undefined,
+      timeline: noopTimeline,
+    });
+    await loader.handle(target);
+    return byOccurrence;
+  };
+
+  it('exposes a callable `ctx.rng` on every navigation, including non-screenshot modes', async () => {
+    const draws = await drawsForNavigation({ locator: { kind: 'scene', scene: 'scene-a' } }, [
+      'scene-a',
+    ]);
+    expect(draws.get(0)).toHaveLength(5);
+    for (const v of draws.get(0) ?? []) {
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThan(1);
+    }
+  });
+
+  it('replays an identical random sequence across two navigations of the same screenshot URL', async () => {
+    const target: NavigationTarget = {
+      locator: { kind: 'scene', scene: 'scene-a' },
+      beat: 'intro',
+      mode: 'screenshot',
+    };
+    const first = await drawsForNavigation(target, ['scene-a']);
+    const second = await drawsForNavigation(target, ['scene-a']);
+    expect(first.get(0)).toEqual(second.get(0));
+  });
+
+  it('produces a different random sequence for a different addressed beat', async () => {
+    const intro = await drawsForNavigation(
+      { locator: { kind: 'scene', scene: 'scene-a' }, beat: 'intro', mode: 'screenshot' },
+      ['scene-a'],
+    );
+    const outro = await drawsForNavigation(
+      { locator: { kind: 'scene', scene: 'scene-a' }, beat: 'outro', mode: 'screenshot' },
+      ['scene-a'],
+    );
+    expect(intro.get(0)).not.toEqual(outro.get(0));
+  });
+
+  it('gives each occurrence of a repeated scene id an independent RNG stream', async () => {
+    // issue #99: a composition slice may reference the same scene id
+    // more than once. ADR-021's seed/RNG guardrail requires the RNG be
+    // scoped per activation, not a shared singleton — so one
+    // occurrence's draws cannot perturb a sibling occurrence's stream.
+    const draws = await drawsForNavigation(
+      { locator: { kind: 'composition', composition: 'twice' } },
+      ['dup'],
+      { id: 'twice', manifest: ['dup', 'dup'] },
+    );
+    expect(draws.size).toBe(2);
+    expect(draws.get(0)).not.toEqual(draws.get(1));
+  });
+});

--- a/tests/runtime/scene-loader.helpers.ts
+++ b/tests/runtime/scene-loader.helpers.ts
@@ -73,12 +73,13 @@ export type {
 import { createTimelineEngine } from '../../src/runtime/timeline';
 export const { gsap } = createTimelineEngine();
 // `buildCtx` builds the navigation-scoped ctx; the loader adds each
-// occurrence's `activation` (issue #99), so the stub's return type
-// omits it — same as the production `SceneLoaderOptions.buildCtx`.
+// occurrence's `activation` (issue #99) and its seeded `rng` (PUL-F018
+// / ADR-021), so the stub's return type omits both — same as the
+// production `SceneLoaderOptions.buildCtx`.
 export const stubCtx = (
   mode: NavigationMode,
   audio: AudioService,
-): Omit<WorkbenchSceneCtx, 'activation'> => ({
+): Omit<WorkbenchSceneCtx, 'activation' | 'rng'> => ({
   stage: null,
   mode,
   gsap,

--- a/tests/scenes/screenshot-rng-fixture.test.ts
+++ b/tests/scenes/screenshot-rng-fixture.test.ts
@@ -1,0 +1,182 @@
+// PUL-F018 / ADR-021 — screenshot RNG verification fixture unit tests.
+//
+// The fixture scene is exercised end-to-end by Playwright in
+// `tests-e2e/screenshot-mode.spec.ts`, where two loads of the same
+// `?scene=screenshot-rng-fixture&mode=screenshot` URL must project an
+// identical `data-pulsar-screenshot-rng` attribute. These unit tests
+// cover the PUL-F001 contract shape, the ctx defensiveness, and the
+// behavior unique to this fixture: `create(ctx)` draws a fixed number
+// of values from `ctx.rng` and projects them onto the fixture
+// element's `data-pulsar-screenshot-rng` attribute, so the same seeded
+// generator yields the same attribute and a different generator does
+// not.
+
+import { describe, expect, it } from 'vitest';
+import { createSeededRng } from '../../src/runtime/rng';
+import { screenshotRngFixtureScene } from '../../src/scenes/screenshot-rng-fixture';
+
+interface FakeStage {
+  readonly children: { attrs: Map<string, string> }[];
+  readonly element: {
+    setAttribute(name: string, value: string): void;
+    removeAttribute(name: string): void;
+    appendChild(node: unknown): unknown;
+    querySelector(selector: string): {
+      setAttribute(name: string, value: string): void;
+      remove(): void;
+    } | null;
+    ownerDocument: {
+      createElement(tag: string): { setAttribute(name: string, value: string): void };
+    };
+  };
+}
+
+// Stage stub mirroring `scrub-fixture.test.ts`: `appendChild` records
+// children, `querySelector` looks them up by the attribute name in the
+// `[<attr>]` selector, and `ownerDocument.createElement` returns a
+// recording stub. The fixture allocates DOM through the stage's owner
+// document rather than an ambient `document` global (ADR-008 #2).
+const buildStage = (): FakeStage => {
+  const children: { attrs: Map<string, string> }[] = [];
+  return {
+    children,
+    element: {
+      setAttribute: () => undefined,
+      removeAttribute: () => undefined,
+      appendChild: (node: unknown) => {
+        children.push(node as { attrs: Map<string, string> });
+        return node;
+      },
+      querySelector: (selector: string) => {
+        const attr = selector.replace(/^\[|\]$/g, '').split('=')[0];
+        if (attr === undefined) return null;
+        for (let i = 0; i < children.length; i += 1) {
+          const child = children[i];
+          if (child === undefined) continue;
+          if (child.attrs.has(attr)) {
+            return {
+              setAttribute: (name: string, value: string) => child.attrs.set(name, value),
+              remove: () => {
+                children.splice(i, 1);
+              },
+            };
+          }
+        }
+        return null;
+      },
+      ownerDocument: {
+        createElement: () => {
+          const attrs = new Map<string, string>();
+          return {
+            attrs,
+            setAttribute: (name: string, value: string) => attrs.set(name, value),
+          };
+        },
+      },
+    },
+  };
+};
+
+const RNG_ATTR = 'data-pulsar-screenshot-rng';
+const TARGET_ATTR = 'data-pulsar-screenshot-rng-target';
+
+// Build a `create`-ready ctx with a seeded `ctx.rng` (PUL-F018).
+const ctxWithSeed = (stage: FakeStage, seed: string): Record<string, unknown> => ({
+  stage: stage.element,
+  mode: 'screenshot',
+  gsap: { timeline: () => ({}) } as never,
+  audio: {} as never,
+  rng: createSeededRng(seed),
+});
+
+describe('screenshotRngFixtureScene', () => {
+  it('declares the PUL-F001 contract fields with kebab-case id', () => {
+    expect(screenshotRngFixtureScene.id).toBe('screenshot-rng-fixture');
+    expect(screenshotRngFixtureScene.title).toBe('Screenshot RNG verification fixture');
+    expect(screenshotRngFixtureScene.duration).toBeNull();
+    expect(screenshotRngFixtureScene.standalone).toBe(true);
+    expect(screenshotRngFixtureScene.trailerSafe).toBe(false);
+    expect(screenshotRngFixtureScene.assets).toEqual([]);
+    expect(screenshotRngFixtureScene.captions).toEqual([]);
+    expect(screenshotRngFixtureScene.audio).toEqual([]);
+    expect(screenshotRngFixtureScene.tags).toEqual(['fixture', 'screenshot']);
+    expect(screenshotRngFixtureScene.defaultNext).toBeNull();
+  });
+
+  it('projects a non-empty comma-separated draw list onto the fixture element on `create`', () => {
+    const stage = buildStage();
+    screenshotRngFixtureScene.create(ctxWithSeed(stage, 'seed-a'));
+    expect(stage.children).toHaveLength(1);
+    const attrs = stage.children[0]?.attrs;
+    expect(attrs?.get(TARGET_ATTR)).toBe('');
+    const draws = (attrs?.get(RNG_ATTR) ?? '').split(',');
+    expect(draws.length).toBeGreaterThan(1);
+    // Every projected value is a parseable float in [0, 1).
+    for (const d of draws) {
+      const n = Number.parseFloat(d);
+      expect(Number.isNaN(n)).toBe(false);
+      expect(n).toBeGreaterThanOrEqual(0);
+      expect(n).toBeLessThan(1);
+    }
+  });
+
+  it('projects an identical attribute for two ctx with the same seed', () => {
+    const a = buildStage();
+    const b = buildStage();
+    screenshotRngFixtureScene.create(ctxWithSeed(a, 'shared-seed'));
+    screenshotRngFixtureScene.create(ctxWithSeed(b, 'shared-seed'));
+    expect(a.children[0]?.attrs.get(RNG_ATTR)).toBe(b.children[0]?.attrs.get(RNG_ATTR));
+  });
+
+  it('projects a different attribute for a different seed', () => {
+    const a = buildStage();
+    const b = buildStage();
+    screenshotRngFixtureScene.create(ctxWithSeed(a, 'seed-a'));
+    screenshotRngFixtureScene.create(ctxWithSeed(b, 'seed-b'));
+    expect(a.children[0]?.attrs.get(RNG_ATTR)).not.toBe(b.children[0]?.attrs.get(RNG_ATTR));
+  });
+
+  it('returns null from `timeline(ctx)` — the fixture declares no animation', () => {
+    const stage = buildStage();
+    expect(screenshotRngFixtureScene.timeline(ctxWithSeed(stage, 'seed-a'))).toBeNull();
+  });
+
+  it('mounts a defined (possibly empty) attribute when ctx carries no rng', () => {
+    // Defensive: an off-contract ctx without `rng` must not throw.
+    const stage = buildStage();
+    screenshotRngFixtureScene.create({
+      stage: stage.element,
+      mode: 'screenshot',
+      gsap: { timeline: () => ({}) } as never,
+      audio: {} as never,
+    });
+    expect(stage.children).toHaveLength(1);
+    expect(typeof stage.children[0]?.attrs.get(RNG_ATTR)).toBe('string');
+  });
+
+  it('removes the fixture element on `cleanup`', () => {
+    const stage = buildStage();
+    screenshotRngFixtureScene.create(ctxWithSeed(stage, 'seed-a'));
+    expect(stage.children).toHaveLength(1);
+    screenshotRngFixtureScene.cleanup(ctxWithSeed(stage, 'seed-a'));
+    expect(stage.children).toHaveLength(0);
+  });
+
+  it('is a no-op when the stage has no ownerDocument (off-DOM harness)', () => {
+    const calls: string[] = [];
+    const bareStage = {
+      setAttribute: (n: string) => calls.push(`set:${n}`),
+      removeAttribute: (n: string) => calls.push(`remove:${n}`),
+    };
+    expect(() =>
+      screenshotRngFixtureScene.create({
+        stage: bareStage,
+        mode: 'screenshot',
+        gsap: { timeline: () => ({}) } as never,
+        audio: {} as never,
+        rng: createSeededRng('seed-a'),
+      }),
+    ).not.toThrow();
+    expect(calls).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Lands the deterministic seeded-RNG axis of PUL-F018 — the third and final screenshot-mode capture-bundle requirement (the frame-freeze and audio-suppression axes were already shipped, and the asset-preload fence is an existing resolver invariant). The runtime now exposes a deterministic random source on the scene context so a `mode=screenshot` capture is reproducible: the same workbench URL replays the same randomness across reloads. With all four runtime axes delivered end to end, PUL-F018 transitions DRAFT → ACTIVE.

## Requirement UIDs

- `PUL-F018`

## Related Issues

Closes #131

## ADR Impact

- ADR-021 (amended)

## Changes

- Add src/runtime/rng.ts: a pure mulberry32 PRNG seeded through an xmur3 string hash — integer arithmetic only, so it satisfies the PUL-Q001 screenshot-determinism source scanner.
- Add rng: () => number to WorkbenchSceneCtx (scene-loader.ts). deriveNavigationSeed builds the per-navigation seed from bounded deterministic URL inputs — the normalized navigation locator, the addressed beat, and PULSAR_RUNTIME_VERSION — and the loader threads an independent seeded generator per scene occurrence, so a repeated scene id never shares a draw stream.
- Add the screenshot-rng-fixture scene (src/scenes/screenshot-rng-fixture.ts), registered in workbench-graph.ts, which projects its ctx.rng draws onto a DOM attribute for end-to-end verification.
- Add tests-e2e/screenshot-mode.spec.ts: two loads of the same screenshot URL replay a byte-identical random sequence in a real browser engine.
- Amend ADR-021 with a dated current-state section recording all three DRAFT→ACTIVE triggers satisfied; file changelog fragment changelog.d/131.added.md.

## Test Plan

- [x] Unit tests pass (`pnpm test`)
- [x] End-to-end spec passes (`pnpm test:browsers`)
- [x] `pnpm lint && pnpm typecheck` passes (Biome + tsc)
- [x] No coverage regression

Local gates green: pnpm lint, pnpm typecheck, pnpm test (2572 vitest tests including the PUL-Q001 entropy scanner), pre-commit --all-files, and tests-e2e/screenshot-mode.spec.ts (chromium). Firefox/webkit run in CI; the PRNG is pure integer arithmetic and engine-independent by construction.

## Ground Control Checks

- [x] `make policy` passes
- [x] Quality gates pass or are unchanged by this repo-only change
- [x] Review sweep reviewed; codex + test-quality pre-push reviews clean (0 findings)

## Traceability

- IMPLEMENTS: PUL-F018 ← src/runtime/rng.ts, PUL-F018 ← src/runtime/scene-loader.ts (deriveNavigationSeed, WorkbenchSceneCtx.rng, per-occurrence threading), PUL-F018 ← src/scenes/screenshot-rng-fixture.ts
- TESTS: PUL-F018 ← tests/runtime/rng.test.ts, PUL-F018 ← tests/runtime/scene-loader-screenshot-seed.test.ts, PUL-F018 ← tests/scenes/screenshot-rng-fixture.test.ts, PUL-F018 ← tests-e2e/screenshot-mode.spec.ts

## Checklist

- [x] Code follows project coding standards
- [x] Runtime engine layer stays app-agnostic (no scene/composition imports in src/runtime/)
- [x] Changelog fragment added at `changelog.d/131.added.md`
- [x] Architectural docs updated (ADR-021 amended)
