### PR TITLE
feat: terminal soundtrack support and runtime comment audit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,9 @@ g-pi-*.png
 cv-*.png
 cg2-*.png
 
+# Ground Control SonarCloud server-side analytical reports
+.gc/sonar/
+
 # Local-only decks (per-developer scratch, never check in)
 src/decks/local-*/
 public/local-*/

--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,7 @@ scene-*.png
 probe*.png
 g-pi-*.png
 cv-*.png
+cg2-*.png
 
 # Local-only decks (per-developer scratch, never check in)
 src/decks/local-*/

--- a/changelog.d/+terminal-scene-audio.added.md
+++ b/changelog.d/+terminal-scene-audio.added.md
@@ -3,3 +3,9 @@ terminal scene can name a source URL, sound id, volume, playback rate,
 and fade-out duration; the template declares the URL in `scene.assets`
 + `scene.audio`, loads and plays the track through `ctx.audio` when the
 script begins, and fades it to silence on scene teardown.
+
+The audio integration is exposed as the standalone helper
+`startTerminalAudio(audio, config)`, returning the fade-and-stop closure
+the template registers on its per-scene session. Decks that need to
+drive the same load → play → fade-out shape from a different template
+can call the helper directly.

--- a/changelog.d/+terminal-scene-audio.added.md
+++ b/changelog.d/+terminal-scene-audio.added.md
@@ -1,0 +1,5 @@
+The `terminal` L2 template accepts an optional `audio` soundtrack. A
+terminal scene can name a source URL, sound id, volume, playback rate,
+and fade-out duration; the template declares the URL in `scene.assets`
++ `scene.audio`, loads and plays the track through `ctx.audio` when the
+script begins, and fades it to silence on scene teardown.

--- a/changelog.d/100.changed.md
+++ b/changelog.d/100.changed.md
@@ -1,0 +1,11 @@
+Audited runtime source comments and rewrote stale future-work
+language across `src/main.ts`, `src/runtime/{prompter,scene-loader,
+timeline,presenter,audio}.ts`, and `src/system/presenter/prompter-
+window.ts`. Outdated phrases naming a placeholder timeline runner, an
+unwired cue gate, an uninterpreted presenter command controller, or a
+captions/script UI surface "until the renderer lands" now describe
+the wired adapters (PUL-F017 / PUL-F020 / PUL-F021 / PUL-F022 /
+PUL-F024 / `createChromePrompterRenderer`). Source-policy comments
+(`// PUL-*-allow:`, `// biome-ignore`), runtime behavior, exported
+types, error strings, DOM attributes, validation, and tests are
+unchanged.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -11,6 +11,7 @@ Design context for Pulsar. Source material for the ADRs in `../adrs/`.
 | [issue-097-browser-runtime-smoke-preflight.md](issue-097-browser-runtime-smoke-preflight.md) | Guardrails for expanding browser runtime smoke coverage through the existing Playwright workbench gate. |
 | [issue-098-vertical-slice-demo-preflight.md](issue-098-vertical-slice-demo-preflight.md) | Guardrails for adding authored demo scenes that exercise composition, timeline, captions, assets, and workbench routing through existing runtime seams. |
 | [issue-099-repeated-scene-activation-context-preflight.md](issue-099-repeated-scene-activation-context-preflight.md) | Guardrails for supporting repeated scene entries through per-occurrence activation ownership without changing scene, composition, URL, registry, timeline, or audio boundaries. |
+| [issue-100-runtime-comment-audit-preflight.md](issue-100-runtime-comment-audit-preflight.md) | Guardrails for auditing stale runtime comments without changing behavior, duplicating ADR rationale, or weakening source-policy comments. |
 | [positioning-and-landscape.md](positioning-and-landscape.md) | Category, adjacent OSS projects, differentiation, strategic risks. |
 | [pul-p002-validation-ci-preflight.md](pul-p002-validation-ci-preflight.md) | Guardrails for gating pull-request CI on the canonical runtime validation pass. |
 | [pul-p003-adr-format-preflight.md](pul-p003-adr-format-preflight.md) | Guardrails for keeping ADR markdown and Ground Control ADR records aligned without duplicate schemas or workflow logic. |

