### PR TITLE
feat: wire presenter pause/resume/skip-forward keys and fix runner command precedence

### DIFF
--- a/changelog.d/132.added.md
+++ b/changelog.d/132.added.md
@@ -1,0 +1,8 @@
+Presenter keyboard controls for skip-forward, pause, and resume —
+PUL-F020 / PUL-F021. In `mode=present` the keyboard presenter source now
+binds `PageDown` to skip-forward (next scene) and `PageUp` as a second
+skip-backward key alongside `ArrowLeft`, completing the PUL-F020 advance
+/ hold / skip surface. `KeyK` pauses the active timeline and `KeyL`
+resumes it from the same playhead position (PUL-F021). The GSAP runner
+translates each command into a master-timeline transport action, so a
+present-mode session responds to every documented key end to end.

--- a/changelog.d/132.changed.md
+++ b/changelog.d/132.changed.md
@@ -1,0 +1,9 @@
+Presenter `hold` and pause/resume now follow ADR-024 cross-command
+precedence. A `hold` command engages a beat hold and is idempotent — it
+no longer toggles playback back on when pressed a second time; `advance`
+releases the hold. An explicit `pause` is now distinct from a beat hold:
+`advance`, `hold`, and `skip-forward` / `skip-backward` received while
+the timeline is explicitly paused no longer resume playback (a skip may
+still move the frozen playhead), and only `resume` lifts an explicit
+pause. A `resume` that lifts a pause engaged while a hold was active
+leaves the master held.

--- a/docs/design/pul-f020-presenter-controls-preflight.md
+++ b/docs/design/pul-f020-presenter-controls-preflight.md
@@ -1,158 +1,207 @@
 # PUL-F020 Presenter Controls Preflight
 
-PUL-F020 specifies the runtime-side acceptance of presenter input
-under `mode=present`: advance to the next beat, hold the current
-beat, skip forward, and skip backward, with beat progression
-interruptible without breaking timeline state. It is one of the
-four facets ADR-016 names as gating PUL-F013 ACTIVE; the visible
-presenter UI surface and the GSAP runner that translates commands
-to transport calls are out of scope for this requirement and are
-the gating deliveries for PUL-F020 ACTIVE.
+PUL-F020 specifies runtime acceptance of presenter input under
+`mode=present`: advance to the next beat, hold the current beat, skip
+forward, and skip backward. Beat progression must be interruptible
+without breaking timeline state.
 
-## Boundary
+This note is design guidance only. It is not an implementation plan.
 
-Presenter input must flow through the existing navigation /
-lifecycle boundary:
+## Current Boundary
 
-- `src/runtime/navigation.ts` owns the `mode` URL grammar and the
-  `NAVIGATION_MODES` allowlist. Presenter input is not a URL
-  parameter; it is a workbench-supplied stream.
-- `effectiveMode()` owns the absent-mode default to `present`. The
-  loader uses this to scope presenter forwarding to mode=present
-  (explicit OR absent).
-- `src/runtime/scene-loader.ts` owns per-navigation mode dispatch,
-  `ctx.mode` construction, AND the per-navigation
-  `PresenterController` construction.
-- `src/runtime/scene-navigation.ts` owns scene/composition target
-  resolution and the lifecycle bridge; it forwards `presenter`
-  without interpretation.
-- `src/runtime/composition-resolver.ts` owns lifecycle ordering,
-  abort propagation, and cleanup; it forwards `presenter` to every
-  scene's run input.
-- `src/runtime/presenter.ts` is the new pure module that defines
-  the command shape, the source/controller interfaces, and the
-  per-navigation controller factory.
+The current repository already has the presenter-control seam and the
+browser input surfaces that issue #132 described as pending. Follow-up
+work must harden and test those seams, not add a second runtime path.
 
-Do not add a parallel keyboard listener at the runtime level, a
-second cleanup pathway for presenter-driven aborts, or a
-per-scene command pump. Mode dispatch and per-navigation
-controller construction live at one seam (`buildLoad` in the
-loader); subscriptions auto-detach via the existing
-`AbortController.signal`.
+- `src/runtime/navigation.ts` owns the URL grammar, `NAVIGATION_MODES`,
+  and `effectiveMode()`. Presenter input is not URL state.
+- `src/main.ts` is the browser composition root. It wires the keyboard
+  source, same-origin presenter bridge, practice overlay subscriber,
+  and `SceneLoaderOptions.presenterCommands`, and disposes those
+  long-lived surfaces during Vite HMR teardown.
+- `src/system/presenter/keyboard-source.ts` owns DOM keyboard event to
+  `PresenterCommand` translation. It is parameterized by
+  `KeyboardPresenterBindings`; do not duplicate the key map elsewhere.
+- `src/system/presenter/bridge.ts` owns same-origin
+  `BroadcastChannel` fan-out and `combinePresenterSources()`. It is a
+  local workbench bridge, not an auth boundary or remote protocol.
+- `src/runtime/presenter.ts` owns the single command schema,
+  allowlist, shape guard, defensive frozen copy, handler isolation, and
+  abort-tied controller cleanup.
+- `src/runtime/scene-loader.ts` owns mode scoping. It builds a
+  `PresenterController` only when `effectiveMode(target) === 'present'`
+  and a source was supplied, then threads it into `ctx.presenter` and
+  the timeline adapter options.
+- `src/runtime/scene-navigation.ts` and
+  `src/runtime/composition-resolver.ts` forward `presenter`; they do
+  not interpret commands. `mode=present` runs the full composition
+  slice, so presenter forwarding is not head-only.
+- `src/runtime/timeline.ts` owns command-to-master-transport behavior
+  through `MasterTimeline`, namespaced beat labels, and segment-start
+  labels. The runner is the only layer that should translate
+  `advance`, `hold`, `skip-forward`, and `skip-backward` into
+  `play()`, `pause()`, or `seek()`.
+- `src/system/helpers/timing.ts` owns scene-authoring helpers such as
+  `addAdvanceGate()`, `aSleep()`, and `holdUntilAdvance()`. Scenes use
+  these helper seams rather than binding keyboard events.
+
+## Architecture Decisions
+
+- Presenter controls are a command stream, not a workbench mode, URL
+  parameter, persistent state, manifest field, or scene schema field.
+- The command bus is single-source. `PRESENTER_COMMAND_KINDS` and
+  `isPresenterCommand()` are the only runtime command allowlist and
+  validator.
+- Local keyboard input and cross-window bridge input are workbench
+  sources. They may be composed into one `PresenterCommandSource`, but
+  the loader remains the mode gate.
+- Timeline behavior is runner-owned. Loader, resolver, scenes, chrome,
+  and keyboard code must not call GSAP transport methods to satisfy
+  PUL-F020.
+- F020 beat-pacing state must not be conflated with F021 transport
+  pause/resume. GSAP exposes one `paused()` bit, but the runtime
+  semantics are not one bit:
+  - `hold` is a beat-pacing hold. It must not be implemented as a
+    toggle that resumes playback on a second `hold`.
+  - `pause` / `resume` are explicit transport-freeze commands owned by
+    PUL-F021. Only `resume` unfreezes an explicit pause.
+  - `advance` may release a beat hold or move to the next authored beat
+    / segment boundary, but it must not silently clear an explicit
+    PUL-F021 pause.
+  - `skip-forward` / `skip-backward` may seek the frozen playhead while
+    paused, but they must not implicitly resume playback when ADR-024's
+    explicit pause gate is active.
+  Any private state needed to distinguish those cases belongs inside
+  the timeline adapter, not in URL state, loader state, scene globals,
+  or storage.
+- Skip semantics are discrete navigation. They seek to canonical master
+  labels: authored beats via `MasterTimeline.beats()` and scene
+  boundaries via `sceneSegmentLabel()` / the segment label map. Do not
+  treat skip as scrub or arbitrary millisecond seeking.
 
 ## Required Reuse
 
-Implementation must reuse these cross-cutting concerns:
+Implementation must reuse these incumbents:
 
-- URL grammar and mode validation: `parseNavigationSearch()`,
-  `NAVIGATION_MODES`, `effectiveMode()`. Do not introduce a
-  parallel "is present" check or a duplicate mode allowlist.
-- Lifecycle orchestration: `loadSceneNavigationTarget()` and
-  `resolveComposition()`. Forward `presenter` through the existing
-  spread-when-defined pattern parallel to `signal`.
-- Abort and cleanup: one per-navigation `AbortController`. The
-  presenter controller's auto-detach binds to the same signal that
-  drives lifecycle cleanup; no separate cleanup wiring.
-- Error rendering: the loader's `onError` sink. Boundary
-  diagnostics from the controller (unknown command kind, handler
-  exception) flow through the same channel as every other
-  runtime-level error.
-- Frozen invariants: `Object.freeze` for the command-kind allowlist
-  and the command discriminator object so a misbehaving runner
-  cannot mutate them post-emission. `deepFreeze` is not needed
-  (commands are flat).
-- Identifier validation: `src/runtime/identifier.ts` is not used
-  here (commands are kind-based, not id-based).
+- URL and mode validation: `parseNavigationSearch()`,
+  `NAVIGATION_MODES`, `effectiveMode()`, and loader-side defensive mode
+  checks for hand-built `NavigationTarget` values.
+- Presenter input schema and cleanup: `PRESENTER_COMMAND_KINDS`,
+  `PresenterCommand`, `isPresenterCommand()`,
+  `PresenterCommandSource`, `PresenterController`, and
+  `createPresenterController()`.
+- Browser input surfaces: `createKeyboardPresenterSource()`,
+  `DEFAULT_KEYBOARD_BINDINGS`, `KeyboardPresenterBindings`,
+  `createPresenterBridge()`, and `combinePresenterSources()`.
+- Lifecycle orchestration: `createSceneLoader()`,
+  `loadSceneNavigationTarget()`, `resolveComposition()`, the
+  per-navigation `AbortSignal`, and resolver cleanup. Presenter
+  commands must not add a cleanup path.
+- Timeline transport and beat grammar: `createGsapCompositionTimeline()`,
+  `MasterTimeline`, `assertSceneTimeline()`, `MasterTimeline.beats()`,
+  `sceneSegmentLabel()`, `sceneTimelineLabel()`, and
+  `parseSceneTimelineLabel()`.
+- Scene authoring helpers: `addAdvanceGate()`, `aSleep()`, and
+  `holdUntilAdvance()` for presenter-driven waits and advance gates.
+- Error rendering and diagnostics: `describeErrorDetailed()`,
+  `formatSceneContext()`, loader `onError`,
+  `data-pulsar-navigation-error`, and `data-pulsar-scene-failures`.
+- Workbench cleanup: HMR disposal of navigation listeners, loader,
+  chrome, transition overlay, keyboard source, presenter bridge,
+  stage observer, practice renderer, scrub controls, and GSAP ticker
+  callbacks.
 