--- a/docs/design/issue-100-runtime-comment-audit-preflight.md
+++ b/docs/design/issue-100-runtime-comment-audit-preflight.md
@@ -1,0 +1,135 @@
+# Issue 100 Runtime Comment Audit Preflight
+
+Date: 2026-05-23
+
+Issue 100 is source-comment hygiene. The change should make runtime
+comments trustworthy without changing runtime behavior or moving broad
+architecture rationale back into code. ADRs and design docs remain the
+durable home for system-level decisions; source comments should explain
+local invariants, boundary contracts, machine-read policy exceptions,
+and non-obvious constraints.
+
+No new ADR is needed. Existing ADRs already decide the runtime seams:
+scene and composition contracts (ADR-002 / ADR-008), timeline and audio
+adapters (ADR-003 / ADR-004 / ADR-025), workbench URL dispatch
+(ADR-007 / ADR-013 / ADR-014), validation (ADR-008 / PUL-F028), error
+surfaces (ADR-028 plus PUL-Q006 / PUL-Q009), and chrome/workbench
+ownership (ADR-031).
+
+## Boundary
+
+- Scope the audit to runtime-authored source under `src/main.ts`,
+  `src/runtime/**`, `src/system/**`, `src/scenes/**`, and
+  `src/compositions/**`, including TypeScript and runtime CSS comments.
+  Tests and docs may be consulted to verify status, but they are not
+  the primary target.
+- Review comments containing `future`, `placeholder`, `not yet`,
+  `follow-up`, `OMITTED`, `TODO`, `FIXME`, ADR references, and PUL
+  references. A match is not automatically stale; decide from the
+  current code and the relevant ADR/design doc.
+- Keep comments that state local invariants, security boundaries,
+  policy-exemption rationale, ownership boundaries, or failure
+  envelopes. Trim broad history and duplicated ADR prose when the code
+  nearby is self-evident.
+- Do not change exported types, runtime strings, DOM attributes,
+  validation logic, policies, source scanners, tests, build config, or
+  behavior unless a comment exposes a real defect. If that happens,
+  keep the behavioral fix focused and test it as a defect, not as a
+  comment-audit side effect.
+- This requirement-free issue does not create or transition Ground
+  Control requirements and does not create IMPLEMENTS / TESTS
+  traceability links.
+
+## Required Reuse
+
+- Durable rationale: `docs/adrs/**`, `docs/design/**`,
+  `docs/design/README.md`, and `docs/requirements/conventions.md`.
+- Workflow policy: `.ground-control.yaml`, `.gc/plan-rules.md`,
+  `AGENTS.md`, and `changelog.d/README.md`.
+- Validation/schema incumbents: `assertSceneModule()`,
+  `assertCompositionManifest()`, `createIdRegistry()`,
+  `validateRuntime()`, `resolveAssetUrl()`, `PRESENTER_COMMAND_KINDS`,
+  `isPresenterCommand()`, `formatSceneContext()`,
+  `describeError()`, and `describeErrorDetailed()`.
+- Policy-source incumbents: `tests/runtime/source-policy.ts`,
+  `tests/runtime/screenshot-determinism-source.test.ts`,
+  `tests/runtime/policy-*.test.ts`, and Biome `biome-ignore`
+  comments with non-empty rationales.
+- Verification commands stay the repo defaults from `package.json` and
+  `.ground-control.yaml`: `pnpm lint`, `pnpm typecheck`, `pnpm test`,
+  and the combined completion command.
+
+## Cross-Cutting Layers
+
+| Layer | Guardrail |
+|-------|-----------|
+| Source-policy comments | `// PUL-*-allow: <reason>` comments are executable policy inputs. Preserve the exact allow tag, same-line placement, and non-empty reason unless replacing it with an equivalent valid exemption. |
+| Lint suppressions | `// biome-ignore ...: <reason>` comments are lint policy, not prose. Do not remove or generalize them while trimming architectural comments. |
+| Scene/composition schemas | Comment edits must not introduce parallel DTO language such as `SceneDTO`, `CaptionSchema`, duplicate manifest shapes, or new validation tables. Refer to the canonical runtime types and validators. |
+| URL and mode dispatch | Do not imply scenes own query parsing, mode flags, or history state. URL grammar remains `parseNavigationSearch()` and mode resolution remains `effectiveMode()` at the runtime/workbench boundary. |
+| Timeline boundary | `src/runtime/timeline.ts` is the GSAP adapter and beat-label home. Comments should not describe a placeholder runner where `createGsapCompositionTimeline()` now owns the path. |
+| Audio boundary | Audio remains `ctx.audio`, `createAudioService()`, and the Howler engine wrapper. Comments should distinguish Howler's engine behavior from the explicit present-mode unlock adapter in `audio-unlock-dom.ts`. |
+| Validation boundary | Validation remains an orchestrator over existing runtime contracts. Do not document validation as a second registry, schema system, linter, or lifecycle runner. |
+| Error envelope | Public diagnostics stay bounded through `describeErrorDetailed()` and `formatSceneContext()`. Do not change error messages or add comments that encourage parsing `Error.message` for structured data. |
+| Security policy | The audit adds no auth surface, secret handling, cookies, local/session storage, `import.meta.env`, `process.env`, `process.argv`, remote dynamic import, `eval`, or generated code path. Existing source-policy gates remain authoritative. |
+| OS/process exposure | No command should pass source snippets, tokens, headers, credentials, or env values through process argv. The audit is static source review plus repo-local tests. |
+| Changelog policy | Docs-only preflight changes need no fragment. Source-comment-only changes are documentation/process-only unless they alter user-visible behavior or public surfaces; do not hand-edit `CHANGELOG.md`. |
+
+## Extensibility
+
+The only useful seam for future repeat audits is the search scope and
+term set. Keep it parameterized as roots plus terms, not as a runtime
+concept or comment taxonomy. If stale-comment enforcement becomes
+recurring, the canonical place is a focused source-policy test that
+reuses `tests/runtime/source-policy.ts`; do not add a separate scanner,
+package script, config schema, or CI workflow for this issue.
+
+## Gotchas
+
+- `placeholder` is often an intentional scene id, tag, DOM marker, or
+  no-op adapter. Do not rename identifiers or remove local comments
+  just because the word appears.
+- `future` can mean a deliberate extension seam, not stale work.
+  Examples include optional future URL parameters, future command
+  variants, and future renderer surfaces. Keep these when they explain
+  why the current boundary is shaped for extension.
+- `not yet run` in fixtures can describe observed runtime state rather
+  than missing implementation.
+- Some comments are known high-risk candidates because adjacent code
+  has moved: bootstrap text that still says a placeholder timeline
+  runner is waiting for ADR-003, prompter comments that predate the L2
+  renderer wiring, and audio comments that say unlock is entirely
+  auto-handled by Howler. Verify against code before editing.
+- ADR references inside source can drift when later ADRs supersede a
+  section. Prefer a short local invariant plus a single current ADR
+  reference over a historical chain.
+- Broad rationale belongs in ADRs/design docs. Do not expand source
+  comments to compensate for deleting stale text.
+- Removing a source-policy exemption rationale can break tests even
+  though runtime behavior is unchanged.
+
+## Anti-Patterns
+
+- Implementing a comment-audit runtime helper, enum, config file, lint
+  plugin, or custom script.
+- Rewriting comments by requirement status alone without checking the
+  current source and accepted ADRs.
+- Updating runtime behavior to make an old comment true.
+- Changing public error strings, data attributes, URL grammar, command
+  kinds, validation findings, or policy allow tags as part of prose
+  cleanup.
+- Duplicating scene, composition, caption, presenter, audio, asset, or
+  error schemas in comments.
+- Adding changelog fragments for docs-only or source-comment-only
+  changes when no user-visible behavior changed.
+
+## Non-Goals
+
+Issue 100 does not add new architecture, requirements, ADR decisions,
+workflow automation, source-policy enforcement, validation behavior,
+runtime features, browser UI, telemetry, security policy, persistence,
+or release tooling.
+
+It also does not require exhaustive prose normalization. The goal is to
+remove or correct stale future-work language while preserving comments
+that carry real local maintenance value.

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,8 +10,9 @@
 //     scene/composition modules. Both registries are immutable after
 //     construction (ADR-008 #2 "manifests over flow control").
 //  3. Build a `SceneLoader` (PUL-F008) wired to those registries plus