-## Guardrails
+## Cross-Cutting Layers
 
-- Presenter input is scoped to `mode=present`. The loader builds
-  the controller only when `effectiveMode(target) === 'present'`
-  AND `presenterCommands` is supplied. No leak into standalone /
-  loop / paused / scrub / screenshot / prompter.
-- Commands are translated to timeline operations by the runner,
-  not the runtime core. ADR-003 names GSAP `play()` / `pause()` /
-  `seek()` / `tweenTo()` as the legitimate transport calls. No
-  `setTimeout` / `setInterval` polling for command arrivals.
-- The runtime does not attach keyboard listeners. The future
-  presenter UI module (a workbench surface) attaches listeners,
-  translates them to `PresenterCommand`s, and emits via a
-  `PresenterCommandSource`. ADR-007's "URL is the only source for
-  mode" rule extends here: the runtime does not look at
-  `window.location` or any global to decide whether commands are
-  active; the workbench-supplied source IS the gate.
-- The controller's auto-detach is a safety net, not a substitute
-  for runner hygiene. A runner that subscribes SHOULD still call
-  the returned unsubscribe on its own scene-exit path; the abort-
-  driven detach catches the runner that forgets.
-- Boundary validation drops unknown command kinds. The runner does
-  not see malformed commands; the diagnostic flows through
-  `onError`. Do not throw from the boundary; do not unmount the
-  scene to report a malformed command.
-- The interruptibility clause ("beat progression SHALL be
-  interruptible without breaking timeline state") is satisfied by
-  the existing PUL-F006 mandatory-cleanup invariant. Do not
-  introduce a second cleanup path or skip cleanup on the abort
-  branch.
+| Layer | Canonical gate | Required behavior |
+|-------|----------------|-------------------|
+| URL grammar | `parseNavigationSearch()` | Add no presenter query keys. Unknown query keys stay ignored; malformed canonical keys fail through the navigation error path. |
+| Mode selection | `effectiveMode()` in the loader | Recompute mode per navigation. Do not read `window.location`, localStorage, sessionStorage, cookies, `history.state`, env, argv, or cached state inside the runner or source. |
+| Keyboard input | `createKeyboardPresenterSource()` | Translate only configured bindings, ignore editable targets, prevent default only for bound keys, and dispose the listener on HMR. The documented mapping must expose every accepted command that the UI claims to support, including `skip-forward`. |
+| Cross-window input | `createPresenterBridge()` | Validate inbound channel data with `isPresenterCommand()`. Treat `BroadcastChannel` as same-origin convenience only; never as remote authorization. No tokens or secrets in channel names or messages. |
+| Source composition | `combinePresenterSources()` | Merge sources once at the composition root. Avoid double-wiring the same keyboard source, which would duplicate commands. |
+| Command shape | `PRESENTER_COMMAND_KINDS` / `isPresenterCommand()` | Keep commands flat and discriminator-based unless a future kind needs data. Unknown kinds are dropped before the runner and reported through the existing diagnostic sink. |
+| Command payload safety | `createPresenterController()` | Fan out one frozen defensive copy per accepted emission, isolate throwing subscribers, and auto-detach on abort/completion. |
+| Timeline shape | `assertSceneTimeline()` / `MasterTimeline` | Only GSAP timelines or null enter the master. Beat labels are kebab-case finite scene-local labels copied into namespaced master labels. |
+| Lifecycle | loader abort + resolver cleanup | Presenter commands do not abort, remount, or call `cleanup(ctx)` directly. Superseding navigation still aborts and cleans up exactly once. |
+| Audio sibling command | loader mute subscriber + `AudioService` | `toggle-master-mute` may share the bus, but the timeline runner ignores audio-owned commands and audio code does not inspect beat commands. |
+| Error envelope | `describeErrorDetailed()` and loader `onError` | Do not serialize raw future remote payloads, stacks, DOM nodes, scene objects, captions, cookies, headers, env, auth values, GSAP instances, or Howler handles. |
+| Config/env/OS exposure | package scripts and in-browser state | No env vars, config files, CLI flags, process argv tokens, shell commands, files, cookies, or browser storage are needed for F020. |
+| Structural validation | `validateRuntime()` over `WORKBENCH_SCENES` / `WORKBENCH_COMPOSITIONS` | Presenter controls do not bypass the canonical graph validation pass or create a deck-only registry path. |
+
+## Extensibility
+
+- New keyboard mappings belong in `KeyboardPresenterBindings` and tests
+  for `createKeyboardPresenterSource()`, not in the loader, runner, or
+  scene modules.
+- Future on-screen controls should implement `PresenterCommandSource`
+  and be composed with existing sources. They should not call the
+  loader, resolver, or `MasterTimeline` directly.
+- Future remote presenter protocols must authenticate and authorize
+  before emitting into `PresenterCommandSource`. The presenter
+  controller remains the local shape gate, not the security boundary.
+- Future command payloads extend `PresenterCommand` as a discriminated
+  union and update `isPresenterCommand()` in the same module. Do not add
+  a second command schema.
+- Future presenter status UI needs a separate runner/workbench status
+  surface. Do not overload `PresenterCommandSource`, URL grammar, stage
+  error attributes, or timeline labels as a state store.
+- L2-only commands such as `toggle-practice` may ride the same bus only
+  with explicit ownership. Runtime transport code must ignore
+  non-transport commands.
+
+## Gotchas
+
+- Issue text may be stale. In this checkout keyboard and GSAP command
+  plumbing already exist; evaluate the live incumbents before adding
+  anything.
+- `MasterTimeline.isPaused()` is not enough to distinguish beat hold,
+  GSAP addPause gates, and explicit PUL-F021 pause. Treating all three
+  as the same state creates resume/advance bugs.
+- `advance` and `skip-forward` are different commands. A keyboard map
+  that exposes only `advance` and `skip-backward` does not prove the
+  full PUL-F020 input surface.
+- `hold` and `pause` are different commands. Reusing one for the other
+  breaks ADR-024 cross-command precedence.
+- `mode=present` and absent `mode` are equivalent only through
+  `effectiveMode()`. Branching on `target.mode === 'present'` misses the
+  default-present path.
+- Presenter forwarding is full-slice under `mode=present`. Making it
+  head-only silently drops controls for later scenes.
+- Source-level validation and controller-level validation are both
+  useful. Do not remove the controller guard because keyboard or bridge
+  sources currently emit typed objects.
+- Same-origin `BroadcastChannel` delivery is asynchronous and may be
+  unavailable. The bridge must remain inert when unsupported.
 
 ## Non-Goals
 
-PUL-F020 should not implement:
+PUL-F020 should not implement new URL grammar, new workbench modes,
+remote presenter auth, persistence, telemetry, new scene or composition
+schemas, a second event bus, a second command validator, a new
+exception hierarchy, direct Howler or raw audio handling, scrub-mode
+controls, export behavior, requirement status transition, or
+traceability automation.
 
-- Pause / resume (PUL-F021 — separate requirement).
-- Master mute (PUL-F025 — separate requirement).
-- Scene-level skip ("jump to next/prev scene"). The four named
-  commands are beat-level navigation within the active scene;
-  scene-level navigation is a URL-grammar concern (PUL-F008 / PUL-F011).
-- Scrub controls (PUL-F017 / `mode=scrub`). Skip is a discrete
-  beat jump, not a continuous millisecond seek.
-- A remote-presenter protocol (HTTP, WebSocket, etc.). The source
-  is workbench-supplied; how it gathers input (keyboard, on-screen
-  controls, future remote-presenter bridge) is the source's
-  concern.
-- The visible presenter UI surface (keyboard listener, on-screen
-  controls). PUL-F020 ACTIVE depends on this surface; the
-  contract layer ships first per the ADR-016 / ADR-017 / ADR-018 /
-  ADR-019 / ADR-020 / ADR-021 / ADR-022 precedent.
-- The GSAP runner that translates commands to transport calls
-  (ADR-003 territory). PUL-F020 ACTIVE depends on this runner.
+It should not redesign PUL-F021 pause/resume or PUL-F025 master mute.
+Those commands share the presenter seam but retain separate behavior
+ownership.
 
 ## Anti-Patterns
 
-- Attaching keyboard listeners at the scene level. Scenes receive
-  commands through the runner's `input.presenter` subscription
-  (when the runner needs that signal); they do not run their own
-  input pumps.
-- Duplicating `PRESENTER_COMMAND_KINDS` or re-validating command
-  shapes inside the runner. The controller's `isPresenterCommand`
-  check is the single boundary; the runner sees only well-formed
+- Attaching keyboard listeners in scenes, decks, templates, or the
+  runtime core.
+- Duplicating `PRESENTER_COMMAND_KINDS`, `NAVIGATION_MODES`, beat-label
+  parsing, or segment-label parsing.
+- Reading mode from globals inside the keyboard source or timeline
+  adapter.
+- Implementing beat controls by mutating URL/history, browser storage,
+  scene globals, or manifest data.
+- Calling `cleanup(ctx)`, aborting navigation, or remounting scenes for
+  `advance`, `hold`, or `skip-*`.
+- Using `setTimeout`, polling, or wall-clock state to detect presenter
   commands.
-- Treating skip as scrub. Skip is a beat-level jump; scrub is a
-  continuous-seek interaction model owned by `mode=scrub`.
-- Treating hold as pause. Hold pauses the current beat (timeline
-  paused at the current position); pause / resume is a separate
-  full-composition transport state owned by PUL-F021.
-- Building a long-lived controller that survives across
-  navigations. The controller is per-navigation; subscriptions
-  auto-detach when the navigation aborts. A long-lived controller
-  re-introduces the leak failure mode the per-navigation design
-  defends against.
-- Reading mode from `window.location` to decide whether to subscribe
-  inside the runner. The runner subscribes when `input.presenter`
-  is present; the loader's mode-scoping decides presence.
-- Building a second exception hierarchy for presenter errors. The
-  controller's boundary diagnostics use the existing `onError`
-  sink with plain `Error` objects. Callers pattern-match on the
-  prefix `presenter command rejected:` if they need to (the
-  message naming follows the resolver's `composition resolution
-  failed:` envelope precedent — same prefix-style diagnostic
-  surface, no separate type).
-- Using `setTimeout` / polling to schedule command arrivals. The
-  source emits synchronously; the controller forwards
-  synchronously; the runner translates to GSAP transport calls
-  that are themselves frame-aligned (ADR-003).
-- Creating a `data-pulsar-mode-*` suppression attribute under
-  `mode=present` to gate the runner's subscription. ADR-016 forbids
-  preemptive suppression attributes under `mode=present`. The
-  runner's behavior is gated by `input.presenter`'s presence, not
-  by stage-attribute introspection.
+- Treating skip as scrub or as arbitrary millisecond seek.
+- Letting audio-owned commands, practice-overlay commands, or future UI
+  commands leak into master-timeline transport behavior.
+- Emitting raw remote/channel payloads into public diagnostics.

--- a/docs/design/pul-f021-pause-resume-preflight.md
+++ b/docs/design/pul-f021-pause-resume-preflight.md
@@ -9,6 +9,14 @@ ADR-024 records the binding architecture decision: extend the existing
 presenter command seam from ADR-023. Do not add a pause-specific input
 surface or lifecycle path.
 
+This note is design guidance only. It is not an implementation plan.
+
+The current repository already has the presenter command seam, browser
+keyboard source, same-origin presenter bridge, and GSAP composition
+timeline adapter. Follow-up work for issue #132 must harden those
+incumbents and their tests. Stale issue text that says a surface is
+missing is not permission to add a second surface.
+
 ## Boundary
 
 Pause/resume must flow through the existing runtime path:
@@ -20,6 +28,17 @@ Pause/resume must flow through the existing runtime path:
 - `src/runtime/scene-loader.ts` owns per-navigation mode dispatch and
   builds the presenter controller only when `mode=present` and the
   workbench supplied a `presenterCommands` source.
+- `src/main.ts` is the browser composition root. It wires the keyboard
+  source, same-origin presenter bridge, source composition, loader
+  `presenterCommands`, and HMR teardown. Do not add another global
+  listener or bus outside this composition root.
+- `src/system/presenter/keyboard-source.ts` owns DOM keyboard event to
+  `PresenterCommand` translation. Key policy is parameterized by
+  `KeyboardPresenterBindings`; do not duplicate the mapping in the
+  loader, runner, scenes, or tests.
+- `src/system/presenter/bridge.ts` owns same-origin `BroadcastChannel`
+  fan-out and `combinePresenterSources()`. The bridge is a local
+  workbench convenience, not a remote presenter protocol.
 - `src/runtime/presenter.ts` owns command kinds, command shape
   validation, boundary diagnostics, handler isolation, and abort-tied
   subscription cleanup.
@@ -43,6 +62,9 @@ Implementation must reuse these incumbents:
 - Presenter input schema: `PRESENTER_COMMAND_KINDS`,
   `PresenterCommand`, `isPresenterCommand`, `PresenterCommandSource`,
   `PresenterController`, and `createPresenterController`.
+- Browser input surfaces: `createKeyboardPresenterSource()`,
+  `DEFAULT_KEYBOARD_BINDINGS`, `KeyboardPresenterBindings`,
+  `createPresenterBridge()`, and `combinePresenterSources()`.
 - Presenter scoping and cleanup: `SceneLoaderOptions.presenterCommands`
   plus the existing loader -> bridge -> resolver forwarding chain.
 - Lifecycle orchestration: `loadSceneNavigationTarget()` and
@@ -54,6 +76,10 @@ Implementation must reuse these incumbents:
 - Runner contract: ADR-003's GSAP transport API (`pause()` and
   resumed `play()` from the current playhead). Do not hand-roll
   timers or scene-local pause flags.
+- Timeline beat/segment addressing: `MasterTimeline.beats()`,
+  `sceneSegmentLabel()`, `sceneTimelineLabel()`, and
+  `parseSceneTimelineLabel()`. Pause/resume must not introduce a
+  second beat or segment grammar.
 - Test locations and shapes: `tests/runtime/presenter.test.ts` for the
   command boundary; `scene-loader.test.ts`, `scene-navigation.test.ts`,
   and `composition-resolver.test.ts` for seam forwarding; the future
@@ -65,6 +91,8 @@ Implementation must reuse these incumbents:
 |-------|--------------------------|
 | URL grammar | No new key. `mode=paused` remains first-frame inspection. Unknown URL keys stay ignored by `parseNavigationSearch()`. |
 | Mode gate | `NAVIGATION_MODES` is unchanged. The loader builds presenter control only for effective `present`. |
+| Keyboard input | Use `createKeyboardPresenterSource()` and `KeyboardPresenterBindings`. Ignore editable targets, prevent default only for bound keys, and dispose the listener on HMR. If pause/resume are keyboard-addressable, bind explicit commands through this map; do not install a second listener. |
+| Cross-window input | Use `createPresenterBridge()` / `combinePresenterSources()`. Inbound channel data is still shape-checked by `isPresenterCommand()`. Do not put tokens, secrets, raw scene data, or timeline state in channel names or messages. |
 | Command shape gate | Extend `PRESENTER_COMMAND_KINDS` with `pause` and `resume`. Keep `isPresenterCommand` as the only validator. |
 | Command payload safety | Commands stay flat and discriminator-based. Do not forward arbitrary objects to the runner. Freeze the emitted command copy as today. |
 | Auth surface | None in this repo. Do not add HTTP/WebSocket/remote control for PUL-F021. A future remote source must authenticate before emitting into `PresenterCommandSource`. |
@@ -73,6 +101,7 @@ Implementation must reuse these incumbents:
 | Lifecycle and cleanup | `AbortSignal` still means navigation supersession/dispose. `pause` and `resume` do not abort and do not trigger cleanup. |
 | Error envelope | Invalid commands and handler exceptions use the presenter controller's existing `onError` path. Do not include raw future payloads in error text. |
 | Observability | Do not add `data-pulsar-mode-*` or pause-state stage attributes until a concrete UI/status requirement needs them. |
+| Timeline transport | The GSAP adapter owns the active master and any private pause gate needed to distinguish explicit PUL-F021 pause from beat hold or GSAP addPause gates. The loader, keyboard source, bridge, and scenes must not call `MasterTimeline` methods directly. |
 
 ## Guardrails
 
@@ -91,6 +120,10 @@ Implementation must reuse these incumbents:
 - Same-point resume means the active timeline instance's current
   playhead. It does not mean first frame, last beat, URL `beat=`, or a
   persisted checkpoint.
+- `MasterTimeline.isPaused()` is not a sufficient state model. GSAP has
+  one paused bit, but PUL-F020 `hold`, GSAP `addPause` gates, and
+  explicit PUL-F021 pause have different semantics. Keep any private
+  disambiguating state inside the timeline adapter.
 - Pause/resume composes with — does not override — the PUL-F020
   beat-pacing commands (`hold` / `advance` / `skip-forward` /
   `skip-backward`). `pause` snapshots beat-pacing state and freezes
@@ -101,6 +134,11 @@ Implementation must reuse these incumbents:
   precedence* is the binding rule the GSAP runner and its tests must
   honor; do not let seam-only delivery imply a particular composition
   behavior.
+- If keyboard UX wants a single pause/resume toggle key, do not invent
+  a source-local hidden paused boolean. Either bind explicit
+  `pause` / `resume` commands through `KeyboardPresenterBindings`, or
+  add a deliberate runner-to-workbench status surface / command
+  contract in its own design pass.
 - `presenter` stays every-scene under `mode=present`; do not make it
   head-only and do not truncate composition slices for pause/resume.
 - The placeholder runner can ignore pause/resume until the GSAP runner
@@ -114,6 +152,10 @@ command needs data, extend `PresenterCommand` as a discriminated union
 with kind-specific fields and update `isPresenterCommand` in the same
 module. Do not add a second command schema.
 
+Keyboard variations belong in `KeyboardPresenterBindings` and its
+tests. Additional input devices or on-screen controls should implement
+`PresenterCommandSource` and be merged once at the composition root.
+
 If a future UI needs to display paused/playing state, add a separate
 runner-to-workbench status surface. Do not overload
 `PresenterCommandSource`, URL mode, or stage diagnostics as a state
@@ -121,11 +163,16 @@ store.
 
 ## Non-Goals
 
-PUL-F021 should not implement the keyboard listener, on-screen
-presenter UI, remote presenter protocol, GSAP runner, master mute,
-scrub controls, `mode=paused`, persistence, status indicators, or
-requirement status transition. It should not change scene or
-composition schemas.
+PUL-F021 should not implement a second keyboard listener, a second
+presenter bridge, on-screen presenter UI, remote presenter protocol,
+master mute, scrub controls, `mode=paused`, persistence, telemetry,
+status indicators, requirement status transition, or traceability
+automation. It should not change scene or composition schemas.
+
+The implementation may touch the existing keyboard source and GSAP
+timeline adapter only through their canonical seams. That is not a
+license to redesign present-mode chrome, command transport, lifecycle,
+audio, or URL navigation.
 
 ## Anti-Patterns
 
@@ -141,3 +188,7 @@ composition schemas.
 - Adding a duplicate exception hierarchy or duplicate command
   validator.
 - Letting pause/resume commands leak into non-present modes.
+- Implementing pause/resume toggling in the keyboard source by guessing
+  runner state.
+- Treating the same-origin `BroadcastChannel` as an authenticated
+  remote-control surface.

--- a/docs/design/pul-f025-master-mute-preflight.md
+++ b/docs/design/pul-f025-master-mute-preflight.md
@@ -3,139 +3,223 @@
 PUL-F025 specifies presenter input that toggles master mute. Master
 mute silences audio without changing timeline state.
 
-No new ADR is needed for this preflight. ADR-004 already owns master
-mute as runtime audio-engine state, and ADR-023 / ADR-024 already own
-the presenter command source, validation, mode scoping, and abort-tied
-subscription cleanup. PUL-F025 composes those two incumbents.
+This note is design guidance only. It is not an implementation plan.
+No new ADR is needed. ADR-004 owns master mute as audio-engine runtime
+state, ADR-023 owns the presenter command seam, ADR-024 owns
+pause/resume transport semantics, and ADR-016 records the current
+present-mode integration boundary.
 
-## Boundary
+The current repository already has the presenter command seam, browser
+keyboard source, same-origin presenter bridge, GSAP composition
+timeline adapter, and loader-side master-mute handler. Follow-up work
+for issue #132 must harden and test those incumbents, not add a second
+input, command, audio, or timeline path. Stale issue text that says a
+surface is missing is not permission to add a duplicate surface.
 
-Master mute must stay on the existing runtime path:
+## Current Boundary
 
-- `src/runtime/presenter.ts` owns presenter command kinds, command
-  shape validation, handler isolation, and abort-tied cleanup. Add the
-  master-mute command there; do not create an audio-specific command
-  bus, validator, controller, or event type.
-- `src/runtime/scene-loader.ts` is the only runtime seam that has both
-  the per-navigation `PresenterController` and the per-navigation
-  `AudioService`. It is the correct place to bind accepted presenter
-  mute input to `audio.mute(!audio.isMuted())`.
-- `src/runtime/audio.ts` owns master mute. The implementation must call
-  `AudioService.mute()` / `isMuted()` and let the service delegate to
-  `AudioEngine.setMasterMute()`. Do not import Howler or call
-  `Howler.mute()` outside the audio boundary.
-- `src/runtime/timeline.ts` owns timeline transport. Master mute must
-  not pause, seek, repeat, kill, rebuild, or otherwise mutate the
-  master timeline.
-- `src/runtime/navigation.ts` owns URL grammar. PUL-F025 adds no query
-  parameter, no mode, no persisted mute state, and no history mutation.
+Master mute must stay on the existing workbench -> presenter -> loader
+-> audio path:
+
+- `src/runtime/navigation.ts` owns URL grammar, `NAVIGATION_MODES`, and
+  `effectiveMode()`. PUL-F025 adds no query key, mode, URL-derived mute
+  state, or history mutation.
+- `src/main.ts` is the browser composition root. It wires the keyboard
+  source, same-origin presenter bridge, combined
+  `PresenterCommandSource`, and `SceneLoaderOptions.presenterCommands`,
+  and disposes those long-lived surfaces during Vite HMR teardown.
+- `src/system/presenter/keyboard-source.ts` owns DOM keydown to
+  `PresenterCommand` translation. `KeyM` maps to
+  `toggle-master-mute` through `KeyboardPresenterBindings`; do not
+  duplicate that map in the loader, runner, scenes, or tests.
+- `src/system/presenter/bridge.ts` owns same-origin
+  `BroadcastChannel` fan-out and `combinePresenterSources()`. It is a
+  local workbench bridge, not an auth boundary or remote presenter
+  protocol.
+- `src/runtime/presenter.ts` owns the single command schema, command
+  allowlist, shape guard, frozen defensive copy, handler isolation, and
+  abort-tied controller cleanup.
+- `src/runtime/scene-loader.ts` owns mode scoping and the PUL-F025
+  audio subscriber. It builds a `PresenterController` only when
+  `effectiveMode(target) === 'present'` and a source was supplied, then
+  subscribes the loader-owned mute handler against the per-navigation
+  `AudioService`.
+- `src/runtime/audio.ts` owns master mute. The handler calls
+  `AudioService.mute(!AudioService.isMuted())`, which delegates to the
+  engine's master-mute state. Howler stays behind
+  `createHowlerAudioEngine()`.
+- `src/runtime/timeline.ts` owns timeline transport. It may subscribe
+  to the same presenter controller for beat and pause/resume commands,
+  but it ignores `toggle-master-mute`; audio-owned commands are not
+  transport commands.
 - `src/runtime/scene-navigation.ts` and
-  `src/runtime/composition-resolver.ts` remain lifecycle/pass-through
-  layers. They should not learn audio mute semantics.
+  `src/runtime/composition-resolver.ts` forward presenter state and own
+  lifecycle cleanup. They do not interpret mute.
 
-The intended command kind is `toggle-master-mute`: a presenter command
-is an input fact, not timeline state. The runtime audio handler toggles
-the engine's current master-mute state at command receipt time.
+## Architecture Decisions
+
+- Master mute is audio-owned runtime state, not scene state, timeline
+  state, URL state, chrome state, storage state, or a composition
+  behavior override.
+- The command kind is `toggle-master-mute`: a presenter command is an
+  input fact, not a target state. The audio handler reads current engine
+  state at receipt time and flips it. Do not keep a second mute boolean.
+- Presenter input is active only through the loader's effective
+  `present` gate. Sources may exist globally, but non-present
+  navigations do not build the controller and therefore cannot toggle
+  mute through this path.
+- The mute handler is additive, not a filter. The runner may still see
+  `toggle-master-mute`, but must ignore it as not the master's concern.
+- Master mute must not pause, resume, seek, repeat, kill, rebuild, or
+  otherwise mutate the master timeline. Playback continues silently
+  while muted and audibly after unmute.
+- The PUL-Q010 responsiveness path is the synchronous loader-owned
+  subscriber: accepted `toggle-master-mute` -> `audio.isMuted()` ->
+  `audio.mute(...)` -> engine `setMasterMute(...)`. Do not insert
+  timers, promises, fades, animation frames, runner hops, or UI status
+  waits on that path.
 
 ## Required Reuse
 
-Use these canonical incumbents:
+Implementation must reuse these incumbents:
 
-- Presenter input schema: `PRESENTER_COMMAND_KINDS`,
-  `PresenterCommand`, `isPresenterCommand`,
+- URL and mode validation: `parseNavigationSearch()`,
+  `NAVIGATION_MODES`, `effectiveMode()`, and loader-side defensive mode
+  checks for hand-built `NavigationTarget` values.
+- Presenter input schema and cleanup: `PRESENTER_COMMAND_KINDS`,
+  `PresenterCommand`, `isPresenterCommand()`,
   `PresenterCommandSource`, `PresenterController`, and
-  `createPresenterController`.
-- Presenter mode gate: `effectiveMode()`,
-  `SceneLoaderOptions.presenterCommands`, and the loader's existing
-  `mode === 'present'` controller construction.
-- Audio service: `AudioService.mute()`, `AudioService.isMuted()`,
+  `createPresenterController()`.
+- Browser input surfaces: `createKeyboardPresenterSource()`,
+  `DEFAULT_KEYBOARD_BINDINGS`, `KeyboardPresenterBindings`,
+  `createPresenterBridge()`, and `combinePresenterSources()`.
+- Presenter scoping and dispatch: `SceneLoaderOptions.presenterCommands`
+  and the loader's `buildPresenterPipe` / per-navigation
+  `AbortController` path.
+- Audio boundary: `AudioService.mute()`, `AudioService.isMuted()`,
   `AudioEngine.setMasterMute()`, `AudioEngine.isMasterMuted()`,
   `createHowlerAudioEngine()`, and `noopAudioEngine`.
-- Lifecycle and cleanup: the existing per-navigation
-  `AbortController.signal`. The mute subscription must be tied to the
-  same controller cleanup as every other presenter subscription.
-- Error handling: the presenter controller's existing handler
-  try/catch and loader `onError` diagnostic sink. Do not add a mute
-  exception hierarchy or navigation failure envelope.
-- Tests: the existing presenter boundary tests, scene-loader presenter
-  seam tests, and audio service / engine tests. Keep mute behavior
-  covered at the seam where it lives.
+- Timeline boundary: `createGsapCompositionTimeline()` and
+  `MasterTimeline` remain transport-only for presenter commands.
+  `toggle-master-mute` is ignored there.
+- Lifecycle orchestration: `loadSceneNavigationTarget()`,
+  `resolveComposition()`, resolver cleanup, per-scene
+  `onSceneCleaned`, and audio `stopGroup()` / `stopAll()` teardown.
+  Master mute is not reset by those cleanup paths.
+- Error rendering and diagnostics: presenter controller `onError`,
+  loader `onError`, `describeErrorDetailed()`,
+  `data-pulsar-navigation-error`, and `data-pulsar-scene-failures`.
+- Structural validation: `validateRuntime()` over
+  `WORKBENCH_SCENES` / `WORKBENCH_COMPOSITIONS`. Presenter mute does
+  not bypass graph validation or create a deck-only registry path.
+- Test locations and shapes: `tests/runtime/presenter.test.ts`,
+  `tests/runtime/scene-loader-present.test.ts`,
+  `tests/runtime/audio.test.ts`, `tests/runtime/audio-engine.test.ts`,
+  `tests/system/presenter-keyboard.test.ts`, and
+  `tests/system/presenter-bridge.test.ts`.
 
 ## Cross-Cutting Layers
 
-| Layer | Requirement for PUL-F025 |
-|-------|--------------------------|
-| URL grammar / mode validation | `NAVIGATION_MODES`, `parseNavigationSearch()`, `effectiveMode()`, and loader-side mode validation remain unchanged. Presenter mute is active only when the loader builds presenter controls for effective `present`. |
-| Presenter command shape | Extend the existing command allowlist with `toggle-master-mute`. Keep `isPresenterCommand` as the only boundary validator and keep emitted commands flat/frozen. |
-| Auth / remote input | No auth surface exists in this repo. A future remote presenter protocol must authenticate/authorize before emitting into `PresenterCommandSource`; the controller still shape-checks every emitted command. |
-| Audio boundary | The handler calls `AudioService.mute()` / `isMuted()`. Howler remains hidden behind `createHowlerAudioEngine()` in `audio.ts`. |
-| Timeline state | The handler must not touch `MasterTimeline`, runner hints, URL beat, pause/resume state, `AbortController`, or `cleanup(ctx)`. Existing playback continues silently while muted and continues audibly when unmuted. |
-| Lifecycle / cleanup | Presenter subscriptions auto-detach on navigation abort. Master mute state is engine-level runtime state and is not reset by per-navigation `stopAll()` or scene cleanup. |
-| Error envelopes | Malformed commands are dropped at the presenter controller and reported through `onError`. A mute-handler exception is non-fatal and must not become `composition resolution failed:` or unmount the scene. Do not include raw future remote payloads in diagnostics. |
-| Config / env / OS exposure | No env vars, config files, process argv tokens, URLs, cookies, localStorage, sessionStorage, files, or shell commands are needed. Do not persist mute state or presenter secrets. |
-| Observability | Reuse `onError` for diagnostics. Do not add stage attributes, analytics, or per-command logs for mute state until a concrete UI/status requirement needs them. |
-
-## Guardrails
-
-- Master mute is audio-owned runtime state, not a scene flag, URL mode,
-  timeline label, composition behavior override, or transport command.
-- Toggle semantics read the current engine state at receipt time. Do
-  not keep a second boolean in the loader, runner, UI, scene, or
-  browser storage.
-- Presenter input remains scoped to `mode=present`. Do not let mute
-  commands leak into standalone, loop, paused, scrub, screenshot, or
-  prompter navigations.
-- The command is accepted even before any sound has been registered.
-  `noopAudioEngine` must round-trip the mute state the same way the
-  Howler engine does.
-- The timeline runner may ignore audio-owned commands. It must not
-  interpret `toggle-master-mute` as pause, hold, cue gating, speed,
-  seek, or scene navigation.
-- Do not add visible mute indicators, keyboard listeners, remote
-  protocols, or workbench chrome in PUL-F025 unless a separate
-  requirement supplies that surface.
+| Layer | Canonical gate | Required behavior |
+|-------|----------------|-------------------|
+| URL grammar | `parseNavigationSearch()` | Add no `mute`, `muted`, `masterMute`, or presenter query keys. Unknown keys stay non-semantic; malformed canonical keys fail through the navigation error path. |
+| Mode selection | `effectiveMode()` in the loader | Recompute mode per navigation. Treat absent mode as present through the helper, not by checking `target.mode === 'present'`. |
+| Keyboard input | `createKeyboardPresenterSource()` | Translate only configured bindings, ignore editable targets, prevent default only for bound keys, and dispose the listener on HMR. `KeyM` remains the local mute binding unless `KeyboardPresenterBindings` is deliberately changed. |
+| Cross-window input | `createPresenterBridge()` | Validate inbound channel data with `isPresenterCommand()`. Treat `BroadcastChannel` as same-origin convenience only; no tokens, secrets, source URLs, timeline state, scene objects, or raw audio data in channel names or messages. |
+| Source composition | `combinePresenterSources()` | Merge sources once at the composition root. Avoid double-wiring the same keyboard source, which would duplicate toggles. |
+| Command shape | `PRESENTER_COMMAND_KINDS` / `isPresenterCommand()` | Keep `toggle-master-mute` on the existing allowlist. Do not add `mute`, `unmute`, `master-mute`, a second schema, or a second validator. |
+| Command payload safety | `createPresenterController()` | Fan out one frozen defensive copy per accepted emission, isolate throwing subscribers, and auto-detach on abort/completion. |
+| Auth surface | None in this repo | Do not add HTTP/WebSocket/remote control for PUL-F025. A future remote source must authenticate and authorize before emitting into `PresenterCommandSource`. |
+| Secret/config/env surface | Existing browser bootstrap and package scripts | No env vars, config files, CLI flags, process argv tokens, shell commands, files, cookies, localStorage, sessionStorage, credentials, or persistent browser state are needed. |
+| Audio source validation | `AudioService` / `resolveAssetUrl()` | Mute does not register or resolve sources. Do not re-check scene audio declarations at command time or route mute through asset allowlists. |
+| Audio engine boundary | `AudioService` -> `AudioEngine` | Silence through engine master mute. Do not import Howler outside `src/runtime/audio.ts`, iterate sounds in the loader, fade, stop, unload, or rebuild services. |
+| Timeline transport | `MasterTimeline` in `src/runtime/timeline.ts` | Timeline state is untouched. The runner ignores audio-owned commands and audio code does not inspect beat, pause, or skip commands. |
+| Lifecycle and cleanup | Loader abort + resolver cleanup | `toggle-master-mute` does not abort, remount, call `cleanup(ctx)`, stop groups, or complete the navigation. Post-abort commands are inert through existing cleanup. |
+| Error envelope | Presenter `onError`, loader `onError`, `describeErrorDetailed()` | Malformed commands and handler failures use existing diagnostics. Do not serialize raw future remote payloads, stacks, DOM nodes, scene objects, captions, cookies, headers, env, auth values, source URLs, GSAP instances, Howler handles, or audio buffers. |
+| Observability | Existing tests and optional `onError` diagnostics | Do not add per-command logs, analytics, stage attributes, or visible mute status until a concrete UI/status requirement needs them. |
 
 ## Extensibility
 
-The extension seam is `PresenterCommand.kind` plus the audio service
-target. Future presenter audio controls should extend the same command
-schema in `src/runtime/presenter.ts` and dispatch to `AudioService`,
-not add a second input bus.
+- New keyboard mappings belong in `KeyboardPresenterBindings` and tests
+  for `createKeyboardPresenterSource()`, not in the loader, runner, or
+  scene modules.
+- Additional local input devices or on-screen controls should implement
+  `PresenterCommandSource` and be merged once at the composition root.
+  They should not call `AudioService` or `MasterTimeline` directly.
+- Future remote presenter protocols must authenticate and authorize
+  before emitting into `PresenterCommandSource`; the presenter
+  controller remains the local shape gate, not the security boundary.
+- Future explicit target-state mute should extend `PresenterCommand` as
+  a discriminated union, for example `set-master-mute` with
+  `muted: boolean`, and update `isPresenterCommand()` in the same
+  module. The behavior still belongs behind `AudioService`.
+- Future presenter audio controls such as bus volume, ducking, or
+  per-output routing extend the audio service seam. They do not expose
+  Howler handles, mutate timeline state, or create a second command bus.
+- Future mute status UI needs a separate audio/workbench status surface.
+  Do not overload `PresenterCommandSource`, URL grammar, timeline
+  labels, cue logs, or error attributes as a state store.
+- L2-only commands such as `toggle-practice` may ride the same command
+  bus only with explicit ownership. Runtime audio and timeline code
+  must ignore unrelated commands.
 
-If a future command needs data, extend `PresenterCommand` as a
-discriminated union with kind-specific fields and update
-`isPresenterCommand` in the same module. Examples: explicit
-`set-master-mute` with a `muted` boolean, bus volume, ducking, or
-rehearsal cue logging. The parameter belongs on the command payload
-and the behavior belongs behind `AudioService`; it must not leak
-Howler handles or timeline internals.
+## Gotchas
 
-If a future UI needs mute status, add a separate status/read surface
-from audio/workbench state. Do not overload `PresenterCommandSource`,
-URL grammar, stage error diagnostics, or timeline labels as a state
-store.
+- Issue text may be stale. In this checkout keyboard, bridge, timeline
+  command plumbing, and loader-side mute dispatch already exist;
+  evaluate the live incumbents before adding anything.
+- Toggle semantics read engine state at command receipt time. A cached
+  loader/UI boolean will desynchronize across services, navigations,
+  and repeated toggles.
+- `stopAll()`, scene cleanup, navigation completion, and composition
+  handoff must not reset master mute. It is engine-level runtime state.
+- Source-level validation and controller-level validation are both
+  useful. Do not remove the controller guard because keyboard or bridge
+  sources currently emit typed objects.
+- Same-origin `BroadcastChannel` delivery is asynchronous and may be
+  unavailable. It must stay inert when unsupported and must not become a
+  security boundary by implication.
+- Double-wiring the keyboard source or bridge turns one key press into
+  two toggles, which nets to no audible change. Source composition is a
+  single composition-root responsibility.
+- The loader-owned mute subscriber must stay before runner subscribers
+  on the controller fan-out path so slow or throwing runner handlers do
+  not delay the PUL-Q010 mute flip.
+- `toggle-master-mute` is accepted even before any sound is registered.
+  `noopAudioEngine` must round-trip mute state the same way the Howler
+  engine does.
 
 ## Non-Goals
 
-PUL-F025 should not implement keyboard listeners, on-screen controls,
-remote presenter protocol, auth, telemetry, persistence, mute UI
-status, per-scene volume, ducking, bus volume, scrub cue gating,
-export mixdown, or requirement status transition. It should not change
-scene schemas, composition schemas, URL grammar, asset preload rules,
-or the resolver lifecycle.
+PUL-F025 should not implement new URL grammar, a new workbench mode,
+new scene or composition schemas, a second keyboard listener, a second
+presenter bridge, remote presenter auth, visible mute UI, telemetry,
+persistence, traceability automation, requirement status transition,
+volume buses, ducking, per-scene mute, export audio, scrub cue gating,
+or audio unlock behavior.
+
+It should not redesign PUL-F020 beat controls, PUL-F021 pause/resume,
+present-mode chrome, command transport, lifecycle, validation, or the
+audio service. The implementation may touch existing seams only to
+reuse or harden them.
 
 ## Anti-Patterns
 
-- Adding `mute=true` / `muted` URL parameters, storage keys, cookies,
-  config flags, or history state.
+- Adding `mute=true`, `muted`, or `masterMute` URL parameters, history
+  state, storage keys, cookies, config flags, env vars, or process argv
+  state.
 - Importing Howler outside `src/runtime/audio.ts`.
-- Adding scene-local mute booleans, hidden `<audio>` controls, or raw
-  Web Audio mute code for ordinary scenes.
-- Implementing mute by pausing or killing the timeline.
-- Implementing mute by aborting navigation, remounting scenes, or
-  calling `cleanup(ctx)`.
-- Duplicating presenter command validation or adding
-  `MuteCommandSource` / `MuteController`.
-- Reusing `hold`, `pause`, `mode=paused`, `headCueGate`, or
-  screenshot silence semantics for master mute.
-- Resetting master mute on scene cleanup or navigation completion.
+- Adding scene-local mute booleans, hidden `<audio>` controls, raw Web
+  Audio mute code, or deck-local audio buses for ordinary mute.
+- Implementing silence by pause, resume, hold, seek, fade, stop,
+  unload, navigation abort, scene remount, `cleanup(ctx)`, or timeline
+  mutation.
+- Duplicating `PRESENTER_COMMAND_KINDS`, `DEFAULT_KEYBOARD_BINDINGS`,
+  `NAVIGATION_MODES`, audio output policies, source URL validation, or
+  error rendering.
+- Adding `MuteCommandSource`, `MuteController`, `MuteError`, a second
+  event type, a second command validator, or a mute-specific workflow
+  path.
+- Letting audio-owned commands, practice-overlay commands, or future UI
+  commands leak into master-timeline transport behavior.
+- Emitting raw remote/channel payloads into public diagnostics.

--- a/src/main.ts
+++ b/src/main.ts
@@ -250,7 +250,8 @@ const renderPrompter: PrompterRenderer = createChromePrompterRenderer(
 // Presenter command source (PUL-F013 / PUL-F020 / PUL-F021 /
 // ADR-023 / ADR-024): present-mode presenter input is wired in this
 // composition root. `createKeyboardPresenterSource()` (arrows /
-// Space / P / M / Escape) and `createPresenterBridge()` (same-origin
+// Space / PageUp / PageDown / P / K / L / M / N / Escape) and
+// `createPresenterBridge()` (same-origin
 // cross-window `BroadcastChannel`) are constructed below and merged
 // by `combinePresenterSources()` into the single
 // `PresenterCommandSource` handed to `createSceneLoader` as
@@ -363,7 +364,9 @@ if (chromeSurfaceEl !== null) {
 const syncScrubControls = (): void => scrubControls?.sync();
 timelineEngine.gsap.ticker.add(syncScrubControls);
 
-// Pulsar L2 keyboard presenter source. Arrows / Space / P / M / Escape.
+// Pulsar L2 keyboard presenter source. Arrows / Space / PageUp /
+// PageDown / P / K / L / M / N / Escape (see `keyboard-source.ts` for
+// the command each key maps to).
 // `onHome` navigates to the default composition; `bootstrapNavigation`
 // in this file owns history state, so we just push the URL and let
 // the existing navigate-on-popstate listener handle the rest.

--- a/src/runtime/presenter.ts
+++ b/src/runtime/presenter.ts
@@ -26,9 +26,11 @@
 // MUST NOT abort the navigation, call `cleanup(ctx)`, remount the
 // scene, rewrite URL/history, or persist the playhead; they are
 // runner-owned transport state on the same command seam, not a new
-// mode or lifecycle path (ADR-024). PUL-F020 and PUL-F021 both stay
-// DRAFT until a real presenter UI lands AND a GSAP runner proves the
-// command-to-transport behavior end to end.
+// mode or lifecycle path (ADR-024). The keyboard presenter source
+// (`src/system/presenter/keyboard-source.ts`) and the GSAP runner's
+// `applyPresenterCommandToMaster` (`src/runtime/timeline.ts`) now
+// deliver and honor these commands end to end — PUL-F020 / PUL-F021 are
+// ACTIVE (issue #132).
 //
 // PUL-F025 (master mute) composes ADR-004 with this same seam by
 // adding the `toggle-master-mute` kind to the allowlist below. The
@@ -42,9 +44,9 @@
 // timeline, aborts the navigation, calls `cleanup(ctx)`, or mutates
 // URL / history. Master mute is engine-level runtime state, so it
 // survives scene cleanup and navigation completion (the existing
-// `AudioService.stopAll()` does not reset it). PUL-F025 stays DRAFT
-// until a presenter UI surface lands and emits the kind end-to-end,
-// mirroring the PUL-F020 / PUL-F021 precedent.
+// `AudioService.stopAll()` does not reset it). The keyboard presenter
+// source emits `toggle-master-mute` (KeyM) end-to-end — PUL-F025 is
+// ACTIVE (issue #132).
 //
 // References:
 //  - PUL-F020 — runtime SHALL accept presenter input under

--- a/src/runtime/timeline.ts
+++ b/src/runtime/timeline.ts
@@ -811,24 +811,60 @@ function buildSegmentLabelMap(
 }
 
 /**
+ * Per-activation presenter transport state, held inside the
+ * {@link createGsapCompositionTimeline} `run` closure (fresh per
+ * navigation). GSAP exposes only a single `paused()` bit, which is not
+ * a sufficient state model: a PUL-F020 beat `hold`, a GSAP `addPause`
+ * advance-gate, and an explicit PUL-F021 `pause` all read as "paused"
+ * but compose differently. ADR-024 *Cross-command precedence* requires
+ * the runner to keep them apart; these two flags are that private
+ * state, scoped to the timeline adapter — not URL, loader, scene, or
+ * storage state.
+ */
+interface PresenterTransportState {
+  /** A PUL-F020 beat `hold` is engaged. */
+  held: boolean;
+  /** A PUL-F021 transport `pause` freeze is engaged. */
+  explicitlyPaused: boolean;
+}
+
+/**
  * Translate a {@link PresenterCommand} into a master-timeline transport
  * action. Wired by {@link createGsapCompositionTimeline} so the
  * presenter keyboard / cross-window bridge / future remote source all
- * drive playback the same way:
+ * drive playback the same way. ADR-024 *Cross-command precedence* is
+ * the binding contract:
  *
- *  - `advance` — if paused (at an addPause gate or a `hold`), resume.
- *    Otherwise seek forward to the next authored beat label OR next
- *    segment boundary (whichever is closer), then keep playing.
- *  - `hold` — toggle pause/resume at the current playhead.
- *  - `skip-forward` — seek to the start of the next segment.
- *  - `skip-backward` — seek to the start of the previous segment, or
- *    frame 0 if before the first segment.
- *  - `pause` / `resume` — explicit pause/play.
- *  - `toggle-master-mute` — handled by the loader against the audio
- *    service; ignored here.
+ *  - `pause` — engage the explicit PUL-F021 transport freeze. The
+ *    playhead stops wherever it is.
+ *  - `resume` — release an explicit `pause`. A `resume` with no explicit
+ *    pause in effect is a no-op; a `resume` that lifts a pause engaged
+ *    while a `hold` was active leaves the master held (the snapshotted
+ *    beat-pacing state survives — only the freeze is lifted).
+ *  - `hold` — engage a PUL-F020 beat hold at the current playhead.
+ *    Idempotent: a second `hold` keeps the master held; it is NOT a
+ *    play/pause toggle.
+ *  - `advance` — release a beat hold / `addPause` gate, or (when
+ *    playing) seek forward to the next authored beat label OR next
+ *    segment boundary (whichever is closer). Dropped while explicitly
+ *    paused — a beat-pacing command never unfreezes an explicit pause.
+ *  - `skip-forward` / `skip-backward` — seek to the start of the next /
+ *    previous segment (frame 0 before the first). While explicitly
+ *    paused this seeks the frozen playhead but does not resume.
+ *  - `toggle-master-mute` / `toggle-practice` — audio-owned / L2-owned;
+ *    ignored here.
  */
-function presenterAdvance(master: MasterTimeline, segments: readonly SceneTimelineSegment[]): void {
+function presenterAdvance(
+  master: MasterTimeline,
+  segments: readonly SceneTimelineSegment[],
+  state: PresenterTransportState,
+): void {
+  // ADR-024: a beat-pacing command received while explicitly paused
+  // MUST NOT resume playback — drop it; the frozen playhead stays put.
+  if (state.explicitlyPaused) return;
+  state.held = false;
   if (master.isPaused()) {
+    // Release the beat hold (or a GSAP addPause advance-gate).
     master.play();
     return;
   }
@@ -839,53 +875,79 @@ function presenterAdvance(master: MasterTimeline, segments: readonly SceneTimeli
     .filter((t) => t > now + 0.05)
     .sort((a, b) => a - b)[0];
   if (next !== undefined) master.seek(next);
+}
+
+/**
+ * Shared skip body: seek to `target` (when defined), then — unless an
+ * explicit PUL-F021 pause is in effect — release any beat hold and
+ * resume playback. ADR-024 permits skip to move the frozen playhead
+ * while paused (presenter scrubbing), but it must not resume.
+ */
+function presenterSkip(
+  master: MasterTimeline,
+  state: PresenterTransportState,
+  target: number | undefined,
+): void {
+  if (target !== undefined) master.seek(target);
+  if (state.explicitlyPaused) return;
+  state.held = false;
   if (master.isPaused()) master.play();
 }
 
 function presenterSkipForward(
   master: MasterTimeline,
   segments: readonly SceneTimelineSegment[],
+  state: PresenterTransportState,
 ): void {
-  const segs = buildSegmentLabelMap(segments, master);
-  const next = segs.find((s) => s.time > master.time() + 0.05);
-  if (next !== undefined) master.seek(next.time);
-  if (master.isPaused()) master.play();
+  const next = buildSegmentLabelMap(segments, master).find((s) => s.time > master.time() + 0.05);
+  presenterSkip(master, state, next?.time);
 }
 
 function presenterSkipBackward(
   master: MasterTimeline,
   segments: readonly SceneTimelineSegment[],
+  state: PresenterTransportState,
 ): void {
   const segs = buildSegmentLabelMap(segments, master);
   const prev = [...segs].reverse().find((s) => s.time < master.time() - 0.2);
-  master.seek(prev?.time ?? 0);
-  if (master.isPaused()) master.play();
+  presenterSkip(master, state, prev?.time ?? 0);
 }
 
 function applyPresenterCommandToMaster(
   master: MasterTimeline,
   segments: readonly SceneTimelineSegment[],
+  state: PresenterTransportState,
   cmd: { readonly kind: string },
 ): void {
   switch (cmd.kind) {
     case 'hold':
-      if (master.isPaused()) master.play();
-      else master.pause();
+      // Engage a PUL-F020 beat hold. Idempotent — NOT a toggle.
+      state.held = true;
+      master.pause();
       return;
     case 'pause':
+      // Engage the explicit PUL-F021 transport freeze.
+      state.explicitlyPaused = true;
       master.pause();
       return;
     case 'resume':
+      // ADR-024: only `resume` unfreezes an explicit pause; a `resume`
+      // with no explicit pause in effect is a no-op.
+      if (!state.explicitlyPaused) return;
+      state.explicitlyPaused = false;
+      // Restore the snapshotted beat-pacing state: a `hold` engaged
+      // before the pause survives the resume — the master stays held.
+      if (state.held) return;
       master.play();
       return;
     case 'advance':
-      presenterAdvance(master, segments);
+      presenterAdvance(master, segments, state);
       return;
     case 'skip-forward':
-      presenterSkipForward(master, segments);
+      presenterSkipForward(master, segments, state);
       return;
     case 'skip-backward':
-      presenterSkipBackward(master, segments);
+      presenterSkipBackward(master, segments, state);
       return;
     default:
       return; // toggle-master-mute / toggle-practice / unknown — not master's concern
@@ -973,12 +1035,14 @@ function runMasterUntilDone(
  * (the resolver wraps it with `composition resolution failed:` and
  * tears every scene down).
  *
- * `opts.presenter` (the presenter command controller) and a segment's
- * `range` (per-entry composition override) are not interpreted here yet
- * — presenter → transport translation is PUL-F020 / PUL-F021's runner
- * contract and sub-range cuts are PUL-F003's; both extend this adapter's
- * `MasterTimeline` transport seam when those requirements are
- * implemented.
+ * `opts.presenter` (the per-navigation presenter command controller) is
+ * subscribed here: each {@link PresenterCommand} is translated into a
+ * master transport action by {@link applyPresenterCommandToMaster}
+ * (PUL-F020 advance / hold / skip-forward / skip-backward; PUL-F021
+ * pause / resume). A segment's `range` (per-entry composition override)
+ * is still not interpreted — sub-range cuts are PUL-F003's and extend
+ * this adapter's `MasterTimeline` transport seam when that requirement
+ * is implemented.
  */
 export function createGsapCompositionTimeline(
   options: GsapCompositionTimelineOptions,
@@ -1025,8 +1089,11 @@ export function createGsapCompositionTimeline(
       // auto-detach on navigation abort), so we never accumulate
       // subscriptions across activations.
       if (opts.presenter !== undefined) {
+        // Per-activation transport state — fresh per navigation, so a
+        // prior navigation's hold / pause never leaks into this run.
+        const transport: PresenterTransportState = { held: false, explicitlyPaused: false };
         opts.presenter.subscribe((cmd) => {
-          applyPresenterCommandToMaster(master, segments, cmd);
+          applyPresenterCommandToMaster(master, segments, transport, cmd);
         });
       }
       return runMasterUntilDone(master, mode, opts.signal);

--- a/src/system/presenter/keyboard-source.ts
+++ b/src/system/presenter/keyboard-source.ts
@@ -3,11 +3,21 @@
 // Translates keyboard events on the document into PresenterCommands.
 // The default mapping covers the documented presenter UX:
 //
-//   ArrowRight, Space  → advance (next beat / next scene)
-//   ArrowLeft          → skip-backward
-//   KeyP               → hold (presenter holds the current beat)
+//   ArrowRight, Space  → advance (next beat)
+//   PageDown           → skip-forward (next scene)
+//   ArrowLeft, PageUp  → skip-backward (previous scene)
+//   KeyP               → hold (hold the current beat)
+//   KeyK               → pause (freeze the active timeline — PUL-F021)
+//   KeyL               → resume (resume from the same point — PUL-F021)
 //   KeyM               → toggle-master-mute
+//   KeyN               → toggle-practice (speaker-notes overlay)
 //   Escape             → navigates to ?composition=default (home)
+//
+// `pause` / `resume` are deliberately separate keys, not one toggle
+// key: the source maps one key to one command kind, and ADR-024 forbids
+// a source-local hidden paused boolean. A future single toggle key
+// belongs with a runner→workbench status surface (ADR-024, own design
+// pass).
 //
 // Listeners are added on construction and removed by the returned
 // `dispose()` so HMR replacement does not leak handlers. Keys
@@ -29,8 +39,12 @@ export interface KeyboardPresenterBindings {
 export const DEFAULT_KEYBOARD_BINDINGS: KeyboardPresenterBindings = {
   ArrowRight: 'advance',
   Space: 'advance',
+  PageDown: 'skip-forward',
   ArrowLeft: 'skip-backward',
+  PageUp: 'skip-backward',
   KeyP: 'hold',
+  KeyK: 'pause',
+  KeyL: 'resume',
   KeyM: 'toggle-master-mute',
   KeyN: 'toggle-practice',
   Escape: 'home',

--- a/tests/runtime/timeline.test.ts
+++ b/tests/runtime/timeline.test.ts
@@ -31,6 +31,11 @@ import type {
   SceneTimelineSegment,
 } from '../../src/runtime/composition-resolver';
 import { resolveComposition } from '../../src/runtime/composition-resolver';
+import {
+  type PresenterCommand,
+  type PresenterCommandSource,
+  createPresenterController,
+} from '../../src/runtime/presenter';
 import { createSceneRegistry } from '../../src/runtime/registry';
 import type { SceneModule } from '../../src/runtime/scene';
 import {
@@ -1003,5 +1008,190 @@ describe('createGsapCompositionTimeline', () => {
     expect(master.isPaused()).toBe(true);
     expect(master.time()).toBe(0);
     master.kill();
+  });
+});
+
+// PUL-F020 (advance / hold / skip-forward / skip-backward) and PUL-F021
+// (pause / resume) — the runner's translation of presenter commands into
+// master-timeline transport. ADR-024 *Cross-command precedence* is the
+// binding contract: an explicit `pause` is distinct from a beat `hold`,
+// and only `resume` unfreezes an explicit pause.
+describe('createGsapCompositionTimeline — presenter command transport (PUL-F020 / PUL-F021)', () => {
+  // A programmatic PresenterCommandSource the test drives via `emit`.
+  const makeSource = (): {
+    source: PresenterCommandSource;
+    emit: (cmd: PresenterCommand) => void;
+  } => {
+    const handlers = new Set<(cmd: PresenterCommand) => void>();
+    return {
+      source: {
+        subscribe(handler) {
+          handlers.add(handler);
+          return () => {
+            handlers.delete(handler);
+          };
+        },
+      },
+      emit(cmd) {
+        for (const handler of [...handlers]) handler(cmd);
+      },
+    };
+  };
+
+  /** Run the adapter with a live presenter controller wired to the runner. */
+  const runWithPresenter = (
+    segments: readonly SceneTimelineSegment[],
+  ): {
+    emit: (cmd: PresenterCommand) => void;
+    master: () => MasterTimeline;
+    abort: () => void;
+    settled: Promise<void>;
+  } => {
+    const ctrl = new AbortController();
+    const { source, emit } = makeSource();
+    const presenter = createPresenterController(source, ctrl.signal);
+    let captured: MasterTimeline | null = null;
+    const adapter = createGsapCompositionTimeline({
+      engine,
+      onMaster: (m) => {
+        captured = m;
+      },
+    });
+    const settled = adapter.run(segments, { signal: ctrl.signal, presenter });
+    return {
+      emit,
+      master: () => {
+        if (captured === null) throw new Error('master not captured');
+        return captured;
+      },
+      abort: () => ctrl.abort(),
+      settled,
+    };
+  };
+
+  it('pause freezes the master at the current playhead; resume continues from there', async () => {
+    const r = runWithPresenter([segment('a', sceneTl(30))]);
+    await flush();
+    expect(r.master().isPaused()).toBe(false);
+    r.emit({ kind: 'pause' });
+    const frozenAt = r.master().time();
+    expect(r.master().isPaused()).toBe(true);
+    await flush();
+    expect(r.master().time()).toBeCloseTo(frozenAt, 3);
+    r.emit({ kind: 'resume' });
+    expect(r.master().isPaused()).toBe(false);
+    expect(r.master().time()).toBeCloseTo(frozenAt, 1);
+    r.abort();
+    await r.settled;
+  });
+
+  it('a second pause keeps the master frozen (idempotent)', async () => {
+    const r = runWithPresenter([segment('a', sceneTl(30))]);
+    await flush();
+    r.emit({ kind: 'pause' });
+    r.emit({ kind: 'pause' });
+    expect(r.master().isPaused()).toBe(true);
+    r.abort();
+    await r.settled;
+  });
+
+  it('resume while playing is a no-op — it does not stop or restart the master', async () => {
+    const r = runWithPresenter([segment('a', sceneTl(30))]);
+    await flush();
+    r.emit({ kind: 'resume' });
+    expect(r.master().isPaused()).toBe(false);
+    r.abort();
+    await r.settled;
+  });
+
+  it('hold pauses the master; a second hold keeps it paused (not a play/pause toggle)', async () => {
+    const r = runWithPresenter([segment('a', sceneTl(30))]);
+    await flush();
+    r.emit({ kind: 'hold' });
+    expect(r.master().isPaused()).toBe(true);
+    r.emit({ kind: 'hold' });
+    expect(r.master().isPaused()).toBe(true);
+    r.abort();
+    await r.settled;
+  });
+
+  it('advance releases a beat hold (resumes playback)', async () => {
+    const r = runWithPresenter([segment('a', sceneTl(30))]);
+    await flush();
+    r.emit({ kind: 'hold' });
+    expect(r.master().isPaused()).toBe(true);
+    r.emit({ kind: 'advance' });
+    expect(r.master().isPaused()).toBe(false);
+    r.abort();
+    await r.settled;
+  });
+
+  it('advance seeks forward to the next authored beat while playing', async () => {
+    const r = runWithPresenter([segment('intro', sceneTl(30, { 'mid-beat': 15 }))]);
+    await flush();
+    r.emit({ kind: 'advance' });
+    expect(r.master().time()).toBeCloseTo(15, 0);
+    r.abort();
+    await r.settled;
+  });
+
+  it('skip-forward seeks to the next scene segment; skip-backward to the previous', async () => {
+    const r = runWithPresenter([segment('a', sceneTl(20)), segment('b', sceneTl(20))]);
+    await flush();
+    r.emit({ kind: 'skip-forward' });
+    expect(r.master().time()).toBeCloseTo(20, 0);
+    r.emit({ kind: 'skip-backward' });
+    expect(r.master().time()).toBeCloseTo(0, 0);
+    r.abort();
+    await r.settled;
+  });
+
+  it('advance received while explicitly paused does not resume or move the playhead (ADR-024)', async () => {
+    const r = runWithPresenter([segment('intro', sceneTl(30, { 'mid-beat': 15 }))]);
+    await flush();
+    r.emit({ kind: 'pause' });
+    const frozenAt = r.master().time();
+    r.emit({ kind: 'advance' });
+    expect(r.master().isPaused()).toBe(true);
+    expect(r.master().time()).toBeCloseTo(frozenAt, 3);
+    r.emit({ kind: 'resume' });
+    expect(r.master().isPaused()).toBe(false);
+    r.abort();
+    await r.settled;
+  });
+
+  it('skip-forward while explicitly paused moves the frozen playhead but does not resume (ADR-024)', async () => {
+    const r = runWithPresenter([segment('a', sceneTl(20)), segment('b', sceneTl(20))]);
+    await flush();
+    r.emit({ kind: 'pause' });
+    r.emit({ kind: 'skip-forward' });
+    expect(r.master().isPaused()).toBe(true);
+    expect(r.master().time()).toBeCloseTo(20, 0);
+    r.abort();
+    await r.settled;
+  });
+
+  it('resume restores a hold engaged before pause — stays paused until advance releases it (ADR-024)', async () => {
+    const r = runWithPresenter([segment('a', sceneTl(30))]);
+    await flush();
+    r.emit({ kind: 'hold' });
+    r.emit({ kind: 'pause' });
+    r.emit({ kind: 'resume' });
+    // resume unfreezes the PUL-F021 pause but MUST NOT clear the prior hold.
+    expect(r.master().isPaused()).toBe(true);
+    r.emit({ kind: 'advance' });
+    expect(r.master().isPaused()).toBe(false);
+    r.abort();
+    await r.settled;
+  });
+
+  it('toggle-master-mute does not affect master transport (audio-owned; runner ignores it)', async () => {
+    const r = runWithPresenter([segment('a', sceneTl(30))]);
+    await flush();
+    expect(r.master().isPaused()).toBe(false);
+    r.emit({ kind: 'toggle-master-mute' });
+    expect(r.master().isPaused()).toBe(false);
+    r.abort();
+    await r.settled;
   });
 });

--- a/tests/system/presenter-keyboard.test.ts
+++ b/tests/system/presenter-keyboard.test.ts
@@ -2,6 +2,12 @@
 
 import { describe, expect, it, vi } from 'vitest';
 import type { PresenterCommand } from '../../src/runtime/presenter';
+import { createPresenterController } from '../../src/runtime/presenter';
+import {
+  type MasterTimeline,
+  createGsapCompositionTimeline,
+  createTimelineEngine,
+} from '../../src/runtime/timeline';
 import {
   DEFAULT_KEYBOARD_BINDINGS,
   createKeyboardPresenterSource,
@@ -58,6 +64,28 @@ describe('keyboard presenter source', () => {
     target.dispatchEvent(fakeKey('KeyP'));
     target.dispatchEvent(fakeKey('KeyM'));
     expect(cmds.map((c) => c.kind)).toEqual(['hold', 'toggle-master-mute']);
+    dispose();
+  });
+
+  it('emits skip-forward on PageDown and skip-backward on PageUp', () => {
+    const target = makeTarget();
+    const { source, dispose } = createKeyboardPresenterSource({ target });
+    const cmds: PresenterCommand[] = [];
+    source.subscribe((c) => cmds.push(c));
+    target.dispatchEvent(fakeKey('PageDown'));
+    target.dispatchEvent(fakeKey('PageUp'));
+    expect(cmds.map((c) => c.kind)).toEqual(['skip-forward', 'skip-backward']);
+    dispose();
+  });
+
+  it('emits pause on KeyK and resume on KeyL', () => {
+    const target = makeTarget();
+    const { source, dispose } = createKeyboardPresenterSource({ target });
+    const cmds: PresenterCommand[] = [];
+    source.subscribe((c) => cmds.push(c));
+    target.dispatchEvent(fakeKey('KeyK'));
+    target.dispatchEvent(fakeKey('KeyL'));
+    expect(cmds.map((c) => c.kind)).toEqual(['pause', 'resume']);
     dispose();
   });
 
@@ -119,5 +147,49 @@ describe('keyboard presenter source', () => {
     target.dispatchEvent(fakeKey('KeyZ'));
     expect(cmds.map((c) => c.kind)).toEqual(['pause']);
     dispose();
+  });
+});
+
+// End-to-end dispatch (issue #132 acceptance criterion): a real DOM
+// keydown flows keyboard source → per-navigation presenter controller →
+// GSAP runner → master timeline. Pins that the wired surface actually
+// moves beat state, not just that the keyboard source emits a command.
+describe('presenter keyboard → GSAP runner (PUL-F020 end-to-end dispatch)', () => {
+  it('a real PageDown keydown drives the master timeline to the next scene segment', async () => {
+    const engine = createTimelineEngine();
+    const sceneTl = (seconds: number): InstanceType<typeof engine.gsap.core.Timeline> => {
+      const tl = engine.gsap.timeline({ paused: true });
+      tl.to({ v: 0 }, { v: 1, duration: seconds });
+      return tl;
+    };
+    const target = makeTarget();
+    const keyboard = createKeyboardPresenterSource({ target });
+    const ctrl = new AbortController();
+    const presenter = createPresenterController(keyboard.source, ctrl.signal);
+    let captured: MasterTimeline | null = null;
+    const adapter = createGsapCompositionTimeline({
+      engine,
+      onMaster: (m) => {
+        captured = m;
+      },
+    });
+    const settled = adapter.run(
+      [
+        { id: 'scene-a', timeline: sceneTl(20) },
+        { id: 'scene-b', timeline: sceneTl(20) },
+      ],
+      { signal: ctrl.signal, presenter },
+    );
+    await new Promise((r) => setTimeout(r, 0));
+    const master = ((): MasterTimeline => {
+      if (captured === null) throw new Error('master not captured');
+      return captured;
+    })();
+    // Real DOM keydown → keyboard source → controller → runner → master.
+    target.dispatchEvent(fakeKey('PageDown'));
+    expect(master.time()).toBeCloseTo(20, 0);
+    ctrl.abort();
+    keyboard.dispose();
+    await settled;
   });
 });


### PR DESCRIPTION
## Summary

Completes the presenter-control delivery for issue #132. The keyboard presenter source, cross-window bridge, loader wiring, and GSAP runner command application already existed (commit af564e6); two real gaps remained. First, the keyboard surface exposed no key for skip-forward, pause, or resume — so the runtime could not accept that presenter input through the shipped surface. Second, the runner decided every transport action off GSAP's single paused() bit, conflating an explicit PUL-F021 pause with a PUL-F020 beat hold, which violates ADR-024 cross-command precedence. This PR binds the missing keys and gives the runner per-activation state so an explicit pause is distinguishable from a beat hold.

## Requirement UIDs

- `PUL-F020`
- `PUL-F021`
- `PUL-F025`

## Related Issues

Closes #132

## ADR Impact

- ADR-023
- ADR-024
- ADR-021

## Changes

- Bind PageDown -> skip-forward, PageUp -> skip-backward (alias), KeyK -> pause, and KeyL -> resume in DEFAULT_KEYBOARD_BINDINGS so mode=present reaches the full PUL-F020 / PUL-F021 command surface
- Add per-activation held / explicitlyPaused transport state to the GSAP composition timeline runner so an explicit PUL-F021 pause is distinguishable from a PUL-F020 beat hold and GSAP addPause gates
- hold now engages a beat hold (idempotent) instead of toggling play/pause; advance releases a hold
- advance / hold / skip received while explicitly paused no longer resume playback; only resume unfreezes an explicit pause, and resume preserves a hold engaged before the pause (ADR-024 cross-command precedence)
- Update stale doc comments in timeline.ts (presenter is now interpreted by the runner) and presenter.ts (PUL-F020/F021/F025 surfaces have landed)
- Refresh the keyboard-source and main.ts comments to document the full key map

## Test Plan

- [x] Unit + system tests pass (`pnpm test` — 2586 passing)
- [x] `pnpm lint` and `pnpm typecheck` pass
- [x] No coverage regression

New unit tests in tests/runtime/timeline.test.ts pin each presenter command's effect on master transport (pause/resume freeze and continue; hold is idempotent and not a toggle; advance releases a hold and seeks to the next beat; skip seeks segments; cross-command precedence — beat-pacing commands never resume an explicit pause). New tests in tests/system/presenter-keyboard.test.ts cover the four new key bindings and an end-to-end dispatch: a real DOM keydown flows keyboard source -> presenter controller -> GSAP runner -> master timeline.

## Ground Control Checks

- [x] `pnpm lint` / `pnpm typecheck` / `pnpm test` pass
- [x] Codex pre-push review clean (0 findings)
- [x] Test-quality pre-push review clean (0 findings)

## Traceability

- IMPLEMENTS: PUL-F020 <- src/system/presenter/keyboard-source.ts, PUL-F020 <- src/runtime/timeline.ts, PUL-F021 <- src/system/presenter/keyboard-source.ts, PUL-F021 <- src/runtime/timeline.ts, PUL-F025 <- src/system/presenter/keyboard-source.ts
- TESTS: PUL-F020 <- tests/runtime/timeline.test.ts, PUL-F020 <- tests/system/presenter-keyboard.test.ts, PUL-F021 <- tests/runtime/timeline.test.ts, PUL-F021 <- tests/system/presenter-keyboard.test.ts, PUL-F025 <- tests/system/presenter-keyboard.test.ts

## Checklist

- [x] Code follows project coding standards
- [x] Changelog fragments added at `changelog.d/132.added.md` and `changelog.d/132.changed.md`
- [x] ADR-023 / ADR-024 honored; no new ADR required