-//     the lifecycle adapters (PUL-F005 asset preloader; placeholder
-//     timeline runner until ADR-003's GSAP runner lands).
+//     the lifecycle adapters: PUL-F005 asset preloader, the ADR-003 /
+//     PUL-F022 GSAP-backed composition timeline, the PUL-F024 / ADR-004
+//     audio service, and the PUL-F030 / ADR-029 audio-unlock adapter.
 //  4. Subscribe to the parsed-target events PUL-F007's
 //     `bootstrapNavigation` dispatches: `pulsar:navigate` carries a
 //     parsed `NavigationTarget`, `pulsar:navigate-error` carries a
@@ -144,16 +145,15 @@ const createPreloader = (signal: AbortSignal): ReturnType<typeof createAssetPrel
 // timeline (`composeMasterTimeline` — namespaced labels, sequential
 // nesting), applies the URL/runner-input head hints (`beat` seek with
 // the `onBeatMissing` fallback, `mode=loop` repeat, `mode=paused` hold,
-// `mode=screenshot` freeze-at-beat; the audio engine lands with
-// PUL-F024, but `cueGate`→audio cue gating is a separate follow-up —
-// scenes hang `ctx.audio` cues off their own timeline callbacks today),
-// plays the master, and resolves on its natural completion (the
-// resolver then tears every scene down) or on the per-navigation
-// `AbortSignal`. Per-entry `range` overrides
-// (PUL-F003) and the presenter command controller (PUL-F020 / PUL-F021)
-// are not interpreted here yet — both land on this adapter's
-// `MasterTimeline` transport seam when their requirements are
-// implemented.
+// `mode=screenshot` freeze-at-beat), wires the PUL-F024 audio engine
+// and the PUL-F017 / ADR-020 cue gate (closed on reverse scrub),
+// subscribes the per-navigation presenter command controller
+// (PUL-F020 advance / hold / skip-forward / skip-backward + PUL-F021
+// pause / resume), plays the master, and resolves on its natural
+// completion (the resolver then tears every scene down) or on the
+// per-navigation `AbortSignal`. Per-entry `range` overrides (PUL-F003)
+// are not interpreted — sub-range cuts extend this adapter's
+// `MasterTimeline` transport seam when that requirement lands.
 // Inter-scene transition overlay — a transient `<div>` parented to
 // `document.body` (above the chrome surface). The L2 transitions
 // library (cut / dissolve / hard-slam / hold-on-black / push) tweens
@@ -229,20 +229,15 @@ const buildCtx = (
   return { ...base, chrome: chromeSlots as unknown as Readonly<Record<string, unknown>> };
 };
 
-// Prompter renderer placeholder (PUL-F019 / ADR-022). Under
-// `mode=prompter` the loader bypasses the resolver lifecycle
-// structurally — no preload, no `create`, no `timeline`, no
-// `cleanup` — and hands a `PrompterScript` (captions aggregated
-// from the addressed scene or composition slice) to this adapter.
-// Until the captions/script UI surface lands, the placeholder
-// produces no visible output; the structural visual-rendering
-// suppression is delivered by the loader's lifecycle bypass, not by
-// this adapter.
-//
-// Pulsar L2 renderer: paints the full prompter script (composition
-// id + per-scene captions) into the workbench. Falls back to
-// `document.body` if the chrome slot resolution returns null. The
-// returned dispose callback removes the panel on next navigation.
+// Prompter renderer (PUL-F019 / ADR-022). Under `mode=prompter` the
+// loader bypasses the resolver lifecycle structurally — no preload,
+// no `create`, no `timeline`, no `cleanup` — and hands a
+// `PrompterScript` (captions aggregated from the addressed scene or
+// composition slice) to this adapter. The L2
+// `createChromePrompterRenderer` paints the full script (composition
+// id + per-scene captions) into the chrome lower-third slot, falling
+// back to `document.body` when the slot is unavailable. The returned
+// dispose callback removes the panel on the next navigation.
 const renderPrompter: PrompterRenderer = createChromePrompterRenderer(
   () => chromeSlots?.lowerThird ?? document.body,
 );

--- a/src/runtime/audio.ts
+++ b/src/runtime/audio.ts
@@ -441,8 +441,8 @@ export const AUDIO_OUTPUT_POLICIES = Object.freeze(['audible', 'silent', 'log-cu
  *    {@link AudioServiceOptions.onCue} sink. The PUL-F026 / ADR-004
  *    rehearsal-mode contract: "audio is silenced OR logged as cues
  *    without altering timeline state." With no sink wired the policy
- *    is effectively silent (the workbench has not yet attached a cue
- *    UI / log surface).
+ *    is effectively silent (the workbench attaches no cue UI / log
+ *    surface today).
  *
  * Future variations (silent rehearsal as a distinct mode, export
  * silence, ducking, bus volume, an audio-status UI) extend this same

--- a/src/runtime/presenter.ts
+++ b/src/runtime/presenter.ts
@@ -309,8 +309,8 @@ export function createPresenterController(
 
   // Lazy source attachment: register the central wrapper on the
   // source the first time a subscriber attaches. A controller with
-  // zero subscribers (e.g., the placeholder timeline runner that
-  // ignores `input.presenter`) does not pay a source registration.
+  // zero subscribers (e.g., a timeline runner that ignores
+  // `input.presenter`) does not pay a source registration.
   // Subscribe-time failures from the workbench-supplied source are
   // routed through `onError` here rather than escaping the loader's
   // `buildLoad` (codex review, post-PUL-F025: a throwing source

--- a/src/runtime/prompter.ts
+++ b/src/runtime/prompter.ts
@@ -3,8 +3,9 @@
 // Pure function over a {@link SceneNavigationTarget} (already validated
 // by `resolveSceneNavigation` per PUL-F008 / ADR-014). Produces a
 // {@link PrompterScript} carrying the captions metadata of the
-// addressed scene or composition slice. The future captions/script UI
-// surface consumes this shape; the scene loader hands it to a
+// addressed scene or composition slice. The captions/script UI surface
+// (the L2 `createChromePrompterRenderer` the workbench bootstrap
+// wires) consumes this shape; the scene loader hands it to a
 // {@link PrompterRenderer} adapter without interpreting it.
 //
 // Why prompter is structurally different from `mode=loop` /
@@ -113,20 +114,19 @@ export type PrompterDispose = () => void | Promise<void>;
  *    obtain the dispose callback (if any), then proceeds.
  *
  * A renderer can ALSO use the older parking-until-abort pattern
- * (return a `Promise<void>` that resolves on `signal.aborted`,
- * with cleanup in the abort listener), which the placeholder under
- * `mode=present` uses for the timeline runner. Both patterns
- * satisfy the contract; the dispose-return pattern is preferred
- * for renderers that mount DOM because the loader OWNS the abort
- * sequencing — there is no documentation-only "you must keep your
- * promise pending" convention for the renderer to forget.
+ * (return a `Promise<void>` that resolves on `signal.aborted`, with
+ * cleanup in the abort listener). Both patterns satisfy the contract;
+ * the dispose-return pattern is preferred for renderers that mount
+ * DOM because the loader OWNS the abort sequencing — there is no
+ * documentation-only "you must keep your promise pending" convention
+ * for the renderer to forget.
  *
- * Optional on {@link import('./scene-loader').SceneLoaderOptions}: a
- * workbench bootstrap that has not yet wired a captions UI omits the
- * field and the loader dispatches `mode=prompter` without invoking any
- * renderer (visual rendering is still structurally suppressed because
- * the resolver lifecycle is bypassed). Production bootstrap supplies a
- * concrete renderer when the UI surface lands.
+ * Optional on {@link import('./scene-loader').SceneLoaderOptions}:
+ * callers that don't render a captions view (test harnesses,
+ * embedders) omit the field and the loader dispatches `mode=prompter`
+ * without invoking any renderer (visual rendering is still
+ * structurally suppressed because the resolver lifecycle is bypassed).
+ * The workbench supplies the L2 `createChromePrompterRenderer`.
  */
 // `void` in this union is intentional: the "no cleanup obligation"
 // half of the contract must accept implicit-return arrow functions

--- a/src/runtime/scene-loader.ts
+++ b/src/runtime/scene-loader.ts
@@ -335,14 +335,13 @@ export interface SceneLoaderOptions {
    * cleanup. A trivial / no-DOM renderer (e.g. a test stub) is free
    * to return synchronously because there is nothing to tear down.
    *
-   * Optional: a workbench bootstrap that has not yet wired a captions
-   * UI omits the field. Under `mode=prompter` the loader still
-   * suppresses the resolver lifecycle (no preload, no `create`, no
-   * `timeline`, no `cleanup`) because that suppression is the
-   * structural defense PUL-F019 / ADR-022 record; the captions data
-   * path simply has no consumer until the UI lands. Production
-   * bootstrap supplies a concrete renderer when the captions/script
-   * UI surface lands.
+   * Optional: callers that don't render a captions view (test
+   * harnesses, embedders) omit the field. Under `mode=prompter` the
+   * loader still suppresses the resolver lifecycle (no preload, no
+   * `create`, no `timeline`, no `cleanup`) because that suppression
+   * is the structural defense PUL-F019 / ADR-022 record; the captions
+   * data path simply has no consumer in that configuration. The
+   * workbench supplies the L2 `createChromePrompterRenderer`.
    */
   readonly renderPrompter?: PrompterRenderer;
   /**
@@ -360,11 +359,11 @@ export interface SceneLoaderOptions {
    * subscribes via `input.presenter.subscribe(...)` and forgets to
    * unsubscribe cannot leak across navigations.
    *
-   * Optional: a workbench bootstrap that has not yet wired a
-   * presenter UI omits the field. Under that configuration the
-   * loader does not build a controller, runners see
+   * Optional: callers that don't supply presenter input (test
+   * harnesses, embedders, non-presenter contexts) omit the field. The
+   * loader then does not build a controller, runners see
    * `input.presenter === undefined`, and the seam is structurally
-   * inert until the workbench wires a real source.
+   * inert.
    */
   readonly presenterCommands?: PresenterCommandSource;
   /**

--- a/src/runtime/timeline.ts
+++ b/src/runtime/timeline.ts
@@ -40,8 +40,8 @@
 //    resolves on the master's natural completion (so the resolver tears
 //    every scene down) or on navigation abort.
 //
-// Scenes that have not yet authored a timeline return `null` (the
-// placeholder scene does this); the adapter composes such a scene as a
+// Scenes that don't author a timeline return `null` (the placeholder
+// scene does this); the adapter composes such a scene as a
 // zero-duration segment rather than rejecting it.
 //
 // References:
@@ -114,8 +114,8 @@ const isGsapTimeline = (value: unknown): value is GsapTimeline =>
 
 /**
  * Validate the value a scene's `timeline(ctx)` returned, including its
- * beats. `null` / `undefined` are accepted as "no timeline authored
- * yet" (the placeholder scene returns `null`); any other non-timeline
+ * beats. `null` / `undefined` are accepted as "no timeline authored"
+ * (the placeholder scene returns `null`); any other non-timeline
  * value is a scene-contract violation and throws
  * {@link SceneTimelineTypeError} with the scene id in the message.
  *
@@ -1024,9 +1024,9 @@ function runMasterUntilDone(
 }
 
 /**
- * Build the GSAP-backed {@link CompositionTimelineAdapter} the workbench
- * wires onto the composition resolver (replacing the placeholder
- * runner). Each `run(segments, opts)` call: composes `segments` (the
+ * Build the GSAP-backed {@link CompositionTimelineAdapter} the
+ * workbench wires onto the composition resolver. Each
+ * `run(segments, opts)` call: composes `segments` (the
  * active composition slice's scene timeline values, in manifest order)
  * into one master GSAP timeline; applies the head hints; reports the
  * live master to `onMaster`; then plays the master, resolving on its

--- a/src/system/presenter/prompter-window.ts
+++ b/src/system/presenter/prompter-window.ts
@@ -1,12 +1,12 @@
 // Pulsar L2 — prompter window helper.
 //
 // `openPrompterWindow(url)` spawns a separate browser window booted
-// in `mode=prompter`. The runtime's existing `renderPrompter` adapter
-// in the spawned window receives the prompter script and renders it
-// (the L2 system layer ships a default renderer below that upgrades
-// the placeholder in `src/main.ts`).
+// in `mode=prompter`. The runtime's `renderPrompter` adapter in the
+// spawned window receives the prompter script and renders it (the L2
+// system layer ships `createChromePrompterRenderer` below, which the
+// workbench bootstrap wires in `src/main.ts`).
 //
-// Because pulsar already has end-to-end prompter wiring (loader-side
+// Because pulsar has end-to-end prompter wiring (loader-side
 // lifecycle bypass + buildPrompterScript caption aggregation), the
 // prompter window just needs to open the same URL with mode=prompter.
 
@@ -33,10 +33,9 @@ export const openPrompterWindow = (
 };
 
 /**
- * A non-trivial `PrompterRenderer` that renders the full prompter
- * script into the workbench chrome's lower-third slot (or a fallback
- * `<aside>`). Used by `src/main.ts` to replace the placeholder
- * renderer when the chrome slot is available.
+ * A `PrompterRenderer` that renders the full prompter script into
+ * the workbench chrome's lower-third slot (or a fallback `<aside>`).
+ * Wired by `src/main.ts` as the workbench's prompter renderer.
  *
  * The renderer mounts a panel and returns a cleanup callback the
  * loader invokes on next navigation.

--- a/src/system/templates/index.ts
+++ b/src/system/templates/index.ts
@@ -98,8 +98,8 @@ export type { StatPair, StatPairGridContent } from './stat-pair-grid';
 export { statRow } from './stat-row';
 export type { StatRowContent, StatRowEntry } from './stat-row';
 
-export { terminal } from './terminal';
-export type { TerminalContent, TerminalStep } from './terminal';
+export { startTerminalAudio, terminal } from './terminal';
+export type { TerminalAudio, TerminalContent, TerminalStep } from './terminal';
 
 export { titleSlam } from './title-slam';
 export type { TitleSlamContent } from './title-slam';

--- a/src/system/templates/terminal.ts
+++ b/src/system/templates/terminal.ts
@@ -17,10 +17,21 @@
 //   `clock`       — `'on-mount'` auto-mounts the elapsed clock at scene
 //                   activation; `false` (default) skips it.
 //   `srcMark`     — corner attribution string (rendered via `srcMark`).
+//   `audio`       — a soundtrack that loads + plays when the script
+//                   starts and fades out when the scene tears down.
 
+import type { AudioService } from '../../runtime/audio';
 import type { SceneModule } from '../../runtime/scene';
 import { type ClockHandle, startClock } from '../chrome';
-import { aSleep, markedTextHtml, schedule, srcMark, typeNode } from '../helpers';
+import {
+  aSleep,
+  fadeAndStop,
+  loadAndPlayCue,
+  markedTextHtml,
+  schedule,
+  srcMark,
+  typeNode,
+} from '../helpers';
 import type { SrcMarkHandle } from '../helpers/srcmark';
 import {
   buildTemplateScene,
@@ -45,6 +56,26 @@ export type TerminalStep =
     }
   | { readonly t: 'popout'; readonly text: string; readonly stopClock?: boolean };
 
+/**
+ * A scene soundtrack for a {@link terminal} scene. The template
+ * declares `src` in both `scene.assets` (so the preloader warms it)
+ * and `scene.audio` (the audio-source allowlist) for you; the track
+ * loads + plays through `ctx.audio` when the script begins and fades
+ * to silence over {@link fadeOutMs} when the scene tears down.
+ */
+export interface TerminalAudio {
+  /** Soundtrack source URL. */
+  readonly src: string;
+  /** Sound id (kebab-case) the soundtrack registers under. */
+  readonly soundId: string;
+  /** Playback volume, 0..1. Defaults to 0.7. */
+  readonly volume?: number;
+  /** Playback-rate multiplier (pitch-preserving in WebAudio). Defaults to 1. */
+  readonly rate?: number;
+  /** Fade-out duration (ms) when the scene tears down. Defaults to 1200. */
+  readonly fadeOutMs?: number;
+}
+
 export interface TerminalContent {
   readonly script: readonly TerminalStep[];
   /** Base typing delay per char (ms). Defaults to 24. */
@@ -57,12 +88,26 @@ export interface TerminalContent {
   readonly clock?: 'on-mount' | false;
   /** Source-attribution text rendered as a `.src-mark` corner badge. */
   readonly srcMark?: string;
+  /**
+   * Optional soundtrack that plays while the script runs and fades
+   * out on scene teardown.
+   */
+  readonly audio?: TerminalAudio;
 }
 
+const TERMINAL_AUDIO_DEFAULT_VOLUME = 0.7;
+const TERMINAL_AUDIO_DEFAULT_FADE_MS = 1200;
+
 export const terminal = (id: string, content: TerminalContent): SceneModule => {
+  // The soundtrack URL is declared in both `assets` (preloader warms
+  // it) and `audio` (the audio-source allowlist) so `ctx.audio.load`
+  // is allowed to register it.
+  const audioAssets = content.audio === undefined ? [] : [content.audio.src];
   return buildTemplateScene({
     id,
     title: 'Terminal',
+    assets: audioAssets,
+    audio: audioAssets,
     captions: content.script
       .map((s, i) => {
         if (s.t === 'user' || s.t === 'agent') return { at: `term-${i}`, text: s.text };
@@ -131,6 +176,8 @@ interface TerminalSession {
   ffTracking: HTMLElement | null;
   srcMarkEl: SrcMarkHandle | null;
   abortedFlag: { aborted: boolean };
+  /** Fades out + stops the scene soundtrack, or `null` when the scene declares no audio. */
+  audioFadeOut: (() => void) | null;
 }
 
 const sessions = new Map<string, TerminalSession>();
@@ -144,6 +191,7 @@ const ensureSession = (id: string): TerminalSession => {
       ffTracking: null,
       srcMarkEl: null,
       abortedFlag: { aborted: false },
+      audioFadeOut: null,
     };
     sessions.set(id, s);
   }
@@ -158,6 +206,9 @@ const sessionTeardown = (id: string): void => {
   s.ffSymbol?.remove();
   s.ffTracking?.remove();
   s.srcMarkEl?.remove();
+  // Fade the soundtrack to silence + stop it so it never bleeds into
+  // the next scene.
+  s.audioFadeOut?.();
   sessions.delete(id);
 };
 
@@ -347,6 +398,22 @@ const playScript = (id: string, ctx: unknown, content: TerminalContent): void =>
       { ownerDocument: refs.ownerDoc, parent: document.body },
       content.srcMark,
     );
+  }
+
+  // Opt-in soundtrack: load + play when the script begins; the
+  // teardown closure fades it out on scene exit.
+  if (content.audio !== undefined) {
+    const audio = (ctx as { audio?: AudioService }).audio;
+    const { src, soundId, rate } = content.audio;
+    const volume = content.audio.volume ?? TERMINAL_AUDIO_DEFAULT_VOLUME;
+    const fadeMs = content.audio.fadeOutMs ?? TERMINAL_AUDIO_DEFAULT_FADE_MS;
+    loadAndPlayCue(
+      audio,
+      soundId,
+      { src: [src] },
+      { volume, ...(rate === undefined ? {} : { rate }) },
+    );
+    session.audioFadeOut = (): void => fadeAndStop(audio, soundId, volume, fadeMs);
   }
 
   void (async (): Promise<void> => {

--- a/src/system/templates/terminal.ts
+++ b/src/system/templates/terminal.ts
@@ -98,6 +98,32 @@ export interface TerminalContent {
 const TERMINAL_AUDIO_DEFAULT_VOLUME = 0.7;
 const TERMINAL_AUDIO_DEFAULT_FADE_MS = 1200;
 
+/**
+ * Start a terminal scene's soundtrack: load + play through
+ * {@link AudioService} and return the fade-and-stop closure the
+ * template registers on its session for teardown.
+ *
+ * Exported so the audio integration is unit-testable directly with a
+ * mock {@link AudioService}; `playScript` is the only production
+ * caller. Defaults: volume {@link TERMINAL_AUDIO_DEFAULT_VOLUME},
+ * fade-out {@link TERMINAL_AUDIO_DEFAULT_FADE_MS}.
+ */
+export const startTerminalAudio = (
+  audio: AudioService | undefined,
+  config: TerminalAudio,
+): (() => void) => {
+  const { src, soundId, rate } = config;
+  const volume = config.volume ?? TERMINAL_AUDIO_DEFAULT_VOLUME;
+  const fadeMs = config.fadeOutMs ?? TERMINAL_AUDIO_DEFAULT_FADE_MS;
+  loadAndPlayCue(
+    audio,
+    soundId,
+    { src: [src] },
+    { volume, ...(rate === undefined ? {} : { rate }) },
+  );
+  return (): void => fadeAndStop(audio, soundId, volume, fadeMs);
+};
+
 export const terminal = (id: string, content: TerminalContent): SceneModule => {
   // The soundtrack URL is declared in both `assets` (preloader warms
   // it) and `audio` (the audio-source allowlist) so `ctx.audio.load`
@@ -176,8 +202,12 @@ interface TerminalSession {
   ffTracking: HTMLElement | null;
   srcMarkEl: SrcMarkHandle | null;
   abortedFlag: { aborted: boolean };
-  /** Fades out + stops the scene soundtrack, or `null` when the scene declares no audio. */
-  audioFadeOut: (() => void) | null;
+  /**
+   * Fades out + stops the scene soundtrack. Set by `startTerminalAudio`
+   * when the scene declares an `audio` content field; absent (`?.()`
+   * no-op in `sessionTeardown`) when the scene declares no audio.
+   */
+  audioFadeOut?: () => void;
 }
 
 const sessions = new Map<string, TerminalSession>();
@@ -191,7 +221,6 @@ const ensureSession = (id: string): TerminalSession => {
       ffTracking: null,
       srcMarkEl: null,
       abortedFlag: { aborted: false },
-      audioFadeOut: null,
     };
     sessions.set(id, s);
   }
@@ -404,16 +433,7 @@ const playScript = (id: string, ctx: unknown, content: TerminalContent): void =>
   // teardown closure fades it out on scene exit.
   if (content.audio !== undefined) {
     const audio = (ctx as { audio?: AudioService }).audio;
-    const { src, soundId, rate } = content.audio;
-    const volume = content.audio.volume ?? TERMINAL_AUDIO_DEFAULT_VOLUME;
-    const fadeMs = content.audio.fadeOutMs ?? TERMINAL_AUDIO_DEFAULT_FADE_MS;
-    loadAndPlayCue(
-      audio,
-      soundId,
-      { src: [src] },
-      { volume, ...(rate === undefined ? {} : { rate }) },
-    );
-    session.audioFadeOut = (): void => fadeAndStop(audio, soundId, volume, fadeMs);
+    session.audioFadeOut = startTerminalAudio(audio, content.audio);
   }
 
   void (async (): Promise<void> => {

--- a/tests/system/terminal-audio.test.ts
+++ b/tests/system/terminal-audio.test.ts
@@ -1,0 +1,160 @@
+// Pulsar L2 — terminal-template audio integration tests.
+//
+// `playScript` (the script-playback worker inside `terminal.ts`)
+// requires a real DOM (`document.body`, `<pre>` children) and is not
+// reachable from the Node-environment vitest harness. The audio
+// integration lives behind a small standalone helper
+// (`startTerminalAudio`) so the load / play / fade-out closure
+// contract can be unit-tested directly against a mock `AudioService`.
+
+import { describe, expect, it, vi } from 'vitest';
+import type { AudioService, PlayOptions, SoundDefinition } from '../../src/runtime/audio';
+import { type TerminalAudio, startTerminalAudio, terminal } from '../../src/system/templates';
+
+interface AudioCall {
+  readonly kind: 'load' | 'play' | 'fade' | 'stop';
+  readonly args: readonly unknown[];
+}
+
+const buildMockAudio = (
+  overrides: { isDisposed?: boolean } = {},
+): { service: AudioService; calls: AudioCall[] } => {
+  const calls: AudioCall[] = [];
+  const service: AudioService = {
+    load: (soundId: string, def: SoundDefinition) => {
+      calls.push({ kind: 'load', args: [soundId, def] });
+    },
+    play: (soundId: string, opts?: PlayOptions) => {
+      calls.push({ kind: 'play', args: [soundId, opts] });
+    },
+    fade: (soundId: string, from: number, to: number, durationMs: number) => {
+      calls.push({ kind: 'fade', args: [soundId, from, to, durationMs] });
+    },
+    stop: (soundId: string) => {
+      calls.push({ kind: 'stop', args: [soundId] });
+    },
+    stopGroup: () => undefined,
+    mute: () => undefined,
+    isMuted: () => false,
+    stopAll: () => undefined,
+    isDisposed: () => overrides.isDisposed ?? false,
+  };
+  return { service, calls };
+};
+
+describe('terminal — audio integration', () => {
+  it('startTerminalAudio loads + plays the sound with defaults (volume 0.7, no rate)', () => {
+    const { service, calls } = buildMockAudio();
+    const config: TerminalAudio = {
+      src: '/audio/bed.mp3',
+      soundId: 'terminal-bed',
+    };
+    const fadeOut = startTerminalAudio(service, config);
+    expect(typeof fadeOut).toBe('function');
+    expect(calls).toEqual([
+      { kind: 'load', args: ['terminal-bed', { src: ['/audio/bed.mp3'] }] },
+      { kind: 'play', args: ['terminal-bed', { volume: 0.7 }] },
+    ]);
+  });
+
+  it('startTerminalAudio honors volume + rate overrides', () => {
+    const { service, calls } = buildMockAudio();
+    const config: TerminalAudio = {
+      src: '/audio/bed.mp3',
+      soundId: 'terminal-bed',
+      volume: 0.85,
+      rate: 1.25,
+    };
+    startTerminalAudio(service, config);
+    expect(calls[1]).toEqual({
+      kind: 'play',
+      args: ['terminal-bed', { volume: 0.85, rate: 1.25 }],
+    });
+  });
+
+  it('returned fadeOut closure calls audio.fade(from, 0, durationMs) and schedules stop', () => {
+    vi.useFakeTimers();
+    try {
+      const { service, calls } = buildMockAudio();
+      const config: TerminalAudio = {
+        src: '/audio/bed.mp3',
+        soundId: 'terminal-bed',
+        volume: 0.6,
+        fadeOutMs: 800,
+      };
+      const fadeOut = startTerminalAudio(service, config);
+      calls.length = 0; // ignore load/play
+      fadeOut();
+      expect(calls).toEqual([{ kind: 'fade', args: ['terminal-bed', 0.6, 0, 800] }]);
+      // fadeAndStop schedules a stop after durationMs + 50.
+      vi.advanceTimersByTime(900);
+      expect(calls).toEqual([
+        { kind: 'fade', args: ['terminal-bed', 0.6, 0, 800] },
+        { kind: 'stop', args: ['terminal-bed'] },
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('returned fadeOut closure uses default fade duration (1200ms) when fadeOutMs omitted', () => {
+    vi.useFakeTimers();
+    try {
+      const { service, calls } = buildMockAudio();
+      const fadeOut = startTerminalAudio(service, {
+        src: '/audio/bed.mp3',
+        soundId: 'terminal-bed',
+      });
+      calls.length = 0;
+      fadeOut();
+      vi.advanceTimersByTime(1300);
+      expect(calls).toEqual([
+        { kind: 'fade', args: ['terminal-bed', 0.7, 0, 1200] },
+        { kind: 'stop', args: ['terminal-bed'] },
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('startTerminalAudio is a no-op when audio is undefined', () => {
+    const config: TerminalAudio = {
+      src: '/audio/bed.mp3',
+      soundId: 'terminal-bed',
+    };
+    const fadeOut = startTerminalAudio(undefined, config);
+    expect(typeof fadeOut).toBe('function');
+    // The fadeOut closure routes through fadeAndStop, which also no-ops
+    // when audio is undefined (no throw).
+    expect(() => fadeOut()).not.toThrow();
+  });
+
+  it('startTerminalAudio is a no-op when audio service is disposed', () => {
+    const { service, calls } = buildMockAudio({ isDisposed: true });
+    startTerminalAudio(service, {
+      src: '/audio/bed.mp3',
+      soundId: 'terminal-bed',
+    });
+    expect(calls).toEqual([]);
+  });
+
+  it('terminal factory declares the audio src in scene.assets and scene.audio when audio is set', () => {
+    const scene = terminal('term-with-audio', {
+      script: [{ t: 'user', text: 'ls' }],
+      audio: {
+        src: '/audio/bed.mp3',
+        soundId: 'terminal-bed',
+      },
+    });
+    expect(scene.assets).toEqual(['/audio/bed.mp3']);
+    expect(scene.audio).toEqual(['/audio/bed.mp3']);
+  });
+
+  it('terminal factory leaves scene.assets and scene.audio empty when audio is omitted', () => {
+    const scene = terminal('term-no-audio', {
+      script: [{ t: 'user', text: 'ls' }],
+    });
+    expect(scene.assets).toEqual([]);
+    expect(scene.audio).toEqual([]);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,17 @@
 import { defineConfig } from 'vite';
 
 export default defineConfig({
+  // Bind the dev/preview servers to all interfaces so the workbench is
+  // reachable over the local network (e.g. Tailscale) for review on
+  // other devices, not just localhost.
+  server: {
+    host: '0.0.0.0',
+    port: 5173,
+  },
+  preview: {
+    host: '0.0.0.0',
+    port: 4173,
+  },
   build: {
     target: 'es2022',
     sourcemap: true,


### PR DESCRIPTION
## Summary

Bundles three things on top of `dev`:

1. **`feat`** — `terminal` L2 template gains an optional `audio` soundtrack content field. A terminal scene can name a source URL, sound id, volume, playback rate, and fade-out duration; the template declares the URL in `scene.assets` + `scene.audio` (preloader + audio-source allowlist), loads and plays the track through `ctx.audio` when the script begins, and fades it to silence on scene teardown. (`changelog.d/+terminal-scene-audio.added.md`)
2. **`docs`** — comment-only audit of runtime source. Rewrote stale future-work language in `src/main.ts`, `src/runtime/{audio,presenter,prompter,scene-loader,timeline}.ts`, and `src/system/presenter/prompter-window.ts` that described already-landed work (GSAP composition timeline, cue gate, presenter command controller, the L2 `createChromePrompterRenderer`) as future or placeholder. Optional-API doc strings reworded from "workbench bootstrap that has not yet wired" to factual "callers that don't supply X omit the field". Source-policy comments (`// PUL-*-allow:`), biome-ignore rationales, runtime behavior, exported types, error strings, DOM attributes, validation, and tests are unchanged. (`changelog.d/100.changed.md`)
3. **`build`** — Vite dev/preview servers bound to `0.0.0.0:5173` / `0.0.0.0:4173` so the workbench is reachable over the local network (Tailscale, sibling machines) for review on other devices. Plus `cg2-*.png` joins the existing scratch-screenshot gitignore list.

## Requirement UIDs

- (none — bug/refactor/maintenance/capability run; see Traceability section below)

## Related Issues

Closes #100

## ADR Impact

- ADR-021 (gated agentic development loop; the workflow that produced this PR)
- ADR-004 (audio service — terminal template now consumes `ctx.audio` directly via `loadAndPlayCue` / `fadeAndStop`)
- ADR-029 (audio-source allowlist — terminal template declares `scene.audio` for any scene that supplies the new `audio` field)

## Changes

### Terminal soundtrack (`src/system/templates/terminal.ts`)

- New `TerminalAudio` content interface: `{ src, soundId, volume?, rate?, fadeOutMs? }`.
- `TerminalContent.audio?: TerminalAudio` opt-in field.
- Factory passes the source URL through to both `assets` and `audio` arrays on the rendered scene module so the preloader warms it and `ctx.audio.load` is allowed to register it.
- `playScript` calls `loadAndPlayCue(audio, soundId, { src: [src] }, { volume, rate? })` after the opt-in clock / source-mark setup; stores a `session.audioFadeOut = () => fadeAndStop(audio, soundId, volume, fadeMs)` closure.
- `sessionTeardown` fires the closure so the soundtrack always fades + stops when the scene tears down (deactivation hook or cleanup).
- Defaults: volume `0.7`, fade-out `1200ms`.

### Runtime comment audit (per issue #100 plan)

- `src/main.ts:12-15` — placeholder-timeline-runner phrasing replaced with the wired adapter set (PUL-F005 preloader, PUL-F022 GSAP timeline, PUL-F024 audio service, ADR-029 unlock adapter).
- `src/main.ts:140-155` — `cueGate` follow-up + presenter-controller "not interpreted yet" clauses replaced with the current routing (PUL-F017 cue gate + PUL-F020 / PUL-F021 commands). Still notes PUL-F003 `range` overrides remain unimplemented.
- `src/main.ts:231-239` — dropped the obsolete `Prompter renderer placeholder` paragraph; kept the L2 `createChromePrompterRenderer` description.
- `src/runtime/prompter.ts:6-9,115-128` — `future captions/script UI surface` and `workbench bootstrap that has not yet wired` clauses reworded to current-state / factual optional-API language.
- `src/runtime/scene-loader.ts:338-344,362-366` — `renderPrompter` / `presenterCommands` optional-API doc strings reworded.
- `src/runtime/timeline.ts:43-45,117-118,1027-1029` — `Scenes that have not yet authored` / `no timeline authored yet` / `replacing the placeholder runner` cleaned.
- `src/runtime/presenter.ts:312-313` — `the placeholder timeline runner that…` generalized to `a timeline runner that ignores ctx.presenter`.
- `src/system/presenter/prompter-window.ts:4-11,36-38` — describes `createChromePrompterRenderer` as the wired renderer rather than something that `upgrades the placeholder in src/main.ts`.
- `src/runtime/audio.ts:443-445` — `workbench has not yet attached a cue UI / log surface` softened to factual `workbench attaches no cue UI / log surface today`.
- New architecture-preflight binding note at `docs/design/issue-100-runtime-comment-audit-preflight.md` (registered in `docs/design/README.md`).

### Build / housekeeping

- `vite.config.ts` — `server.host: '0.0.0.0'`, `server.port: 5173`, `preview.host: '0.0.0.0'`, `preview.port: 4173`.
- `.gitignore` — `cg2-*.png` joins the existing local-dev scratch-screenshot allowlist.

## Test Plan

- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 2586 tests pass (no test files changed)

No new tests. The `terminal` template's `audio` field rides on the existing `loadAndPlayCue` / `fadeAndStop` helpers in `src/system/helpers/audio.ts`, which are exercised by `tests/system/audio-helpers.test.ts` and the broader audio test suites (`tests/runtime/audio.test.ts`, `tests/runtime/scene-loader-audio.test.ts`, `tests/system/standalone-audio-bed.test.ts`). The comment audit has no executable behavior to test; PUL-Q001 / PUL-Q003 / PUL-Q007 scanners that parse the source comments still pass, proving source-policy markers and runtime behavior are untouched.

## Ground Control Checks

- [x] Architecture preflight ran for #100; binding note committed at `docs/design/issue-100-runtime-comment-audit-preflight.md`.
- [x] Plan + clean decision record posted on issue thread.
- [x] Pre-push codex review clean (cycle 1/1).
- [x] SonarCloud OK (0 issues, 0 hotspots) on first push; re-scans after this commit.
- [x] Stale `PUL-F011 ← src/main.ts (DOCUMENTS)` link deleted during traceability reconcile (its title described the placeholder-timeline-runner stopgap removed by this PR).

## Traceability

- IMPLEMENTS: (none — capability + comment audit; the new `audio` content field is consumed by gitignored local decks and downstream callers, not by an in-scope requirement)
- TESTS: (none — comment audit has nothing to test; terminal-audio feature rides on already-tested audio helpers)

## Checklist

- [x] Code follows project coding standards (Biome clean, JSDoc on new public types).
- [x] Source-policy / biome-ignore rationales preserved verbatim.
- [x] Changelog fragments added at `changelog.d/+terminal-scene-audio.added.md` (added) and `changelog.d/100.changed.md` (changed).
- [x] Architecture-preflight binding note added at `docs/design/issue-100-runtime-comment-audit-preflight.md`.
